### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Test
         run: cargo test --workspace --all-targets
 
+      - name: Pre-build release binaries and codex for acceptance step
+        if: github.event_name == 'push'
+        run: |
+          cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang
+          bash scripts/build-vendored-codex.sh release
+
       - name: Local no-fallback smoke
         run: python scripts/smoke_local.py --skip-build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_TARGET_DIR: target
 
 jobs:
   build-and-test:
@@ -33,9 +34,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-
-      - name: Build
-        run: cargo build --workspace --all-targets
 
       - name: Test
         run: cargo test --workspace --all-targets
@@ -61,6 +59,7 @@ jobs:
         run: python scripts/release_readiness.py --self-test
 
       - name: Acceptance install lifecycle
+        if: github.event_name == 'push'
         run: ./scripts/acceptance-install-upgrade-tui-uninstall.sh
 
   windows-build-and-test:
@@ -69,10 +68,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
-
-      - name: Build
-        shell: pwsh
-        run: cargo build --workspace --all-targets
 
       - name: Test
         shell: pwsh

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -108,6 +108,24 @@ expect_failure() {
 echo "acceptance: build release binaries"
 (cd "${REPO_ROOT}" && cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang)
 
+# Resolve the prebuilt Codex binary location so packaging can skip a second
+# full compilation of the large vendored Codex workspace.  The binary is built
+# once during the main CI build step (which uses the same CARGO_TARGET_DIR)
+# and reused here.  If the binary is not present (e.g. first local run) the
+# packaging script will compile it normally.
+CODEX_CANDIDATE="${REPO_ROOT}/target/release/rocm-codex"
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  if [[ "${CARGO_TARGET_DIR}" = /* ]]; then
+    CODEX_CANDIDATE="${CARGO_TARGET_DIR}/release/rocm-codex"
+  else
+    CODEX_CANDIDATE="${REPO_ROOT}/${CARGO_TARGET_DIR}/release/rocm-codex"
+  fi
+fi
+if [[ -x "${CODEX_CANDIDATE}" ]]; then
+  export ROCM_CODEX_PREBUILT_BINARY="${CODEX_CANDIDATE}"
+  echo "acceptance: reusing prebuilt rocm-codex at ${CODEX_CANDIDATE}"
+fi
+
 echo "acceptance: generate signing key"
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "${SIGNING_PRIVATE_KEY}" >/dev/null 2>&1 \
   || fail "failed to generate acceptance signing private key"

--- a/scripts/build-vendored-codex.sh
+++ b/scripts/build-vendored-codex.sh
@@ -28,6 +28,45 @@ need_cmd() {
 
 need_cmd cargo
 
+# ---------------------------------------------------------------------------
+# Prebuilt binary fast path.
+#
+# Set ROCM_CODEX_PREBUILT_BINARY to an absolute path of an already-compiled
+# `codex` binary to skip the full Cargo build.  The binary is still installed
+# into the same ROCM_PROFILE_DIR location as the compiled one, so the rest of
+# the packaging pipeline is unaffected.
+#
+# In CI this lets the acceptance step reuse the binary that was produced by the
+# earlier release build step instead of compiling the large vendored Codex
+# workspace a second time.
+# ---------------------------------------------------------------------------
+if [[ -n "${ROCM_CODEX_PREBUILT_BINARY:-}" ]]; then
+  if [[ ! -f "${ROCM_CODEX_PREBUILT_BINARY}" ]]; then
+    echo "ROCM_CODEX_PREBUILT_BINARY is set but file not found: ${ROCM_CODEX_PREBUILT_BINARY}" >&2
+    exit 1
+  fi
+  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+    if [[ "${CARGO_TARGET_DIR}" = /* ]]; then
+      ROCM_TARGET_DIR="${CARGO_TARGET_DIR}"
+    else
+      ROCM_TARGET_DIR="${REPO_ROOT}/${CARGO_TARGET_DIR}"
+    fi
+  else
+    ROCM_TARGET_DIR="${REPO_ROOT}/target"
+  fi
+  if [[ -n "${TARGET_TRIPLE}" ]]; then
+    ROCM_PROFILE_DIR="${ROCM_TARGET_DIR}/${TARGET_TRIPLE}/${PROFILE}"
+  else
+    ROCM_PROFILE_DIR="${ROCM_TARGET_DIR}/${PROFILE}"
+  fi
+  mkdir -p "${ROCM_PROFILE_DIR}"
+  install -m 0755 "${ROCM_CODEX_PREBUILT_BINARY}" "${ROCM_PROFILE_DIR}/rocm-codex"
+  echo "using prebuilt vendored Codex binary"
+  echo "  source: ${ROCM_CODEX_PREBUILT_BINARY}"
+  echo "  installed wrapper binary: ${ROCM_PROFILE_DIR}/rocm-codex"
+  exit 0
+fi
+
 if [[ "$(uname -s)" == "Linux" ]]; then
   need_cmd pkg-config
   LOCAL_DEV_SYSROOT="${ROCM_CLI_PORTABLE_BUILD_DEPS_ROOT:-${REPO_ROOT}/.rocm-work/tools/wsl-build-deps}/root"


### PR DESCRIPTION
This pull request optimizes the CI pipeline and acceptance test workflow by reusing prebuilt release binaries, particularly the large `rocm-codex` binary, to avoid redundant compilation steps. It introduces environment variable handling and script logic to detect and use existing binaries, improving build efficiency and reducing CI runtime.

**CI/CD pipeline improvements:**
- Added a step in `.github/workflows/ci.yml` to pre-build release binaries and the vendored Codex binary during push events, making them available for later acceptance steps and reducing duplicate compilation.
- Set the `CARGO_TARGET_DIR` environment variable in the CI workflow to ensure consistent target directory usage across steps.
- Acceptance install lifecycle step now runs only on push events, aligning with when prebuilt binaries are available.
- Removed redundant `cargo build` steps from both Linux and Windows jobs, as builds are now handled earlier or reused. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL37-R46) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL73-L76)

**Acceptance and packaging script enhancements:**
- Updated `scripts/acceptance-install-upgrade-tui-uninstall.sh` to resolve and export the location of the prebuilt `rocm-codex` binary, enabling downstream scripts to reuse it if present.
- Modified `scripts/build-vendored-codex.sh` to support a fast path: if the `ROCM_CODEX_PREBUILT_BINARY` environment variable is set and points to an existing binary, the script installs it directly instead of rebuilding, further reducing redundant builds in CI and local development.