### PR TITLE
Pin Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,7 @@ jobs:
       - name: Install native build deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build
         run: cargo build --workspace --all-targets
@@ -68,18 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build
         shell: pwsh
@@ -124,9 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -136,20 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -169,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build workspace
         run: cargo build --workspace --all-targets

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
               set -euo pipefail
               mkdir -p "$HOME"
               yum install -y pkgconfig libcap-devel
-              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
               export PATH="$HOME/.cargo/bin:$PATH"
               cargo build --release --workspace
             '
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build release binaries
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
               set -euo pipefail
               mkdir -p "$HOME"
               yum install -y pkgconfig libcap-devel
-              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
               export PATH="$HOME/.cargo/bin:$PATH"
               cargo build --release --workspace
             '
@@ -127,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build release binaries
         shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/powderluv/rocm-cli"
-rust-version = "1.88"
+rust-version = "1.96"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

Pins the Rust toolchain to **1.96.0** for reproducible builds. Previously builds floated on the latest `stable`, so a new stable release could silently change CI behavior. 1.96.0 also carries security fixes (CVE-2026-33055 / CVE-2026-33056 via Cargo's `tar` bump).

The version lives in **one place** — `rust-toolchain.toml` — and every environment defers to it:

| Environment | Setup | Source of version |
|---|---|---|
| GitHub-hosted runners (CI ×5, Windows nightly/release) | `actions-rust-lang/setup-rust-toolchain@v1` | reads `rust-toolchain.toml` |
| manylinux Docker (Linux nightly/release) | `rustup --default-toolchain none` → `cargo` | rustup auto-installs the pinned channel from the file |

To bump Rust in future, edit one line in `rust-toolchain.toml`.

## Incidental cleanups
- Dropped the manual `actions/cache` blocks — `setup-rust-toolchain` bundles `Swatinem/rust-cache` with more precise keys.
- Dropped `with: components:` on the `fmt`/`clippy` jobs — components now come from the toolchain file.

## MSRV
Aligned `rust-version` (`1.88` → `1.96`). This is an application shipping prebuilt binaries built with the pinned toolchain, so the supported version tracks the toolchain we actually build with rather than an unverified older floor.

## Verification (local, on pinned 1.96.0)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, no new lints
- `cargo build --workspace --all-targets` — clean
- `cargo test --workspace --all-targets` — 747 passed; 1 pre-existing flaky test (`tui::tests::assistant_comfyui_start_result_shows_url_models_and_quit_prompt`, passes in isolation; unaffected by this change as it touches no Rust code)