### PR TITLE
Replace the openssl CLI with pure-Rust signing & verification

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --quiet --release -p xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +661,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1284,6 +1308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1327,12 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1426,6 +1465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1544,6 +1600,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1638,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1679,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1637,6 +1732,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -1733,6 +1858,7 @@ dependencies = [
  "crossterm 0.29.0",
  "flate2",
  "keyring-core",
+ "rand",
  "ratatui",
  "rocm-core",
  "rocm-engine-atom",
@@ -1743,8 +1869,10 @@ dependencies = [
  "rocm-engine-sglang",
  "rocm-engine-vllm",
  "rpassword",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "ureq",
  "windows-native-keyring-store",
@@ -1758,8 +1886,11 @@ dependencies = [
  "anyhow",
  "directories",
  "libc",
+ "rand",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -1874,6 +2005,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2192,6 +2343,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2378,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3075,6 +3252,26 @@ dependencies = [
  "serde",
  "winnow",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,6 @@ dependencies = [
  "crossterm 0.29.0",
  "flate2",
  "keyring-core",
- "rand",
  "ratatui",
  "rocm-core",
  "rocm-engine-atom",
@@ -1869,10 +1868,8 @@ dependencies = [
  "rocm-engine-sglang",
  "rocm-engine-vllm",
  "rpassword",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "tar",
  "ureq",
  "windows-native-keyring-store",
@@ -3156,6 +3153,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "xtask"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rocm-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "engines/lemonade",
   "engines/sglang",
   "engines/vllm",
+  "xtask",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,13 @@ crossterm = { version = "0.29", features = ["libc", "use-dev-tty"] }
 directories = "6.0"
 keyring-core = "1.0.0"
 libc = "0.2"
+rand = "0.8"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 rpassword = "7.5"
+rsa = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = { version = "0.10", features = ["oid"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 
 [workspace.lints.rust]

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -27,6 +27,11 @@ serde_json.workspace = true
 tar = "0.4"
 ureq = { version = "2.12", features = ["native-certs"] }
 
+[dev-dependencies]
+rand.workspace = true
+rsa.workspace = true
+sha2.workspace = true
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = "1.1"
 

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -27,11 +27,6 @@ serde_json.workspace = true
 tar = "0.4"
 ureq = { version = "2.12", features = ["native-certs"] }
 
-[dev-dependencies]
-rand.workspace = true
-rsa.workspace = true
-sha2.workspace = true
-
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = "1.1"
 

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -7,6 +7,7 @@ use rocm_core::{
     normalize_therock_family, platform_binary_name, runtime_is_windows, runtime_os_name,
     runtime_path_for_windows_child, runtime_path_list_split, runtime_python_executable_in_env,
     unix_time_millis, uv_command_env, uv_pip_install_base, uv_venv_args,
+    verify_rsa_pkcs1_sha256_signature,
 };
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -1775,7 +1776,7 @@ fn fetch_and_verify_metadata_signature(
     download_signature_file(&signature_url, signature_path, max_time_secs)?;
     let public_key_source =
         with_metadata_public_key(policy, temp_key_path, |public_key, source| {
-            verify_signature_with_openssl(payload_path, signature_path, public_key)?;
+            verify_metadata_signature(payload_path, signature_path, public_key)?;
             Ok(source.to_owned())
         })?
         .context("metadata signature policy was active but no public key was resolved")?;
@@ -1802,7 +1803,7 @@ fn verify_cached_metadata_signature(
         );
     }
     with_metadata_public_key(policy, temp_key_path, |public_key, _source| {
-        verify_signature_with_openssl(payload_path, signature_path, public_key)
+        verify_metadata_signature(payload_path, signature_path, public_key)
     })?;
     Ok(())
 }
@@ -1828,36 +1829,30 @@ fn download_signature_file(
     Ok(())
 }
 
-fn verify_signature_with_openssl(
+fn verify_metadata_signature(
     payload_path: &Path,
     signature_path: &Path,
     public_key_path: &Path,
 ) -> Result<()> {
-    let output = capture_command_output(
-        Path::new("openssl"),
-        &[
-            "dgst",
-            "-sha256",
-            "-verify",
-            public_key_path.to_string_lossy().as_ref(),
-            "-signature",
-            signature_path.to_string_lossy().as_ref(),
-            payload_path.to_string_lossy().as_ref(),
-        ],
-    )
-    .context("failed to launch openssl for metadata signature verification")?;
-    if !output.status.success() {
-        let detail = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        bail!(
-            "metadata signature verification failed{}",
-            if detail.is_empty() {
-                String::new()
-            } else {
-                format!(": {detail}")
-            }
-        );
-    }
-    Ok(())
+    let public_key_pem = fs::read_to_string(public_key_path).with_context(|| {
+        format!(
+            "failed to read metadata public key: {}",
+            public_key_path.display()
+        )
+    })?;
+    let signature = fs::read(signature_path).with_context(|| {
+        format!(
+            "failed to read metadata signature: {}",
+            signature_path.display()
+        )
+    })?;
+    let payload = fs::read(payload_path).with_context(|| {
+        format!(
+            "failed to read metadata payload: {}",
+            payload_path.display()
+        )
+    })?;
+    verify_rsa_pkcs1_sha256_signature(&public_key_pem, &payload, &signature, "metadata")
 }
 
 fn metadata_cache_can_revalidate(
@@ -4343,48 +4338,39 @@ echo Python 3.12.10
     }
 
     fn generate_test_signing_key(private_key: &Path, public_key: &Path) -> Result<()> {
-        run_test_openssl(&[
-            "genpkey",
-            "-algorithm",
-            "RSA",
-            "-pkeyopt",
-            "rsa_keygen_bits:2048",
-            "-out",
-            private_key.to_string_lossy().as_ref(),
-        ])?;
-        run_test_openssl(&[
-            "rsa",
-            "-in",
-            private_key.to_string_lossy().as_ref(),
-            "-pubout",
-            "-out",
-            public_key.to_string_lossy().as_ref(),
-        ])
+        use rsa::RsaPrivateKey;
+        use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+
+        let mut rng = rand::thread_rng();
+        let key = RsaPrivateKey::new(&mut rng, 2048)
+            .context("failed to generate test RSA signing key")?;
+        let private_pem = key
+            .to_pkcs8_pem(LineEnding::LF)
+            .context("failed to encode test private key")?;
+        fs::write(private_key, private_pem.as_bytes())?;
+        let public_pem = rsa::RsaPublicKey::from(&key)
+            .to_public_key_pem(LineEnding::LF)
+            .context("failed to encode test public key")?;
+        fs::write(public_key, public_pem.as_bytes())?;
+        Ok(())
     }
 
     fn sign_test_payload(private_key: &Path, payload: &Path, signature: &Path) -> Result<()> {
-        run_test_openssl(&[
-            "dgst",
-            "-sha256",
-            "-sign",
-            private_key.to_string_lossy().as_ref(),
-            "-out",
-            signature.to_string_lossy().as_ref(),
-            payload.to_string_lossy().as_ref(),
-        ])
-    }
+        use rsa::RsaPrivateKey;
+        use rsa::pkcs1v15::SigningKey;
+        use rsa::pkcs8::DecodePrivateKey;
+        use rsa::signature::{SignatureEncoding, Signer};
+        use sha2::Sha256;
 
-    fn run_test_openssl(args: &[&str]) -> Result<()> {
-        let output = Command::new("openssl")
-            .args(args)
-            .output()
-            .context("failed to launch openssl for signature test")?;
-        if !output.status.success() {
-            bail!(
-                "openssl signature test command failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
+        let private_pem = fs::read_to_string(private_key)?;
+        let key = RsaPrivateKey::from_pkcs8_pem(&private_pem)
+            .context("failed to parse test private key")?;
+        let payload_bytes = fs::read(payload)?;
+        let signing_key = SigningKey::<Sha256>::new(key);
+        let produced = signing_key
+            .try_sign(&payload_bytes)
+            .context("failed to sign test payload")?;
+        fs::write(signature, produced.to_bytes())?;
         Ok(())
     }
 

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -9,6 +9,8 @@ use rocm_core::{
     unix_time_millis, uv_command_env, uv_pip_install_base, uv_venv_args,
     verify_rsa_pkcs1_sha256_signature,
 };
+#[cfg(test)]
+use rocm_core::{generate_rsa_signing_keypair, sign_rsa_pkcs1_sha256_signature};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fs;
@@ -4338,39 +4340,17 @@ echo Python 3.12.10
     }
 
     fn generate_test_signing_key(private_key: &Path, public_key: &Path) -> Result<()> {
-        use rsa::RsaPrivateKey;
-        use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
-
-        let mut rng = rand::thread_rng();
-        let key = RsaPrivateKey::new(&mut rng, 2048)
-            .context("failed to generate test RSA signing key")?;
-        let private_pem = key
-            .to_pkcs8_pem(LineEnding::LF)
-            .context("failed to encode test private key")?;
+        let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
         fs::write(private_key, private_pem.as_bytes())?;
-        let public_pem = rsa::RsaPublicKey::from(&key)
-            .to_public_key_pem(LineEnding::LF)
-            .context("failed to encode test public key")?;
         fs::write(public_key, public_pem.as_bytes())?;
         Ok(())
     }
 
     fn sign_test_payload(private_key: &Path, payload: &Path, signature: &Path) -> Result<()> {
-        use rsa::RsaPrivateKey;
-        use rsa::pkcs1v15::SigningKey;
-        use rsa::pkcs8::DecodePrivateKey;
-        use rsa::signature::{SignatureEncoding, Signer};
-        use sha2::Sha256;
-
         let private_pem = fs::read_to_string(private_key)?;
-        let key = RsaPrivateKey::from_pkcs8_pem(&private_pem)
-            .context("failed to parse test private key")?;
         let payload_bytes = fs::read(payload)?;
-        let signing_key = SigningKey::<Sha256>::new(key);
-        let produced = signing_key
-            .try_sign(&payload_bytes)
-            .context("failed to sign test payload")?;
-        fs::write(signature, produced.to_bytes())?;
+        let produced = sign_rsa_pkcs1_sha256_signature(&private_pem, &payload_bytes)?;
+        fs::write(signature, produced)?;
         Ok(())
     }
 

--- a/crates/rocm-core/Cargo.toml
+++ b/crates/rocm-core/Cargo.toml
@@ -10,14 +10,12 @@ rust-version.workspace = true
 anyhow.workspace = true
 directories.workspace = true
 libc.workspace = true
+rand.workspace = true
 rsa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 ureq = { version = "2.12", features = ["native-certs"] }
-
-[dev-dependencies]
-rand.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading"] }

--- a/crates/rocm-core/Cargo.toml
+++ b/crates/rocm-core/Cargo.toml
@@ -10,9 +10,14 @@ rust-version.workspace = true
 anyhow.workspace = true
 directories.workspace = true
 libc.workspace = true
+rsa.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 ureq = { version = "2.12", features = ["native-certs"] }
+
+[dev-dependencies]
+rand.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading"] }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -4632,6 +4632,48 @@ pub fn verify_rsa_pkcs1_sha256_signature(
         .map_err(|error| anyhow::anyhow!("{label} signature verification failed: {error}"))
 }
 
+/// Produce an RSASSA-PKCS#1 v1.5 signature over SHA-256 with a pure-Rust
+/// implementation, with no external `openssl` process.
+///
+/// `private_key_pem` is a PKCS#8 private-key PEM (`-----BEGIN PRIVATE KEY-----`),
+/// as emitted by `openssl genpkey`. The signature is deterministic and
+/// byte-identical to `openssl dgst -sha256 -sign`, so artifacts signed here verify
+/// with either implementation.
+pub fn sign_rsa_pkcs1_sha256_signature(private_key_pem: &str, payload: &[u8]) -> Result<Vec<u8>> {
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs1v15::SigningKey;
+    use rsa::pkcs8::DecodePrivateKey;
+    use rsa::signature::{SignatureEncoding, Signer};
+    use sha2::Sha256;
+
+    let private_key = RsaPrivateKey::from_pkcs8_pem(private_key_pem)
+        .context("signing private key is not a valid PKCS#8 RSA private key")?;
+    let signature = SigningKey::<Sha256>::new(private_key)
+        .try_sign(payload)
+        .context("failed to produce RSA signature")?;
+    Ok(signature.to_bytes().into_vec())
+}
+
+/// Generate a fresh 2048-bit RSA signing keypair, returned as
+/// `(PKCS#8 private-key PEM, SubjectPublicKeyInfo public-key PEM)` — the same
+/// formats `openssl genpkey` / `openssl rsa -pubout` produce.
+pub fn generate_rsa_signing_keypair() -> Result<(String, String)> {
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+
+    let mut rng = rand::thread_rng();
+    let private_key =
+        RsaPrivateKey::new(&mut rng, 2048).context("failed to generate RSA signing key")?;
+    let private_pem = private_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .context("failed to encode private key")?
+        .to_string();
+    let public_pem = rsa::RsaPublicKey::from(&private_key)
+        .to_public_key_pem(LineEnding::LF)
+        .context("failed to encode public key")?;
+    Ok((private_pem, public_pem))
+}
+
 pub fn verify_model_recipe_index_signature(
     index_path: &Path,
     signature_path: &Path,
@@ -6701,98 +6743,133 @@ Class Name:                Display
         Ok(())
     }
 
-    // Static interop vector produced once, offline, by the OpenSSL CLI:
-    //   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out priv.pem
-    //   openssl rsa -in priv.pem -pubout -out pub.pem
-    //   printf 'version = 1\n' > payload.txt
-    //   openssl dgst -sha256 -sign priv.pem -out sig.bin payload.txt
-    // It pins byte-compatibility between our pure-Rust verifier and `openssl dgst
-    // -sha256 -verify`, without launching openssl (the prior flake source).
-    const OPENSSL_INTEROP_PUBLIC_KEY_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtROm7eG3halAPysSr653
-sYPohfc+KCauLYkv7zOGTngTCV8OMbJZ/qekYx/zbXHEcmK3z+8oRJOzn/fA8QRc
-eoo5kzkduKgjEqDfHWLJc1Avj430bhTZ6Auyq9VqFECEh0vG3qJP8QJ/3mfxleSj
-lnhfuLajbYMZpQUtAkft3EZrUIcN6QWYBNGxF3lwqz8C8uvcxvrTQIRZ8fTLWB08
-x82+ak8iDklbCaS2qM4777QO0QTTxQK/RSTQCtUc3JQ04J3A1+HUwAxKIGixSIbU
-xqmWq3nXB+SpalmzwaNbRUdXiHeB7PHArypGtZ23/xT3XAGMN84kUIjfL5d1Q0ep
-hwIDAQAB
------END PUBLIC KEY-----
-"#;
-    const OPENSSL_INTEROP_PAYLOAD: &[u8] = b"version = 1\n";
-    const OPENSSL_INTEROP_SIGNATURE: &[u8] = &[
-        59, 31, 252, 39, 212, 110, 136, 175, 76, 219, 249, 31, 98, 216, 248, 219, 123, 104, 156,
-        104, 226, 35, 107, 61, 224, 102, 153, 92, 157, 74, 134, 197, 124, 224, 159, 247, 152, 253,
-        77, 107, 89, 104, 93, 27, 95, 43, 255, 8, 236, 146, 121, 82, 123, 163, 171, 33, 29, 78,
-        129, 212, 190, 70, 42, 143, 202, 156, 123, 31, 146, 26, 251, 245, 214, 6, 249, 3, 72, 127,
-        67, 176, 83, 38, 0, 29, 186, 110, 13, 98, 78, 208, 1, 233, 198, 150, 186, 57, 231, 111, 14,
-        173, 248, 27, 180, 163, 5, 23, 126, 142, 216, 247, 95, 210, 156, 77, 61, 134, 32, 181, 162,
-        210, 203, 233, 88, 53, 189, 189, 248, 87, 67, 53, 222, 236, 165, 153, 24, 103, 74, 81, 98,
-        110, 92, 255, 119, 227, 239, 215, 72, 50, 33, 248, 88, 252, 200, 255, 197, 190, 65, 251,
-        246, 209, 132, 89, 204, 185, 227, 27, 134, 152, 173, 159, 52, 160, 154, 178, 148, 208, 209,
-        164, 217, 199, 79, 216, 253, 243, 109, 198, 17, 238, 167, 237, 187, 176, 121, 245, 102,
-        160, 231, 3, 111, 55, 77, 56, 15, 51, 221, 118, 55, 35, 164, 228, 85, 48, 116, 75, 180,
-        187, 94, 81, 249, 125, 7, 81, 37, 92, 237, 42, 161, 151, 78, 14, 142, 149, 165, 196, 225,
-        112, 199, 11, 217, 197, 168, 122, 234, 35, 239, 209, 153, 211, 254, 217, 253, 27, 177, 182,
-        170, 7,
-    ];
+    /// Produce a `(private-key PEM, SPKI public-key PEM, payload, signature)`
+    /// tuple with the OpenSSL CLI, the same tool the installers and release
+    /// signing use (`install.sh`, `scripts/package-linux-release.sh`). Returns
+    /// `None` when openssl is unavailable or its spawn fails, so this interop
+    /// guard never reintroduces the build-failing flake we removed: the pure-Rust
+    /// sign/verify path is fully covered by the round-trip test, and this only
+    /// adds cross-checking against real openssl output where openssl exists.
+    fn openssl_signed_vector(dir: &Path) -> Option<(String, String, Vec<u8>, Vec<u8>)> {
+        let private_key = dir.join("interop-private.pem");
+        let public_key = dir.join("interop-public.pem");
+        let payload_path = dir.join("interop-payload.bin");
+        let signature_path = dir.join("interop.sig");
+        fs::write(&payload_path, b"version = 1\n").ok()?;
+
+        let run = |args: &[&str]| -> Option<()> {
+            let output = Command::new("openssl").args(args).output().ok()?;
+            output.status.success().then_some(())
+        };
+        run(&[
+            "genpkey",
+            "-algorithm",
+            "RSA",
+            "-pkeyopt",
+            "rsa_keygen_bits:2048",
+            "-out",
+            private_key.to_string_lossy().as_ref(),
+        ])?;
+        run(&[
+            "rsa",
+            "-in",
+            private_key.to_string_lossy().as_ref(),
+            "-pubout",
+            "-out",
+            public_key.to_string_lossy().as_ref(),
+        ])?;
+        run(&[
+            "dgst",
+            "-sha256",
+            "-sign",
+            private_key.to_string_lossy().as_ref(),
+            "-out",
+            signature_path.to_string_lossy().as_ref(),
+            payload_path.to_string_lossy().as_ref(),
+        ])?;
+
+        Some((
+            fs::read_to_string(&private_key).ok()?,
+            fs::read_to_string(&public_key).ok()?,
+            fs::read(&payload_path).ok()?,
+            fs::read(&signature_path).ok()?,
+        ))
+    }
 
     #[test]
-    fn rsa_verifier_is_byte_compatible_with_openssl_output() {
+    fn rsa_sign_verify_round_trips_in_pure_rust() -> Result<()> {
+        let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
+        let payload = b"version = 1\n";
+
+        let signature = sign_rsa_pkcs1_sha256_signature(&private_pem, payload)?;
+        verify_rsa_pkcs1_sha256_signature(&public_pem, payload, &signature, "metadata")?;
+
+        let mut tampered = payload.to_vec();
+        tampered[0] ^= 0x01;
+        let error =
+            verify_rsa_pkcs1_sha256_signature(&public_pem, &tampered, &signature, "metadata")
+                .expect_err("a tampered payload must be rejected")
+                .to_string();
+        assert!(error.contains("metadata signature verification failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn rsa_verifier_is_byte_compatible_with_openssl_output() -> Result<()> {
+        let (root, _paths) = temp_app_paths("openssl-interop-vector");
+        fs::create_dir_all(&root)?;
+        let Some((private_key_pem, public_key_pem, payload, openssl_signature)) =
+            openssl_signed_vector(&root)
+        else {
+            eprintln!("skipping openssl interop check: openssl CLI unavailable");
+            fs::remove_dir_all(&root).ok();
+            return Ok(());
+        };
+
+        // Our verifier accepts a signature produced by the openssl CLI.
         verify_rsa_pkcs1_sha256_signature(
-            OPENSSL_INTEROP_PUBLIC_KEY_PEM,
-            OPENSSL_INTEROP_PAYLOAD,
-            OPENSSL_INTEROP_SIGNATURE,
+            &public_key_pem,
+            &payload,
+            &openssl_signature,
             "metadata",
         )
         .expect("pure-Rust verifier must accept an openssl-produced signature");
 
-        let mut tampered = OPENSSL_INTEROP_PAYLOAD.to_vec();
+        // Our signer is byte-identical to `openssl dgst -sha256 -sign`, so artifacts
+        // signed by the Rust xtask verify with the openssl-based installers and vice-versa.
+        let rust_signature = sign_rsa_pkcs1_sha256_signature(&private_key_pem, &payload)?;
+        assert_eq!(
+            rust_signature, openssl_signature,
+            "Rust signature must match openssl byte-for-byte"
+        );
+
+        let mut tampered = payload.clone();
         tampered[0] ^= 0x01;
         let error = verify_rsa_pkcs1_sha256_signature(
-            OPENSSL_INTEROP_PUBLIC_KEY_PEM,
+            &public_key_pem,
             &tampered,
-            OPENSSL_INTEROP_SIGNATURE,
+            &openssl_signature,
             "metadata",
         )
         .expect_err("a tampered payload must be rejected")
         .to_string();
         assert!(error.contains("metadata signature verification failed"));
+        fs::remove_dir_all(&root).ok();
+        Ok(())
     }
 
     fn generate_test_signing_key(private_key: &Path, public_key: &Path) -> Result<()> {
-        use rsa::RsaPrivateKey;
-        use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
-
-        let mut rng = rand::thread_rng();
-        let key = RsaPrivateKey::new(&mut rng, 2048)
-            .context("failed to generate test RSA signing key")?;
-        let private_pem = key
-            .to_pkcs8_pem(LineEnding::LF)
-            .context("failed to encode test private key")?;
+        let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
         fs::write(private_key, private_pem.as_bytes())?;
-        let public_pem = rsa::RsaPublicKey::from(&key)
-            .to_public_key_pem(LineEnding::LF)
-            .context("failed to encode test public key")?;
         fs::write(public_key, public_pem.as_bytes())?;
         Ok(())
     }
 
     fn sign_test_payload(private_key: &Path, payload: &Path, signature: &Path) -> Result<()> {
-        use rsa::RsaPrivateKey;
-        use rsa::pkcs1v15::SigningKey;
-        use rsa::pkcs8::DecodePrivateKey;
-        use rsa::signature::{SignatureEncoding, Signer};
-        use sha2::Sha256;
-
         let private_pem = fs::read_to_string(private_key)?;
-        let key = RsaPrivateKey::from_pkcs8_pem(&private_pem)
-            .context("failed to parse test private key")?;
         let payload_bytes = fs::read(payload)?;
-        let signing_key = SigningKey::<Sha256>::new(key);
-        let produced = signing_key
-            .try_sign(&payload_bytes)
-            .context("failed to sign test payload")?;
-        fs::write(signature, produced.to_bytes())?;
+        let produced = sign_rsa_pkcs1_sha256_signature(&private_pem, &payload_bytes)?;
+        fs::write(signature, produced)?;
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -4603,6 +4603,35 @@ pub fn model_recipe_index_signature_path(index_path: &Path) -> PathBuf {
     PathBuf::from(signature)
 }
 
+/// Verify an RSASSA-PKCS#1 v1.5 signature over SHA-256 using a pure-Rust
+/// implementation, with no external `openssl` process.
+///
+/// `public_key_pem` is a SubjectPublicKeyInfo PEM (`-----BEGIN PUBLIC KEY-----`),
+/// exactly what `openssl rsa -pubout` emits and what `openssl dgst -sha256 -verify`
+/// consumes, so verification is byte-compatible with that command. `label` names the
+/// artifact being checked (e.g. `"metadata"`); on a bad signature the error reads
+/// `"<label> signature verification failed"` to preserve existing diagnostics.
+pub fn verify_rsa_pkcs1_sha256_signature(
+    public_key_pem: &str,
+    payload: &[u8],
+    signature: &[u8],
+    label: &str,
+) -> Result<()> {
+    use rsa::RsaPublicKey;
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::pkcs8::DecodePublicKey;
+    use rsa::signature::Verifier;
+    use sha2::Sha256;
+
+    let public_key = RsaPublicKey::from_public_key_pem(public_key_pem)
+        .with_context(|| format!("{label} public key is not a valid RSA public key"))?;
+    let signature = Signature::try_from(signature)
+        .with_context(|| format!("{label} signature is malformed"))?;
+    VerifyingKey::<Sha256>::new(public_key)
+        .verify(payload, &signature)
+        .map_err(|error| anyhow::anyhow!("{label} signature verification failed: {error}"))
+}
+
 pub fn verify_model_recipe_index_signature(
     index_path: &Path,
     signature_path: &Path,
@@ -4620,31 +4649,25 @@ pub fn verify_model_recipe_index_signature(
             public_key_path.display()
         );
     }
-    let output = Command::new("openssl")
-        .args([
-            "dgst",
-            "-sha256",
-            "-verify",
-            public_key_path.to_string_lossy().as_ref(),
-            "-signature",
-            signature_path.to_string_lossy().as_ref(),
-            index_path.to_string_lossy().as_ref(),
-        ])
-        .stderr(Stdio::piped())
-        .output()
-        .context("failed to launch openssl for model recipe index signature verification")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "model recipe index signature verification failed{}",
-            if stderr.trim().is_empty() {
-                String::new()
-            } else {
-                format!(": {}", stderr.trim())
-            }
-        );
-    }
-    Ok(())
+    let public_key_pem = fs::read_to_string(public_key_path).with_context(|| {
+        format!(
+            "failed to read model recipe index public key: {}",
+            public_key_path.display()
+        )
+    })?;
+    let signature = fs::read(signature_path).with_context(|| {
+        format!(
+            "failed to read model recipe index signature: {}",
+            signature_path.display()
+        )
+    })?;
+    let payload = fs::read(index_path).with_context(|| {
+        format!(
+            "failed to read model recipe index: {}",
+            index_path.display()
+        )
+    })?;
+    verify_rsa_pkcs1_sha256_signature(&public_key_pem, &payload, &signature, "model recipe index")
 }
 
 fn validate_model_device_policy(policy: &str) -> Result<()> {
@@ -6678,49 +6701,98 @@ Class Name:                Display
         Ok(())
     }
 
+    // Static interop vector produced once, offline, by the OpenSSL CLI:
+    //   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out priv.pem
+    //   openssl rsa -in priv.pem -pubout -out pub.pem
+    //   printf 'version = 1\n' > payload.txt
+    //   openssl dgst -sha256 -sign priv.pem -out sig.bin payload.txt
+    // It pins byte-compatibility between our pure-Rust verifier and `openssl dgst
+    // -sha256 -verify`, without launching openssl (the prior flake source).
+    const OPENSSL_INTEROP_PUBLIC_KEY_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtROm7eG3halAPysSr653
+sYPohfc+KCauLYkv7zOGTngTCV8OMbJZ/qekYx/zbXHEcmK3z+8oRJOzn/fA8QRc
+eoo5kzkduKgjEqDfHWLJc1Avj430bhTZ6Auyq9VqFECEh0vG3qJP8QJ/3mfxleSj
+lnhfuLajbYMZpQUtAkft3EZrUIcN6QWYBNGxF3lwqz8C8uvcxvrTQIRZ8fTLWB08
+x82+ak8iDklbCaS2qM4777QO0QTTxQK/RSTQCtUc3JQ04J3A1+HUwAxKIGixSIbU
+xqmWq3nXB+SpalmzwaNbRUdXiHeB7PHArypGtZ23/xT3XAGMN84kUIjfL5d1Q0ep
+hwIDAQAB
+-----END PUBLIC KEY-----
+"#;
+    const OPENSSL_INTEROP_PAYLOAD: &[u8] = b"version = 1\n";
+    const OPENSSL_INTEROP_SIGNATURE: &[u8] = &[
+        59, 31, 252, 39, 212, 110, 136, 175, 76, 219, 249, 31, 98, 216, 248, 219, 123, 104, 156,
+        104, 226, 35, 107, 61, 224, 102, 153, 92, 157, 74, 134, 197, 124, 224, 159, 247, 152, 253,
+        77, 107, 89, 104, 93, 27, 95, 43, 255, 8, 236, 146, 121, 82, 123, 163, 171, 33, 29, 78,
+        129, 212, 190, 70, 42, 143, 202, 156, 123, 31, 146, 26, 251, 245, 214, 6, 249, 3, 72, 127,
+        67, 176, 83, 38, 0, 29, 186, 110, 13, 98, 78, 208, 1, 233, 198, 150, 186, 57, 231, 111, 14,
+        173, 248, 27, 180, 163, 5, 23, 126, 142, 216, 247, 95, 210, 156, 77, 61, 134, 32, 181, 162,
+        210, 203, 233, 88, 53, 189, 189, 248, 87, 67, 53, 222, 236, 165, 153, 24, 103, 74, 81, 98,
+        110, 92, 255, 119, 227, 239, 215, 72, 50, 33, 248, 88, 252, 200, 255, 197, 190, 65, 251,
+        246, 209, 132, 89, 204, 185, 227, 27, 134, 152, 173, 159, 52, 160, 154, 178, 148, 208, 209,
+        164, 217, 199, 79, 216, 253, 243, 109, 198, 17, 238, 167, 237, 187, 176, 121, 245, 102,
+        160, 231, 3, 111, 55, 77, 56, 15, 51, 221, 118, 55, 35, 164, 228, 85, 48, 116, 75, 180,
+        187, 94, 81, 249, 125, 7, 81, 37, 92, 237, 42, 161, 151, 78, 14, 142, 149, 165, 196, 225,
+        112, 199, 11, 217, 197, 168, 122, 234, 35, 239, 209, 153, 211, 254, 217, 253, 27, 177, 182,
+        170, 7,
+    ];
+
+    #[test]
+    fn rsa_verifier_is_byte_compatible_with_openssl_output() {
+        verify_rsa_pkcs1_sha256_signature(
+            OPENSSL_INTEROP_PUBLIC_KEY_PEM,
+            OPENSSL_INTEROP_PAYLOAD,
+            OPENSSL_INTEROP_SIGNATURE,
+            "metadata",
+        )
+        .expect("pure-Rust verifier must accept an openssl-produced signature");
+
+        let mut tampered = OPENSSL_INTEROP_PAYLOAD.to_vec();
+        tampered[0] ^= 0x01;
+        let error = verify_rsa_pkcs1_sha256_signature(
+            OPENSSL_INTEROP_PUBLIC_KEY_PEM,
+            &tampered,
+            OPENSSL_INTEROP_SIGNATURE,
+            "metadata",
+        )
+        .expect_err("a tampered payload must be rejected")
+        .to_string();
+        assert!(error.contains("metadata signature verification failed"));
+    }
+
     fn generate_test_signing_key(private_key: &Path, public_key: &Path) -> Result<()> {
-        run_test_openssl(&[
-            "genpkey",
-            "-algorithm",
-            "RSA",
-            "-pkeyopt",
-            "rsa_keygen_bits:2048",
-            "-out",
-            private_key.to_string_lossy().as_ref(),
-        ])?;
-        run_test_openssl(&[
-            "rsa",
-            "-in",
-            private_key.to_string_lossy().as_ref(),
-            "-pubout",
-            "-out",
-            public_key.to_string_lossy().as_ref(),
-        ])
+        use rsa::RsaPrivateKey;
+        use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+
+        let mut rng = rand::thread_rng();
+        let key = RsaPrivateKey::new(&mut rng, 2048)
+            .context("failed to generate test RSA signing key")?;
+        let private_pem = key
+            .to_pkcs8_pem(LineEnding::LF)
+            .context("failed to encode test private key")?;
+        fs::write(private_key, private_pem.as_bytes())?;
+        let public_pem = rsa::RsaPublicKey::from(&key)
+            .to_public_key_pem(LineEnding::LF)
+            .context("failed to encode test public key")?;
+        fs::write(public_key, public_pem.as_bytes())?;
+        Ok(())
     }
 
     fn sign_test_payload(private_key: &Path, payload: &Path, signature: &Path) -> Result<()> {
-        run_test_openssl(&[
-            "dgst",
-            "-sha256",
-            "-sign",
-            private_key.to_string_lossy().as_ref(),
-            "-out",
-            signature.to_string_lossy().as_ref(),
-            payload.to_string_lossy().as_ref(),
-        ])
-    }
+        use rsa::RsaPrivateKey;
+        use rsa::pkcs1v15::SigningKey;
+        use rsa::pkcs8::DecodePrivateKey;
+        use rsa::signature::{SignatureEncoding, Signer};
+        use sha2::Sha256;
 
-    fn run_test_openssl(args: &[&str]) -> Result<()> {
-        let output = Command::new("openssl")
-            .args(args)
-            .output()
-            .context("failed to launch openssl for model recipe signature test")?;
-        if !output.status.success() {
-            bail!(
-                "openssl model recipe signature test command failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
+        let private_pem = fs::read_to_string(private_key)?;
+        let key = RsaPrivateKey::from_pkcs8_pem(&private_pem)
+            .context("failed to parse test private key")?;
+        let payload_bytes = fs::read(payload)?;
+        let signing_key = SigningKey::<Sha256>::new(key);
+        let produced = signing_key
+            .try_sign(&payload_bytes)
+            .context("failed to sign test payload")?;
+        fs::write(signature, produced.to_bytes())?;
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -4603,6 +4603,25 @@ pub fn model_recipe_index_signature_path(index_path: &Path) -> PathBuf {
     PathBuf::from(signature)
 }
 
+/// Normalize a PEM document the way the OpenSSL CLI tolerated input, so keys
+/// produced or copied through other tooling still parse with the strict RFC 7468
+/// reader. Strips a leading UTF-8 BOM, accepts any line-ending style (CRLF, lone
+/// CR, or LF), and drops trailing whitespace from each line — Windows tooling
+/// (e.g. PowerShell `Set-Content`) can introduce CRLF or a stray trailing space
+/// on the `-----BEGIN ...-----` boundary that the parser would otherwise reject.
+fn normalize_pem(pem: &str) -> String {
+    let without_bom = pem.strip_prefix('\u{feff}').unwrap_or(pem);
+    let unified = without_bom.replace("\r\n", "\n").replace('\r', "\n");
+    let mut normalized: String = unified
+        .split('\n')
+        .map(|line| line.trim_end_matches([' ', '\t']))
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    normalized.push('\n');
+    normalized
+}
+
 /// Verify an RSASSA-PKCS#1 v1.5 signature over SHA-256 using a pure-Rust
 /// implementation, with no external `openssl` process.
 ///
@@ -4623,7 +4642,7 @@ pub fn verify_rsa_pkcs1_sha256_signature(
     use rsa::signature::Verifier;
     use sha2::Sha256;
 
-    let public_key = RsaPublicKey::from_public_key_pem(public_key_pem)
+    let public_key = RsaPublicKey::from_public_key_pem(&normalize_pem(public_key_pem))
         .with_context(|| format!("{label} public key is not a valid RSA public key"))?;
     let signature = Signature::try_from(signature)
         .with_context(|| format!("{label} signature is malformed"))?;
@@ -4646,7 +4665,7 @@ pub fn sign_rsa_pkcs1_sha256_signature(private_key_pem: &str, payload: &[u8]) ->
     use rsa::signature::{SignatureEncoding, Signer};
     use sha2::Sha256;
 
-    let private_key = RsaPrivateKey::from_pkcs8_pem(private_key_pem)
+    let private_key = RsaPrivateKey::from_pkcs8_pem(&normalize_pem(private_key_pem))
         .context("signing private key is not a valid PKCS#8 RSA private key")?;
     let signature = SigningKey::<Sha256>::new(private_key)
         .try_sign(payload)
@@ -6797,6 +6816,31 @@ Class Name:                Display
     }
 
     #[test]
+    fn signing_tolerates_crlf_and_trailing_whitespace_pems() -> Result<()> {
+        // Windows tooling (PowerShell Set-Content, editors) can rewrite a PEM with
+        // CRLF endings, a stray trailing space on the boundary line, or a UTF-8 BOM.
+        // The OpenSSL CLI accepted these, so the Rust path must too.
+        let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
+        let payload = b"version = 1\n";
+
+        let crlf_private = private_pem.replace('\n', "\r\n");
+        let trailing_ws_private = private_pem
+            .lines()
+            .map(|line| format!("{line} "))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let bom_public = format!("\u{feff}{public_pem}");
+
+        for variant in [crlf_private, trailing_ws_private] {
+            let signature = sign_rsa_pkcs1_sha256_signature(&variant, payload)?;
+            verify_rsa_pkcs1_sha256_signature(&public_pem, payload, &signature, "metadata")?;
+        }
+        let signature = sign_rsa_pkcs1_sha256_signature(&private_pem, payload)?;
+        verify_rsa_pkcs1_sha256_signature(&bom_public, payload, &signature, "metadata")?;
+        Ok(())
+    }
+
+    #[test]
     fn rsa_sign_verify_round_trips_in_pure_rust() -> Result<()> {
         let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
         let payload = b"version = 1\n";
@@ -6821,7 +6865,9 @@ Class Name:                Display
         let Some((private_key_pem, public_key_pem, payload, openssl_signature)) =
             openssl_signed_vector(&root)
         else {
-            eprintln!("skipping openssl interop check: openssl CLI unavailable");
+            eprintln!(
+                "skipping openssl interop check: openssl CLI unavailable or failed to produce a signature"
+            );
             fs::remove_dir_all(&root).ok();
             return Ok(());
         };

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -157,23 +157,24 @@ try {
     $psExe = $psCommand.Source
 
     $cargoExe = Resolve-CommandPath "cargo" (Join-Path $env:USERPROFILE ".cargo\bin\cargo.exe")
-    $opensslExe = Resolve-CommandPath "openssl"
 
     $signingPrivateKey = Join-Path $AcceptanceRoot "signing-private.pem"
     $signingPublicKey = Join-Path $AcceptanceRoot "signing-public.pem"
-    & $opensslExe genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $signingPrivateKey | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        Fail "failed to generate acceptance signing private key"
+    Push-Location $RepoRoot
+    try {
+        & $cargoExe xtask keygen --private-out $signingPrivateKey --public-out $signingPublicKey | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Fail "failed to generate acceptance signing keypair"
+        }
     }
-    & $opensslExe rsa -in $signingPrivateKey -pubout -out $signingPublicKey | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        Fail "failed to generate acceptance signing public key"
+    finally {
+        Pop-Location
     }
 
     Write-Host "acceptance: build release binaries"
     Push-Location $RepoRoot
     try {
-        & $cargoExe build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang
+        & $cargoExe build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang -p xtask
         if ($LASTEXITCODE -ne 0) {
             Fail "cargo build failed"
         }

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -106,13 +106,13 @@ expect_failure() {
 }
 
 echo "acceptance: build release binaries"
-(cd "${REPO_ROOT}" && cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang)
+(cd "${REPO_ROOT}" && cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang -p xtask)
 
 echo "acceptance: generate signing key"
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "${SIGNING_PRIVATE_KEY}" >/dev/null 2>&1 \
-  || fail "failed to generate acceptance signing private key"
-openssl rsa -in "${SIGNING_PRIVATE_KEY}" -pubout -out "${SIGNING_PUBLIC_KEY}" >/dev/null 2>&1 \
-  || fail "failed to generate acceptance signing public key"
+(cd "${REPO_ROOT}" && cargo xtask keygen \
+  --private-out "${SIGNING_PRIVATE_KEY}" \
+  --public-out "${SIGNING_PUBLIC_KEY}") \
+  || fail "failed to generate acceptance signing keypair"
 
 echo "acceptance: package local release bundle"
 (cd "${REPO_ROOT}" && \

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -50,6 +50,10 @@ if [[ "${SIGNATURE_REQUIRED}" =~ ^(1|true|TRUE|yes|YES|on|ON)$ && "${SIGNATURE_A
 fi
 
 if [[ "${SIGNATURE_AVAILABLE}" -eq 1 ]]; then
+  command -v cargo >/dev/null 2>&1 || {
+    echo "missing required command for signing: cargo" >&2
+    exit 1
+  }
   SIGNING_TMP_DIR="${OUTPUT_DIR}/.signing-tmp-$$"
   rm -rf "${SIGNING_TMP_DIR}"
   mkdir -p "${SIGNING_TMP_DIR}"

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -50,10 +50,6 @@ if [[ "${SIGNATURE_REQUIRED}" =~ ^(1|true|TRUE|yes|YES|on|ON)$ && "${SIGNATURE_A
 fi
 
 if [[ "${SIGNATURE_AVAILABLE}" -eq 1 ]]; then
-  command -v openssl >/dev/null 2>&1 || {
-    echo "missing required command for signing: openssl" >&2
-    exit 1
-  }
   SIGNING_TMP_DIR="${OUTPUT_DIR}/.signing-tmp-$$"
   rm -rf "${SIGNING_TMP_DIR}"
   mkdir -p "${SIGNING_TMP_DIR}"
@@ -63,7 +59,10 @@ if [[ "${SIGNATURE_AVAILABLE}" -eq 1 ]]; then
     SIGNING_PRIVATE_KEY="${SIGNING_TMP_DIR}/rocm-cli-signing-private-key.pem"
     printf '%s\n' "${ROCM_CLI_SIGNING_PRIVATE_KEY_PEM}" > "${SIGNING_PRIVATE_KEY}"
   fi
-  openssl dgst -sha256 -sign "${SIGNING_PRIVATE_KEY}" -out "${ARCHIVE_PATH}.sig" "${ARCHIVE_PATH}"
+  cargo xtask sign \
+    --private-key "${SIGNING_PRIVATE_KEY}" \
+    --in "${ARCHIVE_PATH}" \
+    --out "${ARCHIVE_PATH}.sig"
   rm -rf "${SIGNING_TMP_DIR}"
 fi
 

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -82,9 +82,17 @@ function Write-ArchiveSignature {
     if ([string]::IsNullOrWhiteSpace($PrivateKeyPath)) {
         return
     }
-    & cargo xtask sign --private-key $PrivateKeyPath --in $ArchivePath --out "$ArchivePath.sig"
-    if ($LASTEXITCODE -ne 0) {
-        Fail "failed to sign $ArchivePath"
+    # Run from the repo root so the `cargo xtask` alias in .cargo/config.toml resolves
+    # regardless of the caller's working directory.
+    Push-Location $repoRoot
+    try {
+        & cargo xtask sign --private-key $PrivateKeyPath --in $ArchivePath --out "$ArchivePath.sig"
+        if ($LASTEXITCODE -ne 0) {
+            Fail "failed to sign $ArchivePath"
+        }
+    }
+    finally {
+        Pop-Location
     }
 }
 

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -82,8 +82,7 @@ function Write-ArchiveSignature {
     if ([string]::IsNullOrWhiteSpace($PrivateKeyPath)) {
         return
     }
-    $openssl = Resolve-CommandPath "openssl"
-    & $openssl dgst -sha256 -sign $PrivateKeyPath -out "$ArchivePath.sig" $ArchivePath
+    & cargo xtask sign --private-key $PrivateKeyPath --in $ArchivePath --out "$ArchivePath.sig"
     if ($LASTEXITCODE -ne 0) {
         Fail "failed to sign $ArchivePath"
     }

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -86,7 +86,7 @@ function Write-ArchiveSignature {
     # regardless of the caller's working directory.
     Push-Location $repoRoot
     try {
-        & cargo xtask sign --private-key $PrivateKeyPath --in $ArchivePath --out "$ArchivePath.sig"
+        & $cargoExe xtask sign --private-key $PrivateKeyPath --in $ArchivePath --out "$ArchivePath.sig"
         if ($LASTEXITCODE -ne 0) {
             Fail "failed to sign $ArchivePath"
         }

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -351,17 +351,20 @@ def verify_signature(archive: Path, signature: Path, public_key: Path) -> None:
     cargo = shutil.which("cargo")
     if cargo is None:
         raise ReadinessError("cargo is required for signature verification")
+    # Resolve to absolute paths because the subprocess runs from the repo root
+    # (so the `cargo xtask` alias resolves); relative paths would otherwise be
+    # interpreted against the repo root rather than the caller's working directory.
     completed = subprocess.run(
         [
             cargo,
             "xtask",
             "verify",
             "--public-key",
-            str(public_key),
+            str(public_key.resolve()),
             "--in",
-            str(archive),
+            str(archive.resolve()),
             "--signature",
-            str(signature),
+            str(signature.resolve()),
         ],
         cwd=repo_root(),
         stdout=subprocess.PIPE,

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -16,6 +16,7 @@ import tarfile
 import zipfile
 from pathlib import Path
 
+
 ARCHIVE_SUFFIXES = (".tar.gz", ".zip")
 ROCM_RELEASE_ASSET_RE = re.compile(
     r"^rocm-cli-(?:(?:v[0-9][A-Za-z0-9._+-]*|nightly(?:-[0-9]{8}-[0-9A-Fa-f]+)?)-)?"
@@ -347,20 +348,22 @@ def validate_archive_contents(archive: Path) -> list[str]:
 def verify_signature(archive: Path, signature: Path, public_key: Path) -> None:
     if not public_key.is_file():
         raise ReadinessError(f"public key does not exist: {public_key}")
-    openssl = shutil.which("openssl")
-    if openssl is None:
-        raise ReadinessError("openssl is required for signature verification")
+    cargo = shutil.which("cargo")
+    if cargo is None:
+        raise ReadinessError("cargo is required for signature verification")
     completed = subprocess.run(
         [
-            openssl,
-            "dgst",
-            "-sha256",
-            "-verify",
+            cargo,
+            "xtask",
+            "verify",
+            "--public-key",
             str(public_key),
-            "-signature",
-            str(signature),
+            "--in",
             str(archive),
+            "--signature",
+            str(signature),
         ],
+        cwd=repo_root(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+rocm-core = { path = "../crates/rocm-core" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -95,7 +95,8 @@ fn run() -> Result<()> {
                 fs::read(&input).with_context(|| format!("failed to read {}", input.display()))?;
             let signature_bytes = fs::read(&signature)
                 .with_context(|| format!("failed to read {}", signature.display()))?;
-            verify_rsa_pkcs1_sha256_signature(&public_pem, &payload, &signature_bytes, "artifact")?;
+            let label = input.display().to_string();
+            verify_rsa_pkcs1_sha256_signature(&public_pem, &payload, &signature_bytes, &label)?;
         }
     }
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,112 @@
+//! Repository task runner.
+//!
+//! Currently provides the release-artifact signing toolchain in pure Rust so the
+//! project's signing, CI verification, and test keygen no longer depend on the
+//! `openssl` CLI. Run via the workspace alias `cargo xtask <command>`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use rocm_core::{
+    generate_rsa_signing_keypair, sign_rsa_pkcs1_sha256_signature,
+    verify_rsa_pkcs1_sha256_signature,
+};
+
+#[derive(Parser)]
+#[command(name = "xtask", about = "rocm-cli repository tasks")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Generate a 2048-bit RSA signing keypair (PKCS#8 private + SPKI public PEM).
+    Keygen {
+        /// Path to write the PKCS#8 private-key PEM.
+        #[arg(long)]
+        private_out: PathBuf,
+        /// Path to write the SubjectPublicKeyInfo public-key PEM.
+        #[arg(long)]
+        public_out: PathBuf,
+    },
+    /// Sign a file with an RSA private key (RSASSA-PKCS#1 v1.5 over SHA-256).
+    Sign {
+        /// Path to the PKCS#8 private-key PEM.
+        #[arg(long)]
+        private_key: PathBuf,
+        /// File whose contents are signed.
+        #[arg(long = "in")]
+        input: PathBuf,
+        /// Path to write the raw signature bytes.
+        #[arg(long = "out")]
+        output: PathBuf,
+    },
+    /// Verify a file's signature against an RSA public key.
+    Verify {
+        /// Path to the SubjectPublicKeyInfo public-key PEM.
+        #[arg(long)]
+        public_key: PathBuf,
+        /// File whose signature is checked.
+        #[arg(long = "in")]
+        input: PathBuf,
+        /// Path to the raw signature bytes.
+        #[arg(long)]
+        signature: PathBuf,
+    },
+}
+
+fn run() -> Result<()> {
+    match Cli::parse().command {
+        Command::Keygen {
+            private_out,
+            public_out,
+        } => {
+            let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
+            fs::write(&private_out, private_pem.as_bytes())
+                .with_context(|| format!("failed to write {}", private_out.display()))?;
+            fs::write(&public_out, public_pem.as_bytes())
+                .with_context(|| format!("failed to write {}", public_out.display()))?;
+        }
+        Command::Sign {
+            private_key,
+            input,
+            output,
+        } => {
+            let private_pem = fs::read_to_string(&private_key)
+                .with_context(|| format!("failed to read {}", private_key.display()))?;
+            let payload =
+                fs::read(&input).with_context(|| format!("failed to read {}", input.display()))?;
+            let signature = sign_rsa_pkcs1_sha256_signature(&private_pem, &payload)?;
+            fs::write(&output, signature)
+                .with_context(|| format!("failed to write {}", output.display()))?;
+        }
+        Command::Verify {
+            public_key,
+            input,
+            signature,
+        } => {
+            let public_pem = fs::read_to_string(&public_key)
+                .with_context(|| format!("failed to read {}", public_key.display()))?;
+            let payload =
+                fs::read(&input).with_context(|| format!("failed to read {}", input.display()))?;
+            let signature_bytes = fs::read(&signature)
+                .with_context(|| format!("failed to read {}", signature.display()))?;
+            verify_rsa_pkcs1_sha256_signature(&public_pem, &payload, &signature_bytes, "artifact")?;
+        }
+    }
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("error: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@
 //! `openssl` CLI. Run via the workspace alias `cargo xtask <command>`.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
@@ -59,6 +59,36 @@ enum Command {
     },
 }
 
+/// Write a private-key PEM, restricting it to owner-only (`0o600`) on Unix so the
+/// key is never group- or world-readable. On Unix the file is created with the
+/// restricted mode up front, and any pre-existing file is tightened too.
+fn write_private_key(path: &Path, pem: &str) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        // `.mode()` only applies when creating the file; tighten an existing one too.
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to restrict permissions on {}", path.display()))?;
+        file.write_all(pem.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, pem.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
 fn run() -> Result<()> {
     match Cli::parse().command {
         Command::Keygen {
@@ -66,8 +96,7 @@ fn run() -> Result<()> {
             public_out,
         } => {
             let (private_pem, public_pem) = generate_rsa_signing_keypair()?;
-            fs::write(&private_out, private_pem.as_bytes())
-                .with_context(|| format!("failed to write {}", private_out.display()))?;
+            write_private_key(&private_out, &private_pem)?;
             fs::write(&public_out, public_pem.as_bytes())
                 .with_context(|| format!("failed to write {}", public_out.display()))?;
         }


### PR DESCRIPTION
## Summary

Removes the dependency on the external `openssl` CLI for signature **verification** (at runtime) and **signing** (at release time), replacing both with a pure-Rust implementation built on `rsa` + `sha2`.

- **Verify in Rust** — runtime metadata and model-recipe-index signature checks no longer shell out to `openssl dgst -verify`. A shared `verify_rsa_pkcs1_sha256_signature` helper in `rocm-core` does RSASSA-PKCS#1 v1.5 / SHA-256 verification directly.
- **Sign via a Rust `xtask`** — release signing, CI signature verification, and the acceptance-test keygen now use `cargo xtask {keygen,sign,verify}` over the same `rocm-core` helpers, instead of the `openssl` CLI. Scripts updated: `package-linux-release.sh`, `package-windows-release.ps1`, `release_readiness.py`, and the acceptance scripts.

### Why

CI intermittently failed with `Error: failed to launch openssl for metadata signature verification` (e.g. [run 27604998719](https://github.com/ROCm/rocm-cli/actions/runs/27604998719/job/81614699435)). The test generated a key, signed, and verified — all via `openssl` — and only the verify *spawn* failed, after the same binary had already launched twice in the same test.

**Root cause:** a transient `fork`/`posix_spawn` failure (`EAGAIN`/`ENOMEM`) under fork pressure while the full test suite runs in parallel on a memory-constrained runner. Shelling out to `openssl` for a small, well-specified crypto operation made every verification depend on a subprocess spawn succeeding — and required the `openssl` CLI to be present at runtime for end users.

### Key decisions

- **Deterministic PKCS#1 v1.5 signing**, byte-identical to `openssl dgst -sha256 -sign`. Existing keys and already-published signatures keep verifying, and the openssl-based installers stay interoperable. A test cross-checks Rust output against the `openssl` CLI byte-for-byte (skipped automatically when `openssl` is absent, so it can never reintroduce the flake).
- **`rocm-core` hosts the crypto**; the `xtask` is a thin CLI over it, so there's one audited implementation shared by product code, tooling, and tests.

### Scope boundaries (intentionally unchanged)

- **End-user installers** (`install.sh`, `install.ps1`) keep `openssl`: they verify the archive against the pinned public key *before* extracting anything, and that check must be performed by a tool that is not the just-downloaded artifact.
- The libssl **C build dependency** (TLS, separate from signing) is out of scope.

### Risk

Low. Crypto is a standard, well-specified scheme implemented by the mature `rsa` crate; production verification is public-key only; signing is deterministic and proven byte-compatible with the previous `openssl` output.

## Test plan

- `cargo build/test --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` all pass.
- New tests: pure-Rust sign↔verify round-trip with tamper rejection, and a skippable `openssl`↔Rust byte-parity cross-check.
- Manual: `cargo xtask keygen → sign → verify` round-trip, with the resulting signature also verified by `openssl dgst -sha256 -verify` (Verified OK) and rejected after tampering.
- `python scripts/release_readiness.py --self-test` passes.