### PR TITLE
Enable strictest practical linting across the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,42 @@ jobs:
             -p rocm-dash-daemon -p rocm-dash-tui \
             --fail-under-lines 70
 
+  lint:
+    name: Lint (Python / Shell / PowerShell)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ruff (lint + format)
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.15.16
+          args: check scripts engines
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: 0.15.16
+          args: format --check scripts engines
+
+      - name: ShellCheck (all optional checks)
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: --enable=all --exclude=SC2310,SC2312
+        with:
+          scandir: '.'
+          ignore_paths: third_party
+
+      - name: PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+          $files = Get-ChildItem -Recurse -Filter *.ps1 |
+            Where-Object { $_.FullName -notmatch 'third_party' }
+          $findings = $files | ForEach-Object {
+            Invoke-ScriptAnalyzer -Path $_.FullName -Settings ./PSScriptAnalyzerSettings.psd1
+          }
+          if ($findings) { $findings | Format-Table -AutoSize; exit 1 }
+
   gpu-smoke:
     name: GPU Smoke (gfx1151)
     runs-on: [self-hosted, windows-gfx1151-gpu-rocm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
           args: format --check scripts engines
 
       - name: ShellCheck (all optional checks)
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         env:
           SHELLCHECK_OPTS: --enable=all --exclude=SC2310,SC2312
         with:
@@ -185,7 +185,7 @@ jobs:
       - name: PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+          Install-Module PSScriptAnalyzer -Scope CurrentUser -Force -RequiredVersion 1.25.0
           $files = Get-ChildItem -Recurse -Filter *.ps1 |
             Where-Object { $_.FullName -notmatch 'third_party' }
           $findings = $files | ForEach-Object {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,14 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # Shell scripts (install.sh, scripts/*.sh).
+  # Shell scripts (install.sh, scripts/*.sh). `--enable=all` turns on every
+  # optional check; SC2310/SC2312 (set -e suppression in conditionals) are
+  # excluded as they require risky restructuring of these setup scripts.
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+        args: [--enable=all, --exclude=SC2310,SC2312]
 
   # Rust + PowerShell: mirror the CI checks using the local toolchain.
   - repo: local
@@ -69,5 +72,11 @@ repos:
       - id: powershell-syntax
         name: powershell syntax check
         entry: python scripts/check_powershell_syntax.py
+        language: system
+        files: \.ps1$
+      - id: powershell-script-analyzer
+        name: PSScriptAnalyzer
+        # Requires PowerShell (pwsh) + the PSScriptAnalyzer module installed locally.
+        entry: pwsh -NoProfile -Command "$r = $args | ForEach-Object { Invoke-ScriptAnalyzer -Path $_ -Settings ./PSScriptAnalyzerSettings.psd1 }; if ($r) { $r | Format-Table -AutoSize; exit 1 }"
         language: system
         files: \.ps1$

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,53 @@ sha2 = { version = "0.10", features = ["oid"] }
 tokio = { version = "1.48", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+# `deny` (not `forbid`) so the few functions doing platform FFI can opt back in
+# with a documented `#[allow(unsafe_code)]`; everything else is denied.
+# (`unreachable_pub` is intentionally NOT enabled: this workspace is dominated by
+# binary crates where every `pub` item is unreachable, so it only adds noise.)
+unsafe_code = "deny"
+
+# Strictest *practical* clippy config. Lint groups are enabled at warn with a
+# lowered priority so the targeted `allow`s below win. CI promotes warnings to
+# errors via `cargo clippy ... -D warnings`.
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+
+# Documented allow-list: high-noise / low-value lints whose findings would force
+# large, mechanical, or risky churn for little benefit on this codebase. Each is
+# centralized here so it can be re-enabled and burned down later.
+#
+# Docs / naming / metadata churn:
+missing_errors_doc = "allow"      # would require `# Errors` docs on every fallible fn
+missing_panics_doc = "allow"      # would require `# Panics` docs on every fn that can panic
+must_use_candidate = "allow"      # `#[must_use]` on every getter-style fn is noise here
+too_many_lines = "allow"          # long fns (TUI/install flows) are deliberate, not split-worthy
+module_name_repetitions = "allow" # `engine::EngineConfig` naming is intentional and clear
+doc_markdown = "allow"            # flags product names (ROCm, GPU ids) as needing backticks
+similar_names = "allow"           # short domain names (gfx/gpu, src/dst) are intentionally alike
+struct_excessive_bools = "allow"  # flat config/probe-result records use bool fields by design
+multiple_crate_versions = "allow" # unactionable: duplicate versions come from transitive deps
+cargo_common_metadata = "allow"   # internal-only crates don't need description/keywords
+#
+# Signature/API churn (changing these ripples through many call sites for little gain):
+needless_pass_by_value = "allow"     # taking `&T` everywhere would churn many signatures + callers
+trivially_copy_pass_by_ref = "allow" # mirror of the above for small Copy types
+unnecessary_wraps = "allow"          # several fns keep `Result`/`Option` for API consistency
+#
+# Deliberate numeric casts (values are known-in-range; `as` is intentional here):
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+cast_precision_loss = "allow"
+#
+# Nursery lints (still unstable / frequently reduce readability or are micro-opts):
+assigning_clones = "allow"           # `clone_into` micro-opt across 500+ sites; not worth the churn
+option_if_let_else = "allow"         # the rewrite is often less readable than the `if let`
+branches_sharing_code = "allow"      # hoisting shared branch code often hurts clarity
+significant_drop_tightening = "allow" # lock-scope rewrites are subtle; opt in deliberately
+redundant_pub_crate = "allow"        # `pub(crate)` in private modules is intentional/harmless here
+useless_let_if_seq = "allow"         # has false positives; several flags are set across multiple `if`s
+#
+# Style preference: explicit match arms are clearer than merging here.
+match_same_arms = "allow"

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,11 @@
+# PSScriptAnalyzer configuration for the repo's PowerShell scripts
+# (install.ps1, scripts/*.ps1). Used by the prek hook and CI.
+@{
+    # Enforce the full default rule set at Warning and Error severity.
+    Severity = @('Error', 'Warning')
+
+    # install.ps1 and the acceptance/packaging scripts are user-facing console
+    # programs where `Write-Host` is the intended way to print progress to the
+    # terminal, so the "avoid Write-Host" rule does not apply here.
+    ExcludeRules = @('PSAvoidUsingWriteHost')
+}

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -107,11 +107,11 @@ struct ComfyUiRunReport {
     endpoint_reachable: bool,
 }
 
-pub(crate) fn default_host() -> &'static str {
+pub(crate) const fn default_host() -> &'static str {
     COMFYUI_DEFAULT_HOST
 }
 
-pub(crate) fn default_port() -> u16 {
+pub(crate) const fn default_port() -> u16 {
     COMFYUI_DEFAULT_PORT
 }
 
@@ -120,70 +120,64 @@ pub(crate) fn render_status(paths: &AppPaths, config: &RocmCliConfig) -> Result<
     writeln!(output, "{APP_NAME}")?;
     writeln!(output)?;
 
-    match load_manifest(paths)? {
-        Some(manifest) => {
-            writeln!(output, "  installed: yes")?;
-            writeln!(
-                output,
-                "  ROCm install: {}",
-                therock::runtime_version_display(&manifest.runtime_version)
-            )?;
-            writeln!(output, "  folder: {}", manifest.runtime_root.display())?;
-            writeln!(
-                output,
-                "  models path: {}",
-                models_folder_for_manifest(&manifest).display()
-            )?;
-            writeln!(
-                output,
-                "  AMD GPU check: {}",
-                if manifest.torch_cuda_available {
-                    "ready"
-                } else {
-                    "failed"
-                }
-            )?;
-        }
-        None => {
-            writeln!(output, "  installed: no")?;
-            writeln!(output, "  next step: rocm comfyui install")?;
-        }
+    if let Some(manifest) = load_manifest(paths)? {
+        writeln!(output, "  installed: yes")?;
+        writeln!(
+            output,
+            "  ROCm install: {}",
+            therock::runtime_version_display(&manifest.runtime_version)
+        )?;
+        writeln!(output, "  folder: {}", manifest.runtime_root.display())?;
+        writeln!(
+            output,
+            "  models path: {}",
+            models_folder_for_manifest(&manifest).display()
+        )?;
+        writeln!(
+            output,
+            "  AMD GPU check: {}",
+            if manifest.torch_cuda_available {
+                "ready"
+            } else {
+                "failed"
+            }
+        )?;
+    } else {
+        writeln!(output, "  installed: no")?;
+        writeln!(output, "  next step: rocm comfyui install")?;
     }
 
-    match load_state(paths)? {
-        Some(state) => {
-            let run_report = evaluate_running_state(&state);
-            writeln!(output)?;
-            writeln!(output, "Running")?;
-            writeln!(
-                output,
-                "  status: {}",
-                comfyui_run_state_cli_label(run_report.state)
-            )?;
-            writeln!(output, "  url: {}", state.url)?;
-            match run_report.state {
-                ComfyUiRunState::Running => {}
-                ComfyUiRunState::Starting => {
-                    writeln!(output, "  note: starting")?;
-                }
-                ComfyUiRunState::Stopped => {
-                    writeln!(output, "  next step: rocm comfyui start")?;
-                }
+    if let Some(state) = load_state(paths)? {
+        let run_report = evaluate_running_state(&state);
+        writeln!(output)?;
+        writeln!(output, "Running")?;
+        writeln!(
+            output,
+            "  status: {}",
+            comfyui_run_state_cli_label(run_report.state)
+        )?;
+        writeln!(output, "  url: {}", state.url)?;
+        match run_report.state {
+            ComfyUiRunState::Running => {}
+            ComfyUiRunState::Starting => {
+                writeln!(output, "  note: starting")?;
+            }
+            ComfyUiRunState::Stopped => {
+                writeln!(output, "  next step: rocm comfyui start")?;
             }
         }
-        None => {
-            writeln!(output)?;
-            writeln!(output, "Running")?;
-            if let Some(url) = default_unmanaged_running_url() {
-                writeln!(output, "  status: running outside rocm-cli")?;
-                writeln!(output, "  url: {url}")?;
-                writeln!(
-                    output,
-                    "  note: ROCm CLI did not start this ComfyUI process"
-                )?;
-            } else {
-                writeln!(output, "  status: not started by rocm-cli")?;
-            }
+    } else {
+        writeln!(output)?;
+        writeln!(output, "Running")?;
+        if let Some(url) = default_unmanaged_running_url() {
+            writeln!(output, "  status: running outside rocm-cli")?;
+            writeln!(output, "  url: {url}")?;
+            writeln!(
+                output,
+                "  note: ROCm CLI did not start this ComfyUI process"
+            )?;
+        } else {
+            writeln!(output, "  status: not started by rocm-cli")?;
         }
     }
 
@@ -205,66 +199,60 @@ pub(crate) fn render_tui_status(paths: &AppPaths, config: &RocmCliConfig) -> Res
     let mut output = String::new();
     writeln!(output, "{APP_NAME}")?;
     writeln!(output)?;
-    match load_manifest(paths)? {
-        Some(manifest) => {
-            writeln!(output, "Installed")?;
-            writeln!(output, "  status: ready")?;
-            writeln!(
-                output,
-                "  ROCm install: {}",
-                therock::runtime_version_display(&manifest.runtime_version)
-            )?;
-            writeln!(
-                output,
-                "  models path: {}",
-                models_folder_for_manifest(&manifest).display()
-            )?;
-            writeln!(
-                output,
-                "  AMD GPU check: {}",
-                if manifest.torch_cuda_available {
-                    "ready"
-                } else {
-                    "needs attention"
-                }
-            )?;
-        }
-        None => {
-            writeln!(output, "Not installed yet")?;
-            writeln!(output, "  Choose Install ComfyUI below.")?;
-        }
+    if let Some(manifest) = load_manifest(paths)? {
+        writeln!(output, "Installed")?;
+        writeln!(output, "  status: ready")?;
+        writeln!(
+            output,
+            "  ROCm install: {}",
+            therock::runtime_version_display(&manifest.runtime_version)
+        )?;
+        writeln!(
+            output,
+            "  models path: {}",
+            models_folder_for_manifest(&manifest).display()
+        )?;
+        writeln!(
+            output,
+            "  AMD GPU check: {}",
+            if manifest.torch_cuda_available {
+                "ready"
+            } else {
+                "needs attention"
+            }
+        )?;
+    } else {
+        writeln!(output, "Not installed yet")?;
+        writeln!(output, "  Choose Install ComfyUI below.")?;
     }
 
     writeln!(output)?;
-    match load_state(paths)? {
-        Some(state) => {
-            let run_report = evaluate_running_state(&state);
-            writeln!(output, "Running")?;
-            match run_report.state {
-                ComfyUiRunState::Running => {
-                    writeln!(output, "  status: running")?;
-                    writeln!(output, "  URL: {}", state.url)?;
-                }
-                ComfyUiRunState::Starting => {
-                    writeln!(output, "  status: starting")?;
-                    writeln!(output, "  URL: {}", state.url)?;
-                    writeln!(output, "  Waiting for the browser page to answer.")?;
-                }
-                ComfyUiRunState::Stopped => {
-                    writeln!(output, "  status: stopped")?;
-                    writeln!(output, "  Choose Start ComfyUI below to run it again.")?;
-                }
+    if let Some(state) = load_state(paths)? {
+        let run_report = evaluate_running_state(&state);
+        writeln!(output, "Running")?;
+        match run_report.state {
+            ComfyUiRunState::Running => {
+                writeln!(output, "  status: running")?;
+                writeln!(output, "  URL: {}", state.url)?;
+            }
+            ComfyUiRunState::Starting => {
+                writeln!(output, "  status: starting")?;
+                writeln!(output, "  URL: {}", state.url)?;
+                writeln!(output, "  Waiting for the browser page to answer.")?;
+            }
+            ComfyUiRunState::Stopped => {
+                writeln!(output, "  status: stopped")?;
+                writeln!(output, "  Choose Start ComfyUI below to run it again.")?;
             }
         }
-        None => {
-            writeln!(output, "Running")?;
-            if let Some(url) = default_unmanaged_running_url() {
-                writeln!(output, "  status: running outside rocm-cli")?;
-                writeln!(output, "  URL: {url}")?;
-                writeln!(output, "  ROCm CLI did not start this ComfyUI process.")?;
-            } else {
-                writeln!(output, "  status: not started")?;
-            }
+    } else {
+        writeln!(output, "Running")?;
+        if let Some(url) = default_unmanaged_running_url() {
+            writeln!(output, "  status: running outside rocm-cli")?;
+            writeln!(output, "  URL: {url}")?;
+            writeln!(output, "  ROCm CLI did not start this ComfyUI process.")?;
+        } else {
+            writeln!(output, "  status: not started")?;
         }
     }
 
@@ -401,7 +389,7 @@ pub(crate) fn install(
                     "comfyui".to_owned(),
                     "install".to_owned(),
                     "--runtime-id".to_owned(),
-                    runtime.manifest.runtime_key.clone(),
+                    runtime.manifest.runtime_key,
                 ],
             )
         )?;
@@ -424,11 +412,7 @@ pub(crate) fn install(
         fs::remove_dir_all(&source_path)
             .with_context(|| format!("failed to remove {}", source_path.display()))?;
     }
-    if !source_path.exists() {
-        println!("Downloading ComfyUI source...");
-        let _ = io::stdout().flush();
-        download_and_extract_source(&app_root, &source_path, &mut log)?;
-    } else {
+    if source_path.exists() {
         println!("Using existing ComfyUI source folder...");
         let _ = io::stdout().flush();
         writeln!(
@@ -436,6 +420,10 @@ pub(crate) fn install(
             "Using existing ComfyUI folder at {}.",
             source_path.display()
         )?;
+    } else {
+        println!("Downloading ComfyUI source...");
+        let _ = io::stdout().flush();
+        download_and_extract_source(&app_root, &source_path, &mut log)?;
     }
     fs::create_dir_all(&models_folder)
         .with_context(|| format!("failed to create {}", models_folder.display()))?;
@@ -475,9 +463,9 @@ pub(crate) fn install(
         python_executable: runtime.python.clone(),
         source_url: COMFYUI_SOURCE_ARCHIVE_URL.to_owned(),
         source_path: source_path.clone(),
-        requirements_path: requirements_path.clone(),
+        requirements_path,
         pip_cache_dir: None,
-        log_path: log_path.clone(),
+        log_path,
         torch_version: probe.torch_version.clone(),
         torch_cuda_available: probe.torch_cuda_available,
         installed_at_unix_ms: unix_time_millis(),
@@ -535,12 +523,12 @@ pub(crate) fn start(paths: &AppPaths, options: ComfyUiStartOptions) -> Result<St
         port: options.port,
         pid,
         source_path: manifest.source_path.clone(),
-        python_executable: manifest.python_executable.clone(),
+        python_executable: manifest.python_executable,
         log_path: log_path.clone(),
         started_at_unix_ms: unix_time_millis(),
     };
     save_state(paths, &state)?;
-    let run_report = wait_for_running_state(&state, Duration::from_secs(180));
+    let run_report = wait_for_running_state(&state, Duration::from_mins(3));
     if run_report.state == ComfyUiRunState::Stopped {
         bail!(
             "ComfyUI stopped before the local URL was ready. Check the log at {}",
@@ -799,8 +787,10 @@ fn start_log_path_for_manifest(manifest: &ComfyUiManifest) -> PathBuf {
     manifest
         .source_path
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| manifest.runtime_root.join("apps").join(APP_ID))
+        .map_or_else(
+            || manifest.runtime_root.join("apps").join(APP_ID),
+            Path::to_path_buf,
+        )
         .join("logs")
         .join(format!("start-{}.log", unix_time_millis()))
 }
@@ -948,7 +938,7 @@ fn wait_for_running_state(state: &ComfyUiState, timeout: Duration) -> ComfyUiRun
     last_report
 }
 
-fn comfyui_run_state_cli_label(state: ComfyUiRunState) -> &'static str {
+const fn comfyui_run_state_cli_label(state: ComfyUiRunState) -> &'static str {
     match state {
         ComfyUiRunState::Running => "running",
         ComfyUiRunState::Starting => "starting",
@@ -1026,8 +1016,7 @@ fn unix_process_is_running(pid: u32) -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .is_ok_and(|status| status.success())
 }
 
 fn wait_until_stopped(pid: u32) {
@@ -1405,15 +1394,15 @@ fn download_and_extract_source(
             .parent()
             .context("ComfyUI archive path has no parent directory")?,
     )?;
-    if !archive_path.is_file() {
-        writeln!(log, "Downloading {COMFYUI_SOURCE_ARCHIVE_URL}.")?;
-        download_file(COMFYUI_SOURCE_ARCHIVE_URL, &archive_path)?;
-    } else {
+    if archive_path.is_file() {
         writeln!(
             log,
             "Using downloaded source archive {}.",
             archive_path.display()
         )?;
+    } else {
+        writeln!(log, "Downloading {COMFYUI_SOURCE_ARCHIVE_URL}.")?;
+        download_file(COMFYUI_SOURCE_ARCHIVE_URL, &archive_path)?;
     }
     let extract_root = app_root
         .join("extract")
@@ -1475,7 +1464,7 @@ fn copy_dir_all(from: &Path, to: &Path) -> Result<()> {
 }
 
 fn download_file(url: &str, destination: &Path) -> Result<()> {
-    download_file_to_path(url, destination, Duration::from_secs(120))
+    download_file_to_path(url, destination, Duration::from_mins(2))
 }
 
 fn filtered_requirement_specs(requirements_path: &Path) -> Result<Vec<String>> {
@@ -1484,8 +1473,7 @@ fn filtered_requirement_specs(requirements_path: &Path) -> Result<Vec<String>> {
     let mut output = Vec::new();
     for token in requirement_tokens(&text) {
         if requirement_package_name(&token)
-            .map(|name| matches!(name.as_str(), "torch" | "torchvision" | "torchaudio"))
-            .unwrap_or(false)
+            .is_some_and(|name| matches!(name.as_str(), "torch" | "torchvision" | "torchaudio"))
         {
             continue;
         }
@@ -1637,7 +1625,7 @@ fn probe_comfyui(
     let script = format!(
         r#"
 import json, sys
-sys.path.insert(0, {source})
+sys.path.insert(0, {source_literal})
 import torch
 result = {{
     "torch_version": getattr(torch, "__version__", None),
@@ -1647,8 +1635,7 @@ result = {{
 }}
 with open(sys.argv[1], "w", encoding="utf-8") as handle:
     json.dump(result, handle)
-"#,
-        source = source_literal
+"#
     );
     fs::write(&probe_path, script)
         .with_context(|| format!("failed to write {}", probe_path.display()))?;
@@ -1740,7 +1727,7 @@ fn create_temp_dir_under(root: &Path, label: &str) -> Result<PathBuf> {
         ));
         match fs::create_dir(&path) {
             Ok(()) => return Ok(path),
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
             Err(error) => {
                 return Err(error).with_context(|| format!("failed to create {}", path.display()));
             }
@@ -1827,9 +1814,9 @@ mod tests {
         let kept = requirement_tokens(text)
             .into_iter()
             .filter(|token| {
-                !requirement_package_name(token)
-                    .map(|name| matches!(name.as_str(), "torch" | "torchvision" | "torchaudio"))
-                    .unwrap_or(false)
+                !requirement_package_name(token).is_some_and(|name| {
+                    matches!(name.as_str(), "torch" | "torchvision" | "torchaudio")
+                })
             })
             .collect::<Vec<_>>();
         assert_eq!(kept, vec!["numpy>=1.25".to_owned(), "aiohttp".to_owned()]);
@@ -2139,8 +2126,8 @@ mod tests {
             pip_cache_dir: None,
             rocm_sdk: Some(therock::RocmSdkPythonProbe {
                 import_ok: true,
-                root_path: Some(sdk_root.clone()),
-                bin_path: Some(sdk_bin.clone()),
+                root_path: Some(sdk_root),
+                bin_path: Some(sdk_bin),
                 resolved_libraries: vec![
                     therock::RocmSdkLibraryProbe {
                         shortname: "amdhip64".to_owned(),
@@ -2213,7 +2200,7 @@ mod tests {
                 import_ok: true,
                 root_path: Some(sdk_root.clone()),
                 bin_path: Some(sdk_bin.clone()),
-                runtime_roots: vec![runtime_root.clone()],
+                runtime_roots: vec![runtime_root],
                 bin_paths: vec![sdk_bin.clone()],
                 library_paths: vec![sdk_lib.clone()],
                 ..Default::default()
@@ -2300,7 +2287,7 @@ mod tests {
             pip_cache_dir: None,
             rocm_sdk: Some(therock::RocmSdkPythonProbe {
                 import_ok: true,
-                root_path: Some(sdk_root.clone()),
+                root_path: Some(sdk_root),
                 bin_path: Some(sdk_bin),
                 resolved_libraries: vec![
                     therock::RocmSdkLibraryProbe {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -612,7 +612,7 @@ enum SandboxToolArg {
 }
 
 impl SandboxToolArg {
-    fn as_cli_value(self) -> &'static str {
+    const fn as_cli_value(self) -> &'static str {
         match self {
             Self::ListServers => "list_servers",
             Self::RestartServer => "restart_server",
@@ -622,7 +622,7 @@ impl SandboxToolArg {
 }
 
 impl TelemetryModeArg {
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Local => TELEMETRY_MODE_LOCAL,
             Self::Off => TELEMETRY_MODE_OFF,
@@ -924,56 +924,53 @@ fn render_freeform_doctor_answer(
         let _ = writeln!(output, "Target: {target}");
     }
 
-    match active {
-        Some(manifest) => {
-            let status = runtime_usability_status(manifest);
-            if status == "ready" {
-                let _ = writeln!(output, "ROCm/TheRock: installed and active for ROCm CLI");
-            } else {
-                let _ = writeln!(output, "ROCm/TheRock: found, but status is {status}");
-            }
-            let _ = writeln!(output, "Folder: {}", manifest.install_root.display());
+    if let Some(manifest) = active {
+        let status = runtime_usability_status(manifest);
+        if status == "ready" {
+            let _ = writeln!(output, "ROCm/TheRock: installed and active for ROCm CLI");
+        } else {
+            let _ = writeln!(output, "ROCm/TheRock: found, but status is {status}");
+        }
+        let _ = writeln!(output, "Folder: {}", manifest.install_root.display());
+        let _ = writeln!(
+            output,
+            "Version: {}",
+            therock::runtime_version_display(&manifest.version)
+        );
+        let _ = writeln!(output, "GPU package: {}", manifest.family);
+    } else {
+        let setup_root = config.setup.therock_venv.as_deref();
+        if let Some(root) = setup_root {
             let _ = writeln!(
                 output,
-                "Version: {}",
-                therock::runtime_version_display(&manifest.version)
+                "ROCm/TheRock: setup folder saved, but no active runtime is selected"
             );
-            let _ = writeln!(output, "GPU package: {}", manifest.family);
-        }
-        None => {
-            let setup_root = config.setup.therock_venv.as_deref();
-            if let Some(root) = setup_root {
-                let _ = writeln!(
-                    output,
-                    "ROCm/TheRock: setup folder saved, but no active runtime is selected"
-                );
-                let _ = writeln!(output, "Folder: {}", root.display());
-            } else if manifests.len() == 1 {
-                let manifest = &manifests[0];
-                let _ = writeln!(
-                    output,
-                    "ROCm/TheRock: installed, but not selected as the active runtime"
-                );
-                let _ = writeln!(output, "Folder: {}", manifest.install_root.display());
-                let _ = writeln!(output, "Runtime: {}", manifest.runtime_key);
-                let _ = writeln!(
-                    output,
-                    "Next step: rocm runtimes activate {}",
-                    manifest.runtime_key
-                );
-            } else if manifests.is_empty() {
-                let _ = writeln!(output, "ROCm/TheRock: not installed for ROCm CLI yet");
-                let _ = writeln!(
-                    output,
-                    "Next step: run `rocm` and choose Install ROCm, or ask to install TheRock into a folder you choose."
-                );
-            } else {
-                let _ = writeln!(
-                    output,
-                    "ROCm/TheRock: multiple installs found, but none is active"
-                );
-                let _ = writeln!(output, "Run `rocm runtimes list` to choose one.");
-            }
+            let _ = writeln!(output, "Folder: {}", root.display());
+        } else if manifests.len() == 1 {
+            let manifest = &manifests[0];
+            let _ = writeln!(
+                output,
+                "ROCm/TheRock: installed, but not selected as the active runtime"
+            );
+            let _ = writeln!(output, "Folder: {}", manifest.install_root.display());
+            let _ = writeln!(output, "Runtime: {}", manifest.runtime_key);
+            let _ = writeln!(
+                output,
+                "Next step: rocm runtimes activate {}",
+                manifest.runtime_key
+            );
+        } else if manifests.is_empty() {
+            let _ = writeln!(output, "ROCm/TheRock: not installed for ROCm CLI yet");
+            let _ = writeln!(
+                output,
+                "Next step: run `rocm` and choose Install ROCm, or ask to install TheRock into a folder you choose."
+            );
+        } else {
+            let _ = writeln!(
+                output,
+                "ROCm/TheRock: multiple installs found, but none is active"
+            );
+            let _ = writeln!(output, "Run `rocm runtimes list` to choose one.");
         }
     }
 
@@ -1032,7 +1029,7 @@ fn render_freeform_comfyui_status_answer(
 fn dispatch(cli: Cli) -> Result<()> {
     if !matches!(
         cli.command,
-        Some(Command::Update { .. }) | Some(Command::Bootstrap { .. })
+        Some(Command::Update { .. } | Command::Bootstrap { .. })
     ) {
         refresh_startup_update_check_quietly();
     }
@@ -1128,7 +1125,7 @@ fn dispatch(cli: Cli) -> Result<()> {
                     "{}",
                     render_chat_prompt_text(
                         &paths,
-                        provider.map(provider_name).unwrap_or("local"),
+                        provider.map_or("local", provider_name),
                         model.as_deref(),
                         &prompt,
                         tools
@@ -1136,7 +1133,7 @@ fn dispatch(cli: Cli) -> Result<()> {
                 ),
                 None => print!(
                     "{}",
-                    render_chat_text(&paths, provider.map(provider_name).unwrap_or("local"))?
+                    render_chat_text(&paths, provider.map_or("local", provider_name))?
                 ),
             }
             Ok(())
@@ -1283,18 +1280,17 @@ fn dispatch(cli: Cli) -> Result<()> {
                     "`rocm logs` accepts either --search <query> or a positional query, not both"
                 );
             }
-            match service {
-                Some(service_id) => print!("{}", render_service_logs_text(&paths, &service_id)?),
-                None => {
-                    let query = if search.is_empty() {
-                        (!query.is_empty()).then(|| query.join(" "))
-                    } else {
-                        Some(search.join(" "))
-                    };
-                    match query.as_deref() {
-                        Some(query) => print!("{}", render_logs_browser_text(&paths, Some(query))),
-                        None => print!("{}", render_logs_text(&paths)),
-                    }
+            if let Some(service_id) = service {
+                print!("{}", render_service_logs_text(&paths, &service_id)?);
+            } else {
+                let query = if search.is_empty() {
+                    (!query.is_empty()).then(|| query.join(" "))
+                } else {
+                    Some(search.join(" "))
+                };
+                match query.as_deref() {
+                    Some(query) => print!("{}", render_logs_browser_text(&paths, Some(query))),
+                    None => print!("{}", render_logs_text(&paths)),
                 }
             }
             Ok(())
@@ -1390,7 +1386,7 @@ fn builtin_codex_bridge_engine_inventory() -> Vec<CodexBridgeEngine> {
         .collect()
 }
 
-fn builtin_engine_inventory() -> &'static [(&'static str, &'static str)] {
+const fn builtin_engine_inventory() -> &'static [(&'static str, &'static str)] {
     &[
         ("pytorch", "TheRock PyTorch local serving engine"),
         (
@@ -1564,14 +1560,13 @@ fn install(target: InstallTarget) -> Result<()> {
                 InstallFormat::Tarball => "tarball",
             };
             let version_selector = therock_install_version_selector(version, build_date)?;
-            let version_selector_display = version_selector
-                .as_ref()
-                .map(therock_install_version_selector_display)
-                .unwrap_or_else(|| "latest-compatible".to_owned());
+            let version_selector_display = version_selector.as_ref().map_or_else(
+                || "latest-compatible".to_owned(),
+                therock_install_version_selector_display,
+            );
             let prefix_display = prefix
                 .as_ref()
-                .map(|path| path.display().to_string())
-                .unwrap_or_else(|| "<managed>".to_owned());
+                .map_or_else(|| "<managed>".to_owned(), |path| path.display().to_string());
             match therock::install_sdk(
                 &paths,
                 &channel,
@@ -1794,13 +1789,7 @@ fn reconcile_driver_install(paths: &AppPaths) -> Result<String> {
     };
     let doctor = DoctorSummary::gather()?;
     let checks = passive_driver_checks();
-    reconcile_driver_install_state(
-        paths,
-        &mut state,
-        doctor.driver.clone(),
-        current_boot_id(),
-        checks,
-    )
+    reconcile_driver_install_state(paths, &mut state, doctor.driver, current_boot_id(), checks)
 }
 
 fn reconcile_driver_install_state(
@@ -1852,8 +1841,7 @@ fn render_driver_reconciliation(paths: &AppPaths, state: &DriverInstallState) ->
         "  executed_at_unix_ms: {}",
         state
             .executed_at_unix_ms
-            .map(|value| value.to_string())
-            .unwrap_or_else(|| "<not executed>".to_owned())
+            .map_or_else(|| "<not executed>".to_owned(), |value| value.to_string())
     );
     let _ = writeln!(output, "  reboot_required: {}", state.reboot_required);
     let _ = writeln!(output, "  reboot_observed: {}", state.reboot_observed);
@@ -1957,7 +1945,7 @@ fn passive_render_node_check() -> DriverPassiveCheck {
     let present = fs::read_dir("/dev/dri")
         .ok()
         .into_iter()
-        .flat_map(|entries| entries.filter_map(|entry| entry.ok()))
+        .flat_map(|entries| entries.filter_map(std::result::Result::ok))
         .any(|entry| {
             entry
                 .file_name()
@@ -2040,7 +2028,7 @@ struct DriverInstallError {
 }
 
 impl DriverInstallError {
-    fn new(source: anyhow::Error, executed: bool) -> Self {
+    const fn new(source: anyhow::Error, executed: bool) -> Self {
         Self { source, executed }
     }
 }
@@ -2555,7 +2543,7 @@ fn amdgpu_install_sles_rpm_url(repo_version_expr: &str, version_id: &str) -> Str
 fn dnf_repo_version_path(os_id: &str, version_id: &str) -> String {
     match (os_id, version_id) {
         ("rhel", "10.1" | "10.0") | ("ol", "10.1") => "10".to_owned(),
-        ("rhel", "8.10") | ("ol", "8.10") => "8".to_owned(),
+        ("rhel" | "ol", "8.10") => "8".to_owned(),
         _ => version_id.to_owned(),
     }
 }
@@ -2654,7 +2642,11 @@ fn render_driver_install_plan(plan: &DriverInstallPlan, yes: bool, dry_run: bool
     output
 }
 
-fn driver_plan_approval_label(plan: &DriverInstallPlan, yes: bool, dry_run: bool) -> &'static str {
+const fn driver_plan_approval_label(
+    plan: &DriverInstallPlan,
+    yes: bool,
+    dry_run: bool,
+) -> &'static str {
     if !plan.supported || !plan.mutating || dry_run {
         "not required"
     } else if yes {
@@ -2664,7 +2656,7 @@ fn driver_plan_approval_label(plan: &DriverInstallPlan, yes: bool, dry_run: bool
     }
 }
 
-fn empty_as_unknown(value: &str) -> &str {
+const fn empty_as_unknown(value: &str) -> &str {
     if value.is_empty() { "<unknown>" } else { value }
 }
 
@@ -2785,7 +2777,7 @@ fn engines(command: EnginesCommand) -> Result<()> {
                     "engine",
                     "engine_install",
                     "info",
-                    format!("ready engine={} runtime_id={}", engine, runtime_id),
+                    format!("ready engine={engine} runtime_id={runtime_id}"),
                     None,
                 );
                 return Ok(());
@@ -2797,7 +2789,7 @@ fn engines(command: EnginesCommand) -> Result<()> {
                 EngineMethod::Install,
                 &InstallRequest {
                     runtime_id: runtime_id.clone(),
-                    python_version: python_version.clone(),
+                    python_version,
                     reinstall,
                     env_root: env_root.clone(),
                 },
@@ -2812,7 +2804,9 @@ fn engines(command: EnginesCommand) -> Result<()> {
             for warning in response.warnings {
                 println!("  warning: {warning}");
             }
-            if response.managed_env != Some(false) {
+            if response.managed_env == Some(false) {
+                println!("  note: external runtime");
+            } else {
                 let engine_config = config.engine_config_mut(&engine);
                 engine_config.last_installed_runtime_id = Some(runtime_id.clone());
                 engine_config.last_installed_env_id = Some(response.env_id.clone());
@@ -2825,8 +2819,6 @@ fn engines(command: EnginesCommand) -> Result<()> {
                 }
                 config.save(&paths)?;
                 let _ = seeded_preference;
-            } else {
-                println!("  note: external runtime");
             }
             record_cli_audit_event(
                 &paths,
@@ -3287,8 +3279,10 @@ fn serve_model_ref_for_engine(
 ) -> String {
     recipe
         .filter(|recipe| model_recipe_supports_engine(recipe, selected_engine))
-        .map(|recipe| recipe.canonical_model_id.clone())
-        .unwrap_or_else(|| model.to_owned())
+        .map_or_else(
+            || model.to_owned(),
+            |recipe| recipe.canonical_model_id.clone(),
+        )
 }
 
 fn serve_engine_selection_line(selection: &ServeEngineSelection) -> String {
@@ -3407,7 +3401,7 @@ fn serve(
         &ResolveModelRequest {
             model_ref: engine_model_ref,
             runtime_id: resolved_selection.runtime_id.clone(),
-            device_policy: Some(device_policy.clone()),
+            device_policy: Some(device_policy),
             recipe_override: None,
             engine_recipe,
         },
@@ -4074,8 +4068,7 @@ fn runtimes(command: Option<RuntimesCommand>) -> Result<()> {
                     result
                         .removed_install_root
                         .as_ref()
-                        .map(|path| path.display().to_string())
-                        .unwrap_or_else(|| "none".to_owned())
+                        .map_or_else(|| "none".to_owned(), |path| path.display().to_string())
                 ),
                 None,
             );
@@ -4569,9 +4562,7 @@ fn normalize_path_for_compare(path: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();
     }
-    std::env::current_dir()
-        .map(|cwd| cwd.join(path))
-        .unwrap_or_else(|_| path.to_path_buf())
+    std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
 }
 
 fn import_runtime_manifest(
@@ -5715,7 +5706,15 @@ pub(crate) fn render_chat_prompt_result_with_progress(
                 rocm_tools: false,
             },
         )?;
-        if !follow_up.tool_calls.is_empty() {
+        if follow_up.tool_calls.is_empty() {
+            let follow_up_content = visible_chat_content(&follow_up.content);
+            if local_follow_up_content_is_final(&follow_up) && !follow_up_content.trim().is_empty()
+            {
+                let _ = writeln!(output);
+                let _ = writeln!(output, "Assistant after ROCm checks");
+                let _ = writeln!(output, "{}", follow_up_content.trim());
+            }
+        } else {
             let _ = writeln!(output);
             let _ = writeln!(
                 output,
@@ -5725,14 +5724,6 @@ pub(crate) fn render_chat_prompt_result_with_progress(
                 output,
                 "rocm-cli stopped there so the answer is not based on another guess. Nothing was changed."
             );
-        } else {
-            let follow_up_content = visible_chat_content(&follow_up.content);
-            if local_follow_up_content_is_final(&follow_up) && !follow_up_content.trim().is_empty()
-            {
-                let _ = writeln!(output);
-                let _ = writeln!(output, "Assistant after ROCm checks");
-                let _ = writeln!(output, "{}", follow_up_content.trim());
-            }
         }
     } else if tool_result.read_only_tool_error {
         let _ = writeln!(output);
@@ -5772,8 +5763,7 @@ fn latest_user_chat_message(prompt: &str) -> &str {
     const MARKER: &str = "\nNew message:\n";
     prompt
         .rfind(MARKER)
-        .map(|index| &prompt[index + MARKER.len()..])
-        .unwrap_or(prompt)
+        .map_or(prompt, |index| &prompt[index + MARKER.len()..])
         .trim()
 }
 
@@ -6713,37 +6703,34 @@ pub(crate) fn local_chat_service_needed_text(
         "Recommended path:\n  run `rocm`, choose Start a local model, use the recommended assistant model, then start it"
     );
     let _ = writeln!(output);
-    match model.filter(|value| !value.trim().is_empty()) {
-        Some(model) => {
-            let args = vec![
-                "serve".to_owned(),
-                model.to_owned(),
-                "--device".to_owned(),
-                "gpu_required".to_owned(),
-                "--managed".to_owned(),
-            ];
-            let _ = writeln!(
-                output,
-                "Advanced manual command for the selected model:\n  {}",
-                format_structured_tool_call("rocm", &args)
-            );
-        }
-        None => {
-            let example_args = vec![
-                "serve".to_owned(),
-                providers::LEMONADE_ASSISTANT_MODEL_ID.to_owned(),
-                "--engine".to_owned(),
-                "lemonade".to_owned(),
-                "--device".to_owned(),
-                "gpu_required".to_owned(),
-                "--managed".to_owned(),
-            ];
-            let _ = writeln!(
-                output,
-                "Advanced manual command for the recommended assistant model:\n  {}",
-                format_structured_tool_call("rocm", &example_args)
-            );
-        }
+    if let Some(model) = model.filter(|value| !value.trim().is_empty()) {
+        let args = vec![
+            "serve".to_owned(),
+            model.to_owned(),
+            "--device".to_owned(),
+            "gpu_required".to_owned(),
+            "--managed".to_owned(),
+        ];
+        let _ = writeln!(
+            output,
+            "Advanced manual command for the selected model:\n  {}",
+            format_structured_tool_call("rocm", &args)
+        );
+    } else {
+        let example_args = vec![
+            "serve".to_owned(),
+            providers::LEMONADE_ASSISTANT_MODEL_ID.to_owned(),
+            "--engine".to_owned(),
+            "lemonade".to_owned(),
+            "--device".to_owned(),
+            "gpu_required".to_owned(),
+            "--managed".to_owned(),
+        ];
+        let _ = writeln!(
+            output,
+            "Advanced manual command for the recommended assistant model:\n  {}",
+            format_structured_tool_call("rocm", &example_args)
+        );
     }
     let mut chat_args = vec!["chat".to_owned()];
     if rocm_tools {
@@ -6839,7 +6826,7 @@ fn append_chat_tool_results(
             }
         } else {
             report_chat_tool_progress(progress, &format!("Review needed: {label}."));
-            let _ = writeln!(output, "  {}: needs your review", label);
+            let _ = writeln!(output, "  {label}: needs your review");
             let _ = writeln!(
                 output,
                 "    not run: review the approval card before anything runs"
@@ -7101,7 +7088,7 @@ fn validate_chat_port_status_tool_call(call: &providers::ChatToolCall) -> Result
     let Some(port) = object.get("port").and_then(serde_json::Value::as_u64) else {
         bail!("ROCm tool `port_status` requires integer `port`");
     };
-    if !(1..=u16::MAX as u64).contains(&port) {
+    if !(1..=u64::from(u16::MAX)).contains(&port) {
         bail!("ROCm tool `port_status` argument `port` must be between 1 and 65535");
     }
     Ok(())
@@ -7553,10 +7540,10 @@ fn deterministic_rocm_tool_summary(tool_text: &str) -> Option<String> {
             .filter(|value| value != "<unset>" && value != "<unknown>");
         let mut detail = "installed and active for ROCm CLI".to_owned();
         if let Some(family) = family {
-            detail.push_str(&format!(" ({family})"));
+            let _ = write!(detail, " ({family})");
         }
         if let Some(version) = version {
-            detail.push_str(&format!(", {version}"));
+            let _ = write!(detail, ", {version}");
         }
         lines.push(format!("  ROCm/TheRock: {detail}"));
         if let Some(root) = chat_tool_value(tool_text, "active_runtime_root")
@@ -7651,8 +7638,7 @@ fn deterministic_model_tool_summary(tool_text: &str) -> Option<String> {
             "    Fit: needs about {} GPU memory.",
             recipe
                 .min_gpu_mem_gib
-                .map(|value| format!("{value} GiB"))
-                .unwrap_or_else(|| "unknown".to_owned())
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value} GiB"))
         ));
         lines.push(format!(
             "    Engine: {}",
@@ -7685,9 +7671,7 @@ fn deterministic_model_tool_summary(tool_text: &str) -> Option<String> {
         lines.push(format!(
             "    Fit: asks for {}; this can be tight on APUs and depends on available shared GPU memory.",
             recipe
-                .min_gpu_mem_gib
-                .map(|value| format!("{value} GiB"))
-                .unwrap_or_else(|| "unknown GPU memory".to_owned())
+                .min_gpu_mem_gib.map_or_else(|| "unknown GPU memory".to_owned(), |value| format!("{value} GiB"))
         ));
         lines.push(format!(
             "    Engines: {}",
@@ -7703,10 +7687,10 @@ fn deterministic_model_tool_summary(tool_text: &str) -> Option<String> {
             format!(
                 "{} asks for {}",
                 recipe.canonical_id,
-                recipe
-                    .min_gpu_mem_gib
-                    .map(|value| format!("{value} GiB"))
-                    .unwrap_or_else(|| "more GPU memory".to_owned())
+                recipe.min_gpu_mem_gib.map_or_else(
+                    || "more GPU memory".to_owned(),
+                    |value| format!("{value} GiB")
+                )
             )
         })
         .collect::<Vec<_>>();
@@ -7824,7 +7808,7 @@ fn deterministic_engine_fit_summary(recipe: &DeterministicModelRecipe, engine: &
         .engine_statuses
         .iter()
         .find(|status| status.starts_with(&format!("{engine}:")))
-        .map(|status| status.as_str());
+        .map(std::string::String::as_str);
     match status {
         Some(status) if status.contains("unsupported_native_windows") => {
             format!("{engine}: WSL/Linux only on Windows")
@@ -8053,7 +8037,7 @@ fn deterministic_engine_inventory_tool_summary(tool_text: &str) -> Option<String
             empty_as_unknown(&row.runtime)
         );
         if !row.note.trim().is_empty() {
-            line.push_str(&format!(" ({})", row.note.trim()));
+            let _ = write!(line, " ({})", row.note.trim());
         }
         line.push('.');
         lines.push(line);
@@ -8252,11 +8236,11 @@ fn run_internal_mcp_call(
             let action = chat_rocm_command_action(&call)?;
             let output = match action {
                 ChatRocmCommandAction::ReadOnly(args) => {
-                    run_rocm_command_for_paths(paths, &args, Duration::from_secs(120))?
+                    run_rocm_command_for_paths(paths, &args, Duration::from_mins(2))?
                 }
                 ChatRocmCommandAction::Approval { args, .. } if allow_mutation => {
                     let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-                    run_rocm_capture_for_paths(paths, &refs, Duration::from_secs(120))?
+                    run_rocm_capture_for_paths(paths, &refs, Duration::from_mins(2))?
                 }
                 ChatRocmCommandAction::Approval { .. } => {
                     bail!("rocm_command changes local ROCm state and needs approval")
@@ -8270,7 +8254,7 @@ fn run_internal_mcp_call(
         }
         "update_check" => {
             let output =
-                run_rocm_command_for_paths(paths, &["update".to_owned()], Duration::from_secs(60))?;
+                run_rocm_command_for_paths(paths, &["update".to_owned()], Duration::from_mins(1))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran `rocm update`.",
                 output,
@@ -8279,7 +8263,7 @@ fn run_internal_mcp_call(
         }
         "install_sdk_dry_run" => {
             let args = internal_mcp_install_sdk_args(&arguments, true)?;
-            let output = run_rocm_command_for_paths(paths, &args, Duration::from_secs(120))?;
+            let output = run_rocm_command_for_paths(paths, &args, Duration::from_mins(2))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran `rocm install sdk --dry-run`.",
                 output,
@@ -8292,7 +8276,7 @@ fn run_internal_mcp_call(
             let args = rocm_chat_tool_requested_args(&call)
                 .with_context(|| format!("MCP tool `{name}` is missing required arguments"))?;
             let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-            let output = run_rocm_capture_for_paths(paths, &refs, Duration::from_secs(120))?;
+            let output = run_rocm_capture_for_paths(paths, &refs, Duration::from_mins(2))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran approved `rocm` command.",
                 output,
@@ -8676,7 +8660,7 @@ fn run_chat_read_only_tool(
             let ChatRocmCommandAction::ReadOnly(args) = action else {
                 bail!("assistant read-only path cannot run mutating rocm_command");
             };
-            let output = run_rocm_command_for_paths(paths, &args, Duration::from_secs(120))?;
+            let output = run_rocm_command_for_paths(paths, &args, Duration::from_mins(2))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran `rocm` command.",
                 output,
@@ -8685,7 +8669,7 @@ fn run_chat_read_only_tool(
         }
         "update_check" => {
             let output =
-                run_rocm_command_for_paths(paths, &["update".to_owned()], Duration::from_secs(60))?;
+                run_rocm_command_for_paths(paths, &["update".to_owned()], Duration::from_mins(1))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran `rocm update`.",
                 output,
@@ -8695,7 +8679,7 @@ fn run_chat_read_only_tool(
         "install_sdk_dry_run" => {
             let arguments = internal_mcp_arguments(call.arguments.clone());
             let args = internal_mcp_install_sdk_args(&arguments, true)?;
-            let output = run_rocm_command_for_paths(paths, &args, Duration::from_secs(120))?;
+            let output = run_rocm_command_for_paths(paths, &args, Duration::from_mins(2))?;
             Ok(internal_mcp_tool_result_from_command(
                 "Ran `rocm install sdk --dry-run`.",
                 output,
@@ -8714,23 +8698,21 @@ fn run_chat_path_exists_tool(call: &providers::ChatToolCall) -> Result<serde_jso
     let path = json_string(object, "path").context("path_exists requires path")?;
     let path = Path::new(&path);
     let metadata = path.metadata().ok();
-    let path_kind = metadata
-        .as_ref()
-        .map(|metadata| {
-            if metadata.is_dir() {
-                "directory"
-            } else if metadata.is_file() {
-                "file"
-            } else {
-                "other"
-            }
-        })
-        .unwrap_or("missing");
+    let path_kind = metadata.as_ref().map_or("missing", |metadata| {
+        if metadata.is_dir() {
+            "directory"
+        } else if metadata.is_file() {
+            "file"
+        } else {
+            "other"
+        }
+    });
     let parent = path.parent();
     let parent_exists = parent.is_some_and(Path::exists);
-    let parent_display = parent
-        .map(|parent| parent.display().to_string())
-        .unwrap_or_else(|| "<none>".to_owned());
+    let parent_display = parent.map_or_else(
+        || "<none>".to_owned(),
+        |parent| parent.display().to_string(),
+    );
     let text = format!(
         "path: {}\nexists: {}\nkind: {}\nparent: {}\nparent_exists: {}",
         path.display(),
@@ -8852,7 +8834,7 @@ fn mcp_tool_result_is_error(value: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
-fn chat_read_only_tool_status_label(is_error: bool) -> &'static str {
+const fn chat_read_only_tool_status_label(is_error: bool) -> &'static str {
     if is_error {
         "reported an error"
     } else {
@@ -9315,10 +9297,10 @@ pub(crate) fn render_model_registry_text_with_context_and_host(
 }
 
 fn model_recipe_memory_label(recipe: &ModelRecipeRecord) -> String {
-    recipe
-        .min_gpu_mem_gb
-        .map(|value| format!("{value} GiB GPU"))
-        .unwrap_or_else(|| "no GPU minimum".to_owned())
+    recipe.min_gpu_mem_gb.map_or_else(
+        || "no GPU minimum".to_owned(),
+        |value| format!("{value} GiB GPU"),
+    )
 }
 
 fn model_recipe_gpu_fit_label(
@@ -9326,7 +9308,7 @@ fn model_recipe_gpu_fit_label(
     aggregate_gpu_vram_gib: Option<f64>,
 ) -> &'static str {
     match (recipe.min_gpu_mem_gb, aggregate_gpu_vram_gib) {
-        (Some(required), Some(available)) if available >= required as f64 => "fits this GPU",
+        (Some(required), Some(available)) if available >= f64::from(required) => "fits this GPU",
         (Some(_), Some(_)) => "needs a larger GPU",
         (Some(_), None) => "GPU fit unknown",
         (None, _) => "fits",
@@ -9362,10 +9344,10 @@ pub(crate) fn render_model_registry_verbose_text_with_context_and_host(
         } else {
             recipe.preferred_engines.join(", ")
         };
-        let memory = recipe
-            .min_gpu_mem_gb
-            .map(|value| format!("{value} GiB"))
-            .unwrap_or_else(|| "<not required>".to_owned());
+        let memory = recipe.min_gpu_mem_gb.map_or_else(
+            || "<not required>".to_owned(),
+            |value| format!("{value} GiB"),
+        );
         let _ = writeln!(
             output,
             "  {} aliases=[{}] task={} dtype={} device={} min_gpu_mem={} engines=[{}]",
@@ -9428,8 +9410,7 @@ fn append_model_recipe_metadata_lines(
         "      recommended_system_ram: {}",
         recipe
             .recommended_system_ram_gb
-            .map(|value| format!("{value} GiB"))
-            .unwrap_or_else(|| "<unknown>".to_owned())
+            .map_or_else(|| "<unknown>".to_owned(), |value| format!("{value} GiB"))
     );
     let _ = writeln!(
         output,
@@ -9448,20 +9429,18 @@ fn append_model_engine_recipe_settings_lines(output: &mut String, recipe: &Model
     }
     let _ = writeln!(
         output,
-        "      engine_recipes_policy: protocol_contract={} selected-engine hint is passed to adapters during model resolution and required flags are forwarded at launch",
-        ENGINE_RECIPE_CONTRACT_VERSION
+        "      engine_recipes_policy: protocol_contract={ENGINE_RECIPE_CONTRACT_VERSION} selected-engine hint is passed to adapters during model resolution and required flags are forwarded at launch"
     );
     for engine_recipe in &recipe.engine_recipes {
         let required_flags = format_list_or_none(&engine_recipe.required_flags);
         let parser_settings = format_string_map_or_none(&engine_recipe.parser_settings);
-        let endpoint = engine_recipe
-            .preferred_endpoint
-            .as_ref()
-            .map(|endpoint| {
+        let endpoint = engine_recipe.preferred_endpoint.as_ref().map_or_else(
+            || "<none>".to_owned(),
+            |endpoint| {
                 let settings = format_string_map_or_none(&endpoint.settings);
                 format!("mode={} settings=[{}]", endpoint.endpoint_mode, settings)
-            })
-            .unwrap_or_else(|| "<none>".to_owned());
+            },
+        );
         let unsupported = if engine_recipe.unsupported_combinations.is_empty() {
             "<none>".to_owned()
         } else {
@@ -9550,8 +9529,7 @@ fn append_model_artifact_lines(
         };
         let size = artifact
             .size_bytes
-            .map(format_bytes)
-            .unwrap_or_else(|| "<unknown>".to_owned());
+            .map_or_else(|| "<unknown>".to_owned(), format_bytes);
         let gated = artifact.gated.unwrap_or(false);
         let _ = writeln!(
             output,
@@ -9644,13 +9622,13 @@ fn append_model_host_ram_fit_lines(
     };
 
     match host_ram_gib {
-        Some(available) if available >= required as f64 => {
+        Some(available) if available >= f64::from(required) => {
             let _ = writeln!(output, "      system_ram_fit: supported");
             let _ = writeln!(
                 output,
                 "      system_ram_reason: host RAM {} meets recipe recommendation {}",
                 format_gib(available),
-                format_gib(required as f64)
+                format_gib(f64::from(required))
             );
         }
         Some(available) => {
@@ -9659,12 +9637,12 @@ fn append_model_host_ram_fit_lines(
                 output,
                 "      system_ram_reason: host RAM {} is below recipe recommendation {}",
                 format_gib(available),
-                format_gib(required as f64)
+                format_gib(f64::from(required))
             );
             let _ = writeln!(
                 output,
                 "      system_ram_action: consider a smaller recipe or a host with at least {} system RAM for smoother serving",
-                format_gib(required as f64)
+                format_gib(f64::from(required))
             );
         }
         None => {
@@ -9703,13 +9681,13 @@ fn append_model_fit_lines(
             );
         }
         Some(required) => match aggregate_gpu_vram_gib {
-            Some(available) if available >= required as f64 => {
+            Some(available) if available >= f64::from(required) => {
                 let _ = writeln!(output, "      gpu_fit: supported");
                 let _ = writeln!(
                     output,
                     "      reason: aggregate GPU VRAM {} meets recipe minimum {}",
                     format_gib(available),
-                    format_gib(required as f64)
+                    format_gib(f64::from(required))
                 );
                 let _ = writeln!(
                     output,
@@ -9724,13 +9702,13 @@ fn append_model_fit_lines(
                     output,
                     "      reason: aggregate GPU VRAM {} is below recipe minimum {}",
                     format_gib(available),
-                    format_gib(required as f64)
+                    format_gib(f64::from(required))
                 );
                 let _ = writeln!(
                     output,
                     "      action: choose a recipe with min_gpu_mem <= {} or use a GPU with at least {} before serving",
                     format_gib(available),
-                    format_gib(required as f64)
+                    format_gib(f64::from(required))
                 );
                 append_manual_alternative_lines(output, recipe, aggregate_gpu_vram_gib);
             }
@@ -9788,10 +9766,10 @@ fn manual_alternative_recommendations(
             format!(
                 "{} ({})",
                 candidate_ref,
-                candidate
-                    .min_gpu_mem_gb
-                    .map(|value| format!("{} min GPU", format_gib(value as f64)))
-                    .unwrap_or_else(|| "CPU-only".to_owned())
+                candidate.min_gpu_mem_gb.map_or_else(
+                    || "CPU-only".to_owned(),
+                    |value| format!("{} min GPU", format_gib(f64::from(value)))
+                )
             )
         })
         .collect::<Vec<_>>();
@@ -9813,7 +9791,7 @@ fn recipe_is_manual_fit(recipe: &ModelRecipeRecord, aggregate_gpu_vram_gib: Opti
     match recipe.min_gpu_mem_gb {
         None => true,
         Some(required) => {
-            aggregate_gpu_vram_gib.is_some_and(|available| available >= required as f64)
+            aggregate_gpu_vram_gib.is_some_and(|available| available >= f64::from(required))
         }
     }
 }
@@ -9886,7 +9864,7 @@ fn append_model_engine_support_lines(
 }
 
 #[allow(dead_code)]
-fn model_registry_adapter_availability_note(engine: &str) -> Option<&'static str> {
+const fn model_registry_adapter_availability_note(engine: &str) -> Option<&'static str> {
     if rocm_core::runtime_is_windows() && engine.eq_ignore_ascii_case("vllm") {
         Some(
             "runtime_status=unsupported_native_windows reason=native Windows skipped; use WSL/Linux vLLM ROCm; gpu_execution_required=true; run /engine for adapter details",
@@ -9909,8 +9887,7 @@ fn recipe_display_ref(recipe: &ModelRecipeRecord) -> &str {
     recipe
         .aliases
         .first()
-        .map(String::as_str)
-        .unwrap_or(recipe.canonical_model_id.as_str())
+        .map_or(recipe.canonical_model_id.as_str(), String::as_str)
 }
 
 #[allow(dead_code)]
@@ -9918,8 +9895,7 @@ fn preferred_engine_action_target(recipe: &ModelRecipeRecord) -> &str {
     recipe
         .preferred_engines
         .first()
-        .map(String::as_str)
-        .unwrap_or("<engine>")
+        .map_or("<engine>", String::as_str)
 }
 
 #[allow(dead_code)]
@@ -10956,8 +10932,7 @@ fn format_cli_lifecycle_tail_line(line: &str) -> String {
     let action = lifecycle_field(line, "action").unwrap_or("event");
     let message = line
         .split_once(" message=")
-        .map(|(_, message)| message)
-        .unwrap_or(line)
+        .map_or(line, |(_, message)| message)
         .trim();
     let label = lifecycle_event_label(category, action);
     if level == "info" {
@@ -11052,8 +11027,7 @@ fn append_update_surfaces(output: &mut String) {
         .join(",");
     let _ = writeln!(
         output,
-        "    engines: status=package_managed packaged=[{}] reason=first-party engine binaries update with the rocm-cli package; data-dir plugins are user-managed",
-        engine_ids
+        "    engines: status=package_managed packaged=[{engine_ids}] reason=first-party engine binaries update with the rocm-cli package; data-dir plugins are user-managed"
     );
     match load_model_recipe_registry() {
         Ok(registry) => match registry.source {
@@ -11094,8 +11068,7 @@ fn append_update_surfaces(output: &mut String) {
     };
     let _ = writeln!(
         output,
-        "    runtimes: status={} reason=TheRock runtime update checks above are the only live update checks in this build",
-        runtime_status
+        "    runtimes: status={runtime_status} reason=TheRock runtime update checks above are the only live update checks in this build"
     );
     let _ = writeln!(
         output,
@@ -11259,26 +11232,23 @@ pub(crate) fn render_automations_text(paths: &AppPaths, config: &RocmCliConfig) 
             "off"
         }
     );
-    match runtime_state.as_ref() {
-        Some(state) => {
-            let _ = writeln!(
-                output,
-                "  background service: {}",
-                if state.running { "running" } else { "stopped" }
-            );
-            let _ = writeln!(
-                output,
-                "  local event intake: {}",
-                state
-                    .local_webhook_endpoint
-                    .as_deref()
-                    .unwrap_or("disabled")
-            );
-        }
-        None => {
-            let _ = writeln!(output, "  background service: not running");
-            let _ = writeln!(output, "  local event intake: disabled");
-        }
+    if let Some(state) = runtime_state.as_ref() {
+        let _ = writeln!(
+            output,
+            "  background service: {}",
+            if state.running { "running" } else { "stopped" }
+        );
+        let _ = writeln!(
+            output,
+            "  local event intake: {}",
+            state
+                .local_webhook_endpoint
+                .as_deref()
+                .unwrap_or("disabled")
+        );
+    } else {
+        let _ = writeln!(output, "  background service: not running");
+        let _ = writeln!(output, "  local event intake: disabled");
     }
     for watcher in builtin_watchers() {
         let runtime_snapshot = runtime_state.as_ref().and_then(|state| {
@@ -11350,8 +11320,7 @@ pub(crate) fn render_automations_text(paths: &AppPaths, config: &RocmCliConfig) 
                     .arguments
                     .get("artifact_max_bytes")
                     .and_then(serde_json::Value::as_u64)
-                    .map(format_bytes_for_user)
-                    .unwrap_or_else(|| "not set".to_owned());
+                    .map_or_else(|| "not set".to_owned(), format_bytes_for_user);
                 let _ = writeln!(output, "      download: approved up to {limit}");
             } else if proposal_kind(&proposal) == ProposalKind::PrefetchArtifact {
                 let _ = writeln!(output, "      download: not approved yet");
@@ -11502,7 +11471,7 @@ fn format_bytes_for_user(bytes: u64) -> String {
     }
 }
 
-fn watcher_mode_plain_label(mode: WatcherMode) -> &'static str {
+const fn watcher_mode_plain_label(mode: WatcherMode) -> &'static str {
     match mode {
         WatcherMode::Observe => "record only",
         WatcherMode::Propose => "ask before taking action",
@@ -11658,7 +11627,7 @@ pub(crate) fn render_sidebar_text(
         .iter()
         .filter(|watcher| config.watcher_enabled(watcher))
         .count();
-    let _ = writeln!(output, "Background checks: {}", enabled_watchers);
+    let _ = writeln!(output, "Background checks: {enabled_watchers}");
     let _ = writeln!(
         output,
         "Background helper: {}",
@@ -12029,7 +11998,7 @@ enum PlannerIntent {
 }
 
 impl PlannerIntent {
-    fn label(self) -> &'static str {
+    const fn label(self) -> &'static str {
         match self {
             Self::Ask => "ask",
             Self::Serve => "serve",
@@ -12052,7 +12021,7 @@ struct PlannedToolCall {
 }
 
 impl PlannedToolCall {
-    fn read_only(title: &'static str, args: Vec<String>, reason: &'static str) -> Self {
+    const fn read_only(title: &'static str, args: Vec<String>, reason: &'static str) -> Self {
         Self {
             title,
             tool: "rocm",
@@ -12062,7 +12031,11 @@ impl PlannedToolCall {
         }
     }
 
-    fn approval_required(title: &'static str, args: Vec<String>, reason: &'static str) -> Self {
+    const fn approval_required(
+        title: &'static str,
+        args: Vec<String>,
+        reason: &'static str,
+    ) -> Self {
         Self {
             title,
             tool: "rocm",
@@ -12637,11 +12610,10 @@ fn resolve_freeform_plan_with_provider(
 }
 
 fn build_provider_planner_prompt(request: &str, deterministic: &StructuredRequestPlan) -> String {
-    let next_tool_call = deterministic
-        .actions
-        .last()
-        .map(|action| format_structured_tool_call(action.tool, &action.args))
-        .unwrap_or_else(|| "rocm doctor".to_owned());
+    let next_tool_call = deterministic.actions.last().map_or_else(
+        || "rocm doctor".to_owned(),
+        |action| format_structured_tool_call(action.tool, &action.args),
+    );
     format!(
         "You are resolving an ambiguous rocm-cli request. Return only JSON with this shape: \
 {{\"intent\":\"serve|install_sdk|install_driver|update|uninstall|inspect\",\
@@ -13046,7 +13018,10 @@ struct UninstallPlan {
 fn build_uninstall_plan(paths: &AppPaths, options: &UninstallOptions) -> Result<UninstallPlan> {
     let mut plan = UninstallPlan::default();
 
-    if !options.keep_binaries {
+    if options.keep_binaries {
+        plan.skipped
+            .push("binary removal disabled by --keep-binaries".to_owned());
+    } else {
         let current_exe =
             daemon_binary_path().context("failed to discover current rocm executable")?;
         if is_dev_binary_layout(&current_exe) && !options.force_dev_binaries {
@@ -13069,9 +13044,6 @@ fn build_uninstall_plan(paths: &AppPaths, options: &UninstallOptions) -> Result<
                 });
             }
         }
-    } else {
-        plan.skipped
-            .push("binary removal disabled by --keep-binaries".to_owned());
     }
 
     for (keep, kind, path) in [
@@ -13230,7 +13202,7 @@ fn remove_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn engine_inventory() -> &'static [(&'static str, &'static str)] {
+pub(crate) const fn engine_inventory() -> &'static [(&'static str, &'static str)] {
     &[
         ("pytorch", "TheRock PyTorch local serving engine"),
         ("llama.cpp", "external GGUF serving engine for llama-server"),
@@ -13281,7 +13253,7 @@ fn infer_model_from_request(request: &str) -> Option<&str> {
     (!model.is_empty()).then_some(model)
 }
 
-fn provider_name(provider: Provider) -> &'static str {
+const fn provider_name(provider: Provider) -> &'static str {
     match provider {
         Provider::Local => "local",
         Provider::Anthropic => "anthropic",
@@ -13304,7 +13276,7 @@ fn resolve_engine_binary_path_with_paths(engine: &str, paths: &AppPaths) -> Resu
     engine_binary_path(engine)
 }
 
-fn missing_packaged_engine_reason(_engine: &str) -> Option<String> {
+const fn missing_packaged_engine_reason(_engine: &str) -> Option<String> {
     None
 }
 
@@ -13323,9 +13295,9 @@ where
 impl From<WatcherModeArg> for WatcherMode {
     fn from(value: WatcherModeArg) -> Self {
         match value {
-            WatcherModeArg::Observe => WatcherMode::Observe,
-            WatcherModeArg::Propose => WatcherMode::Propose,
-            WatcherModeArg::Contained => WatcherMode::Contained,
+            WatcherModeArg::Observe => Self::Observe,
+            WatcherModeArg::Propose => Self::Propose,
+            WatcherModeArg::Contained => Self::Contained,
         }
     }
 }
@@ -13443,13 +13415,9 @@ where
     if !status.success() && stdout.is_empty() {
         let stderr = String::from_utf8_lossy(&stderr).trim().to_owned();
         if stderr.is_empty() {
-            bail!("engine stdio process exited with status {}", status);
+            bail!("engine stdio process exited with status {status}");
         }
-        bail!(
-            "engine stdio process exited with status {}: {}",
-            status,
-            stderr
-        );
+        bail!("engine stdio process exited with status {status}: {stderr}");
     }
     let envelope: EngineResponseEnvelope = serde_json::from_slice(&stdout).with_context(|| {
         let stderr = String::from_utf8_lossy(&stderr).trim().to_owned();
@@ -13467,10 +13435,10 @@ where
     R: DeserializeOwned,
 {
     if !envelope.ok {
-        let error = envelope
-            .error
-            .map(|value| format!("{}: {}", value.code, value.message))
-            .unwrap_or_else(|| "unknown engine error".to_owned());
+        let error = envelope.error.map_or_else(
+            || "unknown engine error".to_owned(),
+            |value| format!("{}: {}", value.code, value.message),
+        );
         bail!("{error}");
     }
     let data = envelope
@@ -13485,6 +13453,7 @@ struct ScopedEnvVar {
 }
 
 impl ScopedEnvVar {
+    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn set_path(key: &'static str, value: &Path) -> Self {
         let previous = std::env::var_os(key);
         unsafe {
@@ -13495,6 +13464,7 @@ impl ScopedEnvVar {
 }
 
 impl Drop for ScopedEnvVar {
+    #[allow(unsafe_code)] // std::env::set_var/remove_var are unsafe in edition 2024
     fn drop(&mut self) {
         unsafe {
             match self.previous.as_ref() {
@@ -13711,7 +13681,7 @@ fn parse_device_policy(value: Option<&str>) -> Result<DevicePolicy> {
     }
 }
 
-fn device_policy_name(policy: &DevicePolicy) -> &'static str {
+const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
     match policy {
         DevicePolicy::GpuRequired => "gpu_required",
         DevicePolicy::GpuPreferred => "gpu_preferred",
@@ -16754,13 +16724,13 @@ install therock";
         fs::create_dir_all(paths.data_dir.join("logs").join("cli"))?;
         fs::write(
             cli_lifecycle_log_path(&paths),
-            (0..10)
-                .map(|index| {
-                    format!(
-                        "{index} level=info category=runtime action=install_sdk message=event-{index}\n"
-                    )
-                })
-                .collect::<String>(),
+            (0..10).fold(String::new(), |mut acc, index| {
+                let _ = writeln!(
+                    acc,
+                    "{index} level=info category=runtime action=install_sdk message=event-{index}"
+                );
+                acc
+            }),
         )?;
         fs::write(
             paths
@@ -16908,7 +16878,7 @@ install therock";
 
         let mut log = String::new();
         for index in 1..=90 {
-            log.push_str(&format!("entry-{index:03}\n"));
+            let _ = writeln!(log, "entry-{index:03}");
         }
         fs::write(&record.log_path, log)?;
 
@@ -18042,9 +18012,7 @@ VERSION_ID="41"
 
         let finalized = finalize_successful_sdk_install(&paths)?
             .context("sdk install finalization should select the installed runtime")?;
-        let rebased_paths = paths
-            .clone()
-            .with_managed_root(manifest.install_root.clone(), false);
+        let rebased_paths = paths.with_managed_root(manifest.install_root.clone(), false);
         let config = RocmCliConfig::load(&rebased_paths)?;
 
         assert_eq!(finalized.runtime_key, manifest.runtime_key);
@@ -18232,7 +18200,7 @@ VERSION_ID="41"
         )?;
         let config = RocmCliConfig {
             active_runtime_key: Some(manifest.runtime_key.clone()),
-            default_runtime_id: Some(manifest.runtime_id.clone()),
+            default_runtime_id: Some(manifest.runtime_id),
             ..RocmCliConfig::default()
         };
 
@@ -18477,7 +18445,7 @@ VERSION_ID="41"
         let adopted = adopt_runtime_from_probe(
             &paths,
             AdoptRuntimeRequest {
-                python_executable: python_executable.clone(),
+                python_executable,
                 install_root: external_root.clone(),
                 runtime_id: "therock-release:gfx120X-all".to_owned(),
                 runtime_key: "adopted-release-pip-gfx120x-all-7-13-0".to_owned(),
@@ -18488,9 +18456,9 @@ VERSION_ID="41"
                 rocm_sdk_version: Some("7.13.0".to_owned()),
                 root_path: Some(sdk_root.clone()),
                 bin_path: Some(sdk_bin.clone()),
-                runtime_roots: vec![sdk_root.clone()],
+                runtime_roots: vec![sdk_root],
                 bin_paths: vec![sdk_bin.clone()],
-                library_paths: vec![sdk_bin.clone()],
+                library_paths: vec![sdk_bin],
                 resolved_libraries: vec![
                     therock::RocmSdkLibraryProbe {
                         shortname: "amdhip64".to_owned(),
@@ -19255,7 +19223,7 @@ VERSION_ID="41"
                 engine_runtime_status_label("sglang", &detect),
                 "unsupported_native_windows"
             );
-            let mut atom_detect = detect.clone();
+            let mut atom_detect = detect;
             atom_detect.runtime_kind = Some("external_atom".to_owned());
             atom_detect.available_devices[0].reason = Some(
                 "ATOM ROCm serving is supported by rocm-cli only on Linux/WSL; native Windows ATOM is not enabled. No CPU fallback is used."
@@ -19522,7 +19490,7 @@ VERSION_ID="41"
         )?;
         let config = RocmCliConfig {
             default_runtime_id: Some(manifest.runtime_id.clone()),
-            active_runtime_key: Some(manifest.runtime_key.clone()),
+            active_runtime_key: Some(manifest.runtime_key),
             previous_runtime_key: Some("older-release".to_owned()),
             ..RocmCliConfig::default()
         };

--- a/apps/rocm/src/provider_keys.rs
+++ b/apps/rocm/src/provider_keys.rs
@@ -282,7 +282,7 @@ fn native_entry(provider: &str) -> Result<Entry> {
     bail!("this platform does not have a supported secure credential store")
 }
 
-fn native_store_label() -> &'static str {
+const fn native_store_label() -> &'static str {
     if cfg!(target_vendor = "cosmo") {
         "secure credential store"
     } else if cfg!(target_os = "windows") {

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -14,7 +14,7 @@ pub(crate) const LEMONADE_ASSISTANT_MODEL_ID: &str = "Qwen3-4B-Instruct-2507-GGU
 pub(crate) const BUILTIN_ASSISTANT_MODEL_ID: &str = LEMONADE_ASSISTANT_MODEL_ID;
 const LOCAL_PROVIDER_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const LOCAL_SERVICE_READY_TIMEOUT: Duration = Duration::from_secs(2);
-const REMOTE_PROVIDER_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+const REMOTE_PROVIDER_HTTP_TIMEOUT: Duration = Duration::from_mins(1);
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ProviderStatus {
@@ -467,9 +467,8 @@ fn select_local_chat_service(
             .into_iter()
             .next()
             .context("local provider has no ready managed service for this request");
-    } else {
-        services.retain(local_service_is_builtin_assistant);
     }
+    services.retain(local_service_is_builtin_assistant);
     services.sort_by_key(local_service_priority);
     services.into_iter().next()
         .with_context(|| {
@@ -479,11 +478,11 @@ fn select_local_chat_service(
         })
 }
 
-fn local_service_is_builtin_assistant(service: &ManagedServiceRecord) -> bool {
+const fn local_service_is_builtin_assistant(service: &ManagedServiceRecord) -> bool {
     local_service_priority(service) != usize::MAX
 }
 
-fn local_service_priority(service: &ManagedServiceRecord) -> usize {
+const fn local_service_priority(service: &ManagedServiceRecord) -> usize {
     let model = service.canonical_model_id.as_str();
     if model.eq_ignore_ascii_case(LEMONADE_ASSISTANT_MODEL_ID) {
         0
@@ -1591,7 +1590,7 @@ mod tests {
                     }
                 }
                 let request = String::from_utf8_lossy(&request_bytes).into_owned();
-                let body = format!(r#"{{"data":[{{"id":"{}"}}]}}"#, LEMONADE_ASSISTANT_MODEL_ID);
+                let body = format!(r#"{{"data":[{{"id":"{LEMONADE_ASSISTANT_MODEL_ID}"}}]}}"#);
                 write!(
                     stream,
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -13,6 +13,7 @@ use rocm_core::{
 use rocm_core::{generate_rsa_signing_keypair, sign_rsa_pkcs1_sha256_signature};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::fmt::Write as _;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -83,14 +84,14 @@ impl TheRockChannel {
         }
     }
 
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Release => "release",
             Self::Nightly => "nightly",
         }
     }
 
-    fn tarball_base_url(self) -> &'static str {
+    const fn tarball_base_url(self) -> &'static str {
         match self {
             Self::Release => THEROCK_RELEASE_TARBALL_BASE,
             Self::Nightly => THEROCK_NIGHTLY_TARBALL_BASE,
@@ -475,7 +476,6 @@ fn ensure_install_format_supported_for_platform(format: &str, windows: bool) -> 
 pub(crate) fn render_update_report(paths: &AppPaths) -> Result<String> {
     let manifests = load_runtime_manifests(paths)?;
     let mut output = String::new();
-    use std::fmt::Write as _;
     let _ = writeln!(output, "update");
     let _ = writeln!(
         output,
@@ -659,7 +659,7 @@ fn startup_update_check_disabled() -> bool {
     std::env::var_os("ROCM_CLI_DISABLE_STARTUP_UPDATE_CHECK").is_some()
 }
 
-fn startup_update_check_due(previous_unix_ms: u128, now_unix_ms: u128) -> bool {
+const fn startup_update_check_due(previous_unix_ms: u128, now_unix_ms: u128) -> bool {
     now_unix_ms.saturating_sub(previous_unix_ms) >= STARTUP_UPDATE_CHECK_INTERVAL_MS
 }
 
@@ -807,7 +807,6 @@ fn install_wheel_runtime(
     let manifest_path = runtime_manifest_path(paths, &runtime_key);
 
     let mut output = String::new();
-    use std::fmt::Write as _;
     let _ = writeln!(output, "sdk install");
     let _ = writeln!(
         output,
@@ -880,8 +879,7 @@ fn install_wheel_runtime(
         let _ = writeln!(output, "  mode: dry-run");
         let _ = writeln!(
             output,
-            "  command: uv {} && uv {}",
-            venv_args_display, install_args_display
+            "  command: uv {venv_args_display} && uv {install_args_display}"
         );
         let _ = writeln!(
             output,
@@ -1025,7 +1023,6 @@ fn install_tarball_runtime(
     let cache_path = paths.cache_dir.join("therock").join(&artifact.file_name);
 
     let mut output = String::new();
-    use std::fmt::Write as _;
     let _ = writeln!(output, "sdk install");
     let _ = writeln!(output, "  channel: {}", channel.as_str());
     let _ = writeln!(output, "  format: tarball");
@@ -1145,9 +1142,7 @@ fn resolve_pip_runtime_with_timeout(
         version_selector,
     )
     .with_context(|| {
-        let requested = version_selector
-            .map(RuntimeVersionSelector::describe)
-            .unwrap_or_else(|| "latest compatible version".to_owned());
+        let requested = version_selector.map_or_else(|| "latest compatible version".to_owned(), RuntimeVersionSelector::describe);
         format!(
             "no mutually compatible TheRock rocm[libraries,devel], torch, torchvision, and torchaudio versions were found for {requested} in {index_url}"
         )
@@ -1320,9 +1315,7 @@ fn channel_rocm_candidates(versions: &[String], channel: TheRockChannel) -> Vec<
         let stable = all
             .iter()
             .filter(|version| {
-                parse_version(version)
-                    .map(|parsed| parsed.stage == VersionStage::Stable)
-                    .unwrap_or(false)
+                parse_version(version).is_some_and(|parsed| parsed.stage == VersionStage::Stable)
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -1341,9 +1334,7 @@ fn select_latest_stack_package(
     let mut candidates = package_versions_matching_rocm(versions, rocm_version)
         .into_iter()
         .filter(|version| {
-            parse_package_base_version(version)
-                .map(|base| matches_stack(&base))
-                .unwrap_or(false)
+            parse_package_base_version(version).is_some_and(|base| matches_stack(&base))
         })
         .collect::<Vec<_>>();
     candidates.sort_by(|left, right| compare_version_strings(left, right));
@@ -1429,7 +1420,7 @@ fn normalize_requested_build_date(value: &str) -> Result<String> {
     }
     let digits = trimmed
         .chars()
-        .filter(|ch| ch.is_ascii_digit())
+        .filter(char::is_ascii_digit)
         .collect::<String>();
     if digits.len() != 8 {
         bail!("TheRock build date `{trimmed}` must use YYYY-MM-DD, YYYYMMDD, or MMDDYYYY");
@@ -1480,7 +1471,7 @@ fn validate_date_components(year: u32, month: u32, day: u32) -> Result<()> {
     Ok(())
 }
 
-fn days_in_month(year: u32, month: u32) -> u32 {
+const fn days_in_month(year: u32, month: u32) -> u32 {
     match month {
         1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
         4 | 6 | 9 | 11 => 30,
@@ -1490,7 +1481,7 @@ fn days_in_month(year: u32, month: u32) -> u32 {
     }
 }
 
-fn is_leap_year(year: u32) -> bool {
+const fn is_leap_year(year: u32) -> bool {
     (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
 }
 
@@ -1655,10 +1646,7 @@ fn select_latest_version(versions: &[String], channel: TheRockChannel) -> Option
     let mut all = versions.to_vec();
     all.sort_by(|left, right| compare_version_strings(left, right));
     for version in versions {
-        if parse_version(version)
-            .map(|parsed| parsed.stage == VersionStage::Stable)
-            .unwrap_or(false)
-        {
+        if parse_version(version).is_some_and(|parsed| parsed.stage == VersionStage::Stable) {
             stable.push(version.clone());
         }
     }
@@ -1678,7 +1666,7 @@ impl MetadataSignaturePolicy {
         }
     }
 
-    fn active(&self) -> bool {
+    const fn active(&self) -> bool {
         self.required || self.public_key_path.is_some() || self.public_key_pem.is_some()
     }
 
@@ -1705,15 +1693,12 @@ impl MetadataSignaturePolicy {
 }
 
 fn truthy_env(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| {
-            matches!(
-                value.trim(),
-                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
-            )
-        })
-        .unwrap_or(false)
+    std::env::var(name).ok().is_some_and(|value| {
+        matches!(
+            value.trim(),
+            "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+        )
+    })
 }
 
 fn env_nonempty(name: &str) -> Option<String> {
@@ -2022,8 +2007,7 @@ fn http_get(
     }
     let timeout = max_time_secs
         .filter(|value| *value > 0)
-        .map(Duration::from_secs)
-        .unwrap_or_else(|| Duration::from_secs(600));
+        .map_or_else(|| Duration::from_mins(10), Duration::from_secs);
     let agent = ureq::AgentBuilder::new().timeout(timeout).build();
     let mut request = agent.get(url).set("User-Agent", "rocm-cli");
     for (name, value) in headers {
@@ -2057,11 +2041,11 @@ fn http_get(
     })
 }
 
-fn use_curl_http() -> bool {
+const fn use_curl_http() -> bool {
     cfg!(target_vendor = "cosmo")
 }
 
-fn use_windows_powershell_http() -> bool {
+const fn use_windows_powershell_http() -> bool {
     runtime_is_windows() && !cfg!(target_vendor = "cosmo")
 }
 
@@ -2364,7 +2348,7 @@ fn linux_temp_dir(prefix: &str) -> Result<PathBuf> {
         let dir = root.join(format!("{base}-{attempt}"));
         match fs::create_dir(&dir) {
             Ok(()) => return Ok(dir),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(error) => {
                 return Err(error).with_context(|| format!("failed to create {}", dir.display()));
             }
@@ -2383,7 +2367,7 @@ fn windows_temp_dir(prefix: &str) -> Result<PathBuf> {
         let dir = root.join(format!("{base}-{attempt}"));
         match fs::create_dir(&dir) {
             Ok(()) => return Ok(dir),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(error) => {
                 return Err(error).with_context(|| format!("failed to create {}", dir.display()));
             }
@@ -2416,11 +2400,10 @@ fn windows_child_status_success(status: std::process::ExitStatus) -> bool {
 fn windows_http_keep_temp() -> bool {
     std::env::var("ROCM_CLI_DEBUG_WINDOWS_HTTP")
         .ok()
-        .map(|value| {
+        .is_some_and(|value| {
             let value = value.trim().to_ascii_lowercase();
             matches!(value.as_str(), "1" | "true" | "yes" | "on")
         })
-        .unwrap_or(false)
 }
 
 fn windows_http_failure_temp_note(temp_dir: &Path) -> String {
@@ -2431,7 +2414,7 @@ fn windows_http_failure_temp_note(temp_dir: &Path) -> String {
     }
 }
 
-fn windows_http_get_script() -> &'static str {
+const fn windows_http_get_script() -> &'static str {
     r#"
 param(
   [Parameter(Mandatory=$true)][string]$Url,
@@ -2874,7 +2857,7 @@ fn run_command(program: &Path, args: &[&str], context_text: &str) -> Result<()> 
     } else {
         format!("command exited with status {}", output.status)
     };
-    bail!("{}: {}", context_text, detail)
+    bail!("{context_text}: {detail}")
 }
 
 #[allow(dead_code)]
@@ -2913,12 +2896,12 @@ fn run_command_with_env(
         return Ok(());
     }
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-    let detail = if !stderr.is_empty() {
-        stderr
-    } else {
+    let detail = if stderr.is_empty() {
         format!("command exited with status {}", output.status)
+    } else {
+        stderr
     };
-    bail!("{}: {}", context_text, detail)
+    bail!("{context_text}: {detail}")
 }
 
 fn run_uv_progress_command(uv: &Path, args: &[&str], context_text: &str) -> Result<()> {
@@ -2989,11 +2972,10 @@ fn record_managed_python_config(paths: &AppPaths, python: &Path) -> Result<()> {
 fn managed_python_bootstrap_disabled() -> bool {
     std::env::var("ROCM_CLI_DISABLE_MANAGED_PYTHON_BOOTSTRAP")
         .ok()
-        .map(|value| {
+        .is_some_and(|value| {
             let value = value.trim().to_ascii_lowercase();
             matches!(value.as_str(), "1" | "true" | "yes" | "on")
         })
-        .unwrap_or(false)
 }
 
 fn managed_python_version() -> String {
@@ -3212,7 +3194,7 @@ fn verify_python_can_create_venv(program: &Path) -> Result<()> {
         "probe Python virtual environment support",
     );
     let _ = fs::remove_dir_all(&probe_root);
-    result.map(|_| ())
+    result
 }
 
 fn python_venv_probe_temp_root() -> Result<PathBuf> {
@@ -3254,7 +3236,7 @@ fn parse_version(value: &str) -> Option<ParsedVersion> {
 
     let patch_len = patch_and_rest
         .chars()
-        .take_while(|ch| ch.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
         .count();
     if patch_len == 0 {
         return None;
@@ -3285,7 +3267,7 @@ fn therock_index_url(family: &str) -> String {
     format!("{THEROCK_PIP_INDEX_BASE}/{family}")
 }
 
-fn platform_tarball_token() -> &'static str {
+const fn platform_tarball_token() -> &'static str {
     if runtime_is_windows() {
         "windows"
     } else {
@@ -3648,6 +3630,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn python_launcher_prefers_path_python_before_saved_managed_python() -> Result<()> {
         let _guard = PYTHON_RESOLVER_TEST_ENV_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-prefers-path");
@@ -3668,7 +3651,7 @@ mod tests {
         // Keep PATH hermetic: appending the real PATH lets a genuine cp312
         // python (present on CI) win over the fake one and breaks the
         // executable assertion. The fake on PATH is all this test needs.
-        let joined_path = std::env::join_paths([bin_dir.clone()])?;
+        let joined_path = std::env::join_paths([bin_dir])?;
         unsafe {
             std::env::set_var("PATH", joined_path);
             std::env::remove_var("ROCM_CLI_PYTHON");
@@ -3706,6 +3689,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn python_venv_probe_temp_root_uses_windows_temp_env() -> Result<()> {
         if !runtime_is_windows() {
             return Ok(());
@@ -3756,6 +3740,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn python_launcher_prefers_path_python_over_managed_when_venv_capable() -> Result<()> {
         let _guard = PYTHON_RESOLVER_TEST_ENV_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-path-over-managed");
@@ -3766,14 +3751,14 @@ mod tests {
         fs::create_dir_all(&managed_dir)?;
         let managed_python = write_fake_python_with_venv(&managed_dir, "python")?;
         let manifest = ManagedPythonManifest {
-            executable: managed_python.clone(),
+            executable: managed_python,
             version: "3.12".to_owned(),
             installed_at_unix_ms: 123,
         };
         save_managed_python_manifest(&paths, &manifest)?;
         let old_path = std::env::var_os("PATH");
         let old_rocm_cli_python = std::env::var_os("ROCM_CLI_PYTHON");
-        let joined_path = std::env::join_paths([bin_dir.clone()])?;
+        let joined_path = std::env::join_paths([bin_dir])?;
         unsafe {
             std::env::set_var("PATH", joined_path);
             std::env::remove_var("ROCM_CLI_PYTHON");
@@ -3798,6 +3783,7 @@ mod tests {
 
     #[cfg(unix)]
     fn write_fake_python_with_venv(dir: &Path, name: &str) -> Result<PathBuf> {
+        use std::os::unix::fs::PermissionsExt;
         let path = dir.join(name);
         let script = r#"#!/bin/sh
 if [ "$1" = "-c" ]; then
@@ -3816,7 +3802,6 @@ fi
 echo Python 3.12.10
 "#;
         fs::write(&path, script)?;
-        use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755))?;
         Ok(path)
     }
@@ -4124,7 +4109,7 @@ echo Python 3.12.10
                 format: manifest.format.clone(),
                 family: manifest.family.clone(),
                 installed_version: manifest.version.clone(),
-                latest_version: Some(manifest.version.clone()),
+                latest_version: Some(manifest.version),
                 status: "up_to_date".to_owned(),
                 message: None,
                 checked_at_unix_ms: 2_000,
@@ -4366,8 +4351,7 @@ echo Python 3.12.10
             format: "wheel".to_owned(),
             family: runtime_id
                 .split_once(':')
-                .map(|(_, family)| family.to_owned())
-                .unwrap_or_else(|| "gfx120X-all".to_owned()),
+                .map_or_else(|| "gfx120X-all".to_owned(), |(_, family)| family.to_owned()),
             family_source: "test".to_owned(),
             version: "7.13.0a20260416".to_owned(),
             install_root: PathBuf::from("runtime-root"),

--- a/apps/rocm/src/tui.rs
+++ b/apps/rocm/src/tui.rs
@@ -62,7 +62,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 const GPU_MONITOR_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-const GPU_STATIC_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+const GPU_STATIC_REFRESH_INTERVAL: Duration = Duration::from_mins(5);
 const GPU_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const GPU_AMD_SMI_TIMEOUT: Duration = Duration::from_millis(1_500);
 const TUI_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -450,9 +450,9 @@ fn is_doctor_command_input(command: &str) -> bool {
 }
 
 fn tui_mode_for_cli_args(args: &[String]) -> TuiMode {
-    args.first()
-        .map(|head| tui_mode_for_command(head, args.len() > 1))
-        .unwrap_or(TuiMode::Ask)
+    args.first().map_or(TuiMode::Ask, |head| {
+        tui_mode_for_command(head, args.len() > 1)
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -519,7 +519,7 @@ impl TranscriptLine {
         }
     }
 
-    fn blank() -> Self {
+    const fn blank() -> Self {
         Self {
             kind: TranscriptLineKind::Blank,
             text: String::new(),
@@ -919,14 +919,14 @@ enum ServiceLifecycleAction {
 }
 
 impl ServiceLifecycleAction {
-    fn command_word(self) -> &'static str {
+    const fn command_word(self) -> &'static str {
         match self {
             Self::Stop => "stop",
             Self::Restart => "restart",
         }
     }
 
-    fn tool_name(self) -> &'static str {
+    const fn tool_name(self) -> &'static str {
         match self {
             Self::Stop => "stop_server",
             Self::Restart => "restart_server",
@@ -940,14 +940,14 @@ impl ServiceLifecycleAction {
         }
     }
 
-    fn success_title(self) -> &'static str {
+    const fn success_title(self) -> &'static str {
         match self {
             Self::Stop => "Service stopped.",
             Self::Restart => "Service restart started.",
         }
     }
 
-    fn failure_title(self) -> &'static str {
+    const fn failure_title(self) -> &'static str {
         match self {
             Self::Stop => "Service stop failed.",
             Self::Restart => "Service restart failed.",
@@ -1009,14 +1009,14 @@ enum RuntimeAdoptChannel {
 }
 
 impl RuntimeAdoptChannel {
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Release => "release",
             Self::Nightly => "nightly",
         }
     }
 
-    fn toggle(self) -> Self {
+    const fn toggle(self) -> Self {
         match self {
             Self::Release => Self::Nightly,
             Self::Nightly => Self::Release,
@@ -1083,7 +1083,7 @@ enum InstallSdkChannel {
 }
 
 impl InstallSdkChannel {
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Release => "release",
             Self::Nightly => "nightly",
@@ -1098,7 +1098,7 @@ enum InstallSdkFormat {
 }
 
 impl InstallSdkFormat {
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Wheel => "wheel",
             Self::Tarball => "tarball",
@@ -1296,7 +1296,7 @@ enum CommandOutputStream {
 }
 
 impl CommandOutputStream {
-    fn label(self) -> &'static str {
+    const fn label(self) -> &'static str {
         match self {
             Self::Stdout => "stdout",
             Self::Stderr => "stderr",
@@ -1555,7 +1555,6 @@ impl GpuTelemetry {
 
     fn sidebar_text(&self) -> String {
         let mut output = String::new();
-        use std::fmt::Write as _;
 
         let _ = writeln!(output, "GPU status:");
         if self.static_cards.is_empty() && self.monitor_cards.is_empty() {
@@ -1595,7 +1594,6 @@ impl GpuTelemetry {
 
     fn detail_text(&self) -> String {
         let mut output = String::new();
-        use std::fmt::Write as _;
 
         let _ = writeln!(output, "GPU status");
         if self.static_cards.is_empty() && self.monitor_cards.is_empty() {
@@ -1640,8 +1638,7 @@ impl GpuTelemetry {
                 "  Compute units: {}",
                 static_card
                     .and_then(|card| card.compute_units)
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "unknown".to_owned())
+                    .map_or_else(|| "unknown".to_owned(), |value| value.to_string())
             );
             let _ = writeln!(
                 output,
@@ -2076,8 +2073,7 @@ fn format_activity_log_line(line: &str) -> String {
         .unwrap_or("unknown");
     let message = line
         .split_once(" message=")
-        .map(|(_, message)| message)
-        .unwrap_or(line);
+        .map_or(line, |(_, message)| message);
     truncate_activity_message(format!("log: {action} - {message}"))
 }
 
@@ -2199,7 +2195,7 @@ impl App {
         let _ = recover_setup_runtime_registration(&self.paths, &self.config);
     }
 
-    fn should_show_onboarding(&self) -> bool {
+    const fn should_show_onboarding(&self) -> bool {
         !self.config.onboarding_dismissed
     }
 
@@ -2322,8 +2318,7 @@ impl App {
         let selected = self
             .doctor_manager
             .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+            .map_or(0, |state| state.selected);
         if let Some(state) = self.doctor_manager.as_mut() {
             state.selected = selected.min(doctor_manager_choices().len().saturating_sub(1));
             state.detail_scroll = 0;
@@ -2360,15 +2355,14 @@ impl App {
         let selected = self
             .doctor_manager
             .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+            .map_or(0, |state| state.selected);
         doctor_manager_choices()
             .get(selected)
             .copied()
             .unwrap_or(DoctorManagerChoice::Overview)
     }
 
-    fn scroll_doctor_manager_detail(&mut self, lines: i16) {
+    const fn scroll_doctor_manager_detail(&mut self, lines: i16) {
         let Some(state) = self.doctor_manager.as_mut() else {
             return;
         };
@@ -2454,8 +2448,7 @@ impl App {
         let screen = self
             .runtime_manager
             .as_ref()
-            .map(|state| state.screen.clone())
-            .unwrap_or(RuntimeManagerScreen::List);
+            .map_or(RuntimeManagerScreen::List, |state| state.screen.clone());
         self.refresh_config();
         match runtime_manager_items(&self.paths, &self.config) {
             Ok(items) => {
@@ -2920,10 +2913,10 @@ impl App {
                 match self.selected_runtime_manager_action() {
                     Some(RuntimeManagerAction::Install) => self.request_runtime_manager_install(),
                     Some(RuntimeManagerAction::RemoveSelected) => {
-                        self.request_runtime_manager_uninstall()
+                        self.request_runtime_manager_uninstall();
                     }
                     Some(RuntimeManagerAction::AdvancedOptions) => {
-                        self.open_runtime_advanced_options()
+                        self.open_runtime_advanced_options();
                     }
                     None => self.request_runtime_manager_install(),
                 }
@@ -2938,7 +2931,7 @@ impl App {
             RuntimeManagerScreen::ImportManifest { selected, .. } => {
                 match runtime_import_choices().get(*selected).copied() {
                     Some(RuntimeImportChoice::ManifestPath) => {
-                        self.start_runtime_import_path_edit()
+                        self.start_runtime_import_path_edit();
                     }
                     Some(RuntimeImportChoice::Replace) => self.toggle_runtime_import_replace(),
                     Some(RuntimeImportChoice::Import) => self.request_runtime_import_from_form(),
@@ -3075,8 +3068,7 @@ impl App {
         let selected = self
             .install_manager
             .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+            .map_or(0, |state| state.selected);
         install_menu_choices()
             .get(selected)
             .copied()
@@ -3519,10 +3511,10 @@ impl App {
         match self.selected_engine_manager_action() {
             Some(EngineManagerAction::UseSelected) => self.request_selected_engine_default(),
             Some(EngineManagerAction::InstallSelected) => {
-                self.request_selected_engine_install(false)
+                self.request_selected_engine_install(false);
             }
             Some(EngineManagerAction::ReinstallSelected) => {
-                self.request_selected_engine_install(true)
+                self.request_selected_engine_install(true);
             }
             Some(EngineManagerAction::InstallRocm) => self.open_install_manager(),
             Some(EngineManagerAction::Back) => self.close_engine_manager(),
@@ -3647,23 +3639,20 @@ impl App {
         let Some(state) = self.model_picker.as_mut() else {
             return;
         };
-        match state
+        if let Some(index) = state
             .items
             .iter()
             .position(|recipe| recipe.matches_ref(query))
         {
-            Some(index) => {
-                state.selected = index;
-                state.detail_scroll = 0;
-                state.message = None;
-                self.status = "Model selected. Press Enter to start setup.".to_owned();
-            }
-            None => {
-                state.message = Some(format!(
-                    "I could not find `{query}` in the built-in model list.\n\nUse the arrow keys to choose a model, then press Enter."
-                ));
-                self.status = "Choose a model from the list.".to_owned();
-            }
+            state.selected = index;
+            state.detail_scroll = 0;
+            state.message = None;
+            self.status = "Model selected. Press Enter to start setup.".to_owned();
+        } else {
+            state.message = Some(format!(
+                "I could not find `{query}` in the built-in model list.\n\nUse the arrow keys to choose a model, then press Enter."
+            ));
+            self.status = "Choose a model from the list.".to_owned();
         }
     }
 
@@ -3833,8 +3822,7 @@ impl App {
         state.host = plan.host.unwrap_or_else(|| DEFAULT_LOCAL_HOST.to_owned());
         state.port = plan
             .port
-            .map(|port| port.to_string())
-            .unwrap_or_else(|| DEFAULT_LOCAL_PORT.to_string());
+            .map_or_else(|| DEFAULT_LOCAL_PORT.to_string(), |port| port.to_string());
         state.runtime_id = runtime_id;
         state.env_id = env_id;
         state.allow_public_bind = allow_public_bind;
@@ -3909,11 +3897,7 @@ impl App {
     }
 
     fn selected_serve_wizard_choice(&self) -> ServeWizardChoice {
-        let selected = self
-            .serve_wizard
-            .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+        let selected = self.serve_wizard.as_ref().map_or(0, |state| state.selected);
         serve_wizard_choices()
             .get(selected)
             .copied()
@@ -4076,7 +4060,7 @@ impl App {
             ServeWizardChoice::Source => self.toggle_serve_wizard_model_source(),
             ServeWizardChoice::Model => self.cycle_serve_wizard_model(CompletionDirection::Next),
             ServeWizardChoice::Engine | ServeWizardChoice::Device | ServeWizardChoice::Mode => {
-                self.cycle_serve_wizard_value(CompletionDirection::Next)
+                self.cycle_serve_wizard_value(CompletionDirection::Next);
             }
             ServeWizardChoice::LocalPath => {
                 if self
@@ -4087,14 +4071,14 @@ impl App {
                     self.status =
                         "Change Model type to my own model file before editing Path.".to_owned();
                 } else {
-                    self.start_serve_wizard_field_edit(ServeWizardEditField::LocalPath)
+                    self.start_serve_wizard_field_edit(ServeWizardEditField::LocalPath);
                 }
             }
             ServeWizardChoice::Host => {
-                self.start_serve_wizard_field_edit(ServeWizardEditField::Host)
+                self.start_serve_wizard_field_edit(ServeWizardEditField::Host);
             }
             ServeWizardChoice::Port => {
-                self.start_serve_wizard_field_edit(ServeWizardEditField::Port)
+                self.start_serve_wizard_field_edit(ServeWizardEditField::Port);
             }
             ServeWizardChoice::Review => self.review_serve_wizard_plan(),
             ServeWizardChoice::Back => self.close_serve_wizard(),
@@ -4400,8 +4384,7 @@ impl App {
         let selected = self
             .update_manager
             .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+            .map_or(0, |state| state.selected);
         update_menu_choices()
             .get(selected)
             .copied()
@@ -5065,8 +5048,7 @@ impl App {
         let selected = self
             .config_manager
             .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+            .map_or(0, |state| state.selected);
         config_menu_choices()
             .get(selected)
             .copied()
@@ -5540,7 +5522,7 @@ impl App {
             ConfigProviderChoice::ClearKey => self.start_clear_config_provider_key_confirmation(),
             ConfigProviderChoice::ConfirmClearKey => self.confirm_clear_config_provider_key(),
             ConfigProviderChoice::CancelClearKey => {
-                self.cancel_clear_config_provider_key_confirmation()
+                self.cancel_clear_config_provider_key_confirmation();
             }
             ConfigProviderChoice::Back => self.close_config_provider_settings(),
         }
@@ -5581,7 +5563,7 @@ impl App {
             ConfigMenuChoice::DefaultEngine => self.open_engine_manager(),
             ConfigMenuChoice::DefaultRuntime => self.open_runtime_manager(),
             ConfigMenuChoice::Permissions => {
-                self.open_command_screen_target(CommandScreenTarget::Permissions)
+                self.open_command_screen_target(CommandScreenTarget::Permissions);
             }
             ConfigMenuChoice::ShowSetupAgain => self.open_setup_again_confirmation(),
             ConfigMenuChoice::Back => self.close_config_manager(),
@@ -5591,7 +5573,7 @@ impl App {
     fn handle_config_command_args(&mut self, args: &[&str]) {
         self.open_config_manager();
         match args {
-            [] | ["show"] | ["status"] => {}
+            [] | ["show" | "status"] => {}
             ["set-telemetry", mode] if matches!(*mode, "local" | "off") => {
                 self.select_config_menu_choice(ConfigMenuChoice::Telemetry);
                 self.set_active_screen_message(format!(
@@ -6002,9 +5984,10 @@ impl App {
             state.chat_session = Some(session);
         }
         self.sync_chat_session_actions();
-        self.status = endpoint_url
-            .map(|url| format!("Local assistant ready at {url}."))
-            .unwrap_or_else(|| "Local assistant ready.".to_owned());
+        self.status = endpoint_url.map_or_else(
+            || "Local assistant ready.".to_owned(),
+            |url| format!("Local assistant ready at {url}."),
+        );
     }
 
     fn open_local_assistant_start_flow(&mut self, model: Option<String>) {
@@ -6120,7 +6103,7 @@ impl App {
                     state.chat_model = Some(record.canonical_model_id.clone());
                     session.model = Some(record.canonical_model_id.clone());
                     session.service_id = Some(record.service_id.clone());
-                    session.endpoint_url = Some(record.endpoint_url.clone());
+                    session.endpoint_url = Some(record.endpoint_url);
                 }
                 self.sync_chat_session_actions();
                 self.status = format!("Local assistant ready at {endpoint}.");
@@ -6144,20 +6127,20 @@ impl App {
                 "failed" | "unreachable" | "exited" => {
                     "Local assistant did not start.\n\nOpen logs for the reason.".to_owned()
                 }
-                _ => selected_record
-                    .as_ref()
-                    .map(|record| format!("Starting at {}.", record.endpoint_url))
-                    .unwrap_or_else(|| "Local assistant is starting.".to_owned()),
+                _ => selected_record.as_ref().map_or_else(
+                    || "Local assistant is starting.".to_owned(),
+                    |record| format!("Starting at {}.", record.endpoint_url),
+                ),
             });
         }
         self.status = match selected_status.as_str() {
             "failed" | "unreachable" | "exited" => {
                 "Local assistant failed to start. Open logs for the reason.".to_owned()
             }
-            _ => selected_record
-                .as_ref()
-                .map(|record| format!("Local assistant starting at {}.", record.endpoint_url))
-                .unwrap_or_else(|| "Local assistant is starting.".to_owned()),
+            _ => selected_record.as_ref().map_or_else(
+                || "Local assistant is starting.".to_owned(),
+                |record| format!("Local assistant starting at {}.", record.endpoint_url),
+            ),
         };
     }
 
@@ -6197,10 +6180,10 @@ impl App {
             Some(ServicesManagerAction::Chat) => self.open_selected_service_chat(),
             Some(ServicesManagerAction::OpenLogs) => self.open_selected_service_logs(),
             Some(ServicesManagerAction::Stop) => {
-                self.request_selected_service_lifecycle(ServiceLifecycleAction::Stop)
+                self.request_selected_service_lifecycle(ServiceLifecycleAction::Stop);
             }
             Some(ServicesManagerAction::Restart) => {
-                self.request_selected_service_lifecycle(ServiceLifecycleAction::Restart)
+                self.request_selected_service_lifecycle(ServiceLifecycleAction::Restart);
             }
             Some(ServicesManagerAction::Back) => self.close_services_manager(),
             None => self.open_selected_service_logs(),
@@ -6266,7 +6249,7 @@ impl App {
             [] | ["status"] => {
                 self.open_command_screen_target(CommandScreenTarget::Permissions);
             }
-            ["full-access"] | ["full"] => {
+            ["full-access" | "full"] => {
                 self.open_command_screen_target(CommandScreenTarget::Permissions);
                 if self.config.permissions.full_access_enabled() {
                     self.status = "Full access is already on.".to_owned();
@@ -6281,7 +6264,7 @@ impl App {
                         "Confirm full access with Enter/Y, or cancel with Esc/N.".to_owned();
                 }
             }
-            ["ask"] | ["reset"] => {
+            ["ask" | "reset"] => {
                 self.open_command_screen_target(CommandScreenTarget::Permissions);
                 if let Some(state) = self.command_screen.as_mut() {
                     if let Some(index) = state
@@ -6803,33 +6786,33 @@ impl App {
     fn perform_onboarding_selected_action(&mut self) {
         match self.selected_onboarding_choice() {
             OnboardingMenuChoice::Folder if self.pending_approval.is_none() => {
-                self.open_onboarding_install_folder_browser()
+                self.open_onboarding_install_folder_browser();
             }
             OnboardingMenuChoice::Primary if self.pending_approval.is_some() => {
                 self.approve_focused_action();
                 self.reset_onboarding_selection();
             }
             OnboardingMenuChoice::Primary if self.running_job.is_none() => {
-                self.perform_onboarding_primary_action()
+                self.perform_onboarding_primary_action();
             }
             OnboardingMenuChoice::Reinstall if self.pending_approval.is_none() => {
-                self.request_onboarding_reinstall()
+                self.request_onboarding_reinstall();
             }
             OnboardingMenuChoice::Uninstall if self.pending_approval.is_none() => {
-                self.request_onboarding_uninstall()
+                self.request_onboarding_uninstall();
             }
             OnboardingMenuChoice::ShowLog if self.pending_approval.is_none() => {
-                self.toggle_onboarding_log_file()
+                self.toggle_onboarding_log_file();
             }
             OnboardingMenuChoice::Back if self.pending_approval.is_some() => {
                 self.cancel_focused_action();
                 self.reset_onboarding_selection();
             }
             OnboardingMenuChoice::Back if self.running_job.is_none() => {
-                self.return_from_onboarding()
+                self.return_from_onboarding();
             }
             OnboardingMenuChoice::Quit if self.running_job.is_none() => {
-                self.request_quit_overlay_or_wait()
+                self.request_quit_overlay_or_wait();
             }
             _ => {}
         }
@@ -6942,7 +6925,7 @@ impl App {
         }
     }
 
-    fn should_draw_home_dashboard(&self) -> bool {
+    const fn should_draw_home_dashboard(&self) -> bool {
         self.home_dashboard_visible
             && !self.onboarding_active
             && self.doctor_manager.is_none()
@@ -7421,7 +7404,7 @@ impl App {
         self.status = "Use Enter to choose, or Esc to close this card.".to_owned();
     }
 
-    fn scroll_overlay_card_detail(&mut self, lines: i16) {
+    const fn scroll_overlay_card_detail(&mut self, lines: i16) {
         let Some(state) = self.overlay_card.as_mut() else {
             return;
         };
@@ -7686,7 +7669,7 @@ impl App {
     }
 
     fn finish_onboarding_install_folder_choice(&mut self, folder: PathBuf) {
-        self.config.setup.therock_venv = Some(folder.clone());
+        self.config.setup.therock_venv = Some(folder);
         match self.config.save(&self.paths) {
             Ok(()) => {
                 self.rebase_paths_to_saved_setup_folder();
@@ -7754,8 +7737,7 @@ impl App {
         let cpu_mode_not_offered = action.is_none() && plan_request_mentions_cpu_mode(request);
         self.mode = action
             .as_ref()
-            .map(|action| tui_mode_for_cli_args(&action.args))
-            .unwrap_or(TuiMode::Ask);
+            .map_or(TuiMode::Ask, |action| tui_mode_for_cli_args(&action.args));
         let detail = if cpu_mode_not_offered {
             render_plan_cpu_not_offered_text(request)
         } else {
@@ -7912,16 +7894,16 @@ impl App {
             }
             CommandScreenTarget::Gpu => {
                 self.refresh_config();
-                if !self.config.telemetry.local_inspection_enabled() {
-                    self.gpu_telemetry.clear();
-                    ("GPU".to_owned(), disabled_gpu_telemetry_text(&self.config))
-                } else {
+                if self.config.telemetry.local_inspection_enabled() {
                     if force_refresh {
                         self.gpu_telemetry.force_refresh();
                     } else {
                         self.gpu_telemetry.maybe_refresh();
                     }
                     ("GPU".to_owned(), self.gpu_telemetry.detail_text())
+                } else {
+                    self.gpu_telemetry.clear();
+                    ("GPU".to_owned(), disabled_gpu_telemetry_text(&self.config))
                 }
             }
             CommandScreenTarget::Daemon => {
@@ -8049,7 +8031,7 @@ impl App {
                     .saturating_sub(1)
     }
 
-    fn set_chat_session_follow_if_needed(&mut self, should_follow: bool) {
+    const fn set_chat_session_follow_if_needed(&mut self, should_follow: bool) {
         if should_follow
             && let Some(state) = self.command_screen.as_mut()
             && state.chat_session.is_some()
@@ -8120,7 +8102,7 @@ impl App {
         false
     }
 
-    fn active_manager_detail_scroll_mut(&mut self) -> Option<&mut u16> {
+    const fn active_manager_detail_scroll_mut(&mut self) -> Option<&mut u16> {
         if let Some(state) = self.runtime_manager.as_mut() {
             return Some(&mut state.detail_scroll);
         }
@@ -8154,7 +8136,7 @@ impl App {
         None
     }
 
-    fn scroll_active_manager_detail(&mut self, lines: i16) {
+    const fn scroll_active_manager_detail(&mut self, lines: i16) {
         let Some(scroll) = self.active_manager_detail_scroll_mut() else {
             return;
         };
@@ -8171,13 +8153,7 @@ impl App {
         };
         pending.selected = match direction {
             CompletionDirection::Next => (pending.selected + 1) % 2,
-            CompletionDirection::Previous => {
-                if pending.selected == 0 {
-                    1
-                } else {
-                    0
-                }
-            }
+            CompletionDirection::Previous => usize::from(pending.selected == 0),
         };
         self.set_pending_approval_selection_status();
     }
@@ -8186,7 +8162,7 @@ impl App {
         let Some(pending) = self.pending_approval.as_mut() else {
             return;
         };
-        pending.selected = if approve { 0 } else { 1 };
+        pending.selected = usize::from(!approve);
         self.set_pending_approval_selection_status();
     }
 
@@ -8322,8 +8298,7 @@ impl App {
         let rocm_tools = self
             .command_screen
             .as_ref()
-            .map(|state| state.chat_tools)
-            .unwrap_or(false);
+            .is_some_and(|state| state.chat_tools);
         if prompt.trim().is_empty() {
             if let Some(state) = self.command_screen.as_mut() {
                 state.message =
@@ -8356,8 +8331,7 @@ impl App {
         let rocm_tools = self
             .command_screen
             .as_ref()
-            .map(|state| state.chat_tools)
-            .unwrap_or(false);
+            .is_some_and(|state| state.chat_tools);
         self.close_command_screen();
         self.set_input(if prompt.trim().is_empty() {
             if rocm_tools {
@@ -8388,7 +8362,7 @@ impl App {
         if self.handle_pending_chat_install_folder(&prompt) {
             return true;
         }
-        if let Some(reply) = self.simple_chat_session_reply(&prompt) {
+        if let Some(reply) = Self::simple_chat_session_reply(&prompt) {
             self.push_chat_session_turn(ChatSessionRole::User, prompt);
             self.push_chat_session_turn(ChatSessionRole::Assistant, reply);
             if let Some(state) = self.command_screen.as_mut() {
@@ -8579,7 +8553,7 @@ impl App {
         self.request_screen_cli_approval_with_explanation(
             pending_title,
             command_title,
-            args.to_vec(),
+            args,
             Some(display_command),
             Some(reason.to_owned()),
         );
@@ -8675,7 +8649,7 @@ impl App {
         }
     }
 
-    fn simple_chat_session_reply(&self, prompt: &str) -> Option<String> {
+    fn simple_chat_session_reply(prompt: &str) -> Option<String> {
         if !is_plain_casual_input(prompt) {
             return None;
         }
@@ -8929,7 +8903,7 @@ impl App {
         self.services_manager = None;
         self.command_screen = None;
         self.logs_view = Some(LogsViewState {
-            query: query.clone(),
+            query,
             service_id: None,
             page,
             follow,
@@ -8943,7 +8917,7 @@ impl App {
                 0
             },
             detail_scroll: 0,
-            last_rendered: rendered.clone(),
+            last_rendered: rendered,
             last_refresh_at: Instant::now(),
             editing_search: false,
             detail_modal: None,
@@ -9022,7 +8996,7 @@ impl App {
             show_file_locations: false,
             selected: current.selected,
             detail_scroll: current.detail_scroll,
-            last_rendered: rendered.clone(),
+            last_rendered: rendered,
             last_refresh_at: Instant::now(),
             editing_search: false,
             detail_modal: None,
@@ -9130,7 +9104,7 @@ impl App {
         self.status = "Log action selected. Press Enter to continue.".to_owned();
     }
 
-    fn scroll_logs_view_detail(&mut self, lines: i16) {
+    const fn scroll_logs_view_detail(&mut self, lines: i16) {
         let Some(state) = self.logs_view.as_mut() else {
             return;
         };
@@ -9329,7 +9303,7 @@ impl App {
         }
     }
 
-    fn scroll_up(&mut self, lines: u16) {
+    const fn scroll_up(&mut self, lines: u16) {
         self.transcript_scroll = self.transcript_scroll.saturating_sub(lines);
     }
 
@@ -9340,7 +9314,7 @@ impl App {
             .min(self.max_scroll());
     }
 
-    fn reset_completion_selection(&mut self) {
+    const fn reset_completion_selection(&mut self) {
         self.completion_selection = 0;
     }
 
@@ -9375,8 +9349,7 @@ impl App {
         self.input
             .char_indices()
             .nth(self.input_cursor)
-            .map(|(index, _)| index)
-            .unwrap_or(self.input.len())
+            .map_or(self.input.len(), |(index, _)| index)
     }
 
     fn input_byte_index_for_char(&self, char_index: usize) -> usize {
@@ -9386,8 +9359,7 @@ impl App {
         self.input
             .char_indices()
             .nth(char_index)
-            .map(|(index, _)| index)
-            .unwrap_or(self.input.len())
+            .map_or(self.input.len(), |(index, _)| index)
     }
 
     fn insert_input_char(&mut self, ch: char) {
@@ -9430,7 +9402,7 @@ impl App {
         self.set_chat_session_follow_if_needed(should_follow_chat);
     }
 
-    fn move_input_left(&mut self) {
+    const fn move_input_left(&mut self) {
         self.input_cursor = self.input_cursor.saturating_sub(1);
     }
 
@@ -9441,7 +9413,7 @@ impl App {
             .min(self.input_len_chars());
     }
 
-    fn move_input_start(&mut self) {
+    const fn move_input_start(&mut self) {
         self.input_cursor = 0;
         self.chat_input_scroll = 0;
     }
@@ -9941,8 +9913,7 @@ impl App {
                         } else {
                             let engine = self
                                 .selected_engine_manager_item()
-                                .map(|item| item.name)
-                                .unwrap_or_else(|| args[1].to_owned());
+                                .map_or_else(|| args[1].to_owned(), |item| item.name);
                             self.request_engine_install(&engine, reinstall);
                         }
                     }
@@ -10235,25 +10206,22 @@ impl App {
                         return true;
                     };
                     let mode = if action == "enable" && args.len() > 2 {
-                        match args.as_slice() {
-                            ["enable", _, "--mode", mode] => match parse_watcher_mode(mode) {
-                                Some(mode) => Some(mode),
-                                None => {
-                                    self.set_active_screen_message(
-                                        "Choose one of these settings: observe, propose, contained.",
-                                    );
-                                    self.status =
-                                        "Automation setting was not recognized.".to_owned();
-                                    return true;
-                                }
-                            },
-                            _ => {
+                        if let ["enable", _, "--mode", mode] = args.as_slice() {
+                            if let Some(mode) = parse_watcher_mode(mode) {
+                                Some(mode)
+                            } else {
                                 self.set_active_screen_message(
-                                    "Choose an automation check with the arrow keys, then press Enter.",
+                                    "Choose one of these settings: observe, propose, contained.",
                                 );
-                                self.status = "Automation option was not recognized.".to_owned();
+                                self.status = "Automation setting was not recognized.".to_owned();
                                 return true;
                             }
+                        } else {
+                            self.set_active_screen_message(
+                                "Choose an automation check with the arrow keys, then press Enter.",
+                            );
+                            self.status = "Automation option was not recognized.".to_owned();
+                            return true;
                         }
                     } else if action == "disable" && args.len() > 2 {
                         self.set_active_screen_message(
@@ -10329,11 +10297,9 @@ impl App {
                 true
             }
             "comfyui" | "comfy" => {
-                let showing_logs = matches!(args.as_slice(), ["logs"] | ["log"]);
-                let showing_log_files = matches!(
-                    args.as_slice(),
-                    ["log-files"] | ["logs", "files"] | ["log", "files"]
-                );
+                let showing_logs = matches!(args.as_slice(), ["logs" | "log"]);
+                let showing_log_files =
+                    matches!(args.as_slice(), ["log-files"] | ["logs" | "log", "files"]);
                 if showing_logs || showing_log_files {
                     let (title, detail, status) = if showing_logs {
                         (
@@ -10361,7 +10327,7 @@ impl App {
                     self.status = status.to_owned();
                     return true;
                 }
-                let showing_models_path = matches!(args.as_slice(), ["models-path"] | ["models"]);
+                let showing_models_path = matches!(args.as_slice(), ["models-path" | "models"]);
                 let mut detail = if showing_models_path {
                     crate::comfyui::render_models_path(&self.paths)
                         .map(|path| format!("Models path\n\n{}", path.trim()))
@@ -10394,9 +10360,9 @@ impl App {
                 let selected_command = match args.as_slice() {
                     ["install"] => "comfyui install",
                     ["start"] => "comfyui start",
-                    ["models-path"] | ["models"] => "comfyui models-path",
-                    ["logs"] | ["log"] => "comfyui logs",
-                    ["log-files"] | ["logs", "files"] | ["log", "files"] => "comfyui log-files",
+                    ["models-path" | "models"] => "comfyui models-path",
+                    ["logs" | "log"] => "comfyui logs",
+                    ["log-files"] | ["logs" | "log", "files"] => "comfyui log-files",
                     _ => "comfyui start",
                 };
                 self.open_command_screen("ComfyUI", detail, None, actions);
@@ -10418,13 +10384,13 @@ impl App {
                     [] | ["status"] => {
                         self.status = "ComfyUI status shown.".to_owned();
                     }
-                    ["logs"] | ["log"] => {
+                    ["logs" | "log"] => {
                         self.status = "ComfyUI logs shown.".to_owned();
                     }
-                    ["log-files"] | ["logs", "files"] | ["log", "files"] => {
+                    ["log-files"] | ["logs" | "log", "files"] => {
                         self.status = "ComfyUI log file locations shown.".to_owned();
                     }
-                    ["models-path"] | ["models"] => {
+                    ["models-path" | "models"] => {
                         self.status = "ComfyUI models path shown.".to_owned();
                     }
                     ["install"] => {
@@ -10456,13 +10422,13 @@ impl App {
                 self.open_services_manager();
                 match args.as_slice() {
                     [] | ["list"] => {}
-                    ["logs"] | ["log"] => {
+                    ["logs" | "log"] => {
                         self.set_active_screen_message(
                             "Choose a service from this list, then press Enter to open its logs.",
                         );
                         self.status = "Choose a service from the list.".to_owned();
                     }
-                    ["logs", service_id] | ["log", service_id] => {
+                    ["logs" | "log", service_id] => {
                         if self.select_service_by_id(service_id) {
                             self.open_selected_service_logs();
                         } else {
@@ -10553,7 +10519,7 @@ impl App {
                         self.open_logs_browser(None, 0);
                         if let Some(state) = self.logs_view.as_mut() {
                             state.last_rendered =
-                                format!("{}\n\nUse the choices on the left, or press Back.", error);
+                                format!("{error}\n\nUse the choices on the left, or press Back.");
                             state.selected = 0;
                             state.detail_scroll = 0;
                         }
@@ -10885,7 +10851,7 @@ impl App {
         let (sender, receiver) = mpsc::channel();
         let cancel_requested = Arc::new(AtomicBool::new(false));
         let cancel_for_thread = Arc::clone(&cancel_requested);
-        let args_for_thread = args.clone();
+        let args_for_thread = args;
         let paths_for_thread = self.paths.clone();
         std::thread::spawn(move || {
             let result = run_cli_command_streaming(
@@ -10957,7 +10923,7 @@ impl App {
         let (sender, receiver) = mpsc::channel();
         let cancel_requested = Arc::new(AtomicBool::new(false));
         let cancel_for_thread = Arc::clone(&cancel_requested);
-        let args_for_thread = args.clone();
+        let args_for_thread = args;
         let paths_for_thread = self.paths.clone();
         std::thread::spawn(move || {
             let result = run_rocmd_command_streaming(
@@ -11018,7 +10984,7 @@ impl App {
             return false;
         }
         let request = ChatRequest {
-            model: model.clone(),
+            model,
             messages: vec![ChatMessage {
                 role: "user".to_owned(),
                 content: prompt.clone(),
@@ -11094,7 +11060,7 @@ impl App {
         self.running_job = Some(RunningJob {
             title: "Planning".to_owned(),
             kind: RunningJobKind::Planner {
-                title: title.clone(),
+                title,
                 request: request.clone(),
             },
             receiver,
@@ -11321,7 +11287,7 @@ impl App {
             } else {
                 session.turns.push(ChatSessionTurn {
                     role: ChatSessionRole::Assistant,
-                    content: content.clone(),
+                    content,
                     detail: None,
                 });
             }
@@ -11697,13 +11663,7 @@ impl App {
                     && chat_session_owns_command_title(title.as_str())
                 {
                     let should_follow = self.command_screen_chat_should_follow_latest();
-                    let recent_live_output = if !self.running_job_output.is_empty() {
-                        self.running_job_output
-                            .iter()
-                            .map(|line| format!("  {}", display_stream_log_line(line)))
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    } else {
+                    let recent_live_output = if self.running_job_output.is_empty() {
                         recent_screen_output
                             .as_deref()
                             .unwrap_or_default()
@@ -11711,9 +11671,15 @@ impl App {
                             .map(|line| format!("  {}", display_stream_log_line(line.trim())))
                             .collect::<Vec<_>>()
                             .join("\n")
+                    } else {
+                        self.running_job_output
+                            .iter()
+                            .map(|line| format!("  {}", display_stream_log_line(line)))
+                            .collect::<Vec<_>>()
+                            .join("\n")
                     };
                     let mut summary_parts = Vec::new();
-                    if let Some(summary) = screen_summary.clone()
+                    if let Some(summary) = screen_summary
                         && !summary.trim().is_empty()
                     {
                         summary_parts.push(summary);
@@ -12546,8 +12512,7 @@ impl App {
         let title = self
             .pending_approval
             .as_ref()
-            .map(|pending| pending.title.clone())
-            .unwrap_or_else(|| "Approval".to_owned());
+            .map_or_else(|| "Approval".to_owned(), |pending| pending.title.clone());
         let stay_in_chat = self.command_screen_is_chat_session();
         let stay_in_setup = self.onboarding_active;
         self.cancel_focused_action();
@@ -12623,7 +12588,7 @@ impl App {
             "Review",
             args,
             RunningJobKind::Proposal {
-                proposal_id: proposal.proposal_id.clone(),
+                proposal_id: proposal.proposal_id,
             },
         );
         self.status = "Review approved; working on it.".to_owned();
@@ -12743,10 +12708,10 @@ impl App {
         let target_key = field
             .and_then(automation_prefetch_field_from_edit_name)
             .filter(|_| is_pending_prefetch_proposal(&proposal))
-            .map(|field| {
-                AutomationManagerRowKey::PrefetchField(proposal.proposal_id.clone(), field)
-            })
-            .unwrap_or_else(|| AutomationManagerRowKey::Review(proposal.proposal_id.clone()));
+            .map_or_else(
+                || AutomationManagerRowKey::Review(proposal.proposal_id.clone()),
+                |field| AutomationManagerRowKey::PrefetchField(proposal.proposal_id.clone(), field),
+            );
         if let Some(state) = self.automations_manager.as_mut() {
             if let Some(item) = state
                 .items
@@ -12967,6 +12932,7 @@ fn plain_install_input_is_command(args: &[&str]) -> bool {
             .is_some_and(|arg| matches!(*arg, "sdk" | "driver") || arg.starts_with("--"))
 }
 
+#[allow(clippy::case_sensitive_file_extension_comparisons)] // `.gguf` heuristic on raw CLI args; behavior intentionally exact
 fn plain_serve_input_is_command(args: &[&str]) -> bool {
     args.iter().any(|arg| arg.starts_with("--"))
         || args
@@ -12994,10 +12960,10 @@ fn is_plain_casual_input(input: &str) -> bool {
                 && matches!(*second, "there" | "rocm")
     ) || matches!(
         words.as_slice(),
-        ["thank", "you"] | ["good", "morning"] | ["good", "afternoon"] | ["good", "evening"]
+        ["thank", "you"] | ["good", "morning" | "afternoon" | "evening"]
     ) || matches!(
         words.as_slice(),
-        ["can", "you", "hear", "me"] | ["are", "you", "there"] | ["testing"] | ["test"]
+        ["can", "you", "hear", "me"] | ["are", "you", "there"] | ["testing" | "test"]
     )
 }
 
@@ -13193,7 +13159,7 @@ fn flag_without_value(option_name: &str, inline_value: Option<&str>) -> Result<(
     Ok(())
 }
 
-fn serve_usage_text() -> &'static str {
+const fn serve_usage_text() -> &'static str {
     "Usage: /serve <model> [--engine <engine>] [--device gpu|gpu_required] [--managed]\n\nExamples:\n  /serve qwen with lemonade --managed\n  /serve qwen --engine lemonade --device gpu_required"
 }
 
@@ -13215,7 +13181,6 @@ fn render_serve_command_plan(plan: &ServeCommandPlan, config: &RocmCliConfig) ->
     let command = format_command_for_display("rocm", &plan.cli_args());
 
     let mut output = String::new();
-    use std::fmt::Write as _;
     let _ = writeln!(output, "serve plan");
     let _ = writeln!(output, "  requested model: {model}");
     let _ = writeln!(output, "  engine: {engine}");
@@ -13313,7 +13278,6 @@ fn render_serve_wizard_review(plan: &ServeCommandPlan, config: &RocmCliConfig) -
     let port = plan.port.unwrap_or(DEFAULT_LOCAL_PORT);
 
     let mut output = String::new();
-    use std::fmt::Write as _;
     let _ = writeln!(output, "Start local model");
     let _ = writeln!(output, "  model: {model}");
     let _ = writeln!(output, "  engine: {engine}");
@@ -13653,8 +13617,10 @@ fn default_setup_venv_path(paths: &AppPaths) -> PathBuf {
         return config_dir
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
-            .map(|parent| parent.join("rocm_venvs").join("default"))
-            .unwrap_or_else(|| config_dir.join("rocm_venvs").join("default"));
+            .map_or_else(
+                || config_dir.join("rocm_venvs").join("default"),
+                |parent| parent.join("rocm_venvs").join("default"),
+            );
     }
     paths.data_dir.join("envs").join("default")
 }
@@ -13786,7 +13752,7 @@ fn folder_browser_entries(current_dir: &Path) -> (Vec<FolderBrowserEntry>, Optio
     match fs::read_dir(&current_dir) {
         Ok(read_dir) => {
             let mut dirs = read_dir
-                .filter_map(|entry| entry.ok())
+                .filter_map(std::result::Result::ok)
                 .map(|entry| entry.path())
                 .filter(|path| path.is_dir())
                 .filter(|path| folder_browser_should_show_directory(&current_dir, path))
@@ -14358,7 +14324,7 @@ fn onboarding_menu_choices(app: &App) -> Vec<OnboardingMenuChoice> {
     choices
 }
 
-fn onboarding_cancel_install_choices() -> &'static [&'static str] {
+const fn onboarding_cancel_install_choices() -> &'static [&'static str] {
     &["Keep waiting", "Stop install"]
 }
 
@@ -14400,8 +14366,7 @@ fn onboarding_selection_status(app: &App) -> String {
             let title = app
                 .pending_approval
                 .as_ref()
-                .map(|pending| pending.title.as_str())
-                .unwrap_or("setup");
+                .map_or("setup", |pending| pending.title.as_str());
             if title == "Uninstall" {
                 "Press Enter to approve uninstall.".to_owned()
             } else if title == "Reinstall" {
@@ -14536,7 +14501,7 @@ fn read_saved_onboarding_log_lines(path: &Path) -> Result<Vec<String>> {
     Ok(text
         .lines()
         .map(|line| sanitize_terminal_text(line).replace(['\r', '\n'], " "))
-        .map(|line| truncate_stream_line(line.trim()).to_owned())
+        .map(|line| truncate_stream_line(line.trim()))
         .filter(|line| !line.is_empty())
         .collect())
 }
@@ -14739,7 +14704,7 @@ fn render_onboarding_screen_text_with_log_limit(app: &App, install_log_limit: us
     } else {
         "not installed"
     };
-    let _ = writeln!(output, "  {} ROCm: {}", marker, status);
+    let _ = writeln!(output, "  {marker} ROCm: {status}");
     if let Some(runtime) = current_runtime.as_ref()
         && let Some(version) = runtime.version.as_deref()
         && !version.trim().is_empty()
@@ -15459,8 +15424,7 @@ fn install_sdk_argument_candidates(arg_index: usize, parts: &[String]) -> Vec<St
 }
 
 fn install_driver_argument_candidates(parts: &[String]) -> Vec<String> {
-    ["--preview"]
-        .into_iter()
+    std::iter::once("--preview")
         .filter(|option| !slash_option_used(parts, option))
         .map(str::to_owned)
         .collect()
@@ -15792,7 +15756,7 @@ fn selected_completion_index(requested: usize, replacements: &[Option<String>]) 
     }
     if replacements
         .get(requested)
-        .is_some_and(|replacement| replacement.is_some())
+        .is_some_and(std::option::Option::is_some)
     {
         return requested;
     }
@@ -15929,7 +15893,7 @@ struct ScrollMetrics {
 }
 
 impl ScrollMetrics {
-    fn max_offset(self) -> usize {
+    const fn max_offset(self) -> usize {
         self.content_len.saturating_sub(self.viewport_len)
     }
 
@@ -15937,7 +15901,7 @@ impl ScrollMetrics {
         self.offset.min(u16::MAX as usize) as u16
     }
 
-    fn should_draw(self) -> bool {
+    const fn should_draw(self) -> bool {
         self.content_len > self.viewport_len
     }
 }
@@ -16028,7 +15992,7 @@ fn draw_completion_menu(frame: &mut Frame<'_>, menu: &CompletionMenu, area: Rect
             let style = if menu
                 .replacements
                 .get(index)
-                .is_some_and(|replacement| replacement.is_some())
+                .is_some_and(std::option::Option::is_some)
             {
                 Style::default()
             } else {
@@ -16041,7 +16005,7 @@ fn draw_completion_menu(frame: &mut Frame<'_>, menu: &CompletionMenu, area: Rect
     if menu
         .replacements
         .get(menu.selected)
-        .is_some_and(|replacement| replacement.is_some())
+        .is_some_and(std::option::Option::is_some)
     {
         state.select(Some(menu.selected.saturating_sub(visible_start)));
     }
@@ -16086,9 +16050,9 @@ fn draw_command_prompt_popup(
     if area.width < 12 || area.height < 8 {
         return;
     }
-    let completion_height = completion_menu
-        .map(|menu| menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2)
-        .unwrap_or(0);
+    let completion_height = completion_menu.map_or(0, |menu| {
+        menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2
+    });
     let wanted_width = area.width.saturating_sub(4).min(96).max(48.min(area.width));
     let wanted_height = completion_height
         .saturating_add(6)
@@ -16467,7 +16431,7 @@ fn read_fallback_sgr_mouse_sequence(
 fn read_fallback_x10_mouse_sequence(
     next_byte: &mut impl FnMut(Duration) -> Option<u8>,
 ) -> Option<Event> {
-    let code = next_byte(FALLBACK_ESCAPE_SEQUENCE_TIMEOUT)?.saturating_sub(32) as u16;
+    let code = u16::from(next_byte(FALLBACK_ESCAPE_SEQUENCE_TIMEOUT)?.saturating_sub(32));
     let column = u16::from(next_byte(FALLBACK_ESCAPE_SEQUENCE_TIMEOUT)?.saturating_sub(33));
     let row = u16::from(next_byte(FALLBACK_ESCAPE_SEQUENCE_TIMEOUT)?.saturating_sub(33));
     fallback_mouse_event(code, column, row, b'M')
@@ -16505,11 +16469,11 @@ fn fallback_mouse_modifiers(code: u16) -> KeyModifiers {
     modifiers
 }
 
-fn fallback_noop_event() -> Event {
+const fn fallback_noop_event() -> Event {
     Event::FocusGained
 }
 
-fn fallback_key(code: KeyCode) -> Event {
+const fn fallback_key(code: KeyCode) -> Event {
     Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
 }
 
@@ -16560,7 +16524,7 @@ fn handle_terminal_event(app: &mut App, event: Event) {
             }
         }
         Event::Paste(text) if surface_command_prompt_active(app) || should_draw_prompt_box(app) => {
-            app.paste_text(&text)
+            app.paste_text(&text);
         }
         Event::Paste(_) => {
             app.status =
@@ -16744,10 +16708,9 @@ fn main_content_area(app: &App, width: u16, height: u16) -> Rect {
     let command_prompt_popup = surface_command_prompt_active(app);
     let prompt_box_visible = should_draw_prompt_box(app) && !command_prompt_popup;
     let completion_height = if prompt_box_visible {
-        app.slash_completion_menu()
-            .as_ref()
-            .map(|menu| menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2)
-            .unwrap_or(0)
+        app.slash_completion_menu().as_ref().map_or(0, |menu| {
+            menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2
+        })
     } else {
         0
     };
@@ -16816,7 +16779,7 @@ fn folder_browser_list_inner_rect(area: Rect) -> Option<Rect> {
     Some(rect_inner(panes[0]))
 }
 
-fn rect_inner(rect: Rect) -> Rect {
+const fn rect_inner(rect: Rect) -> Rect {
     Rect {
         x: rect.x.saturating_add(1),
         y: rect.y.saturating_add(1),
@@ -16825,7 +16788,7 @@ fn rect_inner(rect: Rect) -> Rect {
     }
 }
 
-fn rect_contains(rect: Rect, column: u16, row: u16) -> bool {
+const fn rect_contains(rect: Rect, column: u16, row: u16) -> bool {
     column >= rect.x && column < rect.right() && row >= rect.y && row < rect.bottom()
 }
 
@@ -16984,8 +16947,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.reject_or_cancel_focused_action();
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             if surface_command_prompt_active(app) && command_popup_should_submit_on_enter(app) {
                 app.submit();
                 return;
@@ -17068,11 +17030,11 @@ fn handle_home_dashboard_key(app: &mut App, key: KeyEvent) -> bool {
             app.perform_home_dashboard_action();
             true
         }
-        (_, KeyCode::Down) | (_, KeyCode::Tab) => {
+        (_, KeyCode::Down | KeyCode::Tab) => {
             app.move_home_dashboard_selection(CompletionDirection::Next);
             true
         }
-        (_, KeyCode::Up) | (_, KeyCode::BackTab) => {
+        (_, KeyCode::Up | KeyCode::BackTab) => {
             app.move_home_dashboard_selection(CompletionDirection::Previous);
             true
         }
@@ -17177,7 +17139,7 @@ fn surface_command_prompt_active(app: &App) -> bool {
         && !should_draw_running_job_modal(app)
 }
 
-fn active_surface_navigation_key(key: KeyEvent) -> bool {
+const fn active_surface_navigation_key(key: KeyEvent) -> bool {
     active_surface_action_key(key)
         || matches!(
             key.code,
@@ -17196,12 +17158,11 @@ fn active_surface_navigation_key(key: KeyEvent) -> bool {
         )
 }
 
-fn active_surface_action_key(key: KeyEvent) -> bool {
+const fn active_surface_action_key(key: KeyEvent) -> bool {
     matches!(
         (key.modifiers, key.code),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-            | (_, KeyCode::Char('\n' | '\r'))
-            | (_, KeyCode::Enter)
+            | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter)
     )
 }
 
@@ -17298,8 +17259,7 @@ fn handle_pending_approval_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_pending_approval_selection();
             true
         }
@@ -17347,8 +17307,7 @@ fn handle_overlay_card_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_overlay_card_action();
             true
         }
@@ -17422,8 +17381,7 @@ fn handle_folder_browser_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_folder_browser_selection();
             true
         }
@@ -17472,8 +17430,7 @@ fn handle_running_job_modal_key(app: &mut App, key: KeyEvent) -> bool {
             }
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.status =
                 "Wait for the running work to finish before choosing another action.".to_owned();
         }
@@ -17530,12 +17487,11 @@ fn handle_doctor_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_doctor_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_doctor_manager();
             true
         }
@@ -17628,7 +17584,7 @@ fn handle_runtime_manager_key(app: &mut App, key: KeyEvent) -> bool {
             }
             true
         }
-        (_, KeyCode::Char('u' | 'U')) | (_, KeyCode::Delete) => {
+        (_, KeyCode::Char('u' | 'U') | KeyCode::Delete) => {
             if app
                 .runtime_manager
                 .as_ref()
@@ -17641,12 +17597,11 @@ fn handle_runtime_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_runtime_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             if app
                 .runtime_manager
                 .as_ref()
@@ -17672,8 +17627,7 @@ fn handle_runtime_manager_text_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             let import_editing = app.runtime_manager.as_ref().is_some_and(|state| {
                 matches!(
                     state.screen,
@@ -17743,7 +17697,7 @@ fn handle_install_manager_key(app: &mut App, key: KeyEvent) -> bool {
         (_, KeyCode::Left) => {
             match app.selected_install_sdk_choice() {
                 InstallSdkChoice::Folder => {
-                    app.cycle_install_sdk_folder_preset(CompletionDirection::Previous)
+                    app.cycle_install_sdk_folder_preset(CompletionDirection::Previous);
                 }
                 _ => {
                     app.status = "Use Up and Down to choose an install option.".to_owned();
@@ -17754,7 +17708,7 @@ fn handle_install_manager_key(app: &mut App, key: KeyEvent) -> bool {
         (_, KeyCode::Right) => {
             match app.selected_install_sdk_choice() {
                 InstallSdkChoice::Folder => {
-                    app.cycle_install_sdk_folder_preset(CompletionDirection::Next)
+                    app.cycle_install_sdk_folder_preset(CompletionDirection::Next);
                 }
                 _ => {
                     app.status = "Use Up and Down to choose an install option.".to_owned();
@@ -17803,12 +17757,11 @@ fn handle_install_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_install_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             if app
                 .install_manager
                 .as_ref()
@@ -17832,8 +17785,7 @@ fn handle_install_manager_text_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_install_sdk_folder_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_install_sdk_folder_edit(),
         (_, KeyCode::Esc) => app.cancel_install_sdk_folder_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -17906,12 +17858,11 @@ fn handle_engine_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_engine_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_engine_manager();
             true
         }
@@ -17965,12 +17916,11 @@ fn handle_model_picker_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.plan_selected_model_recipe();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_model_picker();
             true
         }
@@ -18035,12 +17985,11 @@ fn handle_serve_wizard_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_serve_wizard_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_serve_wizard();
             true
         }
@@ -18056,8 +18005,7 @@ fn handle_serve_wizard_text_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_serve_wizard_field_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_serve_wizard_field_edit(),
         (_, KeyCode::Esc) => app.cancel_serve_wizard_field_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -18120,12 +18068,11 @@ fn handle_update_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_update_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_update_manager();
             true
         }
@@ -18156,10 +18103,10 @@ fn handle_automations_manager_key(app: &mut App, key: KeyEvent) -> bool {
                 match field {
                     AutomationPrefetchField::AllowDownload
                     | AutomationPrefetchField::AllowHuggingFace => {
-                        app.update_prefetch_bool_field(proposal, field, false)
+                        app.update_prefetch_bool_field(proposal, field, false);
                     }
                     AutomationPrefetchField::MaxBytes => {
-                        app.cycle_prefetch_max_bytes(proposal, CompletionDirection::Previous)
+                        app.cycle_prefetch_max_bytes(proposal, CompletionDirection::Previous);
                     }
                 }
             } else {
@@ -18172,10 +18119,10 @@ fn handle_automations_manager_key(app: &mut App, key: KeyEvent) -> bool {
                 match field {
                     AutomationPrefetchField::AllowDownload
                     | AutomationPrefetchField::AllowHuggingFace => {
-                        app.update_prefetch_bool_field(proposal, field, true)
+                        app.update_prefetch_bool_field(proposal, field, true);
                     }
                     AutomationPrefetchField::MaxBytes => {
-                        app.cycle_prefetch_max_bytes(proposal, CompletionDirection::Next)
+                        app.cycle_prefetch_max_bytes(proposal, CompletionDirection::Next);
                     }
                 }
             } else {
@@ -18218,10 +18165,10 @@ fn handle_automations_manager_key(app: &mut App, key: KeyEvent) -> bool {
                 match field {
                     AutomationPrefetchField::AllowDownload
                     | AutomationPrefetchField::AllowHuggingFace => {
-                        app.update_prefetch_bool_field(proposal, field, true)
+                        app.update_prefetch_bool_field(proposal, field, true);
                     }
                     AutomationPrefetchField::MaxBytes => {
-                        app.start_prefetch_max_bytes_edit(&proposal)
+                        app.start_prefetch_max_bytes_edit(&proposal);
                     }
                 }
             } else if let Some(watcher) = app.selected_automation_watcher() {
@@ -18235,15 +18182,15 @@ fn handle_automations_manager_key(app: &mut App, key: KeyEvent) -> bool {
             }
             true
         }
-        (_, KeyCode::Char('n' | 'N')) | (_, KeyCode::Delete) => {
+        (_, KeyCode::Char('n' | 'N') | KeyCode::Delete) => {
             if let Some((proposal, field)) = app.selected_automation_prefetch_field() {
                 match field {
                     AutomationPrefetchField::AllowDownload
                     | AutomationPrefetchField::AllowHuggingFace => {
-                        app.update_prefetch_bool_field(proposal, field, false)
+                        app.update_prefetch_bool_field(proposal, field, false);
                     }
                     AutomationPrefetchField::MaxBytes => {
-                        app.status = "Press Enter to edit the max download.".to_owned()
+                        app.status = "Press Enter to edit the max download.".to_owned();
                     }
                 }
             } else if let Some(watcher) = app.selected_automation_watcher() {
@@ -18271,12 +18218,11 @@ fn handle_automations_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_automations_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_automations_manager();
             true
         }
@@ -18292,8 +18238,7 @@ fn handle_automations_manager_text_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_prefetch_max_bytes_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_prefetch_max_bytes_edit(),
         (_, KeyCode::Esc) => app.cancel_prefetch_max_bytes_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -18383,12 +18328,11 @@ fn handle_config_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_config_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             if app.config_manager_confirming_provider_clear() {
                 app.cancel_clear_config_provider_key_confirmation();
                 return true;
@@ -18416,8 +18360,7 @@ fn handle_config_manager_secret_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_config_provider_key_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_config_provider_key_edit(),
         (_, KeyCode::Esc) => app.cancel_config_provider_key_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -18478,12 +18421,11 @@ fn handle_provider_manager_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.use_selected_provider();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_provider_manager();
             true
         }
@@ -18540,7 +18482,7 @@ fn handle_services_manager_key(app: &mut App, key: KeyEvent) -> bool {
             app.refresh_services_manager();
             true
         }
-        (_, KeyCode::Char('S')) | (_, KeyCode::Char('s')) | (_, KeyCode::Delete) => {
+        (_, KeyCode::Char('S' | 's') | KeyCode::Delete) => {
             app.request_selected_service_lifecycle(ServiceLifecycleAction::Stop);
             true
         }
@@ -18548,14 +18490,12 @@ fn handle_services_manager_key(app: &mut App, key: KeyEvent) -> bool {
             app.request_selected_service_lifecycle(ServiceLifecycleAction::Restart);
             true
         }
-        (_, KeyCode::Char('l' | 'L'))
-        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        (_, KeyCode::Char('l' | 'L' | '\n' | '\r') | KeyCode::Enter)
+        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm')) => {
             app.perform_services_manager_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_services_manager();
             true
         }
@@ -18596,8 +18536,7 @@ fn handle_command_screen_key(app: &mut App, key: KeyEvent) -> bool {
                     true
                 }
                 (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-                | (_, KeyCode::Char('\n' | '\r'))
-                | (_, KeyCode::Enter) => {
+                | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
                     app.status = "Type a message, then press Enter.".to_owned();
                     true
                 }
@@ -18677,8 +18616,7 @@ fn handle_command_screen_key(app: &mut App, key: KeyEvent) -> bool {
                 true
             }
             (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-            | (_, KeyCode::Char('\n' | '\r'))
-            | (_, KeyCode::Enter) => {
+            | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
                 app.perform_command_screen_selected_action();
                 true
             }
@@ -18732,12 +18670,11 @@ fn handle_command_screen_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_command_screen_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_command_screen();
             true
         }
@@ -18759,7 +18696,7 @@ fn handle_command_screen_detail_modal_key(app: &mut App, key: KeyEvent) -> bool 
             app.status = "Detail card is open. Press Esc to close it.".to_owned();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_command_screen_detail_modal();
             true
         }
@@ -18801,10 +18738,16 @@ fn handle_command_screen_detail_modal_key(app: &mut App, key: KeyEvent) -> bool 
             app.status = "Detail card moved to the bottom.".to_owned();
             true
         }
-        (_, KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::BackTab)
-        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        (
+            _,
+            KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Tab
+            | KeyCode::BackTab
+            | KeyCode::Char('\n' | '\r')
+            | KeyCode::Enter,
+        )
+        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm')) => {
             app.status = "Detail card is open. Press Esc to close it.".to_owned();
             true
         }
@@ -18908,12 +18851,11 @@ fn handle_logs_view_key(app: &mut App, key: KeyEvent) -> bool {
             true
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
             app.perform_logs_view_selected_action();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_logs_browser();
             true
         }
@@ -18935,7 +18877,7 @@ fn handle_logs_view_detail_modal_key(app: &mut App, key: KeyEvent) -> bool {
             app.status = "File location card is open. Press Esc to close it.".to_owned();
             true
         }
-        (_, KeyCode::Esc) | (_, KeyCode::Char('q' | 'Q')) => {
+        (_, KeyCode::Esc | KeyCode::Char('q' | 'Q')) => {
             app.close_logs_view_detail_modal();
             true
         }
@@ -18977,10 +18919,16 @@ fn handle_logs_view_detail_modal_key(app: &mut App, key: KeyEvent) -> bool {
             app.status = "File location card moved to the bottom.".to_owned();
             true
         }
-        (_, KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::BackTab)
-        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => {
+        (
+            _,
+            KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Tab
+            | KeyCode::BackTab
+            | KeyCode::Char('\n' | '\r')
+            | KeyCode::Enter,
+        )
+        | (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm')) => {
             app.status = "File location card is open. Press Esc to close it.".to_owned();
             true
         }
@@ -18999,8 +18947,7 @@ fn handle_logs_view_text_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_logs_search_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_logs_search_edit(),
         (_, KeyCode::Esc) => app.cancel_logs_search_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -19030,14 +18977,14 @@ fn handle_onboarding_key(app: &mut App, key: KeyEvent) -> bool {
     if app.onboarding_cancel_install_confirm {
         match (key.modifiers, key.code) {
             (_, KeyCode::Char('y' | 'Y')) => app.cancel_onboarding_install(),
-            (_, KeyCode::Char('n' | 'N')) | (_, KeyCode::Esc) => {
-                app.keep_waiting_for_onboarding_install()
+            (_, KeyCode::Char('n' | 'N') | KeyCode::Esc) => {
+                app.keep_waiting_for_onboarding_install();
             }
             (_, KeyCode::Up | KeyCode::BackTab) => {
-                app.move_onboarding_cancel_install_selection(CompletionDirection::Previous)
+                app.move_onboarding_cancel_install_selection(CompletionDirection::Previous);
             }
             (_, KeyCode::Down | KeyCode::Tab) => {
-                app.move_onboarding_cancel_install_selection(CompletionDirection::Next)
+                app.move_onboarding_cancel_install_selection(CompletionDirection::Next);
             }
             (_, KeyCode::Home) => {
                 app.onboarding_cancel_install_selection = 0;
@@ -19050,8 +18997,9 @@ fn handle_onboarding_key(app: &mut App, key: KeyEvent) -> bool {
                     onboarding_cancel_install_status(app.onboarding_cancel_install_selection);
             }
             (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-            | (_, KeyCode::Char('\n' | '\r'))
-            | (_, KeyCode::Enter) => app.perform_onboarding_cancel_install_selection(),
+            | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => {
+                app.perform_onboarding_cancel_install_selection();
+            }
             (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
                 app.status = "Choose Keep waiting or Stop install.".to_owned();
             }
@@ -19145,8 +19093,7 @@ fn handle_onboarding_key(app: &mut App, key: KeyEvent) -> bool {
             app.status = "Setup is open. Use Up/Down, then Enter.".to_owned();
         }
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter)
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter)
             if app.pending_approval.is_none() && app.running_job.is_none() =>
         {
             app.perform_onboarding_selected_action();
@@ -19184,8 +19131,7 @@ fn handle_onboarding_path_key(app: &mut App, key: KeyEvent) -> bool {
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.clear_input(),
         (KeyModifiers::CONTROL, KeyCode::Char('w')) => app.delete_input_word_before_cursor(),
         (KeyModifiers::CONTROL, KeyCode::Char('j' | 'm'))
-        | (_, KeyCode::Char('\n' | '\r'))
-        | (_, KeyCode::Enter) => app.commit_onboarding_path_edit(),
+        | (_, KeyCode::Char('\n' | '\r') | KeyCode::Enter) => app.commit_onboarding_path_edit(),
         (_, KeyCode::Esc) => app.cancel_onboarding_path_edit(),
         (_, KeyCode::Backspace) => app.backspace_input(),
         (_, KeyCode::Delete) => app.delete_input_char(),
@@ -19228,10 +19174,9 @@ fn draw(frame: &mut Frame<'_>, app: &App) {
     let completion_height = if command_prompt_popup {
         0
     } else {
-        completion_menu
-            .as_ref()
-            .map(|menu| menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2)
-            .unwrap_or(0)
+        completion_menu.as_ref().map_or(0, |menu| {
+            menu.items.len().min(MAX_COMPLETION_MENU_ITEMS) as u16 + 2
+        })
     };
     let input_height = if prompt_box_visible {
         chat_input_area_height(app, frame.area().width, frame.area().height)
@@ -19593,7 +19538,7 @@ fn should_draw_prompt_box(app: &App) -> bool {
         && !app.should_draw_home_dashboard()
 }
 
-fn transcript_title(app: &App) -> &'static str {
+const fn transcript_title(app: &App) -> &'static str {
     if app.transcript.is_empty() {
         "Home"
     } else {
@@ -19735,9 +19680,8 @@ fn home_dashboard_badge_line(label: &'static str, rest: &str, color: Color) -> L
 
 fn render_home_dashboard_overview_text(app: &App) -> String {
     let setup_ready = setup_runtime_ready_for_sidebar(&app.paths, &app.config);
-    let runtime_count = therock::load_runtime_manifests(&app.paths)
-        .map(|manifests| manifests.len())
-        .unwrap_or(0);
+    let runtime_count =
+        therock::load_runtime_manifests(&app.paths).map_or(0, |manifests| manifests.len());
     let services = load_visible_managed_services(&app.paths);
     let service_counts = managed_service_sidebar_counts(&services);
     let default_engine = app
@@ -19867,7 +19811,7 @@ fn home_dashboard_actions(app: &App) -> Vec<HomeDashboardAction> {
     }
 }
 
-fn home_dashboard_action_label(action: HomeDashboardAction) -> &'static str {
+const fn home_dashboard_action_label(action: HomeDashboardAction) -> &'static str {
     match action {
         HomeDashboardAction::Setup => "Set up ROCm",
         HomeDashboardAction::Doctor => "Run setup check",
@@ -19882,7 +19826,7 @@ fn home_dashboard_action_label(action: HomeDashboardAction) -> &'static str {
     }
 }
 
-fn home_dashboard_action_status(action: HomeDashboardAction) -> &'static str {
+const fn home_dashboard_action_status(action: HomeDashboardAction) -> &'static str {
     match action {
         HomeDashboardAction::Setup => "Set up ROCm selected. Press Enter.",
         HomeDashboardAction::Doctor => "Setup check selected. Press Enter.",
@@ -19897,7 +19841,7 @@ fn home_dashboard_action_status(action: HomeDashboardAction) -> &'static str {
     }
 }
 
-fn home_dashboard_action_command(action: HomeDashboardAction) -> &'static str {
+const fn home_dashboard_action_command(action: HomeDashboardAction) -> &'static str {
     match action {
         HomeDashboardAction::Setup => "setup",
         HomeDashboardAction::Doctor => "doctor",
@@ -19919,7 +19863,7 @@ fn selection_style() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
-fn surface_block<'a>(title: &'a str, color: Color) -> Block<'a> {
+fn surface_block(title: &str, color: Color) -> Block<'_> {
     Block::default()
         .borders(Borders::ALL)
         .title(title)
@@ -19927,15 +19871,15 @@ fn surface_block<'a>(title: &'a str, color: Color) -> Block<'a> {
         .style(Style::default().bg(THEME_PANEL))
 }
 
-fn detail_block<'a>(title: &'a str) -> Block<'a> {
+fn detail_block(title: &str) -> Block<'_> {
     surface_block(title, THEME_BORDER)
 }
 
-fn draw_scrollable_text_with_block<'a>(
+fn draw_scrollable_text_with_block(
     frame: &mut Frame<'_>,
     text: String,
     area: Rect,
-    block: Block<'a>,
+    block: Block<'_>,
     style: Style,
     requested_scroll: u16,
 ) -> ScrollMetrics {
@@ -19978,11 +19922,11 @@ fn draw_scrollable_text(
     metrics
 }
 
-fn draw_scrollable_styled_text_with_block<'a>(
+fn draw_scrollable_styled_text_with_block(
     frame: &mut Frame<'_>,
     styled_text: Text<'static>,
     area: Rect,
-    block: Block<'a>,
+    block: Block<'_>,
     style: Style,
     requested_scroll: u16,
 ) -> ScrollMetrics {
@@ -20058,7 +20002,7 @@ fn sidebar_border_color(app: &App) -> Color {
     }
 }
 
-fn should_draw_modal_approval(_app: &App) -> bool {
+const fn should_draw_modal_approval(_app: &App) -> bool {
     true
 }
 
@@ -20463,8 +20407,7 @@ fn render_modal_approval(app: &App, pending: &PendingApproval) -> String {
 fn modal_detail_scroll(app: &App) -> u16 {
     app.pending_approval
         .as_ref()
-        .map(|pending| pending.detail_scroll)
-        .unwrap_or(0)
+        .map_or(0, |pending| pending.detail_scroll)
 }
 
 fn draw_doctor_manager(frame: &mut Frame<'_>, app: &App, area: Rect) {
@@ -20597,8 +20540,7 @@ fn draw_engine_manager(frame: &mut Frame<'_>, app: &App, area: Rect) {
             EngineManagerRow::Item(index) => state
                 .items
                 .get(*index)
-                .map(engine_manager_row_label)
-                .unwrap_or_else(|| "Engine".to_owned()),
+                .map_or_else(|| "Engine".to_owned(), engine_manager_row_label),
             EngineManagerRow::Action(action) => engine_manager_action_label(*action).to_owned(),
         })
         .map(ListItem::new)
@@ -21072,7 +21014,7 @@ fn draw_logs_view_detail_modal(frame: &mut Frame<'_>, app: &App, area: Rect) {
     );
 }
 
-fn doctor_manager_choices() -> &'static [DoctorManagerChoice] {
+const fn doctor_manager_choices() -> &'static [DoctorManagerChoice] {
     &[
         DoctorManagerChoice::Overview,
         DoctorManagerChoice::Gpu,
@@ -21084,7 +21026,7 @@ fn doctor_manager_choices() -> &'static [DoctorManagerChoice] {
     ]
 }
 
-fn doctor_manager_label(choice: DoctorManagerChoice) -> &'static str {
+const fn doctor_manager_label(choice: DoctorManagerChoice) -> &'static str {
     match choice {
         DoctorManagerChoice::Overview => "Overview",
         DoctorManagerChoice::Gpu => "GPU",
@@ -21129,7 +21071,7 @@ fn runtime_manager_actions(state: &RuntimeManagerState) -> Vec<RuntimeManagerAct
     actions
 }
 
-fn runtime_advanced_choices() -> &'static [RuntimeAdvancedChoice] {
+const fn runtime_advanced_choices() -> &'static [RuntimeAdvancedChoice] {
     &[
         RuntimeAdvancedChoice::AdoptExisting,
         RuntimeAdvancedChoice::ImportManifest,
@@ -21137,7 +21079,7 @@ fn runtime_advanced_choices() -> &'static [RuntimeAdvancedChoice] {
     ]
 }
 
-fn runtime_import_choices() -> &'static [RuntimeImportChoice] {
+const fn runtime_import_choices() -> &'static [RuntimeImportChoice] {
     &[
         RuntimeImportChoice::ManifestPath,
         RuntimeImportChoice::Replace,
@@ -21146,7 +21088,7 @@ fn runtime_import_choices() -> &'static [RuntimeImportChoice] {
     ]
 }
 
-fn runtime_adopt_choices() -> &'static [RuntimeAdoptChoice] {
+const fn runtime_adopt_choices() -> &'static [RuntimeAdoptChoice] {
     &[
         RuntimeAdoptChoice::PythonPath,
         RuntimeAdoptChoice::Channel,
@@ -21355,7 +21297,7 @@ fn engine_manager_choice_count(state: &EngineManagerState) -> usize {
     engine_manager_rows(state).len()
 }
 
-fn engine_manager_action_label(action: EngineManagerAction) -> &'static str {
+const fn engine_manager_action_label(action: EngineManagerAction) -> &'static str {
     match action {
         EngineManagerAction::UseSelected => "Use selected engine",
         EngineManagerAction::InstallSelected => "Install selected engine",
@@ -21368,8 +21310,7 @@ fn engine_manager_action_label(action: EngineManagerAction) -> &'static str {
 fn model_picker_row_label(recipe: &ModelRecipeRecord) -> String {
     let gpu = recipe
         .min_gpu_mem_gb
-        .map(|gb| format!("{gb}GB GPU"))
-        .unwrap_or_else(|| "small".to_owned());
+        .map_or_else(|| "small".to_owned(), |gb| format!("{gb}GB GPU"));
     format!("{:<10} {}", gpu, recipe.canonical_model_id)
 }
 
@@ -21397,7 +21338,7 @@ fn serve_wizard_preferred_engine_index(recipes: &[ModelRecipeRecord]) -> Option<
     })
 }
 
-fn serve_wizard_choices() -> &'static [ServeWizardChoice] {
+const fn serve_wizard_choices() -> &'static [ServeWizardChoice] {
     &[
         ServeWizardChoice::Source,
         ServeWizardChoice::Model,
@@ -21475,7 +21416,7 @@ fn next_enabled_serve_wizard_index(
     state.selected.min(choices.len().saturating_sub(1))
 }
 
-fn serve_wizard_device_options() -> &'static [&'static str] {
+const fn serve_wizard_device_options() -> &'static [&'static str] {
     &["gpu_required"]
 }
 
@@ -21486,7 +21427,7 @@ fn serve_wizard_engine_names() -> Vec<String> {
         .collect()
 }
 
-fn cycle_index(current: usize, len: usize, direction: CompletionDirection) -> usize {
+const fn cycle_index(current: usize, len: usize, direction: CompletionDirection) -> usize {
     if len == 0 {
         return 0;
     }
@@ -21525,7 +21466,7 @@ fn selected_serve_wizard_device(state: &ServeWizardState) -> &'static str {
         .unwrap_or("gpu_required")
 }
 
-fn serve_wizard_source_label(source: ServeModelSource) -> &'static str {
+const fn serve_wizard_source_label(source: ServeModelSource) -> &'static str {
     match source {
         ServeModelSource::BuiltInRecipe => "recommended model",
         ServeModelSource::LocalPath => "my own model file",
@@ -21554,11 +21495,10 @@ fn serve_wizard_row_label(app: &App, choice: ServeWizardChoice) -> String {
             "{:<10} {}",
             "Model",
             if state.model_source == ServeModelSource::BuiltInRecipe {
-                selected_serve_wizard_recipe(state)
-                    .map(|recipe| {
-                        format!("fixed {}", compact_model_label(&recipe.canonical_model_id))
-                    })
-                    .unwrap_or_else(|| "no recommended models".to_owned())
+                selected_serve_wizard_recipe(state).map_or_else(
+                    || "no recommended models".to_owned(),
+                    |recipe| format!("fixed {}", compact_model_label(&recipe.canonical_model_id)),
+                )
             } else {
                 "not used".to_owned()
             }
@@ -21604,7 +21544,7 @@ fn serve_wizard_device_label(device: &str) -> &'static str {
     }
 }
 
-fn install_menu_choices() -> &'static [InstallMenuChoice] {
+const fn install_menu_choices() -> &'static [InstallMenuChoice] {
     &[
         InstallMenuChoice::Runtime,
         InstallMenuChoice::DriverPreview,
@@ -21612,7 +21552,7 @@ fn install_menu_choices() -> &'static [InstallMenuChoice] {
     ]
 }
 
-fn install_menu_label(choice: InstallMenuChoice) -> &'static str {
+const fn install_menu_label(choice: InstallMenuChoice) -> &'static str {
     match choice {
         InstallMenuChoice::Runtime => "Install ROCm",
         InstallMenuChoice::DriverPreview => "Check driver setup",
@@ -21620,7 +21560,7 @@ fn install_menu_label(choice: InstallMenuChoice) -> &'static str {
     }
 }
 
-fn install_sdk_choices() -> &'static [InstallSdkChoice] {
+const fn install_sdk_choices() -> &'static [InstallSdkChoice] {
     &[
         InstallSdkChoice::Folder,
         InstallSdkChoice::Install,
@@ -21639,7 +21579,7 @@ fn install_sdk_choice_index(choice: InstallSdkChoice) -> usize {
         .unwrap_or(0)
 }
 
-fn install_sdk_format_label(format: InstallSdkFormat) -> &'static str {
+const fn install_sdk_format_label(format: InstallSdkFormat) -> &'static str {
     match format {
         InstallSdkFormat::Wheel => "Recommended Python install",
         InstallSdkFormat::Tarball => "Advanced archive install",
@@ -21661,7 +21601,7 @@ fn install_sdk_choice_label(choice: InstallSdkChoice, folder: &str) -> String {
     }
 }
 
-fn update_menu_choices() -> &'static [UpdateMenuChoice] {
+const fn update_menu_choices() -> &'static [UpdateMenuChoice] {
     &[
         UpdateMenuChoice::Refresh,
         UpdateMenuChoice::Preview,
@@ -21671,7 +21611,7 @@ fn update_menu_choices() -> &'static [UpdateMenuChoice] {
     ]
 }
 
-fn update_menu_label(choice: UpdateMenuChoice) -> &'static str {
+const fn update_menu_label(choice: UpdateMenuChoice) -> &'static str {
     match choice {
         UpdateMenuChoice::Refresh => "Check for updates",
         UpdateMenuChoice::Preview => "Preview update",
@@ -21681,7 +21621,7 @@ fn update_menu_label(choice: UpdateMenuChoice) -> &'static str {
     }
 }
 
-fn config_menu_choices() -> &'static [ConfigMenuChoice] {
+const fn config_menu_choices() -> &'static [ConfigMenuChoice] {
     &[
         ConfigMenuChoice::Telemetry,
         ConfigMenuChoice::PlannerProvider,
@@ -21695,7 +21635,7 @@ fn config_menu_choices() -> &'static [ConfigMenuChoice] {
     ]
 }
 
-fn config_provider_choices(confirming_clear: bool) -> &'static [ConfigProviderChoice] {
+const fn config_provider_choices(confirming_clear: bool) -> &'static [ConfigProviderChoice] {
     if confirming_clear {
         &[
             ConfigProviderChoice::CancelClearKey,
@@ -21842,7 +21782,7 @@ fn provider_label(provider: &str) -> &'static str {
     }
 }
 
-fn provider_options() -> &'static [ProviderOption] {
+const fn provider_options() -> &'static [ProviderOption] {
     &[
         ProviderOption {
             name: "local",
@@ -21945,7 +21885,7 @@ fn services_manager_choice_count(state: &ServicesManagerState) -> usize {
     state.items.len() + services_manager_actions(state).len()
 }
 
-fn services_manager_action_label(action: ServicesManagerAction) -> &'static str {
+const fn services_manager_action_label(action: ServicesManagerAction) -> &'static str {
     match action {
         ServicesManagerAction::Details => "Service details",
         ServicesManagerAction::Chat => "Chat with selected server",
@@ -22105,7 +22045,7 @@ fn automation_manager_row_label(
             } else {
                 item.proposal.title.as_str()
             };
-            format!("{:<18} {}", status, title)
+            format!("{status:<18} {title}")
         }
         AutomationManagerRow::PrefetchField(index, field) => {
             let Some(item) = state.items.get(index) else {
@@ -22123,7 +22063,7 @@ fn automation_manager_row_label(
     }
 }
 
-fn automation_prefetch_fields() -> &'static [AutomationPrefetchField] {
+const fn automation_prefetch_fields() -> &'static [AutomationPrefetchField] {
     &[
         AutomationPrefetchField::AllowDownload,
         AutomationPrefetchField::MaxBytes,
@@ -22212,8 +22152,7 @@ fn automation_prefetch_field_row_label(
             "  {:<16} {}",
             "Max download",
             proposal_u64_argument(proposal, "artifact_max_bytes")
-                .map(format_bytes_for_tui)
-                .unwrap_or_else(|| "not set".to_owned())
+                .map_or_else(|| "not set".to_owned(), format_bytes_for_tui)
         ),
         AutomationPrefetchField::AllowHuggingFace => format!(
             "  {:<16} {}",
@@ -22226,11 +22165,11 @@ fn automation_prefetch_field_row_label(
     }
 }
 
-fn yes_no_label(value: bool) -> &'static str {
+const fn yes_no_label(value: bool) -> &'static str {
     if value { "yes" } else { "no" }
 }
 
-fn automation_prefetch_field_status(field: AutomationPrefetchField) -> &'static str {
+const fn automation_prefetch_field_status(field: AutomationPrefetchField) -> &'static str {
     match field {
         AutomationPrefetchField::AllowDownload => {
             "Download setting selected. Press Enter or Left/Right to change it."
@@ -22244,7 +22183,7 @@ fn automation_prefetch_field_status(field: AutomationPrefetchField) -> &'static 
     }
 }
 
-fn automation_prefetch_field_saved_message(field: AutomationPrefetchField) -> &'static str {
+const fn automation_prefetch_field_saved_message(field: AutomationPrefetchField) -> &'static str {
     match field {
         AutomationPrefetchField::AllowDownload => "Download permission updated.",
         AutomationPrefetchField::MaxBytes => "Max download updated.",
@@ -22289,8 +22228,7 @@ fn render_prefetch_field_detail(
                 output,
                 "  Max download: {}",
                 proposal_u64_argument(proposal, "artifact_max_bytes")
-                    .map(format_bytes_for_tui)
-                    .unwrap_or_else(|| "not set".to_owned())
+                    .map_or_else(|| "not set".to_owned(), format_bytes_for_tui)
             );
             let _ = writeln!(
                 output,
@@ -22312,7 +22250,7 @@ fn render_prefetch_field_detail(
     output.trim_end().to_owned()
 }
 
-fn automation_watcher_mode_plain_label(mode: WatcherMode) -> &'static str {
+const fn automation_watcher_mode_plain_label(mode: WatcherMode) -> &'static str {
     match mode {
         WatcherMode::Observe => "record only",
         WatcherMode::Propose => "ask before taking action",
@@ -22609,7 +22547,7 @@ fn command_screen_action_label(action: CommandScreenAction) -> &'static str {
     }
 }
 
-fn overlay_action_from_command_screen_action(
+const fn overlay_action_from_command_screen_action(
     action: CommandScreenAction,
 ) -> Option<OverlayCardAction> {
     match action {
@@ -22693,7 +22631,7 @@ fn overlay_card_detail_text(state: &OverlayCardState) -> String {
     }
 }
 
-fn help_topic_label(topic: HelpTopic) -> &'static str {
+const fn help_topic_label(topic: HelpTopic) -> &'static str {
     match topic {
         HelpTopic::GettingStarted => "Start here",
         HelpTopic::TuiBasics => "Using the TUI",
@@ -23156,7 +23094,7 @@ fn help_command_detail(command: &str) -> String {
     format!("{title}\n\n{body}\n\nPress Enter to open this screen.")
 }
 
-fn logs_view_actions() -> &'static [LogsViewAction] {
+const fn logs_view_actions() -> &'static [LogsViewAction] {
     &[
         LogsViewAction::PreviousPage,
         LogsViewAction::NextPage,
@@ -23168,7 +23106,7 @@ fn logs_view_actions() -> &'static [LogsViewAction] {
     ]
 }
 
-fn logs_view_action_label(
+const fn logs_view_action_label(
     action: LogsViewAction,
     follow: bool,
     show_file_locations: bool,
@@ -23868,14 +23806,18 @@ fn doctor_folders_text(report: &str) -> String {
     let cache = doctor_report_value(report, "cache_dir");
     let rocm_downloads = doctor_report_raw_value(report, "active_runtime_pip_cache_dir")
         .or_else(|| doctor_report_raw_value(report, "setup_runtime_pip_cache_dir"))
-        .map(friendly_doctor_value)
-        .unwrap_or_else(|| "choose a ROCm install folder first".to_owned());
+        .map_or_else(
+            || "choose a ROCm install folder first".to_owned(),
+            friendly_doctor_value,
+        );
     let models = doctor_report_value(report, "model_cache_entries");
     let active_status = doctor_report_value(report, "active_runtime_status");
     let active_install = doctor_report_raw_value(report, "active_runtime_root")
         .or_else(|| doctor_report_raw_value(report, "setup_runtime_root"))
-        .map(friendly_doctor_value)
-        .unwrap_or_else(|| friendly_runtime_status(&active_status));
+        .map_or_else(
+            || friendly_runtime_status(&active_status),
+            friendly_doctor_value,
+        );
     let mut output = String::new();
     let _ = writeln!(output, "Folders");
     let _ = writeln!(output);
@@ -23895,8 +23837,7 @@ fn doctor_folders_text(report: &str) -> String {
 
 fn doctor_report_value(report: &str, key: &str) -> String {
     doctor_report_raw_value(report, key)
-        .map(friendly_doctor_value)
-        .unwrap_or_else(|| "not checked".to_owned())
+        .map_or_else(|| "not checked".to_owned(), friendly_doctor_value)
 }
 
 fn doctor_report_raw_value<'a>(report: &'a str, key: &str) -> Option<&'a str> {
@@ -24199,10 +24140,10 @@ fn model_picker_detail_text(app: &App) -> String {
     let _ = writeln!(
         output,
         "  GPU memory: {}",
-        recipe
-            .min_gpu_mem_gb
-            .map(|gb| format!("{gb} GB minimum"))
-            .unwrap_or_else(|| "not required".to_owned())
+        recipe.min_gpu_mem_gb.map_or_else(
+            || "not required".to_owned(),
+            |gb| format!("{gb} GB minimum")
+        )
     );
     if !recipe.preferred_engines.is_empty() {
         let _ = writeln!(output, "  engines: {}", recipe.preferred_engines.join(", "));
@@ -24349,28 +24290,28 @@ fn serve_wizard_detail_text(app: &App) -> String {
 fn model_recipe_fit_summary(recipe: &ModelRecipeRecord, total_vram_gib: Option<f64>) -> String {
     match (recipe.min_gpu_mem_gb, total_vram_gib) {
         (None, _) => "This recipe does not require GPU memory.".to_owned(),
-        (Some(required), Some(available)) if available >= (required as f64 + 2.0) => {
+        (Some(required), Some(available)) if available >= (f64::from(required) + 2.0) => {
             format!(
                 "Good fit: {} GPU memory available; recipe asks for {}.",
                 format_gib_for_tui(available),
-                format_gib_for_tui(required as f64)
+                format_gib_for_tui(f64::from(required))
             )
         }
-        (Some(required), Some(available)) if available >= required as f64 => {
+        (Some(required), Some(available)) if available >= f64::from(required) => {
             format!(
                 "Tight but usable: {} GPU memory available; recipe asks for {}.",
                 format_gib_for_tui(available),
-                format_gib_for_tui(required as f64)
+                format_gib_for_tui(f64::from(required))
             )
         }
         (Some(required), Some(available)) => format!(
             "Likely not enough GPU memory: {} available; recipe asks for {}.",
             format_gib_for_tui(available),
-            format_gib_for_tui(required as f64)
+            format_gib_for_tui(f64::from(required))
         ),
         (Some(required), None) => format!(
             "GPU memory is unknown; recipe asks for {}. Start may fail if this APU has too little shared memory.",
-            format_gib_for_tui(required as f64)
+            format_gib_for_tui(f64::from(required))
         ),
     }
 }
@@ -24914,51 +24855,48 @@ fn render_plan_review_text(request: &str, action: Option<&FreeformPlanAction>) -
     let _ = writeln!(output, "Request");
     let _ = writeln!(output, "  {}", request.trim());
     let _ = writeln!(output);
-    match action {
-        Some(action) => {
-            let _ = writeln!(output, "Ready action");
-            let _ = writeln!(output, "  {}", action.title);
-            for line in plan_action_summary_lines(action) {
-                let _ = writeln!(output, "  {line}");
-            }
-            let _ = writeln!(output);
-            if action.has_placeholders {
-                let _ = writeln!(output, "Needs more detail");
-                let _ = writeln!(
-                    output,
-                    "  Some values are still missing. Choose Edit request and be more specific."
-                );
-            } else if action.approval_required {
-                let _ = writeln!(output, "Before it runs");
-                let _ = writeln!(
-                    output,
-                    "  ROCm CLI will ask you to approve the change before it starts."
-                );
-            } else {
-                let _ = writeln!(output, "Before it runs");
-                let _ = writeln!(output, "  This action only reads local information.");
-            }
-            let _ = writeln!(output);
-            let _ = writeln!(output, "Controls");
-            let _ = writeln!(output, "  Run: review and start this action");
-            let _ = writeln!(output, "  Edit request: change the request text");
-            let _ = writeln!(output, "  Back: leave without running anything");
+    if let Some(action) = action {
+        let _ = writeln!(output, "Ready action");
+        let _ = writeln!(output, "  {}", action.title);
+        for line in plan_action_summary_lines(action) {
+            let _ = writeln!(output, "  {line}");
         }
-        None => {
+        let _ = writeln!(output);
+        if action.has_placeholders {
             let _ = writeln!(output, "Needs more detail");
             let _ = writeln!(
                 output,
-                "  I could not turn this into a supported ROCm CLI action yet."
+                "  Some values are still missing. Choose Edit request and be more specific."
             );
+        } else if action.approval_required {
+            let _ = writeln!(output, "Before it runs");
             let _ = writeln!(
                 output,
-                "  Choose Edit request and include the model, engine, or task you want."
+                "  ROCm CLI will ask you to approve the change before it starts."
             );
-            let _ = writeln!(output);
-            let _ = writeln!(output, "Controls");
-            let _ = writeln!(output, "  Edit request: change the request text");
-            let _ = writeln!(output, "  Back: leave without running anything");
+        } else {
+            let _ = writeln!(output, "Before it runs");
+            let _ = writeln!(output, "  This action only reads local information.");
         }
+        let _ = writeln!(output);
+        let _ = writeln!(output, "Controls");
+        let _ = writeln!(output, "  Run: review and start this action");
+        let _ = writeln!(output, "  Edit request: change the request text");
+        let _ = writeln!(output, "  Back: leave without running anything");
+    } else {
+        let _ = writeln!(output, "Needs more detail");
+        let _ = writeln!(
+            output,
+            "  I could not turn this into a supported ROCm CLI action yet."
+        );
+        let _ = writeln!(
+            output,
+            "  Choose Edit request and include the model, engine, or task you want."
+        );
+        let _ = writeln!(output);
+        let _ = writeln!(output, "Controls");
+        let _ = writeln!(output, "  Edit request: change the request text");
+        let _ = writeln!(output, "  Back: leave without running anything");
     }
     output.trim_end().to_owned()
 }
@@ -25645,8 +25583,7 @@ fn running_job_recent_output_visual_lines(app: &App, limit: usize, width: usize)
 fn display_stream_log_line(line: &str) -> String {
     line.strip_prefix("output:")
         .or_else(|| line.strip_prefix("Output:"))
-        .map(str::trim_start)
-        .unwrap_or(line)
+        .map_or(line, str::trim_start)
         .to_owned()
 }
 
@@ -26621,6 +26558,7 @@ fn chat_session_command_result_lines(
     kept
 }
 
+#[allow(clippy::case_sensitive_file_extension_comparisons)] // `text` is already lowercased above
 fn looks_like_log_path(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     lower.ends_with(".log")
@@ -26950,7 +26888,6 @@ fn render_command_output(
         "failed"
     });
     if let Some(code) = output.status.code() {
-        use std::fmt::Write as _;
         let _ = write!(rendered, " ({code})");
     }
     rendered.push('\n');
@@ -27350,7 +27287,6 @@ fn truncate_command_output(rendered: &str) -> String {
         return rendered.trim_end().to_owned();
     }
     let mut output = lines[..MAX_COMMAND_OUTPUT_LINES].join("\n");
-    use std::fmt::Write as _;
     let _ = write!(
         output,
         "\n... truncated {} line(s); use /logs or service logs for full output",
@@ -27445,7 +27381,6 @@ fn proposal_u64_argument(proposal: &AutomationProposalRecord, key: &str) -> Opti
 
 fn render_proposal_approval(proposal: &AutomationProposalRecord) -> String {
     let mut output = String::new();
-    use std::fmt::Write as _;
     let tool = proposal_tool_name(proposal);
     let _ = writeln!(output, "Review this request");
     let _ = writeln!(output, "  {}", proposal_plain_title(tool));
@@ -27722,8 +27657,8 @@ fn chat_install_sdk_approval_needs_prefix(args: &[String]) -> bool {
         && args.get(1).map(String::as_str) == Some("sdk")
         && cli_arg_value(args, "--prefix")
             .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_none()
+            .as_ref()
+            .is_none_or(|value| value.is_empty())
 }
 
 fn install_args_require_approval(args: &[&str]) -> Result<bool> {
@@ -27912,7 +27847,7 @@ where
     if count == 0 {
         None
     } else {
-        Some(sum / count as f64)
+        Some(sum / f64::from(count))
     }
 }
 
@@ -27931,27 +27866,19 @@ fn format_elapsed(duration: Duration) -> String {
 }
 
 fn format_optional_percent(value: Option<f64>) -> String {
-    value
-        .map(|value| format!("{value:.0}%"))
-        .unwrap_or_else(|| "--".to_owned())
+    value.map_or_else(|| "--".to_owned(), |value| format!("{value:.0}%"))
 }
 
 fn format_optional_watts(value: Option<f64>) -> String {
-    value
-        .map(|value| format!("{value:.0}W"))
-        .unwrap_or_else(|| "--".to_owned())
+    value.map_or_else(|| "--".to_owned(), |value| format!("{value:.0}W"))
 }
 
 fn format_optional_celsius(value: Option<f64>) -> String {
-    value
-        .map(|value| format!("{value:.0}C"))
-        .unwrap_or_else(|| "--".to_owned())
+    value.map_or_else(|| "--".to_owned(), |value| format!("{value:.0}C"))
 }
 
 fn format_optional_mhz(value: Option<f64>) -> String {
-    value
-        .map(|value| format!("{value:.0}MHz"))
-        .unwrap_or_else(|| "--".to_owned())
+    value.map_or_else(|| "--".to_owned(), |value| format!("{value:.0}MHz"))
 }
 
 fn format_vram_line(card: Option<&GpuMonitorCard>) -> String {
@@ -27968,6 +27895,8 @@ fn format_vram_line(card: Option<&GpuMonitorCard>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::{
         App, ChatToolApprovalRequest, GpuMonitorCard, GpuTelemetry, LOG_FOLLOW_REFRESH_INTERVAL,
         TuiMode, handle_key, load_gpu_monitor_cards_from_json, load_gpu_static_cards_from_json,
@@ -28511,7 +28440,7 @@ mod tests {
         let rendered = log.iter().cloned().collect::<Vec<_>>().join("\n");
         let display = {
             let mut app = test_app();
-            app.activity_log = log.clone();
+            app.activity_log = log;
             app.activity_text()
         };
 
@@ -33001,11 +32930,7 @@ mod tests {
             .iter()
             .position(|action| *action == super::LogsViewAction::ToggleFileLocations)
             .expect("file locations action should exist");
-        let current_index = app
-            .logs_view
-            .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+        let current_index = app.logs_view.as_ref().map_or(0, |state| state.selected);
         let steps = (file_locations_index + super::logs_view_actions().len() - current_index)
             % super::logs_view_actions().len();
         for _ in 0..steps {
@@ -33142,7 +33067,7 @@ mod tests {
         record.write()?;
         let mut log = String::new();
         for index in 1..=90 {
-            log.push_str(&format!("service-line-{index:03}\n"));
+            let _ = writeln!(log, "service-line-{index:03}");
         }
         fs::write(&record.log_path, log)?;
         assert!(app.handle_command("services"));
@@ -33541,8 +33466,7 @@ mod tests {
             .turns
             .iter()
             .find(|turn| turn.role == super::ChatSessionRole::Assistant)
-            .map(|turn| turn.content.as_str())
-            .unwrap_or("<missing>");
+            .map_or("<missing>", |turn| turn.content.as_str());
         assert!(
             assistant_content.contains("Here is what I found on this computer.")
                 && (assistant_content.contains("GPU:")
@@ -33902,35 +33826,32 @@ mod tests {
             app.set_input(prompt.to_owned());
             handle_key(&mut app, key_event(KeyCode::Enter, KeyModifiers::NONE));
 
-            match request_receiver.recv_timeout(Duration::from_millis(300)) {
-                Ok(request) => {
-                    assert_eq!(
-                        request.get("model").and_then(Value::as_str),
-                        Some(super::VALIDATED_LOCAL_ASSISTANT_MODEL),
-                        "{prompt}"
-                    );
-                    assert!(app.command_screen_is_chat_session(), "{prompt}");
-                    assert!(app.transcript.is_empty(), "{prompt}");
-                    assert!(app.services_manager.is_none(), "{prompt}");
-                    assert!(app.doctor_manager.is_none(), "{prompt}");
-                    assert!(app.install_manager.is_none(), "{prompt}");
-                    poll_app_until_idle(&mut app);
-                }
-                Err(_) => {
-                    let rendered = render_test_terminal(&app, 140, 32);
-                    assert!(
-                        app.pending_approval.is_some()
-                            || app.install_manager.is_some()
-                            || app.serve_wizard.is_some(),
-                        "{prompt}: {rendered}"
-                    );
-                    assert!(app.transcript.is_empty(), "{prompt}: {rendered}");
-                    assert!(!rendered.contains("I checked ROCm"), "{prompt}: {rendered}");
-                    assert!(
-                        !rendered.contains("ROCm CLI summary"),
-                        "{prompt}: {rendered}"
-                    );
-                }
+            if let Ok(request) = request_receiver.recv_timeout(Duration::from_millis(300)) {
+                assert_eq!(
+                    request.get("model").and_then(Value::as_str),
+                    Some(super::VALIDATED_LOCAL_ASSISTANT_MODEL),
+                    "{prompt}"
+                );
+                assert!(app.command_screen_is_chat_session(), "{prompt}");
+                assert!(app.transcript.is_empty(), "{prompt}");
+                assert!(app.services_manager.is_none(), "{prompt}");
+                assert!(app.doctor_manager.is_none(), "{prompt}");
+                assert!(app.install_manager.is_none(), "{prompt}");
+                poll_app_until_idle(&mut app);
+            } else {
+                let rendered = render_test_terminal(&app, 140, 32);
+                assert!(
+                    app.pending_approval.is_some()
+                        || app.install_manager.is_some()
+                        || app.serve_wizard.is_some(),
+                    "{prompt}: {rendered}"
+                );
+                assert!(app.transcript.is_empty(), "{prompt}: {rendered}");
+                assert!(!rendered.contains("I checked ROCm"), "{prompt}: {rendered}");
+                assert!(
+                    !rendered.contains("ROCm CLI summary"),
+                    "{prompt}: {rendered}"
+                );
             }
         }
 
@@ -37217,9 +37138,10 @@ Full log
     #[test]
     fn onboarding_folder_rejects_system_folder() {
         let system_path = if cfg!(windows) {
-            std::env::var_os("WINDIR")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"))
+            std::env::var_os("WINDIR").map_or_else(
+                || std::path::PathBuf::from(r"C:\Windows"),
+                std::path::PathBuf::from,
+            )
         } else {
             std::path::PathBuf::from("/usr")
         };
@@ -37449,7 +37371,7 @@ Full log
         assert!(rendered.contains("Install is working."));
         assert!(rendered.contains("Progress"));
         assert!(rendered.contains("Live output"));
-        assert!(rendered.contains("["));
+        assert!(rendered.contains('['));
         assert!(rendered.contains("Collecting torch"));
         assert_eq!(
             rendered.matches("Collecting torch").count(),
@@ -37707,7 +37629,7 @@ Full log
             streamed_stderr_lines: 0,
         });
 
-        for index in 0..(super::MAX_STREAM_EVENTS_PER_POLL + 1) {
+        for index in 0..=super::MAX_STREAM_EVENTS_PER_POLL {
             sender
                 .send(super::RunningJobEvent::Stream {
                     stream: super::CommandOutputStream::Stdout,
@@ -38216,7 +38138,7 @@ Full log
         app.onboarding_active = true;
         let mut stdout = String::new();
         for index in 1..=1_000 {
-            stdout.push_str(&format!("pip progress line {index:04}\n"));
+            let _ = writeln!(stdout, "pip progress line {index:04}");
         }
         let command_output = super::render_command_output(
             "rocm",
@@ -38752,7 +38674,7 @@ Full log
 
     #[test]
     fn input_viewport_follows_cursor_for_long_paths() {
-        let input = r#"/serve C:\models\very-long-folder\tiny.gguf --engine llama.cpp"#;
+        let input = r"/serve C:\models\very-long-folder\tiny.gguf --engine llama.cpp";
         let cursor = input.chars().count();
 
         let (visible, cursor_column) = super::input_viewport(input, cursor, 24);
@@ -38976,10 +38898,10 @@ Full log
 
     #[test]
     fn command_parser_preserves_windows_path_backslashes() {
-        let parts = super::split_command_line(r#"serve C:\models\tiny.gguf --engine llama.cpp"#)
+        let parts = super::split_command_line(r"serve C:\models\tiny.gguf --engine llama.cpp")
             .expect("windows path should parse");
 
-        assert_eq!(parts[1], r#"C:\models\tiny.gguf"#);
+        assert_eq!(parts[1], r"C:\models\tiny.gguf");
     }
 
     #[test]
@@ -38989,7 +38911,7 @@ Full log
         )
         .expect("quoted windows path should parse");
 
-        assert_eq!(parts[1], r#"C:\Users\jam\My Models\tiny.gguf"#);
+        assert_eq!(parts[1], r"C:\Users\jam\My Models\tiny.gguf");
     }
 
     #[test]
@@ -39064,7 +38986,7 @@ Full log
         for file_index in 0..3 {
             let mut body = String::new();
             for line_index in 0..12 {
-                body.push_str(&format!("entry-{file_index}-{line_index}\n"));
+                let _ = writeln!(body, "entry-{file_index}-{line_index}");
             }
             fs::write(action_dir.join(format!("test-{file_index}.log")), body)?;
         }
@@ -39130,11 +39052,7 @@ Full log
             .iter()
             .position(|action| *action == super::LogsViewAction::ToggleFileLocations)
             .expect("file locations action should exist");
-        let current_index = app
-            .logs_view
-            .as_ref()
-            .map(|state| state.selected)
-            .unwrap_or(0);
+        let current_index = app.logs_view.as_ref().map_or(0, |state| state.selected);
         let steps = (file_locations_index + super::logs_view_actions().len() - current_index)
             % super::logs_view_actions().len();
         for _ in 0..steps {
@@ -39222,8 +39140,11 @@ Full log
         app.logs_view
             .as_mut()
             .expect("follow state should be open")
-            .last_refresh_at =
-            Instant::now() - LOG_FOLLOW_REFRESH_INTERVAL - Duration::from_millis(1);
+            .last_refresh_at = Instant::now()
+            .checked_sub(LOG_FOLLOW_REFRESH_INTERVAL)
+            .unwrap()
+            .checked_sub(Duration::from_millis(1))
+            .unwrap();
         app.refresh_following_logs();
 
         assert!(
@@ -39497,7 +39418,7 @@ Full log
                     if args == &vec![
                         "engines".to_owned(),
                         "install".to_owned(),
-                        target_name.clone(),
+                        target_name,
                     ]
             ),
             "{pending_action:?}"
@@ -43186,7 +43107,7 @@ Full log
         let rendered = render_test_terminal(&app, 120, 28);
         assert!(rendered.contains("I could not find that automation check"));
         assert!(rendered.contains("Choose one from this list"));
-        assert!(rendered.contains(">"));
+        assert!(rendered.contains('>'));
 
         assert!(app.handle_command("automations enable cache-warm --mode turbo"));
 
@@ -43911,7 +43832,7 @@ Full log
             provider_key_store: Arc::new(TestProviderKeyStore::default()),
             mode: TuiMode::Ask,
             host_gpu_summary: HostGpuSummary::default(),
-            gpu_telemetry: Default::default(),
+            gpu_telemetry: GpuTelemetry::default(),
             transcript: Vec::new(),
             transcript_scroll: 0,
             input: String::new(),
@@ -44190,7 +44111,7 @@ Full log
                 let request_value = serde_json::from_slice::<Value>(body).ok();
                 if let Some(value) = request_value.as_ref() {
                     let _ = sender.send(value.clone());
-                };
+                }
                 served_chat_responses += 1;
                 if request_value
                     .as_ref()
@@ -44296,8 +44217,7 @@ Full log
         assert!(
             app.running_job
                 .as_ref()
-                .map(|job| !matches!(job.kind, super::RunningJobKind::DoctorRefresh))
-                .unwrap_or(true),
+                .is_none_or(|job| !matches!(job.kind, super::RunningJobKind::DoctorRefresh)),
             "{command} should discard hidden Doctor refresh before continuing"
         );
         assert!(
@@ -44547,7 +44467,7 @@ Full log
         render_test_buffer(app, width, height)
             .content()
             .iter()
-            .map(|cell| cell.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect::<String>()
     }
 
@@ -44665,7 +44585,7 @@ Full log
         let manifest = serde_json::json!({
             "runtime_key": runtime_key,
             "runtime_id": runtime_id,
-            "install_root": install_root.clone(),
+            "install_root": install_root,
             "selected_artifact_url": "https://example.invalid/therock",
             "index_url": "https://example.invalid/therock",
             "python_executable": python_executable,

--- a/apps/rocmd/Cargo.toml
+++ b/apps/rocmd/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -54,7 +54,7 @@ const GPU_THERMAL_HOTSPOT_PRESSURE_C: f64 = 95.0;
 const GPU_THERMAL_MEMORY_PRESSURE_C: f64 = 95.0;
 const GPU_MEMORY_VRAM_PRESSURE_PERCENT: f64 = 95.0;
 const AMD_SMI_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-const ARTIFACT_PREFETCH_TIMEOUT: Duration = Duration::from_secs(600);
+const ARTIFACT_PREFETCH_TIMEOUT: Duration = Duration::from_mins(10);
 
 #[derive(Parser, Debug)]
 #[command(name = "rocmd", about = "rocm-cli local supervisor", version)]
@@ -177,7 +177,7 @@ enum SandboxToolArg {
 }
 
 impl SandboxToolArg {
-    fn as_cli_value(self) -> &'static str {
+    const fn as_cli_value(self) -> &'static str {
         match self {
             Self::CheckUpdates => "check_updates",
             Self::DriverPlan => "driver_plan",
@@ -191,7 +191,7 @@ impl SandboxToolArg {
     }
 
     #[cfg(target_os = "linux")]
-    fn writes_data(self) -> bool {
+    const fn writes_data(self) -> bool {
         matches!(
             self,
             Self::RestartServer | Self::StopServer | Self::NotifyUser
@@ -199,7 +199,7 @@ impl SandboxToolArg {
     }
 
     #[cfg(target_os = "linux")]
-    fn writes_cache(self) -> bool {
+    const fn writes_cache(self) -> bool {
         matches!(self, Self::CheckUpdates | Self::PrefetchArtifact)
     }
 }
@@ -494,7 +494,7 @@ fn run_bubblewrap_sandbox(
         policy,
     );
 
-    let output = run_process_with_timeout(command, Duration::from_secs(60))?;
+    let output = run_process_with_timeout(command, Duration::from_mins(1))?;
     let value = parse_sandbox_child_output(output, "bubblewrap sandbox")?;
     record_sandbox_audit(paths, tool, "bubblewrap", true, service_id.as_deref())?;
     Ok(sandbox_report(tool, "bubblewrap", value))
@@ -552,14 +552,14 @@ fn run_sandbox_tool(
 ) -> Result<Value> {
     match tool {
         SandboxToolArg::CheckUpdates => {
-            let output = run_rocm_capture_for_paths(paths, &["update"], Duration::from_secs(60))?;
+            let output = run_rocm_capture_for_paths(paths, &["update"], Duration::from_mins(1))?;
             Ok(sandbox_check_updates_value(output))
         }
         SandboxToolArg::DriverPlan => {
             let output = run_rocm_capture_for_paths(
                 paths,
                 &["install", "driver", "--dkms", "--dry-run"],
-                Duration::from_secs(60),
+                Duration::from_mins(1),
             )?;
             Ok(sandbox_driver_plan_value(output))
         }
@@ -896,13 +896,13 @@ fn declared_source_policy_block_message(artifact: &ModelRecipeArtifactRecord) ->
 
     match source_policy.policy.as_str() {
         "direct_https_sha256" => {
-            if !artifact.uri.starts_with("https://") {
+            if artifact.uri.starts_with("https://") {
+                None
+            } else {
                 Some(
                     "recipe source policy direct_https_sha256 requires an HTTPS artifact URI"
                         .to_owned(),
                 )
-            } else {
-                None
             }
         }
         "huggingface_public" => {
@@ -1029,7 +1029,9 @@ fn download_artifact_bytes(
     }
     let response = request.call().map_err(|error| match error {
         ureq::Error::Status(status, _) => anyhow::anyhow!("HTTP {status} while fetching {url}"),
-        other => anyhow::anyhow!("HTTP request failed for {url}: {other}"),
+        other @ ureq::Error::Transport(_) => {
+            anyhow::anyhow!("HTTP request failed for {url}: {other}")
+        }
     })?;
     let mut reader = response.into_reader().take(max_bytes.saturating_add(1));
     let mut bytes = Vec::new();
@@ -1043,11 +1045,12 @@ fn download_artifact_bytes(
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
     let digest = Sha256::digest(bytes);
-    digest
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>()
+    digest.iter().fold(String::new(), |mut acc, byte| {
+        let _ = write!(acc, "{byte:02x}");
+        acc
+    })
 }
 
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -1369,7 +1372,7 @@ fn bridge_engine_inventory() -> Vec<CodexBridgeEngine> {
         .collect()
 }
 
-fn rocmd_engine_inventory() -> &'static [(&'static str, &'static str)] {
+const fn rocmd_engine_inventory() -> &'static [(&'static str, &'static str)] {
     &[
         ("pytorch", "default local serving engine"),
         (
@@ -2241,7 +2244,7 @@ struct CommandCapture {
 
 fn run_rocm_capture(args: &[&str]) -> Result<CommandCapture> {
     let paths = AppPaths::discover()?;
-    run_rocm_capture_for_paths(&paths, args, Duration::from_secs(120))
+    run_rocm_capture_for_paths(&paths, args, Duration::from_mins(2))
 }
 
 fn run_rocm_capture_for_paths(
@@ -2591,9 +2594,10 @@ fn stop_managed_service(paths: &AppPaths, service_id: &str) -> Result<Value> {
         if !seen_pids.insert(pid) {
             continue;
         }
-        match terminate_process(pid)? {
-            true => signaled_pids.push(pid),
-            false => skipped_pids.push(pid),
+        if terminate_process(pid)? {
+            signaled_pids.push(pid);
+        } else {
+            skipped_pids.push(pid);
         }
     }
     let force_signaled_pids = force_terminate_remaining_processes(&signaled_pids)?;
@@ -2891,58 +2895,55 @@ async fn run_daemon(
                 state.write(paths)?;
             }
             event = receive_local_webhook_event(&mut local_webhook_receiver) => {
-                match event {
-                    Some(event) => {
-                        let config = RocmCliConfig::load(paths)?;
-                        reconcile_watcher_snapshots(&config, &mut state);
+                if let Some(event) = event {
+                    let config = RocmCliConfig::load(paths)?;
+                    reconcile_watcher_snapshots(&config, &mut state);
+                    record_event(
+                        paths,
+                        &mut state,
+                        "rocmd",
+                        "info",
+                        "local_webhook_event",
+                        &format!(
+                            "received local webhook event kind={} watcher_hint={}; dispatching through existing watcher policy; webhook payload grants no new action",
+                            event.kind,
+                            event.watcher_hint.as_deref().unwrap_or("<none>")
+                        ),
+                        event.service_id.clone(),
+                    )?;
+                    if let Err(error) =
+                        evaluate_watchers_for_events(paths, &config, &mut state, &[event])
+                    {
                         record_event(
                             paths,
                             &mut state,
                             "rocmd",
-                            "info",
-                            "local_webhook_event",
+                            "error",
+                            "local_webhook_dispatch_failed",
                             &format!(
-                                "received local webhook event kind={} watcher_hint={}; dispatching through existing watcher policy; webhook payload grants no new action",
-                                event.kind,
-                                event.watcher_hint.as_deref().unwrap_or("<none>")
+                                "local webhook event could not be dispatched through watcher policy: {error}"
                             ),
-                            event.service_id.clone(),
-                        )?;
-                        if let Err(error) =
-                            evaluate_watchers_for_events(paths, &config, &mut state, &[event])
-                        {
-                            record_event(
-                                paths,
-                                &mut state,
-                                "rocmd",
-                                "error",
-                                "local_webhook_dispatch_failed",
-                                &format!(
-                                    "local webhook event could not be dispatched through watcher policy: {error}"
-                                ),
-                                None,
-                            )?;
-                        }
-                        state.last_tick_unix_ms = unix_time_millis();
-                        state.write(paths)?;
-                    }
-                    None => {
-                        local_webhook_receiver = None;
-                        state.local_webhook_endpoint = None;
-                        record_event(
-                            paths,
-                            &mut state,
-                            "rocmd",
-                            "warn",
-                            "local_webhook_stopped",
-                            "local webhook source stopped; automation daemon continues without webhook ingestion",
                             None,
                         )?;
-                        state.write(paths)?;
                     }
+                    state.last_tick_unix_ms = unix_time_millis();
+                    state.write(paths)?;
+                } else {
+                    local_webhook_receiver = None;
+                    state.local_webhook_endpoint = None;
+                    record_event(
+                        paths,
+                        &mut state,
+                        "rocmd",
+                        "warn",
+                        "local_webhook_stopped",
+                        "local webhook source stopped; automation daemon continues without webhook ingestion",
+                        None,
+                    )?;
+                    state.write(paths)?;
                 }
             }
-            _ = &mut shutdown => {
+            () = &mut shutdown => {
                 break;
             }
         }
@@ -3060,7 +3061,7 @@ fn supervise_service(
         engine.clone(),
         model_ref,
         canonical_model_id.clone(),
-        host.clone(),
+        host,
         port,
         "managed",
         std::process::id(),
@@ -3096,7 +3097,7 @@ fn supervise_service(
         .stdout(Stdio::from(log_file))
         .stderr(Stdio::from(log_file_err))
         .spawn()
-        .with_context(|| format!("failed to spawn engine supervisor child for {}", engine))?;
+        .with_context(|| format!("failed to spawn engine supervisor child for {engine}"))?;
 
     record.engine_pid = Some(child.id());
     record.status = "running".to_owned();
@@ -3107,7 +3108,7 @@ fn supervise_service(
         &record.service_id,
         &record.host,
         record.port,
-        Duration::from_secs(180),
+        Duration::from_mins(3),
     ) {
         record.status = "ready".to_owned();
         record.write()?;
@@ -3724,7 +3725,7 @@ fn restricted_check_updates_result(value: &Value) -> Result<RestrictedCheckUpdat
     let exit_status = value
         .get("exit_status")
         .and_then(Value::as_i64)
-        .unwrap_or(if status == "error" { 1 } else { 0 });
+        .unwrap_or_else(|| i64::from(status == "error"));
     Ok(RestrictedCheckUpdatesResult {
         status,
         update_available,
@@ -3766,8 +3767,7 @@ fn therock_update_due(state: &AutomationRuntimeState, now: u128) -> bool {
     };
     snapshot
         .last_event_unix_ms
-        .map(|last_event| now.saturating_sub(last_event) >= THEROCK_UPDATE_INTERVAL_MS)
-        .unwrap_or(true)
+        .is_none_or(|last_event| now.saturating_sub(last_event) >= THEROCK_UPDATE_INTERVAL_MS)
 }
 
 fn gpu_metrics_due(state: &AutomationRuntimeState, now: u128) -> bool {
@@ -3780,8 +3780,7 @@ fn gpu_metrics_due(state: &AutomationRuntimeState, now: u128) -> bool {
     };
     snapshot
         .last_event_unix_ms
-        .map(|last_event| now.saturating_sub(last_event) >= GPU_METRICS_INTERVAL_MS)
-        .unwrap_or(true)
+        .is_none_or(|last_event| now.saturating_sub(last_event) >= GPU_METRICS_INTERVAL_MS)
 }
 
 fn gpu_thermal_protect_due(state: &AutomationRuntimeState, now: u128) -> bool {
@@ -3794,8 +3793,7 @@ fn gpu_thermal_protect_due(state: &AutomationRuntimeState, now: u128) -> bool {
     };
     snapshot
         .last_event_unix_ms
-        .map(|last_event| now.saturating_sub(last_event) >= GPU_METRICS_INTERVAL_MS)
-        .unwrap_or(true)
+        .is_none_or(|last_event| now.saturating_sub(last_event) >= GPU_METRICS_INTERVAL_MS)
 }
 
 fn handle_gpu_metrics_event(
@@ -3943,8 +3941,7 @@ fn gpu_pressure_event(now: u128, reading: GpuPressureReading) -> Option<Automati
     };
     let gpu_label = reading
         .gpu_index
-        .map(|gpu| format!("GPU {gpu}"))
-        .unwrap_or_else(|| "the GPU".to_owned());
+        .map_or_else(|| "the GPU".to_owned(), |gpu| format!("GPU {gpu}"));
     let unit = if metric_label == "VRAM use" {
         "%"
     } else {
@@ -4439,7 +4436,7 @@ fn restricted_driver_plan_result(value: &Value) -> Result<RestrictedDriverPlanRe
     let exit_status = value
         .get("exit_status")
         .and_then(Value::as_i64)
-        .unwrap_or(if status == "error" { 1 } else { 0 });
+        .unwrap_or_else(|| i64::from(status == "error"));
     Ok(RestrictedDriverPlanResult {
         status,
         exit_status,
@@ -4638,8 +4635,7 @@ fn server_recover_due(state: &AutomationRuntimeState, now: u128) -> bool {
     };
     snapshot
         .last_event_unix_ms
-        .map(|last_event| now.saturating_sub(last_event) >= SERVER_RECOVER_BACKOFF_MS)
-        .unwrap_or(true)
+        .is_none_or(|last_event| now.saturating_sub(last_event) >= SERVER_RECOVER_BACKOFF_MS)
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -4649,7 +4645,7 @@ enum WatcherPolicyAction {
     RunContained,
 }
 
-fn watcher_policy_action(watcher_id: &str, mode: WatcherMode) -> WatcherPolicyAction {
+const fn watcher_policy_action(watcher_id: &str, mode: WatcherMode) -> WatcherPolicyAction {
     match (watcher_id, mode) {
         (_, WatcherMode::Observe) => WatcherPolicyAction::Observe,
         (_, WatcherMode::Propose) => WatcherPolicyAction::QueueProposal,
@@ -4841,13 +4837,12 @@ fn record_event(
             category: "automation".to_owned(),
             actor: audit_watcher_id
                 .as_deref()
-                .map(|id| format!("watcher:{id}"))
-                .unwrap_or_else(|| "rocmd".to_owned()),
+                .map_or_else(|| "rocmd".to_owned(), |id| format!("watcher:{id}")),
             level: level.to_owned(),
             action: action.to_owned(),
             message: message.to_owned(),
             watcher_id: audit_watcher_id,
-            service_id: event.service_id.clone(),
+            service_id: event.service_id,
         },
     )
 }
@@ -4890,7 +4885,7 @@ fn queue_proposal_with_arguments(
             title: title.to_owned(),
             message: message.to_owned(),
             status: "pending".to_owned(),
-            service_id: service_id.clone(),
+            service_id,
             tool: proposal_tool_for_action(action).map(str::to_owned),
             arguments,
             reviewed_at_unix_ms: None,
@@ -7624,7 +7619,7 @@ mod tests {
                 .and_then(Value::as_array)
                 .is_some_and(|pids| pids
                     .iter()
-                    .any(|pid| pid.as_u64() == Some(current_pid as u64)))
+                    .any(|pid| pid.as_u64() == Some(u64::from(current_pid))))
         );
         Ok(())
     }
@@ -8557,10 +8552,10 @@ where
     let envelope: EngineResponseEnvelope =
         serde_json::from_slice(&output.stdout).context("failed to parse engine response")?;
     if !envelope.ok {
-        let detail = envelope
-            .error
-            .map(|error| format!("{}: {}", error.code, error.message))
-            .unwrap_or_else(|| "unknown engine error".to_owned());
+        let detail = envelope.error.map_or_else(
+            || "unknown engine error".to_owned(),
+            |error| format!("{}: {}", error.code, error.message),
+        );
         bail!(detail);
     }
     let data = envelope

--- a/crates/rocm-core/Cargo.toml
+++ b/crates/rocm-core/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 directories.workspace = true

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3829,15 +3829,15 @@ fn default_dashboard_theme() -> String {
     "default-dark".to_owned()
 }
 
-fn default_gpu_tick_secs() -> f64 {
+const fn default_gpu_tick_secs() -> f64 {
     1.0
 }
 
-fn default_discovery_tick_secs() -> f64 {
+const fn default_discovery_tick_secs() -> f64 {
     5.0
 }
 
-fn default_instance_tick_secs() -> f64 {
+const fn default_instance_tick_secs() -> f64 {
     2.0
 }
 
@@ -3892,7 +3892,7 @@ impl DashboardDaemonConfig {
 /// Dashboard TUI spec. The chat endpoint URL / model / auth-header *name* are
 /// plain data; the auth-header *value* (API key) is always env-only and never
 /// stored here (AMD gateway invariant).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DashboardTuiConfig {
     #[serde(default = "default_dashboard_connect")]
     pub connect: String,
@@ -3930,6 +3930,7 @@ impl DashboardConfig {
     /// Return a copy with the chat endpoint base URL + model set and the custom
     /// auth header cleared (mirrors the rocm-dash `config_with_chat` behavior).
     /// Immutable transform — scoped to the dashboard sub-config only.
+    #[must_use]
     pub fn with_chat_endpoint(
         mut self,
         base_url: impl Into<String>,
@@ -3942,12 +3943,14 @@ impl DashboardConfig {
     }
 
     /// Return a copy with the dashboard theme set.
+    #[must_use]
     pub fn with_theme(mut self, theme: impl Into<String>) -> Self {
         self.tui.theme = theme.into();
         self
     }
 
     /// Return a copy with the telemetry daemon listen address set.
+    #[must_use]
     pub fn with_daemon_listen(mut self, listen: impl Into<String>) -> Self {
         self.daemon.listen = listen.into();
         self
@@ -7498,6 +7501,7 @@ Class Name:                Display
     // ===== Dashboard sub-config + migration =====
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn dashboard_config_defaults_and_json_round_trip() {
         let cfg = DashboardConfig::default();
         assert_eq!(cfg.daemon.listen, "unix:/tmp/rocmdashd.sock");
@@ -7574,6 +7578,7 @@ Class Name:                Display
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn migrate_legacy_dashboard_toml_maps_knobs_and_is_one_shot() -> Result<()> {
         let (root, paths) = temp_app_paths("migrate-dash");
         paths.ensure()?;

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -250,7 +250,7 @@ fn model_ref_basename(value: &str) -> &str {
         .trim()
         .rsplit(['/', '\\'])
         .next()
-        .unwrap_or(value.trim())
+        .unwrap_or_else(|| value.trim())
 }
 
 fn model_ref_family_matches(reported: &str, expected_family: &str) -> bool {
@@ -267,7 +267,7 @@ fn normalize_model_ref_family(value: &str) -> String {
     value
         .trim()
         .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .flat_map(char::to_lowercase)
         .collect()
 }
@@ -324,6 +324,7 @@ pub fn read_tcp_stream_to_string(stream: &mut TcpStream) -> Result<String> {
 }
 
 #[cfg(all(target_vendor = "cosmo", not(windows)))]
+#[allow(unsafe_code)] // libc socket FFI
 fn cosmo_send_all(stream: &TcpStream, mut bytes: &[u8]) -> Result<()> {
     let fd = stream.as_raw_fd();
     while !bytes.is_empty() {
@@ -344,6 +345,7 @@ fn cosmo_send_all(stream: &TcpStream, mut bytes: &[u8]) -> Result<()> {
 }
 
 #[cfg(all(target_vendor = "cosmo", not(windows)))]
+#[allow(unsafe_code)] // libc socket FFI
 fn cosmo_recv_to_string(stream: &TcpStream) -> Result<String> {
     let fd = stream.as_raw_fd();
     let mut response = Vec::new();
@@ -405,6 +407,7 @@ pub fn spawn_hidden_console_no_inherit(
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)] // Win32 FFI
 pub fn spawn_hidden_console_with_log(
     program: &Path,
     args: &[String],
@@ -478,6 +481,7 @@ pub fn spawn_hidden_console_with_log(
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)] // Win32 FFI
 pub fn wait_for_process_exit(pid: u32) -> Result<u32> {
     use windows_sys::Win32::Foundation::CloseHandle;
 
@@ -510,6 +514,7 @@ pub fn wait_for_process_exit(pid: u32) -> Result<u32> {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)] // Win32 FFI
 pub fn terminate_process(pid: u32) -> Result<()> {
     use windows_sys::Win32::Foundation::CloseHandle;
 
@@ -534,8 +539,9 @@ pub fn terminate_process(pid: u32) -> Result<()> {
 }
 
 #[cfg(not(windows))]
+#[allow(unsafe_code)] // libc FFI
 pub fn terminate_process(pid: u32) -> Result<()> {
-    let status = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    let status = unsafe { libc::kill(pid.cast_signed(), libc::SIGTERM) };
     if status == 0 {
         Ok(())
     } else {
@@ -545,6 +551,7 @@ pub fn terminate_process(pid: u32) -> Result<()> {
 }
 
 #[cfg(windows)]
+#[allow(unsafe_code)] // Win32 FFI
 pub fn process_is_running(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::CloseHandle;
 
@@ -564,6 +571,7 @@ pub fn process_is_running(pid: u32) -> bool {
 }
 
 #[cfg(not(windows))]
+#[allow(unsafe_code)] // libc FFI
 pub fn process_is_running(pid: u32) -> bool {
     if pid == 0 {
         return false;
@@ -579,6 +587,7 @@ pub fn process_is_running(pid: u32) -> bool {
 }
 
 #[cfg(unix)]
+#[allow(unsafe_code)] // libc FFI (pre_exec/setsid)
 pub fn detach_command_session(command: &mut Command) {
     use std::os::unix::process::CommandExt;
 
@@ -597,6 +606,7 @@ pub fn detach_command_session(command: &mut Command) {
 pub fn detach_command_session(_command: &mut Command) {}
 
 #[cfg(windows)]
+#[allow(unsafe_code)] // Win32 FFI
 fn spawn_windows_no_inherit(
     program: &Path,
     args: &[String],
@@ -772,6 +782,7 @@ impl AppPaths {
         self
     }
 
+    #[must_use]
     pub fn with_managed_root(mut self, root: impl Into<PathBuf>, keep_cache_dir: bool) -> Self {
         self.data_dir = normalize_runtime_path_for_host(&root.into());
         if !keep_cache_dir {
@@ -814,9 +825,10 @@ impl AppPaths {
     }
 
     pub fn engine_envs_root(&self) -> PathBuf {
-        env_path_override("ROCM_CLI_ENGINE_ENVS_ROOT")
-            .map(|root| normalize_runtime_path_for_host(&root))
-            .unwrap_or_else(|| self.data_dir.join("engines"))
+        env_path_override("ROCM_CLI_ENGINE_ENVS_ROOT").map_or_else(
+            || self.data_dir.join("engines"),
+            |root| normalize_runtime_path_for_host(&root),
+        )
     }
 
     pub fn engine_envs_dir(&self, engine: &str) -> PathBuf {
@@ -917,14 +929,12 @@ pub fn engine_plugin_dirs(paths: &AppPaths) -> Vec<PathBuf> {
 }
 
 fn env_flag(name: &str) -> bool {
-    std::env::var(name)
-        .map(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
+    std::env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1169,8 +1179,7 @@ impl DoctorSummary {
             self.distro.as_deref().unwrap_or("<unknown>"),
             self.cpu.as_deref().unwrap_or("<unknown>"),
             self.system_ram_gib
-                .map(format_gib_value)
-                .unwrap_or_else(|| "<unknown>".to_owned()),
+                .map_or_else(|| "<unknown>".to_owned(), format_gib_value),
             self.interactive_terminal,
             self.default_engine,
             self.detected_gfx_target.as_deref().unwrap_or("<unknown>"),
@@ -1187,15 +1196,14 @@ impl DoctorSummary {
             legacy_paths,
             self.legacy_rocm.detail.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm_guidance(),
-            wsl.map(|summary| summary.is_wsl).unwrap_or(false),
-            wsl.map(|summary| summary.dxg_device).unwrap_or(false),
-            wsl.map(|summary| summary.dxcore).unwrap_or(false),
-            wsl.map(|summary| summary.librocdxg).unwrap_or(false),
-            wsl.map(|summary| summary.rocdxg_dids).unwrap_or(false),
-            wsl.map(|summary| summary.ldconfig_librocdxg)
-                .unwrap_or(false),
-            wsl.map(|summary| summary.rocminfo).unwrap_or(false),
-            wsl.map(|summary| summary.cargo).unwrap_or(false),
+            wsl.is_some_and(|summary| summary.is_wsl),
+            wsl.is_some_and(|summary| summary.dxg_device),
+            wsl.is_some_and(|summary| summary.dxcore),
+            wsl.is_some_and(|summary| summary.librocdxg),
+            wsl.is_some_and(|summary| summary.rocdxg_dids),
+            wsl.is_some_and(|summary| summary.ldconfig_librocdxg),
+            wsl.is_some_and(|summary| summary.rocminfo),
+            wsl.is_some_and(|summary| summary.cargo),
             wsl.and_then(|summary| summary.detail.as_deref())
                 .unwrap_or("<not WSL>"),
             self.managed_runtime_count,
@@ -1207,7 +1215,7 @@ impl DoctorSummary {
         )
     }
 
-    fn legacy_rocm_guidance(&self) -> &'static str {
+    const fn legacy_rocm_guidance(&self) -> &'static str {
         if self.legacy_rocm.paths.is_empty() {
             return "none";
         }
@@ -1222,7 +1230,7 @@ pub fn interactive_terminal() -> bool {
     stdin().is_terminal() && stdout().is_terminal()
 }
 
-pub fn default_engine_for_platform() -> &'static str {
+pub const fn default_engine_for_platform() -> &'static str {
     "lemonade"
 }
 
@@ -1541,6 +1549,7 @@ fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
     }
 }
 
+#[allow(clippy::case_sensitive_file_extension_comparisons)] // ROCm installs the runtime DLL as lowercase `amdhip64.dll`
 fn legacy_rocm_candidate_exists(candidate: &Path) -> bool {
     if !candidate.exists() {
         return false;
@@ -1569,8 +1578,7 @@ fn legacy_rocm_candidate_exists(candidate: &Path) -> bool {
             entry
                 .file_name()
                 .to_str()
-                .map(|name| name.starts_with("amdhip64") && name.ends_with(".dll"))
-                .unwrap_or(false)
+                .is_some_and(|name| name.starts_with("amdhip64") && name.ends_with(".dll"))
         })
 }
 
@@ -1586,7 +1594,7 @@ fn detect_windows_amd_display_driver() -> Option<String> {
 }
 
 #[cfg(not(any(windows, target_vendor = "cosmo")))]
-fn detect_windows_amd_display_driver() -> Option<String> {
+const fn detect_windows_amd_display_driver() -> Option<String> {
     None
 }
 
@@ -1689,17 +1697,14 @@ fn detect_windows_doctor_inventory_from_pnp_entity() -> Option<WindowsDoctorInve
 }
 
 #[cfg(not(any(windows, target_vendor = "cosmo")))]
-fn detect_windows_doctor_inventory() -> Option<WindowsDoctorInventory> {
+const fn detect_windows_doctor_inventory() -> Option<WindowsDoctorInventory> {
     None
 }
 
 #[cfg(any(windows, target_vendor = "cosmo", test))]
 fn clean_windows_display_name(value: &str) -> String {
     let value = value.trim();
-    let value = value
-        .rsplit_once(';')
-        .map(|(_, name)| name)
-        .unwrap_or(value);
+    let value = value.rsplit_once(';').map_or(value, |(_, name)| name);
     value.trim().to_owned()
 }
 
@@ -1825,8 +1830,8 @@ fn push_windows_pnputil_display(
 }
 
 pub fn detect_host_gpu_diagnostics() -> String {
-    let mut output = String::new();
     use std::fmt::Write as _;
+    let mut output = String::new();
     let _ = writeln!(output, "GPU detection diagnostics");
     let _ = writeln!(output, "  runtime_os: {}", runtime_os_name());
     let summary = detect_host_gpu_summary(None);
@@ -1920,7 +1925,7 @@ fn append_windows_gpu_probe_diagnostics(output: &mut String) {
 }
 
 #[cfg(not(any(windows, target_vendor = "cosmo")))]
-fn append_windows_gpu_probe_diagnostics(_output: &mut String) {}
+const fn append_windows_gpu_probe_diagnostics(_output: &mut String) {}
 
 #[cfg(any(windows, target_vendor = "cosmo"))]
 fn append_windows_probe_diagnostics(
@@ -2140,9 +2145,7 @@ fn count_json_files(dir: &Path) -> usize {
 }
 
 fn count_dir_entries(dir: &Path) -> usize {
-    fs::read_dir(dir)
-        .map(|entries| entries.flatten().count())
-        .unwrap_or(0)
+    fs::read_dir(dir).map_or(0, |entries| entries.flatten().count())
 }
 
 pub fn require_nonempty(value: &str, field_name: &str) -> Result<()> {
@@ -2300,7 +2303,7 @@ fn newest_therock_family_in_manifest_dir(path: &Path) -> Option<(u128, String)> 
 fn detect_managed_therock_sdk_gfx_target(paths: &AppPaths) -> Option<String> {
     managed_therock_sdk_probe_candidates(&paths.data_dir.join("runtimes").join("registry"))
         .into_iter()
-        .filter_map(|candidate| {
+        .find_map(|candidate| {
             let tool = managed_sdk_tool_path(&candidate.bin_path, "rocm_agent_enumerator")?;
             let mut envs = Vec::new();
             if let Some(ld_library_path) = managed_sdk_ld_library_path(&candidate) {
@@ -2309,7 +2312,6 @@ fn detect_managed_therock_sdk_gfx_target(paths: &AppPaths) -> Option<String> {
             capture_optional_path_command_with_env(&tool, &[], &envs, OPTIONAL_COMMAND_TIMEOUT)
                 .and_then(|output| extract_first_gfx_token(&output))
         })
-        .next()
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2601,9 +2603,8 @@ fn newer_therock_family(
 ) -> Option<(u128, String)> {
     match (left, right) {
         (Some(left), Some(right)) if left.0 > right.0 => Some(left),
-        (Some(_), Some(right)) => Some(right),
+        (Some(_) | None, Some(right)) => Some(right),
         (Some(left), None) => Some(left),
-        (None, Some(right)) => Some(right),
         (None, None) => None,
     }
 }
@@ -2642,8 +2643,7 @@ impl TheRockFamilyManifest {
             || self
                 .runtime_id
                 .as_deref()
-                .map(|runtime_id| runtime_id.to_ascii_lowercase().starts_with("therock-"))
-                .unwrap_or(false)
+                .is_some_and(|runtime_id| runtime_id.to_ascii_lowercase().starts_with("therock-"))
     }
 }
 
@@ -2833,10 +2833,9 @@ fn capture_optional_command_candidate_with_timeout(
                     .unwrap_or_default();
                 if status.success() {
                     return String::from_utf8(bytes).ok();
-                } else {
-                    debug_command_capture_failure(program, "exit", &format!("status {status}"));
-                    return None;
                 }
+                debug_command_capture_failure(program, "exit", &format!("status {status}"));
+                return None;
             }
             Ok(None) if start.elapsed() < timeout => {
                 thread::sleep(Duration::from_millis(25));
@@ -2894,12 +2893,9 @@ fn capture_optional_path_command_with_env(
     for (key, value) in envs {
         command.env(key, value);
     }
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(_) => {
-            let _ = fs::remove_file(&output_path);
-            return None;
-        }
+    let Ok(mut child) = command.spawn() else {
+        let _ = fs::remove_file(&output_path);
+        return None;
     };
 
     let start = Instant::now();
@@ -2917,13 +2913,7 @@ fn capture_optional_path_command_with_env(
             Ok(None) if start.elapsed() < timeout => {
                 thread::sleep(Duration::from_millis(25));
             }
-            Ok(None) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = fs::remove_file(&output_path);
-                return None;
-            }
-            Err(_) => {
+            Ok(None) | Err(_) => {
                 let _ = child.kill();
                 let _ = child.wait();
                 let _ = fs::remove_file(&output_path);
@@ -2934,15 +2924,13 @@ fn capture_optional_path_command_with_env(
 }
 
 fn tool_on_path(program: &str) -> bool {
-    std::env::var_os("PATH")
-        .map(|path| {
-            std::env::split_paths(&path).any(|dir| {
-                tool_path_candidates(program)
-                    .into_iter()
-                    .any(|name| dir.join(name).is_file())
-            })
+    std::env::var_os("PATH").is_some_and(|path| {
+        std::env::split_paths(&path).any(|dir| {
+            tool_path_candidates(program)
+                .into_iter()
+                .any(|name| dir.join(name).is_file())
         })
-        .unwrap_or(false)
+    })
 }
 
 fn tool_path_candidates(program: &str) -> Vec<String> {
@@ -3008,7 +2996,7 @@ fn detect_windows_display_gfx_target() -> Option<String> {
 }
 
 #[cfg(not(any(windows, target_vendor = "cosmo")))]
-fn detect_windows_display_gfx_target() -> Option<String> {
+const fn detect_windows_display_gfx_target() -> Option<String> {
     None
 }
 
@@ -3089,8 +3077,7 @@ fn is_wsl_environment_fast() -> bool {
     }
     Path::new("/dev/dxg").exists()
         || fs::read_to_string("/proc/version")
-            .map(|text| text.to_ascii_lowercase().contains("microsoft"))
-            .unwrap_or(false)
+            .is_ok_and(|text| text.to_ascii_lowercase().contains("microsoft"))
 }
 
 #[cfg(target_os = "linux")]
@@ -3163,7 +3150,7 @@ fn amd_pci_device_id_from_pnp_id(pnp_id: &str) -> Option<String> {
     let start = upper.find("DEV_")? + "DEV_".len();
     let device_id = upper[start..]
         .chars()
-        .take_while(|ch| ch.is_ascii_hexdigit())
+        .take_while(char::is_ascii_hexdigit)
         .take(4)
         .collect::<String>();
     if device_id.len() == 4 {
@@ -3586,7 +3573,7 @@ pub enum WatcherMode {
 }
 
 impl WatcherMode {
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Observe => "observe",
             Self::Propose => "propose",
@@ -3649,7 +3636,7 @@ const BUILTIN_WATCHERS: &[BuiltinWatcherSpec] = &[
     },
 ];
 
-pub fn builtin_watchers() -> &'static [BuiltinWatcherSpec] {
+pub const fn builtin_watchers() -> &'static [BuiltinWatcherSpec] {
     BUILTIN_WATCHERS
 }
 
@@ -4058,8 +4045,7 @@ impl RocmCliConfig {
         provider.eq_ignore_ascii_case("local")
             || self
                 .provider_config(provider)
-                .map(|cfg| cfg.enabled)
-                .unwrap_or(false)
+                .is_some_and(|cfg| cfg.enabled)
     }
 
     pub fn watcher_config(&self, watcher: &str) -> Option<&WatcherUserConfig> {
@@ -4079,8 +4065,7 @@ impl RocmCliConfig {
 
     pub fn watcher_enabled(&self, watcher: &BuiltinWatcherSpec) -> bool {
         self.watcher_config(watcher.id)
-            .map(|cfg| cfg.enabled)
-            .unwrap_or(false)
+            .is_some_and(|cfg| cfg.enabled)
     }
 
     pub fn effective_watcher_mode(&self, watcher: &BuiltinWatcherSpec) -> WatcherMode {
@@ -4234,7 +4219,7 @@ pub struct AutomationEventRecord {
     pub service_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AutomationTriggerEvent {
     pub at_unix_ms: u128,
     pub kind: String,
@@ -4413,7 +4398,7 @@ pub fn update_automation_proposal_status(
     else {
         bail!("automation proposal `{proposal_id}` not found");
     };
-    proposal.status = status.to_owned();
+    status.clone_into(&mut proposal.status);
     if status != "pending" {
         proposal.reviewed_at_unix_ms = Some(unix_time_millis());
     }
@@ -5648,13 +5633,13 @@ impl ManagedServiceRecord {
         };
 
         let previous = self.status.clone();
-        self.status = status.to_owned();
+        status.clone_into(&mut self.status);
         if let Some(endpoint_url) = state
             .get("endpoint_url")
             .and_then(serde_json::Value::as_str)
             .filter(|value| !value.trim().is_empty())
         {
-            self.endpoint_url = endpoint_url.to_owned();
+            endpoint_url.clone_into(&mut self.endpoint_url);
         }
         if let Some(runtime_id) = state
             .get("runtime_id")
@@ -7179,7 +7164,7 @@ Class Name:                Display
             "Rust signature must match openssl byte-for-byte"
         );
 
-        let mut tampered = payload.clone();
+        let mut tampered = payload;
         tampered[0] ^= 0x01;
         let error = verify_rsa_pkcs1_sha256_signature(
             &public_key_pem,
@@ -7339,6 +7324,7 @@ Class Name:                Display
     }
 
     #[test]
+    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn engine_envs_dir_honors_dedicated_root_override() {
         let (root, paths) = temp_app_paths("engine-envs-root-override");
         let override_root = root.join("runtime").join("engines");

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -11,7 +11,7 @@ pub enum RuntimePlatform {
 }
 
 impl RuntimePlatform {
-    pub fn current() -> Self {
+    pub const fn current() -> Self {
         #[cfg(target_vendor = "cosmo")]
         {
             if cosmo_hostos_has(COSMO_HOST_WINDOWS) {
@@ -31,7 +31,7 @@ impl RuntimePlatform {
         }
     }
 
-    pub fn os_name(self) -> &'static str {
+    pub const fn os_name(self) -> &'static str {
         match self {
             Self::Windows => "windows",
             Self::Linux => "linux",
@@ -39,11 +39,11 @@ impl RuntimePlatform {
         }
     }
 
-    pub fn is_windows(self) -> bool {
+    pub const fn is_windows(self) -> bool {
         matches!(self, Self::Windows)
     }
 
-    pub fn is_linux(self) -> bool {
+    pub const fn is_linux(self) -> bool {
         matches!(self, Self::Linux)
     }
 }
@@ -55,63 +55,63 @@ pub struct RuntimeHost {
 }
 
 impl RuntimeHost {
-    pub fn current() -> Self {
+    pub const fn current() -> Self {
         Self {
             platform: RuntimePlatform::current(),
             cosmopolitan: cfg!(target_vendor = "cosmo"),
         }
     }
 
-    pub fn platform(self) -> RuntimePlatform {
+    pub const fn platform(self) -> RuntimePlatform {
         self.platform
     }
 
-    pub fn os_name(self) -> &'static str {
+    pub const fn os_name(self) -> &'static str {
         self.platform.os_name()
     }
 
-    pub fn is_windows(self) -> bool {
+    pub const fn is_windows(self) -> bool {
         self.platform.is_windows()
     }
 
-    pub fn is_linux(self) -> bool {
+    pub const fn is_linux(self) -> bool {
         self.platform.is_linux()
     }
 
-    pub fn is_cosmopolitan(self) -> bool {
+    pub const fn is_cosmopolitan(self) -> bool {
         self.cosmopolitan
     }
 
-    pub fn uses_unix_path_separator_on_windows(self) -> bool {
+    pub const fn uses_unix_path_separator_on_windows(self) -> bool {
         self.is_windows() && std::path::MAIN_SEPARATOR == '/'
     }
 }
 
-pub fn runtime_is_windows() -> bool {
+pub const fn runtime_is_windows() -> bool {
     RuntimeHost::current().is_windows()
 }
 
-pub fn runtime_is_linux() -> bool {
+pub const fn runtime_is_linux() -> bool {
     RuntimeHost::current().is_linux()
 }
 
-pub fn runtime_os_name() -> &'static str {
+pub const fn runtime_os_name() -> &'static str {
     RuntimeHost::current().os_name()
 }
 
-pub fn runtime_is_cosmopolitan_windows() -> bool {
+pub const fn runtime_is_cosmopolitan_windows() -> bool {
     RuntimeHost::current().uses_unix_path_separator_on_windows()
 }
 
-pub fn runtime_tcp_timeouts_are_supported() -> bool {
+pub const fn runtime_tcp_timeouts_are_supported() -> bool {
     !runtime_is_cosmopolitan_windows()
 }
 
-pub fn runtime_exe_suffix() -> &'static str {
+pub const fn runtime_exe_suffix() -> &'static str {
     if runtime_is_windows() { ".exe" } else { "" }
 }
 
-pub fn runtime_python_bin_dir_name() -> &'static str {
+pub const fn runtime_python_bin_dir_name() -> &'static str {
     if runtime_is_windows() {
         "Scripts"
     } else {
@@ -119,7 +119,7 @@ pub fn runtime_python_bin_dir_name() -> &'static str {
     }
 }
 
-pub fn runtime_python_executable_name() -> &'static str {
+pub const fn runtime_python_executable_name() -> &'static str {
     if runtime_is_windows() {
         "python.exe"
     } else {
@@ -153,6 +153,9 @@ pub fn runtime_python_activation_hint(env_root: &Path) -> String {
     }
 }
 
+// `shortname` is always an internal, lowercase ROCm library name (never user
+// input), so the `.dll`/`.so` suffix checks are intentionally case-sensitive.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
 pub fn runtime_rocm_library_filename(shortname: &str) -> String {
     if runtime_is_windows() {
         match shortname {
@@ -422,11 +425,10 @@ enum RuntimePathSeparator {
 }
 
 impl RuntimePathSeparator {
-    fn separator(self) -> char {
+    const fn separator(self) -> char {
         match self {
             Self::Native if std::path::MAIN_SEPARATOR == '\\' => '\\',
-            Self::Native => '/',
-            Self::Slash => '/',
+            Self::Native | Self::Slash => '/',
             Self::Backslash => '\\',
         }
     }
@@ -439,11 +441,13 @@ const COSMO_HOST_LINUX: i32 = 1;
 const COSMO_HOST_WINDOWS: i32 = 4;
 
 #[cfg(target_vendor = "cosmo")]
+#[allow(unsafe_code)] // Cosmopolitan host-OS symbol
 unsafe extern "C" {
     static __hostos: i32;
 }
 
 #[cfg(target_vendor = "cosmo")]
+#[allow(unsafe_code)] // reads the Cosmopolitan __hostos extern static
 fn cosmo_hostos_has(mask: i32) -> bool {
     // Cosmopolitan exposes the active host through libc/dce.h. Calling it
     // directly keeps the Rust APE tied to Cosmopolitan's runtime instead of a
@@ -473,8 +477,7 @@ fn current_exe_is_cosmopolitan_loader(path: &Path) -> bool {
     }
     path.file_name()
         .and_then(|value| value.to_str())
-        .map(|name| matches!(name, "ape" | "ape-x86_64.elf" | "ape-aarch64.elf"))
-        .unwrap_or(false)
+        .is_some_and(|name| matches!(name, "ape" | "ape-x86_64.elf" | "ape-aarch64.elf"))
 }
 
 fn current_executable_path_from_argv0() -> Result<PathBuf> {

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -42,7 +42,7 @@ struct ManagedUvManifest {
 }
 
 /// The platform-specific file name of the `uv` executable.
-pub fn uv_binary_name() -> &'static str {
+pub const fn uv_binary_name() -> &'static str {
     if runtime_is_windows() { "uv.exe" } else { "uv" }
 }
 
@@ -280,8 +280,7 @@ fn uv_binary_is_usable(path: &Path) -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .is_ok_and(|status| status.success())
 }
 
 fn write_uv_manifest(paths: &AppPaths, manifest: &ManagedUvManifest) {
@@ -319,6 +318,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::case_sensitive_file_extension_comparisons)] // asset names are internally generated and always lowercase
     fn asset_name_has_archive_extension() {
         // Whatever the host, the asset is one of the two known archive kinds.
         let asset = uv_asset_name().expect("supported host platform for tests");

--- a/crates/rocm-dash-collectors/Cargo.toml
+++ b/crates/rocm-dash-collectors/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 rocm-dash-core = { path = "../rocm-dash-core" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/rocm-dash-collectors/src/amd_smi.rs
+++ b/crates/rocm-dash-collectors/src/amd_smi.rs
@@ -121,7 +121,10 @@ pub fn parse_metrics(v: &Value) -> Vec<GpuMetrics> {
     };
     gpus.iter()
         .map(|g| {
-            let id = g.get("gpu").and_then(serde_json::Value::as_u64).unwrap_or(0);
+            let id = g
+                .get("gpu")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
             // Prefer hotspot — edge is N/A on MI300X SR-IOV.
             let temperature_c = val_f32(nested(g, &["temperature", "hotspot", "value"]))
                 .or_else(|| val_f32(nested(g, &["temperature", "edge", "value"])))
@@ -212,7 +215,10 @@ pub fn parse_processes(v: &Value) -> Vec<GpuProcess> {
 
     let mut out = Vec::new();
     for g in entries {
-        let id = g.get("gpu").and_then(serde_json::Value::as_u64).unwrap_or(0);
+        let id = g
+            .get("gpu")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
         let device_id = format!("gpu-{id}");
         let plist = g
             .get("process_list")
@@ -267,7 +273,8 @@ pub fn parse_system_info(
             info.gpu_model = nested(first, &["asic", "market_name"])
                 .and_then(|x| x.as_str())
                 .filter(|s| *s != "N/A")
-                .or_else(|| nested(first, &["board", "product_name"]).and_then(|x| x.as_str())).map_or_else(|| "Unknown".into(), str::to_owned);
+                .or_else(|| nested(first, &["board", "product_name"]).and_then(|x| x.as_str()))
+                .map_or_else(|| "Unknown".into(), str::to_owned);
         }
     }
 

--- a/crates/rocm-dash-collectors/src/amd_smi.rs
+++ b/crates/rocm-dash-collectors/src/amd_smi.rs
@@ -121,7 +121,7 @@ pub fn parse_metrics(v: &Value) -> Vec<GpuMetrics> {
     };
     gpus.iter()
         .map(|g| {
-            let id = g.get("gpu").and_then(|x| x.as_u64()).unwrap_or(0);
+            let id = g.get("gpu").and_then(serde_json::Value::as_u64).unwrap_or(0);
             // Prefer hotspot — edge is N/A on MI300X SR-IOV.
             let temperature_c = val_f32(nested(g, &["temperature", "hotspot", "value"]))
                 .or_else(|| val_f32(nested(g, &["temperature", "edge", "value"])))
@@ -212,7 +212,7 @@ pub fn parse_processes(v: &Value) -> Vec<GpuProcess> {
 
     let mut out = Vec::new();
     for g in entries {
-        let id = g.get("gpu").and_then(|x| x.as_u64()).unwrap_or(0);
+        let id = g.get("gpu").and_then(serde_json::Value::as_u64).unwrap_or(0);
         let device_id = format!("gpu-{id}");
         let plist = g
             .get("process_list")
@@ -267,9 +267,7 @@ pub fn parse_system_info(
             info.gpu_model = nested(first, &["asic", "market_name"])
                 .and_then(|x| x.as_str())
                 .filter(|s| *s != "N/A")
-                .or_else(|| nested(first, &["board", "product_name"]).and_then(|x| x.as_str()))
-                .map(str::to_owned)
-                .unwrap_or_else(|| "Unknown".into());
+                .or_else(|| nested(first, &["board", "product_name"]).and_then(|x| x.as_str())).map_or_else(|| "Unknown".into(), str::to_owned);
         }
     }
 
@@ -343,13 +341,14 @@ mod tests {
         let g = &m[0];
         assert_eq!(g.device_id, "gpu-0");
         assert_eq!(g.vram_used_mb, 1234);
-        assert_eq!(g.vram_total_mb, 196608);
+        assert_eq!(g.vram_total_mb, 196_608);
         assert!((g.gpu_utilization_pct - 42.5).abs() < 0.01);
         assert!((g.temperature_c - 68.0).abs() < 0.01);
         assert!((g.power_w - 410.5).abs() < 0.01);
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn missing_fields_default_safely() {
         let v: Value = serde_json::from_str(r#"{ "gpu_data": [ { "gpu": 7 } ] }"#).unwrap();
         let m = parse_metrics(&v);

--- a/crates/rocm-dash-collectors/src/bench_tail.rs
+++ b/crates/rocm-dash-collectors/src/bench_tail.rs
@@ -18,7 +18,7 @@ pub struct CsvBenchTailer {
 }
 
 impl CsvBenchTailer {
-    pub fn new(path: PathBuf) -> Self {
+    pub const fn new(path: PathBuf) -> Self {
         Self { path, rows_seen: 0 }
     }
 }
@@ -131,7 +131,7 @@ mod tests {
         let dir = tempdir();
         let path = dir.join("results.csv");
         write(&path, "cell,run\nO-arch,7\n");
-        let mut t = CsvBenchTailer::new(path.clone());
+        let mut t = CsvBenchTailer::new(path);
         let rows = t.drain().unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].cell, "O-arch");

--- a/crates/rocm-dash-collectors/src/bench_tail.rs
+++ b/crates/rocm-dash-collectors/src/bench_tail.rs
@@ -142,13 +142,12 @@ mod tests {
     }
 
     fn tempdir() -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let mut p = std::env::temp_dir();
         let pid = std::process::id();
-        let ts = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        p.push(format!("rocm-dash-test-{pid}-{ts}"));
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        p.push(format!("rocm-dash-bench-tail-{pid}-{n}"));
         std::fs::create_dir_all(&p).unwrap();
         p
     }

--- a/crates/rocm-dash-collectors/src/cgroup.rs
+++ b/crates/rocm-dash-collectors/src/cgroup.rs
@@ -13,7 +13,7 @@
 
 /// Whether `c` is a lowercase hex digit (`0-9a-f`). Docker/containerd ids are
 /// lowercase hex; uppercase and other characters act as token delimiters.
-fn is_lower_hex(c: char) -> bool {
+const fn is_lower_hex(c: char) -> bool {
     c.is_ascii_digit() || matches!(c, 'a'..='f')
 }
 
@@ -36,8 +36,9 @@ pub fn parse_container_id_from_cgroup(contents: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Resolve the docker container id owning host process `pid` by reading
-/// `/proc/<pid>/cgroup`. Returns `None` on any read error (process gone,
+/// Resolve the docker container id owning host process `pid` by reading `/proc/<pid>/cgroup`.
+///
+/// Returns `None` on any read error (process gone,
 /// permission denied) or when the cgroup names no container — never panics.
 #[cfg(target_os = "linux")]
 pub fn container_id_for_pid(pid: u32) -> Option<String> {

--- a/crates/rocm-dash-collectors/src/engine_registry.rs
+++ b/crates/rocm-dash-collectors/src/engine_registry.rs
@@ -1,5 +1,6 @@
-//! Engine registry seam — one place that maps a discovered serving engine to its
-//! per-engine sample parser, so the daemon can pick a backend per service instead
+//! Engine registry seam — one place that maps a discovered serving engine to its per-engine sample parser.
+//!
+//! The daemon can pick a backend per service instead
 //! of hard-coding vLLM. The existing vLLM Prometheus parser
 //! (`vllm_prom::parse`) is reachable through this seam **unchanged**; Lemonade
 //! adds a second parser. This is a focused seam, not a rewrite.
@@ -20,11 +21,11 @@ pub enum EngineKind {
 
 impl EngineKind {
     /// Stable lowercase label (matches `rocm engines` / config engine names).
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
-            EngineKind::Vllm => "vllm",
-            EngineKind::Lemonade => "lemonade",
-            EngineKind::LlamaCpp => "llama.cpp",
+            Self::Vllm => "vllm",
+            Self::Lemonade => "lemonade",
+            Self::LlamaCpp => "llama.cpp",
         }
     }
 
@@ -32,11 +33,11 @@ impl EngineKind {
     /// services the bound port comes from the registry
     /// (`ManagedServiceRecord.port`); this default is used only for
     /// unmanaged/external discovery where no registry record exists.
-    pub fn default_port(self) -> u16 {
+    pub const fn default_port(self) -> u16 {
         match self {
-            EngineKind::Vllm => 8000,
-            EngineKind::Lemonade => crate::lemonade::LEMONADE_PORT, // 13305
-            EngineKind::LlamaCpp => 8080,
+            Self::Vllm => 8000,
+            Self::Lemonade => crate::lemonade::LEMONADE_PORT, // 13305
+            Self::LlamaCpp => 8080,
         }
     }
 
@@ -44,9 +45,9 @@ impl EngineKind {
     /// accepts the `llama.cpp` / `llamacpp` / `llama_cpp` spellings.
     pub fn from_label(label: &str) -> Option<Self> {
         match label.trim().to_ascii_lowercase().as_str() {
-            "vllm" => Some(EngineKind::Vllm),
-            "lemonade" => Some(EngineKind::Lemonade),
-            "llama.cpp" | "llamacpp" | "llama_cpp" => Some(EngineKind::LlamaCpp),
+            "vllm" => Some(Self::Vllm),
+            "lemonade" => Some(Self::Lemonade),
+            "llama.cpp" | "llamacpp" | "llama_cpp" => Some(Self::LlamaCpp),
             _ => None,
         }
     }
@@ -57,9 +58,9 @@ impl EngineKind {
     /// return an empty sample (never panic).
     pub fn parse_sample(self, body: &str) -> InstanceSample {
         match self {
-            EngineKind::Vllm => crate::vllm_prom::parse(body),
-            EngineKind::Lemonade => crate::lemonade::parse_stats(body),
-            EngineKind::LlamaCpp => InstanceSample::default(),
+            Self::Vllm => crate::vllm_prom::parse(body),
+            Self::Lemonade => crate::lemonade::parse_stats(body),
+            Self::LlamaCpp => InstanceSample::default(),
         }
     }
 }

--- a/crates/rocm-dash-collectors/src/host.rs
+++ b/crates/rocm-dash-collectors/src/host.rs
@@ -30,7 +30,7 @@ impl HostCollector {
         self.sys.refresh_memory();
 
         let cpu_overall_pct = self.sys.global_cpu_usage();
-        let cpu_per_core_pct: Vec<f32> = self.sys.cpus().iter().map(|c| c.cpu_usage()).collect();
+        let cpu_per_core_pct: Vec<f32> = self.sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).collect();
 
         // sysinfo reports memory in bytes.
         let memory_used_mb = self.sys.used_memory() / 1024 / 1024;

--- a/crates/rocm-dash-collectors/src/host.rs
+++ b/crates/rocm-dash-collectors/src/host.rs
@@ -30,7 +30,12 @@ impl HostCollector {
         self.sys.refresh_memory();
 
         let cpu_overall_pct = self.sys.global_cpu_usage();
-        let cpu_per_core_pct: Vec<f32> = self.sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).collect();
+        let cpu_per_core_pct: Vec<f32> = self
+            .sys
+            .cpus()
+            .iter()
+            .map(sysinfo::Cpu::cpu_usage)
+            .collect();
 
         // sysinfo reports memory in bytes.
         let memory_used_mb = self.sys.used_memory() / 1024 / 1024;

--- a/crates/rocm-dash-collectors/src/lemonade.rs
+++ b/crates/rocm-dash-collectors/src/lemonade.rs
@@ -56,8 +56,9 @@ pub struct LemonadeHealth {
     pub model_loaded: Option<String>,
 }
 
-/// PURE: parse a `/api/v1/stats` body into an [`InstanceSample`]. Lemonade reports
-/// an instantaneous `tokens_per_second` rate (mapped to `gen_tps`) rather than a
+/// PURE: parse a `/api/v1/stats` body into an [`InstanceSample`].
+///
+/// Lemonade reports an instantaneous `tokens_per_second` rate (mapped to `gen_tps`) rather than a
 /// cumulative counter; it exposes no KV-cache / running / waiting metrics, so
 /// those stay `None`. Malformed/empty JSON → an all-`None` default, never panics.
 pub fn parse_stats(body: &str) -> InstanceSample {
@@ -121,8 +122,9 @@ pub fn lemonade_service(host: &str, port: u16, model_name: &str) -> DiscoveredSe
     }
 }
 
-/// PURE: build a finished `Instance` from a Lemonade `/health` model name + a
-/// `/stats` body — the fixture→Instance anchor (no network). `gen_tps` flows from
+/// PURE: build a finished `Instance` from a Lemonade `/health` model name + a `/stats` body.
+///
+/// This is the fixture→Instance anchor (no network). `gen_tps` flows from
 /// `tokens_per_second`; KV/req fields stay `None` (Lemonade does not report them).
 pub fn lemonade_instance(host: &str, port: u16, model_name: &str, stats_body: &str) -> Instance {
     let svc = lemonade_service(host, port, model_name);

--- a/crates/rocm-dash-collectors/src/llama_slots.rs
+++ b/crates/rocm-dash-collectors/src/llama_slots.rs
@@ -8,7 +8,7 @@ use rocm_dash_core::traits::{
 pub struct LlamaSlotsCollector;
 
 impl LlamaSlotsCollector {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/crates/rocm-dash-collectors/src/parallel.rs
+++ b/crates/rocm-dash-collectors/src/parallel.rs
@@ -71,7 +71,7 @@ impl WarningBus {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.lock().map(|v| v.is_empty()).unwrap_or(true)
+        self.inner.lock().map_or(true, |v| v.is_empty())
     }
 }
 

--- a/crates/rocm-dash-collectors/src/proc_scan.rs
+++ b/crates/rocm-dash-collectors/src/proc_scan.rs
@@ -6,7 +6,7 @@ use rocm_dash_core::traits::{CollectorError, DiscoveredService, Result, ServiceD
 pub struct ProcDiscovery;
 
 impl ProcDiscovery {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/crates/rocm-dash-collectors/src/sysfs.rs
+++ b/crates/rocm-dash-collectors/src/sysfs.rs
@@ -7,7 +7,7 @@ use rocm_dash_core::traits::{CollectorError, GpuCollector, GpuDevice, GpuProcess
 pub struct SysfsGpuCollector;
 
 impl SysfsGpuCollector {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/crates/rocm-dash-collectors/src/vllm_log.rs
+++ b/crates/rocm-dash-collectors/src/vllm_log.rs
@@ -12,6 +12,7 @@ pub struct VllmPeaks {
     pub n_requests: u32,
 }
 
+#[allow(clippy::struct_field_names)] // `_re` suffix is meaningful (these are Regex fields)
 pub struct VllmLogSlicer {
     prompt_tps_re: Regex,
     gen_tps_re: Regex,
@@ -71,7 +72,7 @@ mod tests {
 
     #[test]
     fn parses_throughput_peaks_and_request_count() {
-        let log = r#"
+        let log = r"
 [2026-05-26 10:00:00] Avg prompt throughput: 1234.5 tokens/s
 [2026-05-26 10:00:01] Avg generation throughput: 67.8 tokens/s
 [2026-05-26 10:00:02] Running: 8, Waiting: 2
@@ -82,7 +83,7 @@ INFO POST /v1/chat/completions 200
 INFO POST /v1/completions 200
 INFO POST /v1/messages 200
 INFO POST /v1/chat/completions 200
-"#;
+";
         let slicer = VllmLogSlicer::new();
         let peaks = slicer.parse_slice(log);
         assert_eq!(peaks.prompt_tps, Some(2000.1));

--- a/crates/rocm-dash-collectors/src/vllm_prom.rs
+++ b/crates/rocm-dash-collectors/src/vllm_prom.rs
@@ -27,7 +27,7 @@ pub struct VllmPrometheusCollector {
 
 impl Default for VllmPrometheusCollector {
     fn default() -> Self {
-        Self::new("127.0.0.1", Duration::from_millis(2000))
+        Self::new("127.0.0.1", Duration::from_secs(2))
     }
 }
 
@@ -163,7 +163,7 @@ vllm:generation_tokens_total{model=\"deepseek-r1\"} 1234567.0
         assert_eq!(s.waiting_reqs, Some(3));
         let kv = s.kv_cache_usage_pct.unwrap();
         assert!((kv - 42.31).abs() < 0.01, "kv was {kv}");
-        assert_eq!(s.gen_tokens_total, Some(1234567.0));
+        assert_eq!(s.gen_tokens_total, Some(1_234_567.0));
     }
 
     #[test]

--- a/crates/rocm-dash-collectors/tests/vllm_prom_http.rs
+++ b/crates/rocm-dash-collectors/tests/vllm_prom_http.rs
@@ -45,7 +45,7 @@ async fn fetch_async_against_local_mock_server() {
         let _ = sock.shutdown().await;
     });
 
-    let collector = VllmPrometheusCollector::new("127.0.0.1", Duration::from_millis(2000));
+    let collector = VllmPrometheusCollector::new("127.0.0.1", Duration::from_secs(2));
     let svc = DiscoveredService {
         container_id: "test".into(),
         port: Some(port),
@@ -76,7 +76,7 @@ async fn fetch_async_propagates_non_200() {
         let _ = sock.shutdown().await;
     });
 
-    let collector = VllmPrometheusCollector::new("127.0.0.1", Duration::from_millis(2000));
+    let collector = VllmPrometheusCollector::new("127.0.0.1", Duration::from_secs(2));
     let svc = DiscoveredService {
         container_id: "test".into(),
         port: Some(port),

--- a/crates/rocm-dash-core/Cargo.toml
+++ b/crates/rocm-dash-core/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/rocm-dash-core/src/bench_rollup.rs
+++ b/crates/rocm-dash-core/src/bench_rollup.rs
@@ -14,10 +14,11 @@ use std::collections::BTreeMap;
 use crate::bench_schema::{BenchmarkRow, PassFail};
 
 /// Effective verdict for one row: prefer the rolled-up `pass_fail`, fall back
+///
 /// to the judge verdict when the rollup is `Unknown`. A row that is `Unknown`
 /// under both returns `Unknown` and never counts as a pass.
 #[must_use]
-pub fn row_verdict(row: &BenchmarkRow) -> PassFail {
+pub const fn row_verdict(row: &BenchmarkRow) -> PassFail {
     match row.pass_fail {
         PassFail::Unknown => row.judge_pass_fail,
         v => v,

--- a/crates/rocm-dash-core/src/bench_schema.rs
+++ b/crates/rocm-dash-core/src/bench_schema.rs
@@ -13,6 +13,7 @@ pub enum PassFail {
 }
 
 /// The canonical row from a benchmark run.
+///
 /// Fields are a superset of the 30-col CSV from `csv_emitter.py` plus the expanded fields
 /// from `normalize-results.py`. Optional where upstream sets defaults from `UNKNOWN_DEFAULTS`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -66,9 +66,10 @@ pub struct Config {
     pub engines: BTreeMap<String, EngineConfig>,
 }
 
-/// Per-engine user preferences. Plain data only (mirrors rocm-cli's
-/// `EngineUserConfig`); no I/O or behavior lives in core. Immutable config
-/// transforms + persistence live in the `rocm` binary, off the core boundary.
+/// Per-engine user preferences. Plain data only (mirrors rocm-cli's `EngineUserConfig`).
+///
+/// No I/O or behavior lives in core. Immutable config transforms + persistence
+/// live in the `rocm` binary, off the core boundary.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EngineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -240,6 +241,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn load_overrides_only_specified_fields() {
         let mut p = std::env::temp_dir();
         p.push(format!(

--- a/crates/rocm-dash-core/src/efficiency.rs
+++ b/crates/rocm-dash-core/src/efficiency.rs
@@ -1,6 +1,7 @@
-//! Pure efficiency derivations (tokens-per-watt). No I/O, no rendering — this
-//! is the join that turns vLLM throughput + amd-smi power into a per-instance
-//! capacity number. See `../wiki/concepts/metric-registry.md`.
+//! Pure efficiency derivations (tokens-per-watt). No I/O, no rendering.
+//!
+//! This is the join that turns vLLM throughput + amd-smi power into a
+//! per-instance capacity number. See `../wiki/concepts/metric-registry.md`.
 
 use crate::metrics::GpuMetrics;
 
@@ -20,9 +21,11 @@ pub(crate) fn device_in(device_id: &str, gpu_ids: &[String]) -> bool {
     gpu_ids.iter().any(|id| normalize_gpu_id(id) == dev)
 }
 
-/// Whether any GPU in `gpus` belongs to `gpu_ids`. Distinguishes a failed id
-/// join (no overlap) from a successful join where power happens to be zero —
-/// used by the runner to warn when ids don't line up on real hardware.
+/// Whether any GPU in `gpus` belongs to `gpu_ids`.
+///
+/// Distinguishes a failed id join (no overlap) from a successful join where
+/// power happens to be zero — used by the runner to warn when ids don't line
+/// up on real hardware.
 pub fn gpu_ids_overlap(gpu_ids: &[String], gpus: &[GpuMetrics]) -> bool {
     gpus.iter().any(|g| device_in(&g.device_id, gpu_ids))
 }
@@ -43,7 +46,7 @@ pub fn tokens_per_watt(
     let total_w: f64 = gpus
         .iter()
         .filter(|g| device_in(&g.device_id, gpu_ids))
-        .map(|g| g.power_w as f64)
+        .map(|g| f64::from(g.power_w))
         .sum();
     if total_w > 0.0 {
         Some(tps / total_w)

--- a/crates/rocm-dash-core/src/persist.rs
+++ b/crates/rocm-dash-core/src/persist.rs
@@ -23,8 +23,7 @@ impl PersistedEntry {
     pub fn now(event: Event) -> Self {
         let ts_us = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_micros() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_micros() as u64);
         Self { ts_us, event }
     }
 }

--- a/crates/rocm-dash-core/src/state.rs
+++ b/crates/rocm-dash-core/src/state.rs
@@ -54,7 +54,7 @@ pub struct JobState {
 
 impl JobState {
     /// `true` once the job has reached any terminal status.
-    pub fn is_terminal(&self) -> bool {
+    pub const fn is_terminal(&self) -> bool {
         !matches!(self.status, JobStatus::Running)
     }
 
@@ -285,6 +285,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::cast_possible_wrap)]
     fn history_caps_at_ring_size() {
         let mut s = State::default();
         for i in 0..(SNAPSHOT_RING_CAP + 5) as i64 {
@@ -420,9 +421,8 @@ mod tests {
         let mut s = State::default();
         let fx = start(&mut s, "j1");
         // Grab the runtime's cancel handle from the emitted effect.
-        let cancel = match fx.into_iter().next().unwrap() {
-            SideEffect::SpawnJob { cancel, .. } => cancel,
-            _ => unreachable!(),
+        let SideEffect::SpawnJob { cancel, .. } = fx.into_iter().next().unwrap() else {
+            unreachable!()
         };
         s.apply(StateEvent::CancelJob("j1".into()));
         assert_eq!(s.job("j1").unwrap().status, JobStatus::Cancelled);

--- a/crates/rocm-dash-core/src/vram.rs
+++ b/crates/rocm-dash-core/src/vram.rs
@@ -1,7 +1,8 @@
-//! Pure VRAM attribution helpers. No I/O, no rendering — the `/proc` read and
-//! the amd-smi subprocess that feed these live in the collectors/daemon; here
-//! we only do the math that turns per-process VRAM + device totals into a
-//! per-instance `(used, total)` pair.
+//! Pure VRAM attribution helpers. No I/O, no rendering.
+//!
+//! The `/proc` read and the amd-smi subprocess that feed these live in the
+//! collectors/daemon; here we only do the math that turns per-process VRAM +
+//! device totals into a per-instance `(used, total)` pair.
 //!
 //! The attribution has two paths, in priority order:
 //!  1. **Per-process** — sum the VRAM of the GPU processes that resolve (via an
@@ -58,11 +59,11 @@ pub fn aggregate_process_vram<F: Fn(u32) -> Option<String>>(
 /// `total` is always the device-summed total over `gpu_ids`. `used` is the
 /// per-container value from `per_container_used` when present (the per-process
 /// path) and otherwise the device-summed used over `gpu_ids` (the fallback).
-pub fn resolve_instance_vram(
+pub fn resolve_instance_vram<S: std::hash::BuildHasher>(
     container_id: &str,
     gpu_ids: &[String],
     gpus: &[GpuMetrics],
-    per_container_used: &HashMap<String, u64>,
+    per_container_used: &HashMap<String, u64, S>,
 ) -> (u64, u64) {
     let (device_used, total) = device_vram(gpu_ids, gpus);
     let used = match per_container_used.get(container_id) {

--- a/crates/rocm-dash-daemon/Cargo.toml
+++ b/crates/rocm-dash-daemon/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "rocm_dash_daemon"
 path = "src/lib.rs"

--- a/crates/rocm-dash-daemon/src/demo.rs
+++ b/crates/rocm-dash-daemon/src/demo.rs
@@ -111,8 +111,7 @@ pub fn generate_to_writer<W: Write>(opts: &DemoOptions, w: &mut W) -> anyhow::Re
         // Any bench rows scheduled at this second.
         while bench_iter
             .peek()
-            .map(|(t_off, _)| *t_off == t)
-            .unwrap_or(false)
+            .is_some_and(|(t_off, _)| *t_off == t)
         {
             let (_t_off, row) = bench_iter.next().unwrap();
             let ev = PersistedEntry {
@@ -438,7 +437,7 @@ fn demo_bench_rows() -> Vec<(u64, BenchmarkRow)> {
 /// Deterministic pseudo-random oscillator. Same seed + t → same value.
 fn osc(t_s: f64, period_s: f64, phase_s: f64, mean: f32, amp: f32) -> f32 {
     let theta = 2.0 * PI * (t_s + phase_s) / period_s;
-    mean + amp * theta.sin() as f32
+    amp.mul_add(theta.sin() as f32, mean)
 }
 
 /// Tiny xorshift32 used to give each value a small jitter so the trace
@@ -452,7 +451,7 @@ fn jitter(seed: &mut u64) -> f32 {
 
 fn build_host(t_s: f64, seed: &mut u64) -> SystemMetrics {
     // Inference is GPU-bound, so CPU stays moderate with some noise.
-    let agg = osc(t_s, 23.0, 0.0, 28.0, 8.0) + (jitter(seed) - 0.5) * 4.0;
+    let agg = (jitter(seed) - 0.5).mul_add(4.0, osc(t_s, 23.0, 0.0, 28.0, 8.0));
     let agg = agg.clamp(0.0, 100.0);
 
     let mut per_core: Vec<f32> = Vec::with_capacity(HOST_CORES);
@@ -460,11 +459,11 @@ fn build_host(t_s: f64, seed: &mut u64) -> SystemMetrics {
         // Each core's load is the aggregate ± a per-core offset so the
         // CoreBars widget shows visible variation across cores.
         let off = osc(t_s, 7.0 + (i as f64 % 11.0), i as f64 * 0.7, 0.0, 18.0);
-        let v = (agg + off + (jitter(seed) - 0.5) * 6.0).clamp(0.0, 100.0);
+        let v = (jitter(seed) - 0.5).mul_add(6.0, agg + off).clamp(0.0, 100.0);
         per_core.push(v);
     }
 
-    let mem_used = (MEMORY_TOTAL_MB as f64 * 0.42 * (1.0 + 0.02 * (t_s / 31.0).sin())) as u64;
+    let mem_used = (MEMORY_TOTAL_MB as f64 * 0.42 * 0.02f64.mul_add((t_s / 31.0).sin(), 1.0)) as u64;
 
     SystemMetrics {
         cpu_overall_pct: agg,
@@ -489,20 +488,19 @@ fn build_gpu(idx: usize, t_s: f64, seed: &mut u64) -> GpuMetrics {
                 .iter()
                 .any(|g| g.parse::<usize>().ok() == Some(idx))
         })
-        .map(|c| (c.util_mean, c.util_amp, c.phase_s))
-        .unwrap_or((20.0, 5.0, 0.0));
+        .map_or((20.0, 5.0, 0.0), |c| (c.util_mean, c.util_amp, c.phase_s));
 
     let util =
-        osc(t_s, 11.0, phase + idx as f64 * 1.3, util_mean, util_amp) + (jitter(seed) - 0.5) * 5.0;
+        (jitter(seed) - 0.5).mul_add(5.0, osc(t_s, 11.0, (idx as f64).mul_add(1.3, phase), util_mean, util_amp));
     let util = util.clamp(0.0, 100.0);
 
     // Temp tracks util with thermal lag — small offset, narrower swing.
-    let temp = 55.0 + 0.22 * util + (jitter(seed) - 0.5) * 1.5;
+    let temp = (jitter(seed) - 0.5).mul_add(1.5, 0.22f32.mul_add(util, 55.0));
     // Power tracks util more linearly. MI355X TDP ~ 750W.
-    let power = 220.0 + 5.2 * util + (jitter(seed) - 0.5) * 18.0;
+    let power = (jitter(seed) - 0.5).mul_add(18.0, 5.2f32.mul_add(util, 220.0));
     // VRAM is mostly the model weights once loaded.
     let vram_used =
-        (VRAM_TOTAL_MB as f64 * 0.74 + (jitter(seed) as f64 * VRAM_TOTAL_MB as f64 * 0.02)) as u64;
+        (f64::from(jitter(seed)) * VRAM_TOTAL_MB as f64).mul_add(0.02, VRAM_TOTAL_MB as f64 * 0.74) as u64;
 
     GpuMetrics {
         device_id: format!("gpu-{idx}"),
@@ -511,7 +509,7 @@ fn build_gpu(idx: usize, t_s: f64, seed: &mut u64) -> GpuMetrics {
         gpu_utilization_pct: util,
         temperature_c: temp,
         power_w: power,
-        clock_mhz: Some(1850.0 + (jitter(seed) - 0.5) * 80.0),
+        clock_mhz: Some((jitter(seed) - 0.5).mul_add(80.0, 1850.0)),
     }
 }
 
@@ -537,7 +535,7 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
     CONTAINERS
         .iter()
         .map(|c| {
-            let kv = osc(t_s, 13.0, c.phase_s, c.kv_mean, c.kv_amp) + (jitter(seed) - 0.5) * 4.0;
+            let kv = (jitter(seed) - 0.5).mul_add(4.0, osc(t_s, 13.0, c.phase_s, c.kv_mean, c.kv_amp));
             let kv = kv.clamp(0.0, 100.0);
             let running = ((c.req_mean as f32
                 + osc(t_s, 17.0, c.phase_s, 0.0, c.req_mean as f32 * 0.6))
@@ -563,7 +561,7 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
             // oscillates with load; tokens_per_watt is filled in build_snapshot
             // once GPU power is known (mirrors the runner's assembly step).
             let gen_tps =
-                (c.gpu_ids.len() as f64 * osc(t_s, 19.0, c.phase_s, 180.0, 90.0) as f64).max(0.0);
+                (c.gpu_ids.len() as f64 * f64::from(osc(t_s, 19.0, c.phase_s, 180.0, 90.0))).max(0.0);
 
             Instance {
                 container_id: c.container_id.into(),
@@ -572,7 +570,7 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
                 model_name: c.model_name.into(),
                 gpu_ids: c.gpu_ids.iter().map(|s| (*s).to_string()).collect(),
                 partition_info: Some("SPX/NPS1".into()),
-                quantization: c.quantization.map(|s| s.to_string()),
+                quantization: c.quantization.map(std::string::ToString::to_string),
                 tensor_parallel_size: c.tp,
                 port: Some(c.port),
                 vram_used_mb: vram_used,

--- a/crates/rocm-dash-daemon/src/demo.rs
+++ b/crates/rocm-dash-daemon/src/demo.rs
@@ -109,10 +109,7 @@ pub fn generate_to_writer<W: Write>(opts: &DemoOptions, w: &mut W) -> anyhow::Re
         }
 
         // Any bench rows scheduled at this second.
-        while bench_iter
-            .peek()
-            .is_some_and(|(t_off, _)| *t_off == t)
-        {
+        while bench_iter.peek().is_some_and(|(t_off, _)| *t_off == t) {
             let (_t_off, row) = bench_iter.next().unwrap();
             let ev = PersistedEntry {
                 ts_us: ts_us + 500_000, // half a tick after the snapshot
@@ -459,11 +456,14 @@ fn build_host(t_s: f64, seed: &mut u64) -> SystemMetrics {
         // Each core's load is the aggregate ± a per-core offset so the
         // CoreBars widget shows visible variation across cores.
         let off = osc(t_s, 7.0 + (i as f64 % 11.0), i as f64 * 0.7, 0.0, 18.0);
-        let v = (jitter(seed) - 0.5).mul_add(6.0, agg + off).clamp(0.0, 100.0);
+        let v = (jitter(seed) - 0.5)
+            .mul_add(6.0, agg + off)
+            .clamp(0.0, 100.0);
         per_core.push(v);
     }
 
-    let mem_used = (MEMORY_TOTAL_MB as f64 * 0.42 * 0.02f64.mul_add((t_s / 31.0).sin(), 1.0)) as u64;
+    let mem_used =
+        (MEMORY_TOTAL_MB as f64 * 0.42 * 0.02f64.mul_add((t_s / 31.0).sin(), 1.0)) as u64;
 
     SystemMetrics {
         cpu_overall_pct: agg,
@@ -490,8 +490,16 @@ fn build_gpu(idx: usize, t_s: f64, seed: &mut u64) -> GpuMetrics {
         })
         .map_or((20.0, 5.0, 0.0), |c| (c.util_mean, c.util_amp, c.phase_s));
 
-    let util =
-        (jitter(seed) - 0.5).mul_add(5.0, osc(t_s, 11.0, (idx as f64).mul_add(1.3, phase), util_mean, util_amp));
+    let util = (jitter(seed) - 0.5).mul_add(
+        5.0,
+        osc(
+            t_s,
+            11.0,
+            (idx as f64).mul_add(1.3, phase),
+            util_mean,
+            util_amp,
+        ),
+    );
     let util = util.clamp(0.0, 100.0);
 
     // Temp tracks util with thermal lag — small offset, narrower swing.
@@ -499,8 +507,8 @@ fn build_gpu(idx: usize, t_s: f64, seed: &mut u64) -> GpuMetrics {
     // Power tracks util more linearly. MI355X TDP ~ 750W.
     let power = (jitter(seed) - 0.5).mul_add(18.0, 5.2f32.mul_add(util, 220.0));
     // VRAM is mostly the model weights once loaded.
-    let vram_used =
-        (f64::from(jitter(seed)) * VRAM_TOTAL_MB as f64).mul_add(0.02, VRAM_TOTAL_MB as f64 * 0.74) as u64;
+    let vram_used = (f64::from(jitter(seed)) * VRAM_TOTAL_MB as f64)
+        .mul_add(0.02, VRAM_TOTAL_MB as f64 * 0.74) as u64;
 
     GpuMetrics {
         device_id: format!("gpu-{idx}"),
@@ -535,7 +543,8 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
     CONTAINERS
         .iter()
         .map(|c| {
-            let kv = (jitter(seed) - 0.5).mul_add(4.0, osc(t_s, 13.0, c.phase_s, c.kv_mean, c.kv_amp));
+            let kv =
+                (jitter(seed) - 0.5).mul_add(4.0, osc(t_s, 13.0, c.phase_s, c.kv_mean, c.kv_amp));
             let kv = kv.clamp(0.0, 100.0);
             let running = ((c.req_mean as f32
                 + osc(t_s, 17.0, c.phase_s, 0.0, c.req_mean as f32 * 0.6))
@@ -560,8 +569,9 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
             // Generation throughput scales with the instance's GPU count and
             // oscillates with load; tokens_per_watt is filled in build_snapshot
             // once GPU power is known (mirrors the runner's assembly step).
-            let gen_tps =
-                (c.gpu_ids.len() as f64 * f64::from(osc(t_s, 19.0, c.phase_s, 180.0, 90.0))).max(0.0);
+            let gen_tps = (c.gpu_ids.len() as f64
+                * f64::from(osc(t_s, 19.0, c.phase_s, 180.0, 90.0)))
+            .max(0.0);
 
             Instance {
                 container_id: c.container_id.into(),

--- a/crates/rocm-dash-daemon/src/registry.rs
+++ b/crates/rocm-dash-daemon/src/registry.rs
@@ -36,8 +36,9 @@ use rocm_dash_core::metrics::Instance;
 use rocm_dash_core::traits::DiscoveredService;
 use serde::Deserialize;
 
-/// Minimal read-only view of a rocm-cli `ManagedServiceRecord` on disk. Mirrors
-/// the stable subset the scrape seam needs; unknown fields (manifest paths,
+/// Minimal read-only view of a rocm-cli `ManagedServiceRecord` on disk.
+///
+/// Mirrors the stable subset the scrape seam needs; unknown fields (manifest paths,
 /// pids, recipe json, …) are ignored. Every field defaults so partial/older
 /// records still parse.
 #[derive(Debug, Clone, Deserialize)]
@@ -60,9 +61,10 @@ pub struct ServiceRecord {
     pub created_at_unix_ms: u128,
 }
 
-/// Service statuses worth scraping. Matches the live set the rocm-cli supervisor
-/// overlays onto a record (`ready`/`running`/`starting`); a `failed`/`stopped`
-/// record is skipped so we never poll a dead port.
+/// Service statuses worth scraping.
+///
+/// Matches the live set the rocm-cli supervisor overlays onto a record (`ready`/`running`/`starting`);
+/// a `failed`/`stopped` record is skipped so we never poll a dead port.
 pub fn is_scrapeable_status(status: &str) -> bool {
     matches!(
         status.trim().to_ascii_lowercase().as_str(),
@@ -134,8 +136,9 @@ pub fn engine_kind_for(record: &ServiceRecord) -> Option<EngineKind> {
     EngineKind::from_label(&record.engine)
 }
 
-/// The result of turning a batch of registry records into dashboard instances:
-/// the live instances to upsert, their ids (`seen`), and the subset whose engine
+/// The result of turning a batch of registry records into dashboard instances.
+///
+/// Contains the live instances to upsert, their ids (`seen`), and the subset whose engine
 /// is NOT vLLM (`non_vllm`, excluded from the vLLM Prometheus scrape so they are
 /// not mis-parsed). Pure — the runner applies it (upsert/broadcast/Gone-diff).
 #[derive(Debug, Default)]
@@ -145,9 +148,9 @@ pub struct ManagedDiscovery {
     pub non_vllm: HashSet<String>,
 }
 
-/// Convert the loaded registry records into a [`ManagedDiscovery`] — the pure
-/// core of the daemon's managed-service discovery tick. Non-scrapeable records
-/// (bad status / port 0) are dropped; vLLM-engine services flow to the
+/// Convert the loaded registry records into a [`ManagedDiscovery`] — the pure core of the daemon's managed-service discovery tick.
+///
+/// Non-scrapeable records (bad status / port 0) are dropped; vLLM-engine services flow to the
 /// Prometheus scrape, others are flagged in `non_vllm`.
 ///
 /// NOTE: gen_tps for managed **non-vLLM** engines (e.g. Lemonade) is not yet

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -143,15 +143,12 @@ pub async fn run_loop(
     });
 
     let docker = if opts.enable_docker {
-        match DockerDiscovery::detect(opts.image_patterns.clone()).await {
-            Some(d) => {
-                info!("docker discovery enabled");
-                Some(d)
-            }
-            None => {
-                warn!("docker discovery requested but daemon unreachable; disabled");
-                None
-            }
+        if let Some(d) = DockerDiscovery::detect(opts.image_patterns.clone()).await {
+            info!("docker discovery enabled");
+            Some(d)
+        } else {
+            warn!("docker discovery requested but daemon unreachable; disabled");
+            None
         }
     } else {
         None
@@ -192,18 +189,15 @@ pub async fn run_loop(
         tick_count += 1;
 
         let mut warnings = Vec::new();
-        let gpus = match &gpu {
-            Some(g) => match g.metrics().await {
-                Ok(v) => v,
-                Err(e) => {
-                    warnings.push(format!("amd-smi metric: {e}"));
-                    Vec::new()
-                }
-            },
-            None => {
-                warnings.push("amd-smi unavailable (no /dev/kfd or binary missing)".into());
+        let gpus = if let Some(g) = &gpu { match g.metrics().await {
+            Ok(v) => v,
+            Err(e) => {
+                warnings.push(format!("amd-smi metric: {e}"));
                 Vec::new()
             }
+        } } else {
+            warnings.push("amd-smi unavailable (no /dev/kfd or binary missing)".into());
+            Vec::new()
         };
 
         if gpu.is_some()
@@ -686,7 +680,7 @@ mod tests {
     fn inst(container_id: &str, gpu_ids: &[&str]) -> Instance {
         Instance {
             container_id: container_id.into(),
-            gpu_ids: gpu_ids.iter().map(|s| s.to_string()).collect(),
+            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
             ..Instance::default()
         }
     }

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -189,13 +189,15 @@ pub async fn run_loop(
         tick_count += 1;
 
         let mut warnings = Vec::new();
-        let gpus = if let Some(g) = &gpu { match g.metrics().await {
-            Ok(v) => v,
-            Err(e) => {
-                warnings.push(format!("amd-smi metric: {e}"));
-                Vec::new()
+        let gpus = if let Some(g) = &gpu {
+            match g.metrics().await {
+                Ok(v) => v,
+                Err(e) => {
+                    warnings.push(format!("amd-smi metric: {e}"));
+                    Vec::new()
+                }
             }
-        } } else {
+        } else {
             warnings.push("amd-smi unavailable (no /dev/kfd or binary missing)".into());
             Vec::new()
         };
@@ -680,7 +682,10 @@ mod tests {
     fn inst(container_id: &str, gpu_ids: &[&str]) -> Instance {
         Instance {
             container_id: container_id.into(),
-            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
+            gpu_ids: gpu_ids
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             ..Instance::default()
         }
     }

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -47,9 +47,9 @@ async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
     use tokio::net::UnixListener;
 
     if path.exists() {
-        std::fs::remove_file(&path).with_context(|| format!("removing stale socket {path:?}"))?;
+        std::fs::remove_file(&path).with_context(|| format!("removing stale socket {}", path.display()))?;
     }
-    let listener = UnixListener::bind(&path).with_context(|| format!("binding {path:?}"))?;
+    let listener = UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
     info!(socket = %path.display(), "listening");
 
     let (snap_tx, _) = broadcast::channel::<Event>(BROADCAST_CAP);

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -47,9 +47,11 @@ async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
     use tokio::net::UnixListener;
 
     if path.exists() {
-        std::fs::remove_file(&path).with_context(|| format!("removing stale socket {}", path.display()))?;
+        std::fs::remove_file(&path)
+            .with_context(|| format!("removing stale socket {}", path.display()))?;
     }
-    let listener = UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
+    let listener =
+        UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
     info!(socket = %path.display(), "listening");
 
     let (snap_tx, _) = broadcast::channel::<Event>(BROADCAST_CAP);

--- a/crates/rocm-dash-daemon/src/transport.rs
+++ b/crates/rocm-dash-daemon/src/transport.rs
@@ -5,6 +5,7 @@ use std::io;
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+#[allow(clippy::future_not_send)]
 pub async fn write_line<W, T>(w: &mut W, value: &T) -> io::Result<()>
 where
     W: AsyncWriteExt + Unpin,

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -123,7 +123,10 @@ async fn ring_accumulates_snapshots_for_replay() {
         if n >= 3 {
             break;
         }
-        assert!(Instant::now() <= deadline, "ring never reached 3 snapshots; len={n}");
+        assert!(
+            Instant::now() <= deadline,
+            "ring never reached 3 snapshots; len={n}"
+        );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
@@ -192,7 +195,10 @@ async fn bench_ring_accumulates_rows_for_replay() {
         if n >= 1 {
             break;
         }
-        assert!(Instant::now() <= deadline, "bench ring never accumulated a row; len={n}");
+        assert!(
+            Instant::now() <= deadline,
+            "bench ring never accumulated a row; len={n}"
+        );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -123,9 +123,7 @@ async fn ring_accumulates_snapshots_for_replay() {
         if n >= 3 {
             break;
         }
-        if Instant::now() > deadline {
-            panic!("ring never reached 3 snapshots; len={n}");
-        }
+        assert!(Instant::now() <= deadline, "ring never reached 3 snapshots; len={n}");
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
@@ -194,9 +192,7 @@ async fn bench_ring_accumulates_rows_for_replay() {
         if n >= 1 {
             break;
         }
-        if Instant::now() > deadline {
-            panic!("bench ring never accumulated a row; len={n}");
-        }
+        assert!(Instant::now() <= deadline, "bench ring never accumulated a row; len={n}");
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 

--- a/crates/rocm-dash-tui/Cargo.toml
+++ b/crates/rocm-dash-tui/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 name = "rocm_dash_tui"
 path = "src/lib.rs"

--- a/crates/rocm-dash-tui/examples/gen_cast.rs
+++ b/crates/rocm-dash-tui/examples/gen_cast.rs
@@ -12,6 +12,7 @@
 //! string. Frames overwrite in place (cursor home), so the cast plays back
 //! as a smooth animation rather than a scrolling log.
 
+use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -72,13 +73,10 @@ fn main() -> anyhow::Result<()> {
     // Snapshot events drive the animated widgets (sparklines, gauges). We
     // index them so the storyboard can advance the timeline a few snapshots
     // at a time between frames.
-    let snapshot_idxs: Vec<usize> = entries
+    let total_snaps = entries
         .iter()
-        .enumerate()
-        .filter(|(_, e)| matches!(e.event, Event::Snapshot(_)))
-        .map(|(i, _)| i)
-        .collect();
-    let total_snaps = snapshot_idxs.len();
+        .filter(|e| matches!(e.event, Event::Snapshot(_)))
+        .count();
     eprintln!("  {total_snaps} snapshots in timeline");
 
     let mut state = AppState::new("demo-mi355x-01".into(), "default-dark".into());
@@ -230,8 +228,7 @@ fn write_cast(args: &Args, frames: &[String]) -> anyhow::Result<()> {
 
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     let header = serde_json::json!({
         "version": 2,
@@ -280,7 +277,7 @@ fn buffer_to_ansi(buf: &Buffer) -> String {
         let mut cur_fg: Option<(u8, u8, u8)> = None;
         let mut cur_bg: Option<(u8, u8, u8)> = None;
         let mut cur_bold = false;
-        out.push_str(&format!("\u{1b}[{};1H\u{1b}[0m", y + 1));
+        let _ = write!(out, "\u{1b}[{};1H\u{1b}[0m", y + 1);
 
         for x in 0..cols {
             let cell = buf.cell((x, y)).unwrap();
@@ -302,11 +299,11 @@ fn buffer_to_ansi(buf: &Buffer) -> String {
                 }
                 if Some(fg) != cur_fg {
                     let (r, g, b) = fg;
-                    out.push_str(&format!("\u{1b}[38;2;{r};{g};{b}m"));
+                    let _ = write!(out, "\u{1b}[38;2;{r};{g};{b}m");
                 }
                 if Some(bg) != cur_bg {
                     let (r, g, b) = bg;
-                    out.push_str(&format!("\u{1b}[48;2;{r};{g};{b}m"));
+                    let _ = write!(out, "\u{1b}[48;2;{r};{g};{b}m");
                 }
                 cur_fg = Some(fg);
                 cur_bg = Some(bg);
@@ -329,7 +326,7 @@ fn buffer_to_ansi(buf: &Buffer) -> String {
 
 /// Map a ratatui `Color` to a concrete RGB triple, falling back to `default`
 /// for `Reset`/indexed/named variants we don't translate.
-fn resolve_color(c: Option<Color>, default: (u8, u8, u8)) -> (u8, u8, u8) {
+const fn resolve_color(c: Option<Color>, default: (u8, u8, u8)) -> (u8, u8, u8) {
     match c {
         Some(Color::Rgb(r, g, b)) => (r, g, b),
         Some(Color::Black) => (0, 0, 0),

--- a/crates/rocm-dash-tui/examples/gen_screenshots.rs
+++ b/crates/rocm-dash-tui/examples/gen_screenshots.rs
@@ -324,7 +324,10 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
             let rx = f64::from(start) * CELL_W;
             let ry = f64::from(y) * CELL_H;
             let rw = f64::from(end - start) * CELL_W;
-            let _ = write!(out, r#"<rect x="{rx:.2}" y="{ry:.2}" width="{rw:.2}" height="{CELL_H}" fill="{bg_hex_run}"/>"#);
+            let _ = write!(
+                out,
+                r#"<rect x="{rx:.2}" y="{ry:.2}" width="{rw:.2}" height="{CELL_H}" fill="{bg_hex_run}"/>"#
+            );
             x = end;
         }
     }

--- a/crates/rocm-dash-tui/examples/gen_screenshots.rs
+++ b/crates/rocm-dash-tui/examples/gen_screenshots.rs
@@ -11,6 +11,7 @@
 //! AppState configuration (tab + modal + theme). Cells get run-length
 //! coalesced per row so the SVG stays compact (~30-80 KB / view).
 
+use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::PathBuf;
 
@@ -53,6 +54,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    type BuildFn = Box<dyn Fn() -> AppState>;
     let args = Args::parse();
     fs::create_dir_all(&args.output_dir)?;
 
@@ -70,7 +72,6 @@ fn main() -> anyhow::Result<()> {
     // Each screenshot is (filename, mutator) — the mutator fork-edits a
     // clone of base_state for that view. Theme variants get a fresh state
     // with a different theme so the picker and gradients re-render.
-    type BuildFn = Box<dyn Fn() -> AppState>;
     let mut tasks: Vec<(&str, BuildFn)> = Vec::new();
     let make = |theme: &'static str| {
         let entries = entries.clone();
@@ -277,8 +278,8 @@ const FONT_FAMILY: &str = "ui-monospace, 'JetBrains Mono', 'Cascadia Code', \
 fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
     let cols = buf.area.width;
     let rows = buf.area.height;
-    let w_px = cols as f64 * CELL_W;
-    let h_px = rows as f64 * CELL_H;
+    let w_px = f64::from(cols) * CELL_W;
+    let h_px = f64::from(rows) * CELL_H;
     let bg_hex = color_to_hex(default_bg).unwrap_or_else(|| "#13141a".into());
 
     let mut out = String::with_capacity(rows as usize * cols as usize * 16);
@@ -294,9 +295,7 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
         ff = FONT_FAMILY,
         fs = FONT_PX,
     ));
-    out.push_str(&format!(
-        r#"<rect width="100%" height="100%" fill="{bg_hex}"/>"#
-    ));
+    let _ = write!(out, r#"<rect width="100%" height="100%" fill="{bg_hex}"/>"#);
 
     // Per-row background runs.
     for y in 0..rows {
@@ -308,12 +307,9 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
                 x += 1;
                 continue;
             }
-            let bg_hex_run = match color_to_hex(bg) {
-                Some(h) => h,
-                None => {
-                    x += 1;
-                    continue;
-                }
+            let Some(bg_hex_run) = color_to_hex(bg) else {
+                x += 1;
+                continue;
             };
             let start = x;
             let mut end = x + 1;
@@ -325,12 +321,10 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
                     break;
                 }
             }
-            let rx = start as f64 * CELL_W;
-            let ry = y as f64 * CELL_H;
-            let rw = (end - start) as f64 * CELL_W;
-            out.push_str(&format!(
-                r#"<rect x="{rx:.2}" y="{ry:.2}" width="{rw:.2}" height="{CELL_H}" fill="{bg_hex_run}"/>"#
-            ));
+            let rx = f64::from(start) * CELL_W;
+            let ry = f64::from(y) * CELL_H;
+            let rw = f64::from(end - start) * CELL_W;
+            let _ = write!(out, r#"<rect x="{rx:.2}" y="{ry:.2}" width="{rw:.2}" height="{CELL_H}" fill="{bg_hex_run}"/>"#);
             x = end;
         }
     }
@@ -338,7 +332,7 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
     // Per-row foreground runs. Group by (fg, bold) and emit one <text> per run.
     for y in 0..rows {
         let mut x = 0u16;
-        let baseline = y as f64 * CELL_H + FONT_PX * 0.85;
+        let baseline = FONT_PX.mul_add(0.85, f64::from(y) * CELL_H);
         while x < cols {
             let cell = buf.cell((x, y)).unwrap();
             let sym = cell.symbol();
@@ -366,12 +360,12 @@ fn buffer_to_svg(buf: &Buffer, default_bg: Color) -> String {
                 text.push_str(&xml_escape(nsym));
                 end += 1;
             }
-            let tx = start as f64 * CELL_W;
+            let tx = f64::from(start) * CELL_W;
             let fg_hex = fg.unwrap_or_else(|| "#eaebec".into());
             let weight = if bold { "700" } else { "400" };
             // Render each glyph at its own x via `textLength` so coalesced
             // runs preserve monospace alignment regardless of font metrics.
-            let span_w = (end - start) as f64 * CELL_W;
+            let span_w = f64::from(end - start) * CELL_W;
             out.push_str(&format!(
                 concat!(
                     r#"<text x="{tx:.2}" y="{baseline:.2}" "#,

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -111,9 +111,7 @@ pub fn annotate_reply(reply: String, skills: &[String]) -> String {
 // ---------------------------------------------------------------------------
 
 fn gpus_of(snap: &StateSnapshot) -> &[GpuMetrics] {
-    snap.latest
-        .as_ref()
-        .map_or(&[], |s| s.gpus.as_slice())
+    snap.latest.as_ref().map_or(&[], |s| s.gpus.as_slice())
 }
 
 fn gpu_json(g: &GpuMetrics) -> Value {

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -113,8 +113,7 @@ pub fn annotate_reply(reply: String, skills: &[String]) -> String {
 fn gpus_of(snap: &StateSnapshot) -> &[GpuMetrics] {
     snap.latest
         .as_ref()
-        .map(|s| s.gpus.as_slice())
-        .unwrap_or(&[])
+        .map_or(&[], |s| s.gpus.as_slice())
 }
 
 fn gpu_json(g: &GpuMetrics) -> Value {
@@ -345,8 +344,9 @@ impl Tool for TokensPerWattTool {
     }
 }
 
-/// Read-only tool exposing the rocm-dash **skills** registry (auto-config /
-/// auto-install). The agent can list skills and fetch a skill's dry-run plan;
+/// Read-only tool exposing the rocm-dash **skills** registry (auto-config / auto-install).
+///
+/// The agent can list skills and fetch a skill's dry-run plan;
 /// it never executes a skill (execution is `--apply`-gated in the CLI).
 pub struct ListSkillsTool {
     pub fired: FiredLog,
@@ -552,8 +552,9 @@ impl AgentClient for RigAgentClient {
     }
 }
 
-/// No-key ChatGPT backend over Rig's native `chatgpt` OAuth provider — the
-/// no-key default that restores the ChatGPT device-login the vendored Codex
+/// No-key ChatGPT backend over Rig's native `chatgpt` OAuth provider.
+///
+/// This is the no-key default that restores the ChatGPT device-login the vendored Codex
 /// path provided. It takes NO api_key (the env-only key invariant is untouched:
 /// this path authenticates with an OAuth device-code flow, not a key). The
 /// `on_device_code` callback surfaces the verification URL + user code so the
@@ -691,7 +692,7 @@ impl MockAgentClient {
     }
 
     /// A mock whose `complete` always fails (to exercise the error path).
-    pub fn failing() -> Self {
+    pub const fn failing() -> Self {
         Self {
             reply: String::new(),
             fail: true,
@@ -732,7 +733,7 @@ mod tests {
                     temperature_c: 40.0,
                     power_w: 100.0,
                     vram_used_mb: 1000,
-                    vram_total_mb: 192000,
+                    vram_total_mb: 192_000,
                     ..Default::default()
                 },
                 GpuMetrics {
@@ -741,7 +742,7 @@ mod tests {
                     temperature_c: 60.0,
                     power_w: 200.0,
                     vram_used_mb: 50000,
-                    vram_total_mb: 192000,
+                    vram_total_mb: 192_000,
                     ..Default::default()
                 },
                 GpuMetrics {
@@ -750,7 +751,7 @@ mod tests {
                     temperature_c: 71.0,
                     power_w: 250.0,
                     vram_used_mb: 90000,
-                    vram_total_mb: 192000,
+                    vram_total_mb: 192_000,
                     ..Default::default()
                 },
             ],

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -106,31 +106,33 @@ pub enum ActiveTab {
 }
 
 impl ActiveTab {
-    pub fn next(self) -> Self {
+    #[must_use]
+    pub const fn next(self) -> Self {
         match self {
-            ActiveTab::Overview => ActiveTab::Hardware,
-            ActiveTab::Hardware => ActiveTab::Instances,
-            ActiveTab::Instances => ActiveTab::Bench,
-            ActiveTab::Bench => ActiveTab::Chat,
-            ActiveTab::Chat => ActiveTab::Overview,
+            Self::Overview => Self::Hardware,
+            Self::Hardware => Self::Instances,
+            Self::Instances => Self::Bench,
+            Self::Bench => Self::Chat,
+            Self::Chat => Self::Overview,
         }
     }
-    pub fn prev(self) -> Self {
+    #[must_use]
+    pub const fn prev(self) -> Self {
         match self {
-            ActiveTab::Overview => ActiveTab::Chat,
-            ActiveTab::Hardware => ActiveTab::Overview,
-            ActiveTab::Instances => ActiveTab::Hardware,
-            ActiveTab::Bench => ActiveTab::Instances,
-            ActiveTab::Chat => ActiveTab::Bench,
+            Self::Overview => Self::Chat,
+            Self::Hardware => Self::Overview,
+            Self::Instances => Self::Hardware,
+            Self::Bench => Self::Instances,
+            Self::Chat => Self::Bench,
         }
     }
-    pub fn from_digit(d: char) -> Option<Self> {
+    pub const fn from_digit(d: char) -> Option<Self> {
         match d {
-            '1' => Some(ActiveTab::Overview),
-            '2' => Some(ActiveTab::Hardware),
-            '3' => Some(ActiveTab::Instances),
-            '4' => Some(ActiveTab::Bench),
-            '5' => Some(ActiveTab::Chat),
+            '1' => Some(Self::Overview),
+            '2' => Some(Self::Hardware),
+            '3' => Some(Self::Instances),
+            '4' => Some(Self::Bench),
+            '5' => Some(Self::Chat),
             _ => None,
         }
     }
@@ -224,7 +226,7 @@ pub struct ReplayState {
 }
 
 impl ReplayState {
-    pub fn new(controller: crate::replay::ReplayController) -> Self {
+    pub const fn new(controller: crate::replay::ReplayController) -> Self {
         Self {
             controller,
             paused: false,
@@ -455,11 +457,11 @@ impl AppState {
         if len == 0 {
             return;
         }
-        let next = (self.theme_picker_sel as isize + delta).clamp(0, len as isize - 1) as usize;
+        let next = (self.theme_picker_sel.cast_signed() + delta).clamp(0, len.cast_signed() - 1) as usize;
         self.theme_picker_sel = next;
     }
 
-    pub fn theme_picker_first(&mut self) {
+    pub const fn theme_picker_first(&mut self) {
         self.theme_picker_sel = 0;
     }
 
@@ -471,15 +473,15 @@ impl AppState {
     }
 
     /// Reset the bench-detail scroll offset (called when opening the modal).
-    pub fn reset_bench_detail_scroll(&mut self) {
+    pub const fn reset_bench_detail_scroll(&mut self) {
         self.bench_detail_scroll = 0;
     }
 
     /// Adjust the bench-detail scroll. `delta` is in lines; clamped at 0
     /// (no upper bound — the renderer clamps against the actual line count).
     pub fn scroll_bench_detail(&mut self, delta: i16) {
-        let cur = self.bench_detail_scroll as i32;
-        let next = (cur + delta as i32).max(0) as u16;
+        let cur = i32::from(self.bench_detail_scroll);
+        let next = (cur + i32::from(delta)).max(0) as u16;
         self.bench_detail_scroll = next;
     }
 
@@ -497,7 +499,7 @@ impl AppState {
 
     /// Accept the detected endpoint and enable chat. No-op when no endpoint is
     /// available. Focuses the input so the user can type immediately.
-    pub fn accept_chat_consent(&mut self) {
+    pub const fn accept_chat_consent(&mut self) {
         if self.chat_llm.is_some() {
             self.chat_consent = ChatConsent::Accepted;
             self.chat_focused = true;
@@ -505,7 +507,7 @@ impl AppState {
     }
 
     /// Decline the detected endpoint. Chat stays off (re-enable with `y`).
-    pub fn decline_chat_consent(&mut self) {
+    pub const fn decline_chat_consent(&mut self) {
         if self.chat_llm.is_some() {
             self.chat_consent = ChatConsent::Declined;
             self.chat_focused = false;
@@ -530,16 +532,13 @@ impl AppState {
     /// flag either way.
     pub fn set_detect_result(&mut self, offer: Option<crate::llm::LlmConfig>) {
         self.chat_detecting = false;
-        match offer {
-            Some(cfg) => {
-                self.chat_detect_msg = None;
-                self.chat_detect_offer = Some(cfg);
-            }
-            None => {
-                self.chat_detect_offer = None;
-                self.chat_detect_msg =
-                    Some("no local engine found (Lemonade :13305 / vLLM :8000)".into());
-            }
+        if let Some(cfg) = offer {
+            self.chat_detect_msg = None;
+            self.chat_detect_offer = Some(cfg);
+        } else {
+            self.chat_detect_offer = None;
+            self.chat_detect_msg =
+                Some("no local engine found (Lemonade :13305 / vLLM :8000)".into());
         }
     }
 
@@ -632,7 +631,7 @@ impl AppState {
         match self.active_tab {
             ActiveTab::Instances => self.instances.len(),
             ActiveTab::Bench => self.bench_rows.len(),
-            ActiveTab::Hardware => self.latest.as_ref().map(|s| s.gpus.len()).unwrap_or(0),
+            ActiveTab::Hardware => self.latest.as_ref().map_or(0, |s| s.gpus.len()),
             _ => 0,
         }
     }
@@ -644,7 +643,7 @@ impl AppState {
             return;
         }
         let sel = self.selection_for(self.active_tab);
-        let next = (sel as isize + delta).clamp(0, len as isize - 1) as usize;
+        let next = (sel.cast_signed() + delta).clamp(0, len.cast_signed() - 1) as usize;
         self.set_selection(self.active_tab, next);
     }
 
@@ -659,7 +658,7 @@ impl AppState {
         }
     }
 
-    fn selection_for(&self, tab: ActiveTab) -> usize {
+    const fn selection_for(&self, tab: ActiveTab) -> usize {
         match tab {
             ActiveTab::Instances => self.instance_sel,
             ActiveTab::Bench => self.bench_sel,
@@ -684,8 +683,8 @@ impl AppState {
     /// Derives the visible row count from the last rendered body area; with no
     /// prior draw it is a no-op (the renderer self-corrects on the next frame).
     fn sync_gpu_scroll(&mut self) {
-        let n = self.latest.as_ref().map(|s| s.gpus.len()).unwrap_or(0);
-        let body_h = self.last_body_area.map(|r| r.height).unwrap_or(0);
+        let n = self.latest.as_ref().map_or(0, |s| s.gpus.len());
+        let body_h = self.last_body_area.map_or(0, |r| r.height);
         let visible = crate::ui::tabs::hardware::gpu_visible_count(body_h, n);
         self.gpu_scroll =
             crate::ui::tabs::hardware::scroll_to_show(self.gpu_sel, self.gpu_scroll, visible);
@@ -694,17 +693,17 @@ impl AppState {
     /// Clamp both selectors after a state update that may have shrunk the
     /// underlying collection. Call after push_snapshot / instance changes.
     fn clamp_selectors(&mut self) {
-        if !self.instances.is_empty() {
-            self.instance_sel = self.instance_sel.min(self.instances.len() - 1);
-        } else {
+        if self.instances.is_empty() {
             self.instance_sel = 0;
-        }
-        if !self.bench_rows.is_empty() {
-            self.bench_sel = self.bench_sel.min(self.bench_rows.len() - 1);
         } else {
-            self.bench_sel = 0;
+            self.instance_sel = self.instance_sel.min(self.instances.len() - 1);
         }
-        let gpu_count = self.latest.as_ref().map(|s| s.gpus.len()).unwrap_or(0);
+        if self.bench_rows.is_empty() {
+            self.bench_sel = 0;
+        } else {
+            self.bench_sel = self.bench_sel.min(self.bench_rows.len() - 1);
+        }
+        let gpu_count = self.latest.as_ref().map_or(0, |s| s.gpus.len());
         if gpu_count > 0 {
             self.gpu_sel = self.gpu_sel.min(gpu_count - 1);
         } else {
@@ -804,12 +803,9 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
     // replay task below — the spawned agent task feeds replies back through the
     // same `rx.recv()` arm the daemon events already use (no new plumbing).
     let chat_tx = tx.clone();
-    let replay_controller = match args.replay.clone() {
-        Some(path) => Some(crate::replay::spawn(path, tx)),
-        None => {
-            client::spawn(args.connect.clone(), tx);
-            None
-        }
+    let replay_controller = if let Some(path) = args.replay.clone() { Some(crate::replay::spawn(path, tx)) } else {
+        client::spawn(args.connect.clone(), tx);
+        None
     };
 
     let mut events = EventStream::new();
@@ -1365,7 +1361,7 @@ fn apply_action(state: &mut AppState, action: KeyAction) -> bool {
         KeyAction::ChatDetectSave => state.save_detect_offer(),
         KeyAction::ChatDetectDismiss => state.dismiss_detect_offer(),
         KeyAction::ChatScroll(d) => {
-            let next = (state.chat_scroll as i32 + d as i32).max(0) as u16;
+            let next = (i32::from(state.chat_scroll) + i32::from(d)).max(0) as u16;
             state.chat_scroll = next;
         }
         KeyAction::Nothing => {}
@@ -1376,7 +1372,7 @@ fn apply_action(state: &mut AppState, action: KeyAction) -> bool {
 /// Translate a mouse event into a `KeyAction` using whatever state context
 /// is needed (last drawn areas, active tab, current modal).
 fn resolve_mouse(me: MouseEvent, state: &AppState) -> KeyAction {
-    if let MouseEventKind::Down(MouseButton::Left) = me.kind {
+    if me.kind == MouseEventKind::Down(MouseButton::Left) {
         if let Some(area) = state.last_tab_bar_area
             && let Some(tab) = tab_bar_hit(area, me.column, me.row)
         {
@@ -1486,13 +1482,13 @@ fn handle_key(k: KeyEvent, current: ActiveTab, modal: &Modal, chat: ChatKeyCtx) 
         // is wired with persistence.) Other keys fall through to the globals.
         if chat.offer_pending && chat.consent != ChatConsent::Accepted {
             match k.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
                     return KeyAction::ChatDetectAccept;
                 }
-                KeyCode::Char('s') | KeyCode::Char('S') => {
+                KeyCode::Char('s' | 'S') => {
                     return KeyAction::ChatDetectSave;
                 }
-                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                KeyCode::Char('n' | 'N') | KeyCode::Esc => {
                     return KeyAction::ChatDetectDismiss;
                 }
                 _ => {}
@@ -1526,13 +1522,13 @@ fn handle_key(k: KeyEvent, current: ActiveTab, modal: &Modal, chat: ChatKeyCtx) 
                 // engine. Other keys (q, digits, Tab, ?) fall through to the
                 // globals so the user isn't trapped.
                 match k.code {
-                    KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                    KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
                         return KeyAction::ChatConsentAccept;
                     }
-                    KeyCode::Char('n') | KeyCode::Char('N') => {
+                    KeyCode::Char('n' | 'N') => {
                         return KeyAction::ChatConsentDecline;
                     }
-                    KeyCode::Char('d') | KeyCode::Char('D') => {
+                    KeyCode::Char('d' | 'D') => {
                         return KeyAction::ChatDetect;
                     }
                     _ => {}
@@ -1540,7 +1536,7 @@ fn handle_key(k: KeyEvent, current: ActiveTab, modal: &Modal, chat: ChatKeyCtx) 
             }
             // No endpoint configured: the only gate action is to detect one.
             ChatConsent::Unavailable => {
-                if let KeyCode::Char('d') | KeyCode::Char('D') = k.code {
+                if let KeyCode::Char('d' | 'D') = k.code {
                     return KeyAction::ChatDetect;
                 }
             }
@@ -1601,8 +1597,8 @@ fn handle_key(k: KeyEvent, current: ActiveTab, modal: &Modal, chat: ChatKeyCtx) 
         KeyCode::PageDown => KeyAction::Move(10),
         KeyCode::PageUp => KeyAction::Move(-10),
         KeyCode::Char(' ') => KeyAction::ReplayTogglePause,
-        KeyCode::Char('+') | KeyCode::Char('=') => KeyAction::ReplaySpeedUp,
-        KeyCode::Char('-') | KeyCode::Char('_') => KeyAction::ReplaySpeedDown,
+        KeyCode::Char('+' | '=') => KeyAction::ReplaySpeedUp,
+        KeyCode::Char('-' | '_') => KeyAction::ReplaySpeedDown,
         KeyCode::Char('[') => KeyAction::ReplayJump(-10),
         KeyCode::Char(']') => KeyAction::ReplayJump(10),
         KeyCode::Char('{') => KeyAction::ReplayJump(-60),

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -457,7 +457,8 @@ impl AppState {
         if len == 0 {
             return;
         }
-        let next = (self.theme_picker_sel.cast_signed() + delta).clamp(0, len.cast_signed() - 1) as usize;
+        let next =
+            (self.theme_picker_sel.cast_signed() + delta).clamp(0, len.cast_signed() - 1) as usize;
         self.theme_picker_sel = next;
     }
 
@@ -803,7 +804,9 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
     // replay task below — the spawned agent task feeds replies back through the
     // same `rx.recv()` arm the daemon events already use (no new plumbing).
     let chat_tx = tx.clone();
-    let replay_controller = if let Some(path) = args.replay.clone() { Some(crate::replay::spawn(path, tx)) } else {
+    let replay_controller = if let Some(path) = args.replay.clone() {
+        Some(crate::replay::spawn(path, tx))
+    } else {
         client::spawn(args.connect.clone(), tx);
         None
     };

--- a/crates/rocm-dash-tui/src/client.rs
+++ b/crates/rocm-dash-tui/src/client.rs
@@ -113,7 +113,7 @@ async fn connect_and_run(connect: &str, tx: UnboundedSender<ClientMsg>) -> anyho
             }
             (host, daemon_version)
         }
-        Some(other) => return Err(anyhow!("expected Welcome, got {:?}", other)),
+        Some(other) => return Err(anyhow!("expected Welcome, got {other:?}")),
         None => return Err(anyhow!("connection closed before Welcome")),
     };
 

--- a/crates/rocm-dash-tui/src/jobs.rs
+++ b/crates/rocm-dash-tui/src/jobs.rs
@@ -29,8 +29,9 @@ use tokio::sync::mpsc::UnboundedSender;
 /// How often the runtime wakes to re-check the cancel flag while idle.
 const CANCEL_POLL: Duration = Duration::from_millis(100);
 
-/// Drive a batch of reducer side effects, spawning a job task for each
-/// [`SideEffect::SpawnJob`]. Non-job effects are ignored here — the daemon owns
+/// Drive a batch of reducer side effects, spawning a job task for each [`SideEffect::SpawnJob`].
+///
+/// Non-job effects are ignored here — the daemon owns
 /// broadcast/persist; in the TUI the job-bridge only cares about `SpawnJob`.
 pub fn run_effects(effects: Vec<SideEffect>, tx: &UnboundedSender<StateEvent>) {
     for fx in effects {
@@ -138,7 +139,7 @@ async fn run_job(
 
             // Idle wake-up so cancellation is observed within CANCEL_POLL even
             // when the child produces no output.
-            _ = tokio::time::sleep(CANCEL_POLL) => {}
+            () = tokio::time::sleep(CANCEL_POLL) => {}
         }
     }
 }

--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -1,5 +1,6 @@
-//! Chat LLM configuration: a pure precedence resolver plus a std-only TCP
-//! liveness probe. No HTTP client here — the Rig-built `AgentClient` (Phase 3)
+//! Chat LLM configuration: a pure precedence resolver plus a std-only TCP liveness probe.
+//!
+//! No HTTP client here — the Rig-built `AgentClient` (Phase 3)
 //! lives in `agent.rs`. Keeping detection in the TUI crate preserves the
 //! core's render/async-free boundary.
 
@@ -58,9 +59,7 @@ pub fn resolve_llm_config(
 
     // model precedence: CLI > config > built-in default.
     let model = cli_model
-        .or(cfg_model)
-        .map(str::to_string)
-        .unwrap_or_else(|| DEFAULT_CHAT_MODEL.to_string());
+        .or(cfg_model).map_or_else(|| DEFAULT_CHAT_MODEL.to_string(), str::to_string);
 
     Some(LlmConfig {
         base_url,
@@ -98,8 +97,9 @@ pub fn parse_host_port(base_url: &str) -> Option<(String, u16)> {
     }
 }
 
-/// Best-effort TCP liveness probe for a candidate endpoint. Returns `true`
-/// only if a connection to the parsed host:port succeeds within `timeout`.
+/// Best-effort TCP liveness probe for a candidate endpoint.
+///
+/// Returns `true` only if a connection to the parsed host:port succeeds within `timeout`.
 /// Never panics; any parse/DNS/connect failure yields `false`.
 pub fn probe_endpoint(base_url: &str, timeout: Duration) -> bool {
     let Some((host, port)) = parse_host_port(base_url) else {
@@ -116,9 +116,9 @@ pub fn probe_endpoint(base_url: &str, timeout: Duration) -> bool {
     false
 }
 
-/// Probe the known local serving endpoints in priority order (Lemonade, then
-/// vLLM) and return the first reachable one. Used by the TUI's in-app
-/// "detect a local engine" action so the user need not run the CLI skill first.
+/// Probe the known local serving endpoints in priority order (Lemonade, then vLLM) and return the first reachable one.
+///
+/// Used by the TUI's in-app "detect a local engine" action so the user need not run the CLI skill first.
 /// TCP-only (no HTTP); never blocks longer than [`PROBE_TIMEOUT`] per candidate.
 pub fn detect_local_endpoint() -> Option<&'static str> {
     [
@@ -129,8 +129,9 @@ pub fn detect_local_endpoint() -> Option<&'static str> {
     .find(|ep| probe_endpoint(ep, PROBE_TIMEOUT))
 }
 
-/// Pick the first model id from an OpenAI-compatible `/v1/models` response
-/// (`{"data":[{"id":"…"}]}`). Pure — no HTTP. `None` when the shape is missing,
+/// Pick the first model id from an OpenAI-compatible `/v1/models` response (`{"data":[{"id":"…"}]}`).
+///
+/// Pure — no HTTP. `None` when the shape is missing,
 /// empty, or malformed, so the caller can fall back to [`DEFAULT_CHAT_MODEL`].
 pub fn pick_first_model(models_json: &serde_json::Value) -> Option<String> {
     models_json

--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -59,7 +59,8 @@ pub fn resolve_llm_config(
 
     // model precedence: CLI > config > built-in default.
     let model = cli_model
-        .or(cfg_model).map_or_else(|| DEFAULT_CHAT_MODEL.to_string(), str::to_string);
+        .or(cfg_model)
+        .map_or_else(|| DEFAULT_CHAT_MODEL.to_string(), str::to_string);
 
     Some(LlmConfig {
         base_url,

--- a/crates/rocm-dash-tui/src/reconnect.rs
+++ b/crates/rocm-dash-tui/src/reconnect.rs
@@ -15,7 +15,7 @@ impl Default for Backoff {
 }
 
 impl Backoff {
-    pub fn new(initial: Duration, max: Duration, factor: u32) -> Self {
+    pub const fn new(initial: Duration, max: Duration, factor: u32) -> Self {
         Self {
             current: initial,
             max,

--- a/crates/rocm-dash-tui/src/replay.rs
+++ b/crates/rocm-dash-tui/src/replay.rs
@@ -195,7 +195,7 @@ async fn run(
                 break;
             }
             tokio::select! {
-                _ = tokio::time::sleep_until(target) => break,
+                () = tokio::time::sleep_until(target) => break,
                 maybe = ctl.recv() => match maybe {
                     Some(c) => {
                         let jumped = handle_control(c, &mut paused, &mut speed, &mut cursor,
@@ -450,6 +450,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn next_speed_walks_steps_and_caps_at_max() {
         assert_eq!(next_speed(0.25), 0.5);
         assert_eq!(next_speed(1.0), 2.0);
@@ -458,6 +459,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn prev_speed_walks_steps_and_floors_at_min() {
         assert_eq!(prev_speed(8.0), 4.0);
         assert_eq!(prev_speed(0.25), 0.25);
@@ -563,7 +565,7 @@ mod tests {
                     saw_seek = true;
                     break;
                 }
-                Ok(Some(_)) => continue,
+                Ok(Some(_)) => {}
                 _ => break,
             }
         }
@@ -612,7 +614,7 @@ mod tests {
                     saw_seek = true;
                     break;
                 }
-                Ok(Some(_)) => continue,
+                Ok(Some(_)) => {}
                 _ => break,
             }
         }

--- a/crates/rocm-dash-tui/src/skills.rs
+++ b/crates/rocm-dash-tui/src/skills.rs
@@ -40,12 +40,12 @@ impl Step {
     /// One-line, human-readable rendering for a plan.
     pub fn describe(&self) -> String {
         match self {
-            Step::Check { command } => format!("check: {command}"),
-            Step::Run { cmd, args } => format!("run: {cmd} {}", args.join(" "))
+            Self::Check { command } => format!("check: {command}"),
+            Self::Run { cmd, args } => format!("run: {cmd} {}", args.join(" "))
                 .trim_end()
                 .to_string(),
-            Step::Download { url, dest } => format!("download: {url} -> {dest}"),
-            Step::WriteConfig { key, value } => format!("write-config: {key} = {value}"),
+            Self::Download { url, dest } => format!("download: {url} -> {dest}"),
+            Self::WriteConfig { key, value } => format!("write-config: {key} = {value}"),
         }
     }
 }
@@ -126,8 +126,9 @@ pub fn build_plan(m: &SkillManifest) -> Vec<String> {
 // manifests in the user skills dir; discovery merges them in (in the binary).
 // ---------------------------------------------------------------------------
 
-/// install-lemonade: install AMD's Lemonade local LLM server from the official
-/// **embeddable SDK** release (the `lemond` server + `lemonade` CLI), not pip.
+/// install-lemonade: install AMD's Lemonade local LLM server from the official **embeddable SDK** release.
+///
+/// Installs the `lemond` server + `lemonade` CLI, not pip.
 /// The real apply path is special-cased + `--apply`-gated in the binary
 /// (`apply_install_lemonade`): it queries the latest GitHub release, picks the
 /// per-OS embeddable archive, downloads + extracts it into a rocm-owned dir, and
@@ -162,8 +163,9 @@ key = "default_engine"
 value = "lemonade"
 "#;
 
-/// auto-config-endpoint: detect a running local LLM endpoint (Lemonade/vLLM) and
-/// set `default_engine` for `serve`. Chat keeps the user's configured backend
+/// auto-config-endpoint: detect a running local LLM endpoint (Lemonade/vLLM) and set `default_engine` for `serve`.
+///
+/// Chat keeps the user's configured backend
 /// (e.g. the LLM gateway); `tui.chat_url` is filled only when it is unset.
 pub const AUTO_CONFIG_ENDPOINT_TOML: &str = r#"
 name = "auto-config-endpoint"
@@ -303,8 +305,9 @@ pub fn embeddable_artifact(os: &str, arch: &str, version: &str) -> Option<Embedd
     })
 }
 
-/// PURE: pick the embeddable asset from a GitHub `releases/latest` JSON body for
-/// the host `(os, arch)`. Reads `tag_name` + `assets[].{name, browser_download_url}`
+/// PURE: pick the embeddable asset from a GitHub `releases/latest` JSON body for the host `(os, arch)`.
+///
+/// Reads `tag_name` + `assets[].{name, browser_download_url}`
 /// and matches the `lemonade-embeddable-*-<os-arch>.<ext>` asset, skipping the
 /// `.pkg`/`.rpm`/`.msi` decoys. Returns `None` for an unsupported triple, malformed
 /// JSON, or a missing asset/url. Never panics. The release publishes no checksum
@@ -360,7 +363,7 @@ pub struct AutoConfigPlan {
 
 impl AutoConfigPlan {
     /// True when applying this plan would write nothing.
-    pub fn is_noop(&self) -> bool {
+    pub const fn is_noop(&self) -> bool {
         self.set_chat_url.is_none() && self.set_default_engine.is_none()
     }
 }

--- a/crates/rocm-dash-tui/src/transport.rs
+++ b/crates/rocm-dash-tui/src/transport.rs
@@ -6,6 +6,7 @@ use std::io;
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+#[allow(clippy::future_not_send)]
 pub async fn write_line<W, T>(w: &mut W, value: &T) -> io::Result<()>
 where
     W: AsyncWriteExt + Unpin,

--- a/crates/rocm-dash-tui/src/ui/approval.rs
+++ b/crates/rocm-dash-tui/src/ui/approval.rs
@@ -80,9 +80,7 @@ pub const fn approval_key(
         KeyCode::Char('n' | 'N') => (choice, Some(ApprovalVerdict::Deny)),
         // Esc and `q` both cancel — `q` must never be silently swallowed while a
         // modal is up, so the user is never trapped on any screen.
-        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
-            (choice, Some(ApprovalVerdict::Cancel))
-        }
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => (choice, Some(ApprovalVerdict::Cancel)),
         KeyCode::Enter => {
             let verdict = match choice {
                 ApprovalChoice::Approve => ApprovalVerdict::Approve,

--- a/crates/rocm-dash-tui/src/ui/approval.rs
+++ b/crates/rocm-dash-tui/src/ui/approval.rs
@@ -51,10 +51,11 @@ pub enum ApprovalChoice {
 }
 
 impl ApprovalChoice {
-    pub fn toggle(self) -> Self {
+    #[must_use]
+    pub const fn toggle(self) -> Self {
         match self {
-            ApprovalChoice::Approve => ApprovalChoice::Deny,
-            ApprovalChoice::Deny => ApprovalChoice::Approve,
+            Self::Approve => Self::Deny,
+            Self::Deny => Self::Approve,
         }
     }
 }
@@ -69,17 +70,17 @@ pub enum ApprovalVerdict {
 
 /// Pure key handler. Returns the (possibly moved) cursor and an optional
 /// verdict. No side effects — the caller routes the verdict CLI-side.
-pub fn approval_key(
+pub const fn approval_key(
     key: KeyCode,
     choice: ApprovalChoice,
 ) -> (ApprovalChoice, Option<ApprovalVerdict>) {
     match key {
         KeyCode::Up | KeyCode::Down | KeyCode::Tab | KeyCode::BackTab => (choice.toggle(), None),
-        KeyCode::Char('y') | KeyCode::Char('Y') => (choice, Some(ApprovalVerdict::Approve)),
-        KeyCode::Char('n') | KeyCode::Char('N') => (choice, Some(ApprovalVerdict::Deny)),
+        KeyCode::Char('y' | 'Y') => (choice, Some(ApprovalVerdict::Approve)),
+        KeyCode::Char('n' | 'N') => (choice, Some(ApprovalVerdict::Deny)),
         // Esc and `q` both cancel — `q` must never be silently swallowed while a
         // modal is up, so the user is never trapped on any screen.
-        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('Q') => {
+        KeyCode::Esc | KeyCode::Char('q' | 'Q') => {
             (choice, Some(ApprovalVerdict::Cancel))
         }
         KeyCode::Enter => {

--- a/crates/rocm-dash-tui/src/ui/automations_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/automations_manager.rs
@@ -51,17 +51,17 @@ pub enum AutomationAction {
 }
 
 impl AutomationAction {
-    fn verb(self) -> &'static str {
+    const fn verb(self) -> &'static str {
         match self {
-            AutomationAction::Enable => "enable",
-            AutomationAction::Disable => "disable",
+            Self::Enable => "enable",
+            Self::Disable => "disable",
         }
     }
 
-    fn job_id(self) -> &'static str {
+    const fn job_id(self) -> &'static str {
         match self {
-            AutomationAction::Enable => "automations-enable",
-            AutomationAction::Disable => "automations-disable",
+            Self::Enable => "automations-enable",
+            Self::Disable => "automations-disable",
         }
     }
 }
@@ -107,7 +107,7 @@ pub fn on_key(
                     return spawn_toggle(a, jobs, pending.action, pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => a.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => a.approval = None,
             None => {}
         }
         return Vec::new();
@@ -520,7 +520,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Automations"));
         assert!(out.contains("therock-update"));

--- a/crates/rocm-dash-tui/src/ui/command_screen.rs
+++ b/crates/rocm-dash-tui/src/ui/command_screen.rs
@@ -84,7 +84,7 @@ pub fn on_key(
                     return spawn_command(c, jobs, pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => c.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => c.approval = None,
             None => {}
         }
         return Vec::new();
@@ -416,7 +416,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Run a command"));
         assert!(out.contains("rocm doctor"));

--- a/crates/rocm-dash-tui/src/ui/config_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/config_manager.rs
@@ -48,16 +48,16 @@ pub const ACTIONS: &[ConfigAction] = &[
 ];
 
 impl ConfigAction {
-    fn label(self) -> &'static str {
+    const fn label(self) -> &'static str {
         match self {
-            ConfigAction::ShowConfig => "Show saved config",
-            ConfigAction::EnableProvider => "Enable provider",
-            ConfigAction::DisableProvider => "Disable provider",
+            Self::ShowConfig => "Show saved config",
+            Self::EnableProvider => "Enable provider",
+            Self::DisableProvider => "Disable provider",
         }
     }
 
-    fn is_mutating(self) -> bool {
-        !matches!(self, ConfigAction::ShowConfig)
+    const fn is_mutating(self) -> bool {
+        !matches!(self, Self::ShowConfig)
     }
 }
 
@@ -100,7 +100,7 @@ pub fn on_key(
                     return spawn_config(c, jobs, "config-provider", pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => c.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => c.approval = None,
             None => {}
         }
         return Vec::new();
@@ -464,7 +464,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Config & providers"));
         assert!(out.contains("Show saved config"));

--- a/crates/rocm-dash-tui/src/ui/core_bars.rs
+++ b/crates/rocm-dash-tui/src/ui/core_bars.rs
@@ -31,19 +31,22 @@ impl<'a> CoreBars<'a> {
         }
     }
 
+    #[must_use]
     pub fn max(mut self, m: f32) -> Self {
         self.max = if m > 0.0 { m } else { 1.0 };
         self
     }
 
-    pub fn style(mut self, s: Style) -> Self {
+    #[must_use]
+    pub const fn style(mut self, s: Style) -> Self {
         self.style = s;
         self
     }
 
     /// Color each bar by its fill ratio (low → stops[0], full → stops[2]).
     /// When set, overrides `style.fg` per column.
-    pub fn gradient(mut self, start: Color, mid: Color, end: Color) -> Self {
+    #[must_use]
+    pub const fn gradient(mut self, start: Color, mid: Color, end: Color) -> Self {
         self.gradient = Some([start, mid, end]);
         self
     }
@@ -63,7 +66,7 @@ impl Widget for CoreBars<'_> {
             let lit = ((v / self.max) * total_dot_rows as f32).round() as usize;
             let first_lit = total_dot_rows.saturating_sub(lit);
             let style = match self.gradient {
-                Some(stops) if v > 0.0 => self.style.fg(lerp3_t(stops, (v / self.max) as f64)),
+                Some(stops) if v > 0.0 => self.style.fg(lerp3_t(stops, f64::from(v / self.max))),
                 _ => self.style,
             };
             for cy in 0..rows {
@@ -86,7 +89,7 @@ impl Widget for CoreBars<'_> {
     }
 }
 
-fn braille_both_cols(mask: u8) -> char {
+const fn braille_both_cols(mask: u8) -> char {
     let mut code = 0u32;
     if mask & 0b0001 != 0 {
         code |= 0x01 | 0x08;

--- a/crates/rocm-dash-tui/src/ui/doctor_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/doctor_manager.rs
@@ -44,7 +44,9 @@ pub fn on_key(
             ConsoleOutcome::Unhandled => {
                 // `r` re-runs after a terminal result.
                 if key.code == KeyCode::Char('r')
-                    && jobs.job(&job_id).is_none_or(rocm_dash_core::state::JobState::is_terminal)
+                    && jobs
+                        .job(&job_id)
+                        .is_none_or(rocm_dash_core::state::JobState::is_terminal)
                 {
                     d.active_job = None;
                     return run_doctor(d, jobs);

--- a/crates/rocm-dash-tui/src/ui/doctor_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/doctor_manager.rs
@@ -44,7 +44,7 @@ pub fn on_key(
             ConsoleOutcome::Unhandled => {
                 // `r` re-runs after a terminal result.
                 if key.code == KeyCode::Char('r')
-                    && jobs.job(&job_id).map(|j| j.is_terminal()).unwrap_or(true)
+                    && jobs.job(&job_id).is_none_or(rocm_dash_core::state::JobState::is_terminal)
                 {
                     d.active_job = None;
                     return run_doctor(d, jobs);
@@ -233,7 +233,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Doctor"));
         assert!(out.contains("rocm doctor"));

--- a/crates/rocm-dash-tui/src/ui/engine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/engine_manager.rs
@@ -62,24 +62,24 @@ pub enum EngineAction {
 }
 
 impl EngineAction {
-    pub fn verb(self) -> &'static str {
+    pub const fn verb(self) -> &'static str {
         match self {
-            EngineAction::Use => "use",
-            EngineAction::Install => "install",
-            EngineAction::Reinstall => "reinstall",
+            Self::Use => "use",
+            Self::Install => "install",
+            Self::Reinstall => "reinstall",
         }
     }
 
     /// The `rocm` argv (after the binary) for this action on `engine`.
     fn args(self, engine: &str) -> Vec<String> {
         match self {
-            EngineAction::Use => vec![
+            Self::Use => vec![
                 "config".into(),
                 "set-default-engine".into(),
                 engine.to_string(),
             ],
-            EngineAction::Install => vec!["engines".into(), "install".into(), engine.to_string()],
-            EngineAction::Reinstall => vec![
+            Self::Install => vec!["engines".into(), "install".into(), engine.to_string()],
+            Self::Reinstall => vec![
                 "engines".into(),
                 "install".into(),
                 engine.to_string(),
@@ -129,7 +129,7 @@ pub fn on_key(
                     return spawn_engine_op(em, jobs, pending);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => em.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => em.approval = None,
             None => {}
         }
         return Vec::new();
@@ -440,7 +440,7 @@ mod tests {
         term.draw(|f| draw_engine_manager(f, f.area(), em, jobs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/engine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/engine_manager.rs
@@ -440,7 +440,10 @@ mod tests {
         term.draw(|f| draw_engine_manager(f, f.area(), em, jobs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+        buf.content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/exec.rs
+++ b/crates/rocm-dash-tui/src/ui/exec.rs
@@ -9,7 +9,8 @@
 /// `current_exe()` is unavailable — never a silent no-op.
 pub fn resolve_exe() -> String {
     std::env::current_exe()
-        .ok().map_or_else(|| "rocm".to_string(), |p| p.to_string_lossy().into_owned())
+        .ok()
+        .map_or_else(|| "rocm".to_string(), |p| p.to_string_lossy().into_owned())
 }
 
 /// Short, human-readable basename of a resolved command, for approval previews.

--- a/crates/rocm-dash-tui/src/ui/exec.rs
+++ b/crates/rocm-dash-tui/src/ui/exec.rs
@@ -1,5 +1,6 @@
-//! Shared helpers for launching `rocm` sub-commands from operational screens
-//! (Phase 3 Wave 1). Every screen that routes a mutating action through the
+//! Shared helpers for launching `rocm` sub-commands from operational screens (Phase 3 Wave 1).
+//!
+//! Every screen that routes a mutating action through the
 //! approval gate + job-bridge resolves the binary the same way, so the logic
 //! lives here once instead of being re-implemented per screen.
 
@@ -8,9 +9,7 @@
 /// `current_exe()` is unavailable — never a silent no-op.
 pub fn resolve_exe() -> String {
     std::env::current_exe()
-        .ok()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "rocm".to_string())
+        .ok().map_or_else(|| "rocm".to_string(), |p| p.to_string_lossy().into_owned())
 }
 
 /// Short, human-readable basename of a resolved command, for approval previews.

--- a/crates/rocm-dash-tui/src/ui/folder_browser.rs
+++ b/crates/rocm-dash-tui/src/ui/folder_browser.rs
@@ -90,8 +90,8 @@ impl FolderBrowser {
         if self.entries.is_empty() {
             return;
         }
-        let max = self.entries.len() as isize - 1;
-        self.selected = (self.selected as isize + delta).clamp(0, max) as usize;
+        let max = self.entries.len().cast_signed() - 1;
+        self.selected = (self.selected.cast_signed() + delta).clamp(0, max) as usize;
     }
 
     fn navigate_to(&mut self, dir: PathBuf) {

--- a/crates/rocm-dash-tui/src/ui/format.rs
+++ b/crates/rocm-dash-tui/src/ui/format.rs
@@ -82,6 +82,7 @@ pub fn si(value: f64) -> String {
 }
 
 /// Byte-rate (bytes per second), SI-suffixed: `512/s`, `1.20 k/s`, `1.20 M/s`.
+///
 /// Used for disk and network throughput on the Hardware tab. Reuses [`si`], so
 /// the magnitude suffix (k/M/B) carries the scale and `/s` marks it as a rate;
 /// the unit is bytes-per-second by context (the panel labels say disk / net).
@@ -134,7 +135,7 @@ pub fn duration(seconds: f64) -> String {
 /// Request counter rendered with SI suffix for big numbers and `-` for None.
 pub fn reqs_opt(value: Option<u32>) -> String {
     match value {
-        Some(v) if v >= 1_000 => si(v as f64),
+        Some(v) if v >= 1_000 => si(f64::from(v)),
         Some(v) => v.to_string(),
         None => "-".to_string(),
     }

--- a/crates/rocm-dash-tui/src/ui/gradient.rs
+++ b/crates/rocm-dash-tui/src/ui/gradient.rs
@@ -23,7 +23,7 @@ pub struct GradientGauge<'a> {
 }
 
 impl<'a> GradientGauge<'a> {
-    pub fn new(ratio: f64) -> Self {
+    pub const fn new(ratio: f64) -> Self {
         Self {
             ratio: ratio.clamp(0.0, 1.0),
             stops: [
@@ -37,22 +37,26 @@ impl<'a> GradientGauge<'a> {
         }
     }
 
-    pub fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
+    #[must_use]
+    pub const fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
         self.stops = [start, mid, end];
         self
     }
 
-    pub fn track_bg(mut self, c: Color) -> Self {
+    #[must_use]
+    pub const fn track_bg(mut self, c: Color) -> Self {
         self.track_bg = c;
         self
     }
 
-    pub fn label(mut self, label: &'a str) -> Self {
+    #[must_use]
+    pub const fn label(mut self, label: &'a str) -> Self {
         self.label = Some(label);
         self
     }
 
-    pub fn label_fg(mut self, c: Color) -> Self {
+    #[must_use]
+    pub const fn label_fg(mut self, c: Color) -> Self {
         self.label_fg = c;
         self
     }
@@ -133,13 +137,13 @@ fn lerp2(a: Color, b: Color, t: f64) -> Color {
     let (br, bg, bb) = rgb_of(b);
     let t = t.clamp(0.0, 1.0);
     let lerp = |x: u8, y: u8| -> u8 {
-        let v = x as f64 + (y as f64 - x as f64) * t;
+        let v = (f64::from(y) - f64::from(x)).mul_add(t, f64::from(x));
         v.round().clamp(0.0, 255.0) as u8
     };
     Color::Rgb(lerp(ar, br), lerp(ag, bg), lerp(ab, bb))
 }
 
-fn rgb_of(c: Color) -> (u8, u8, u8) {
+const fn rgb_of(c: Color) -> (u8, u8, u8) {
     match c {
         Color::Rgb(r, g, b) => (r, g, b),
         // Fallback: indexed / named colors aren't blendable without a

--- a/crates/rocm-dash-tui/src/ui/heatmap.rs
+++ b/crates/rocm-dash-tui/src/ui/heatmap.rs
@@ -40,7 +40,8 @@ impl HeatmapRow {
         }
     }
 
-    pub fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
+    #[must_use]
+    pub const fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
         self.stops = Some([start, mid, end]);
         self
     }
@@ -78,22 +79,26 @@ impl<'a> Heatmap<'a> {
         }
     }
 
-    pub fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
+    #[must_use]
+    pub const fn stops(mut self, start: Color, mid: Color, end: Color) -> Self {
         self.stops = [start, mid, end];
         self
     }
 
-    pub fn track_bg(mut self, c: Color) -> Self {
+    #[must_use]
+    pub const fn track_bg(mut self, c: Color) -> Self {
         self.track_bg = c;
         self
     }
 
-    pub fn label_style(mut self, s: Style) -> Self {
+    #[must_use]
+    pub const fn label_style(mut self, s: Style) -> Self {
         self.label_style = s;
         self
     }
 
-    pub fn label_width(mut self, w: u16) -> Self {
+    #[must_use]
+    pub const fn label_width(mut self, w: u16) -> Self {
         self.label_width = w;
         self
     }

--- a/crates/rocm-dash-tui/src/ui/install_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/install_manager.rs
@@ -94,8 +94,8 @@ impl InstallManagerState {
     }
 
     fn move_field(&mut self, delta: isize) {
-        let max = FIELDS.len() as isize - 1;
-        self.field = (self.field as isize + delta).clamp(0, max) as usize;
+        let max = FIELDS.len().cast_signed() - 1;
+        self.field = (self.field.cast_signed() + delta).clamp(0, max) as usize;
     }
 
     fn cycle(&mut self) {
@@ -187,7 +187,7 @@ pub fn on_key(
                     return spawn_install(i, jobs, pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => i.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => i.approval = None,
             None => {}
         }
         return Vec::new();
@@ -596,7 +596,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Install"));
         assert!(out.contains("Channel"));

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -46,7 +46,9 @@ pub fn on_console_key(job_id: &str, jobs: &mut State, key: KeyEvent) -> ConsoleO
         // (the job keeps running in the background).
         KeyCode::Char('q') => ConsoleOutcome::Closed,
         KeyCode::Esc | KeyCode::Enter
-            if jobs.job(job_id).is_none_or(rocm_dash_core::state::JobState::is_terminal) =>
+            if jobs
+                .job(job_id)
+                .is_none_or(rocm_dash_core::state::JobState::is_terminal) =>
         {
             ConsoleOutcome::Dismissed
         }

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -17,8 +17,9 @@ use rocm_dash_core::state::{JobState, JobStatus, SideEffect, State, StateEvent};
 use crate::ui::modal::{centered_rect, draw_popup_frame};
 use crate::ui::theme::Theme;
 
-/// What a console keypress means to the owning screen. The shared seam every
-/// operational overlay routes its `active_job` keys through, so the
+/// What a console keypress means to the owning screen.
+///
+/// The shared seam every operational overlay routes its `active_job` keys through, so the
 /// Ctrl+C/`q`/Esc-Enter behavior is defined once instead of per screen.
 #[derive(Debug)]
 pub enum ConsoleOutcome {
@@ -45,7 +46,7 @@ pub fn on_console_key(job_id: &str, jobs: &mut State, key: KeyEvent) -> ConsoleO
         // (the job keeps running in the background).
         KeyCode::Char('q') => ConsoleOutcome::Closed,
         KeyCode::Esc | KeyCode::Enter
-            if jobs.job(job_id).map(|j| j.is_terminal()).unwrap_or(true) =>
+            if jobs.job(job_id).is_none_or(rocm_dash_core::state::JobState::is_terminal) =>
         {
             ConsoleOutcome::Dismissed
         }

--- a/crates/rocm-dash-tui/src/ui/logs_view.rs
+++ b/crates/rocm-dash-tui/src/ui/logs_view.rs
@@ -227,7 +227,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Logs"));
         assert!(out.contains("search"));

--- a/crates/rocm-dash-tui/src/ui/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/mod.rs
@@ -158,7 +158,7 @@ fn draw_header(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         Span::raw("   "),
         Span::styled(status_text, Style::default().fg(status_color)),
     ];
-    let warning_count = state.latest.as_ref().map(|s| s.warnings.len()).unwrap_or(0);
+    let warning_count = state.latest.as_ref().map_or(0, |s| s.warnings.len());
     if warning_count > 0 {
         spans.push(Span::raw("   "));
         spans.push(Span::styled(

--- a/crates/rocm-dash-tui/src/ui/modal.rs
+++ b/crates/rocm-dash-tui/src/ui/modal.rs
@@ -62,6 +62,7 @@ pub fn draw_popup_frame(f: &mut Frame, area: Rect, title: &str, theme: &Theme) -
 }
 
 /// Shared chrome: a titled popup whose body is a scrollable block of `lines`.
+///
 /// Centralizes the `draw_modal_*` pattern so operational screens don't rebuild
 /// it (Phase 3 Wave 0). `scroll` is the first visible line offset.
 pub fn draw_scrollable_lines(
@@ -336,9 +337,9 @@ pub fn draw_theme_preview(f: &mut Frame, area: Rect, preview_theme: &Theme, acti
     // preview is visually rich and stable.
     let data: Vec<u64> = (0..rows[2].width as usize)
         .map(|i| {
-            let t = i as f64 / rows[2].width.max(1) as f64;
+            let t = i as f64 / f64::from(rows[2].width.max(1));
             // Two-bump curve so the gradient sweeps through all three stops.
-            let v = ((t * std::f64::consts::PI * 2.0).sin() * 40.0 + 60.0).max(2.0);
+            let v = (t * std::f64::consts::PI * 2.0).sin().mul_add(40.0, 60.0).max(2.0);
             v as u64
         })
         .collect();

--- a/crates/rocm-dash-tui/src/ui/modal.rs
+++ b/crates/rocm-dash-tui/src/ui/modal.rs
@@ -339,7 +339,10 @@ pub fn draw_theme_preview(f: &mut Frame, area: Rect, preview_theme: &Theme, acti
         .map(|i| {
             let t = i as f64 / f64::from(rows[2].width.max(1));
             // Two-bump curve so the gradient sweeps through all three stops.
-            let v = (t * std::f64::consts::PI * 2.0).sin().mul_add(40.0, 60.0).max(2.0);
+            let v = (t * std::f64::consts::PI * 2.0)
+                .sin()
+                .mul_add(40.0, 60.0)
+                .max(2.0);
             v as u64
         })
         .collect();

--- a/crates/rocm-dash-tui/src/ui/model_picker.rs
+++ b/crates/rocm-dash-tui/src/ui/model_picker.rs
@@ -87,8 +87,7 @@ impl ModelPicker {
             KeyCode::Enter => self
                 .filtered(recipes)
                 .get(self.selected)
-                .map(|r| PickerOutcome::Chosen((*r).clone()))
-                .unwrap_or(PickerOutcome::None),
+                .map_or(PickerOutcome::None, |r| PickerOutcome::Chosen((*r).clone())),
             KeyCode::Backspace => {
                 self.query.pop();
                 self.selected = 0;
@@ -310,7 +309,7 @@ mod tests {
         term.draw(|f| draw_model_picker(f, f.area(), &p, &rs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        let out: String = buf.content().iter().map(|c| c.symbol()).collect();
+        let out: String = buf.content().iter().map(ratatui::buffer::Cell::symbol).collect();
         assert!(out.contains("Pick a model recipe"));
         assert!(out.contains("Qwen3-4B-Instruct"));
         assert!(out.contains("engine"));

--- a/crates/rocm-dash-tui/src/ui/model_picker.rs
+++ b/crates/rocm-dash-tui/src/ui/model_picker.rs
@@ -309,7 +309,11 @@ mod tests {
         term.draw(|f| draw_model_picker(f, f.area(), &p, &rs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        let out: String = buf.content().iter().map(ratatui::buffer::Cell::symbol).collect();
+        let out: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
         assert!(out.contains("Pick a model recipe"));
         assert!(out.contains("Qwen3-4B-Instruct"));
         assert!(out.contains("engine"));

--- a/crates/rocm-dash-tui/src/ui/onboarding.rs
+++ b/crates/rocm-dash-tui/src/ui/onboarding.rs
@@ -82,12 +82,8 @@ impl OnboardingChoice {
 
     const fn explanation(self) -> &'static str {
         match self {
-            Self::InstallSdk => {
-                "This downloads and installs TheRock ROCm wheels on this machine."
-            }
-            Self::AdoptExisting => {
-                "This registers an existing ROCm folder without modifying it."
-            }
+            Self::InstallSdk => "This downloads and installs TheRock ROCm wheels on this machine.",
+            Self::AdoptExisting => "This registers an existing ROCm folder without modifying it.",
         }
     }
 }

--- a/crates/rocm-dash-tui/src/ui/onboarding.rs
+++ b/crates/rocm-dash-tui/src/ui/onboarding.rs
@@ -59,33 +59,33 @@ pub const CHOICES: &[OnboardingChoice] = &[
 ];
 
 impl OnboardingChoice {
-    fn label(self) -> &'static str {
+    const fn label(self) -> &'static str {
         match self {
-            OnboardingChoice::InstallSdk => "Install ROCm SDK (release · pip)",
-            OnboardingChoice::AdoptExisting => "Adopt an existing ROCm folder",
+            Self::InstallSdk => "Install ROCm SDK (release · pip)",
+            Self::AdoptExisting => "Adopt an existing ROCm folder",
         }
     }
 
-    fn job_id(self) -> &'static str {
+    const fn job_id(self) -> &'static str {
         match self {
-            OnboardingChoice::InstallSdk => "onboard-install",
-            OnboardingChoice::AdoptExisting => "onboard-adopt",
+            Self::InstallSdk => "onboard-install",
+            Self::AdoptExisting => "onboard-adopt",
         }
     }
 
-    fn title(self) -> &'static str {
+    const fn title(self) -> &'static str {
         match self {
-            OnboardingChoice::InstallSdk => "install ROCm SDK",
-            OnboardingChoice::AdoptExisting => "adopt existing ROCm folder",
+            Self::InstallSdk => "install ROCm SDK",
+            Self::AdoptExisting => "adopt existing ROCm folder",
         }
     }
 
-    fn explanation(self) -> &'static str {
+    const fn explanation(self) -> &'static str {
         match self {
-            OnboardingChoice::InstallSdk => {
+            Self::InstallSdk => {
                 "This downloads and installs TheRock ROCm wheels on this machine."
             }
-            OnboardingChoice::AdoptExisting => {
+            Self::AdoptExisting => {
                 "This registers an existing ROCm folder without modifying it."
             }
         }
@@ -167,7 +167,7 @@ pub fn on_key(
                     return spawn_onboard(o, jobs, pending.choice, pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => o.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => o.approval = None,
             None => {}
         }
         return Vec::new();
@@ -184,8 +184,7 @@ pub fn on_key(
                 // message so the wizard never claims success it didn't earn.
                 let ok = jobs
                     .job(&job_id)
-                    .map(|j| matches!(j.status, JobStatus::Done { code: 0 }))
-                    .unwrap_or(false);
+                    .is_some_and(|j| matches!(j.status, JobStatus::Done { code: 0 }));
                 o.active_job = None;
                 if ok {
                     o.message = None;
@@ -629,7 +628,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("first-run setup"));
         assert!(out.contains("get ROCm set up"));
@@ -647,7 +646,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Install ROCm SDK"));
         assert!(out.contains("Adopt an existing"));

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -34,8 +34,9 @@ use crate::ui::job_console::{ConsoleOutcome, draw_job_console, on_console_key};
 use crate::ui::modal::{centered_rect, draw_popup_frame};
 use crate::ui::theme::Theme;
 
-/// A flattened registered-runtime entry for the list. Mirrors the fields of the
-/// bin's `InstalledRuntimeManifest` (+ active/rollback status from config) that
+/// A flattened registered-runtime entry for the list.
+///
+/// Mirrors the fields of the bin's `InstalledRuntimeManifest` (+ active/rollback status from config) that
 /// the manager needs, with no `rocm-core` dependency.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RuntimeSummary {
@@ -67,33 +68,33 @@ pub enum RuntimeAction {
 
 impl RuntimeAction {
     /// Stable job id (one console per verb).
-    fn job_id(self) -> &'static str {
+    const fn job_id(self) -> &'static str {
         match self {
-            RuntimeAction::Activate => "runtimes-activate",
-            RuntimeAction::Rollback => "runtimes-rollback",
-            RuntimeAction::Uninstall => "runtimes-uninstall",
-            RuntimeAction::Adopt => "runtimes-adopt",
-            RuntimeAction::Import => "runtimes-import",
+            Self::Activate => "runtimes-activate",
+            Self::Rollback => "runtimes-rollback",
+            Self::Uninstall => "runtimes-uninstall",
+            Self::Adopt => "runtimes-adopt",
+            Self::Import => "runtimes-import",
         }
     }
 
-    fn title(self) -> &'static str {
+    const fn title(self) -> &'static str {
         match self {
-            RuntimeAction::Activate => "activate runtime",
-            RuntimeAction::Rollback => "roll back to previous runtime",
-            RuntimeAction::Uninstall => "uninstall runtime",
-            RuntimeAction::Adopt => "adopt existing ROCm folder",
-            RuntimeAction::Import => "import runtime manifest",
+            Self::Activate => "activate runtime",
+            Self::Rollback => "roll back to previous runtime",
+            Self::Uninstall => "uninstall runtime",
+            Self::Adopt => "adopt existing ROCm folder",
+            Self::Import => "import runtime manifest",
         }
     }
 
-    fn explanation(self) -> &'static str {
+    const fn explanation(self) -> &'static str {
         match self {
-            RuntimeAction::Activate => "This switches the default ROCm runtime for this machine.",
-            RuntimeAction::Rollback => "This restores the previously active ROCm runtime.",
-            RuntimeAction::Uninstall => "This removes the runtime record from ROCm CLI.",
-            RuntimeAction::Adopt => "This registers an existing ROCm folder without modifying it.",
-            RuntimeAction::Import => "This registers a runtime from a saved manifest file.",
+            Self::Activate => "This switches the default ROCm runtime for this machine.",
+            Self::Rollback => "This restores the previously active ROCm runtime.",
+            Self::Uninstall => "This removes the runtime record from ROCm CLI.",
+            Self::Adopt => "This registers an existing ROCm folder without modifying it.",
+            Self::Import => "This registers a runtime from a saved manifest file.",
         }
     }
 }
@@ -203,7 +204,7 @@ pub fn on_key(
                     return spawn_runtime(r, jobs, pending.action, pending.cmd, pending.args);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => r.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => r.approval = None,
             None => {}
         }
         return Vec::new();
@@ -754,7 +755,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Runtimes"));
         assert!(out.contains("therock-release-gfx94"));
@@ -777,7 +778,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("No runtimes registered"));
     }

--- a/crates/rocm-dash-tui/src/ui/serve_wizard.rs
+++ b/crates/rocm-dash-tui/src/ui/serve_wizard.rs
@@ -132,8 +132,8 @@ impl ServeWizardState {
     }
 
     fn move_field(&mut self, delta: isize) {
-        let max = FIELDS.len() as isize - 1;
-        self.field = (self.field as isize + delta).clamp(0, max) as usize;
+        let max = FIELDS.len().cast_signed() - 1;
+        self.field = (self.field.cast_signed() + delta).clamp(0, max) as usize;
     }
 
     fn cycle(&mut self, delta: isize) {
@@ -212,16 +212,17 @@ impl ServeWizardState {
     }
 }
 
-fn cycle_idx(cur: usize, len: usize, delta: isize) -> usize {
+const fn cycle_idx(cur: usize, len: usize, delta: isize) -> usize {
     if len == 0 {
         return 0;
     }
-    let n = len as isize;
-    (((cur as isize + delta) % n + n) % n) as usize
+    let n = len.cast_signed();
+    (((cur.cast_signed() + delta) % n + n) % n) as usize
 }
 
-/// Handle a key while the wizard is open. Mirrors the services-manager seam:
-/// mutates the overlay + job model in place and returns reducer side effects
+/// Handle a key while the wizard is open.
+///
+/// Mirrors the services-manager seam: mutates the overlay + job model in place and returns reducer side effects
 /// (e.g. `SpawnJob`) for the event loop to drive through the job-bridge.
 pub fn on_key(
     wizard: &mut Option<ServeWizardState>,
@@ -276,7 +277,7 @@ pub fn on_key(
                     return spawn_serve(w, jobs, pending);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => w.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => w.approval = None,
             None => {}
         }
         return Vec::new();
@@ -929,7 +930,7 @@ mod tests {
         term.draw(|f| draw_serve_wizard(f, f.area(), w, jobs, &[], &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/serve_wizard.rs
+++ b/crates/rocm-dash-tui/src/ui/serve_wizard.rs
@@ -930,7 +930,10 @@ mod tests {
         term.draw(|f| draw_serve_wizard(f, f.area(), w, jobs, &[], &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+        buf.content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -81,7 +81,9 @@ pub struct ServiceRow {
 }
 
 /// Build the sorted service list from the daemon-surfaced instances.
-pub fn service_rows<S: ::std::hash::BuildHasher>(instances: &HashMap<String, Instance, S>) -> Vec<ServiceRow> {
+pub fn service_rows<S: ::std::hash::BuildHasher>(
+    instances: &HashMap<String, Instance, S>,
+) -> Vec<ServiceRow> {
     let mut rows: Vec<ServiceRow> = instances
         .values()
         .map(|i| ServiceRow {
@@ -435,7 +437,10 @@ mod tests {
         term.draw(|f| draw_services_manager(f, f.area(), sm, insts, jobs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+        buf.content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -40,10 +40,10 @@ pub enum LifecycleAction {
 }
 
 impl LifecycleAction {
-    pub fn verb(self) -> &'static str {
+    pub const fn verb(self) -> &'static str {
         match self {
-            LifecycleAction::Stop => "stop",
-            LifecycleAction::Restart => "restart",
+            Self::Stop => "stop",
+            Self::Restart => "restart",
         }
     }
 }
@@ -81,7 +81,7 @@ pub struct ServiceRow {
 }
 
 /// Build the sorted service list from the daemon-surfaced instances.
-pub fn service_rows(instances: &HashMap<String, Instance>) -> Vec<ServiceRow> {
+pub fn service_rows<S: ::std::hash::BuildHasher>(instances: &HashMap<String, Instance, S>) -> Vec<ServiceRow> {
     let mut rows: Vec<ServiceRow> = instances
         .values()
         .map(|i| ServiceRow {
@@ -96,14 +96,15 @@ pub fn service_rows(instances: &HashMap<String, Instance>) -> Vec<ServiceRow> {
     rows
 }
 
-/// Handle a key while the overlay is open. Mutates the overlay + the job model
-/// in place and returns the reducer side effects (e.g. `SpawnJob`) for the
+/// Handle a key while the overlay is open.
+///
+/// Mutates the overlay + the job model in place and returns the reducer side effects (e.g. `SpawnJob`) for the
 /// event loop to run through the job-bridge. Returns `true` (via the closed
 /// state) — the caller checks `state.services` for closure.
-pub fn on_key(
+pub fn on_key<S: ::std::hash::BuildHasher>(
     services: &mut Option<ServicesManagerState>,
     jobs: &mut State,
-    instances: &HashMap<String, Instance>,
+    instances: &HashMap<String, Instance, S>,
     key: KeyEvent,
 ) -> Vec<SideEffect> {
     let rows = service_rows(instances);
@@ -123,7 +124,7 @@ pub fn on_key(
                     return spawn_lifecycle(sm, jobs, pending);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => {
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => {
                 sm.approval = None;
             }
             None => {}
@@ -214,16 +215,15 @@ fn spawn_lifecycle(
 }
 
 fn port_str(port: Option<u16>) -> String {
-    port.map(|p| p.to_string())
-        .unwrap_or_else(|| "—".to_string())
+    port.map_or_else(|| "—".to_string(), |p| p.to_string())
 }
 
 /// Render the overlay (list, or the approval modal, or the job console).
-pub fn draw_services_manager(
+pub fn draw_services_manager<S: ::std::hash::BuildHasher>(
     f: &mut Frame,
     area: Rect,
     sm: &ServicesManagerState,
-    instances: &HashMap<String, Instance>,
+    instances: &HashMap<String, Instance, S>,
     jobs: &State,
     theme: &Theme,
 ) {
@@ -435,7 +435,7 @@ mod tests {
         term.draw(|f| draw_services_manager(f, f.area(), sm, insts, jobs, &theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/sparkline.rs
+++ b/crates/rocm-dash-tui/src/ui/sparkline.rs
@@ -30,12 +30,14 @@ impl<'a> BrailleSparkline<'a> {
         }
     }
 
+    #[must_use]
     pub fn max(mut self, m: u64) -> Self {
         self.max = m.max(1);
         self
     }
 
-    pub fn style(mut self, s: Style) -> Self {
+    #[must_use]
+    pub const fn style(mut self, s: Style) -> Self {
         self.style = s;
         self
     }
@@ -44,7 +46,8 @@ impl<'a> BrailleSparkline<'a> {
     /// across the gradient (low value = stops[0], peak = stops[2]). When
     /// set, overrides `style.fg` per cell. Leaves `style.fg` as the fallback
     /// for empty/zero cells.
-    pub fn gradient(mut self, start: Color, mid: Color, end: Color) -> Self {
+    #[must_use]
+    pub const fn gradient(mut self, start: Color, mid: Color, end: Color) -> Self {
         self.gradient = Some([start, mid, end]);
         self
     }
@@ -124,7 +127,7 @@ fn lit_dots(value: Option<u64>, max: u64, total_dot_rows: usize, row_top: usize)
 ///     3 ●            6 ●        bits 0x04 / 0x20
 ///     7 ●            8 ●        bits 0x40 / 0x80
 /// ```
-fn braille_char(left: u8, right: u8) -> char {
+const fn braille_char(left: u8, right: u8) -> char {
     let mut code = 0u32;
     if left & 0b0001 != 0 {
         code |= 0x01;

--- a/crates/rocm-dash-tui/src/ui/tabs/bench.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/bench.rs
@@ -58,7 +58,7 @@ fn compute_rollup_height(n_groups: usize) -> u16 {
 
 /// Compact `tp·dtype` config token, e.g. `4·fp8`. `-` for missing parts.
 fn cfg_token(r: &PassNRollup) -> String {
-    let tp = r.tp.map(|v| v.to_string()).unwrap_or_else(|| "-".into());
+    let tp = r.tp.map_or_else(|| "-".into(), |v| v.to_string());
     let dtype = r.dtype.as_deref().unwrap_or("-");
     format!("{tp}·{dtype}")
 }
@@ -147,7 +147,7 @@ fn draw_rollup(f: &mut Frame, area: Rect, rows: &[PassNRollup], theme: &Theme) {
 
 // ---------- wide rows table ----------
 
-fn verdict_label(r: &BenchmarkRow) -> &'static str {
+const fn verdict_label(r: &BenchmarkRow) -> &'static str {
     match row_verdict(r) {
         PassFail::Pass => "Pass",
         PassFail::Fail => "Fail",
@@ -155,7 +155,7 @@ fn verdict_label(r: &BenchmarkRow) -> &'static str {
     }
 }
 
-fn verdict_color(r: &BenchmarkRow, theme: &Theme) -> Color {
+const fn verdict_color(r: &BenchmarkRow, theme: &Theme) -> Color {
     match row_verdict(r) {
         PassFail::Pass => theme.ok,
         PassFail::Fail => theme.err,
@@ -247,7 +247,7 @@ fn draw_rows_table(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     {
         let cell = trunc_str(&r.cell, 10);
         let model = trunc_str(r.model.as_deref().unwrap_or("?"), 20);
-        let tp = r.tp.map(|v| v.to_string()).unwrap_or_else(|| "-".into());
+        let tp = r.tp.map_or_else(|| "-".into(), |v| v.to_string());
         let dtype = trunc_str(r.dtype.as_deref().unwrap_or("-"), 6);
         let wall = match r.wall_s {
             Some(v) => format::duration(v),
@@ -256,9 +256,7 @@ fn draw_rows_table(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         let ptps = format::tps_opt(r.prompt_tps);
         let gtps = format::tps_opt(r.gen_tps);
         let mrun = r
-            .max_running_reqs
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "-".into());
+            .max_running_reqs.map_or_else(|| "-".into(), |v| v.to_string());
         let v_text = verdict_label(r);
         let v_color = verdict_color(r, theme);
 
@@ -364,7 +362,7 @@ fn draw_sparkline(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
 ///
 /// Row 0 of `rows_table_inner` is the header; rows 1..=visible are data
 /// lines mapped to `[start, end)` in order.
-fn row_hit(rows_table_inner: Rect, start: usize, end: usize, x: u16, y: u16) -> Option<usize> {
+const fn row_hit(rows_table_inner: Rect, start: usize, end: usize, x: u16, y: u16) -> Option<usize> {
     if rows_table_inner.width == 0 || rows_table_inner.height == 0 {
         return None;
     }
@@ -421,7 +419,7 @@ pub fn hit_test(area: Rect, x: u16, y: u16, state: &AppState) -> Option<KeyActio
     if target == state.bench_sel {
         Some(KeyAction::OpenDetail)
     } else {
-        let delta = target as isize - state.bench_sel as isize;
+        let delta = target.cast_signed() - state.bench_sel.cast_signed();
         Some(KeyAction::Move(delta))
     }
 }
@@ -476,6 +474,7 @@ pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
 
 // ---------- detail body ----------
 
+#[allow(clippy::ref_option)]
 fn fmt_opt<T: std::fmt::Display>(v: &Option<T>) -> String {
     match v {
         Some(x) => x.to_string(),
@@ -493,7 +492,7 @@ fn fmt_opt_f64_4(v: Option<f64>) -> String {
 /// SI-formatted optional `u32` counter (`-` when None).
 fn fmt_opt_u32_si(v: Option<u32>) -> String {
     match v {
-        Some(x) => format::si(x as f64),
+        Some(x) => format::si(f64::from(x)),
         None => "-".to_string(),
     }
 }
@@ -513,7 +512,7 @@ fn fmt_opt_f32_4(v: Option<f32>) -> String {
     }
 }
 
-fn fmt_opt_bool(v: Option<bool>) -> &'static str {
+const fn fmt_opt_bool(v: Option<bool>) -> &'static str {
     match v {
         Some(true) => "true",
         Some(false) => "false",
@@ -535,7 +534,7 @@ fn verdict_span(v: PassFail, theme: &Theme) -> Span<'static> {
 
 fn section_header(title: &str, theme: &Theme) -> Line<'static> {
     Line::from(Span::styled(
-        format!("— {} —", title),
+        format!("— {title} —"),
         Style::default()
             .fg(theme.muted)
             .add_modifier(Modifier::BOLD),
@@ -585,9 +584,7 @@ fn build_detail_lines(row: &BenchmarkRow, theme: &Theme) -> Vec<Line<'static>> {
     lines.push(section_header("performance", theme));
     lines.push(kv_line(
         "wall_s",
-        row.wall_s
-            .map(format::duration)
-            .unwrap_or_else(|| "-".into()),
+        row.wall_s.map_or_else(|| "-".into(), format::duration),
         theme,
     ));
     lines.push(kv_line("n_requests", fmt_opt_u32_si(row.n_requests), theme));
@@ -677,7 +674,7 @@ mod tests {
             model: None,
             engine: None,
             tp,
-            dtype: dtype.map(|s| s.to_string()),
+            dtype: dtype.map(std::string::ToString::to_string),
             concurrency: None,
             n_trials: 0,
             n_passed: 0,

--- a/crates/rocm-dash-tui/src/ui/tabs/bench.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/bench.rs
@@ -256,7 +256,8 @@ fn draw_rows_table(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         let ptps = format::tps_opt(r.prompt_tps);
         let gtps = format::tps_opt(r.gen_tps);
         let mrun = r
-            .max_running_reqs.map_or_else(|| "-".into(), |v| v.to_string());
+            .max_running_reqs
+            .map_or_else(|| "-".into(), |v| v.to_string());
         let v_text = verdict_label(r);
         let v_color = verdict_color(r, theme);
 
@@ -362,7 +363,13 @@ fn draw_sparkline(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
 ///
 /// Row 0 of `rows_table_inner` is the header; rows 1..=visible are data
 /// lines mapped to `[start, end)` in order.
-const fn row_hit(rows_table_inner: Rect, start: usize, end: usize, x: u16, y: u16) -> Option<usize> {
+const fn row_hit(
+    rows_table_inner: Rect,
+    start: usize,
+    end: usize,
+    x: u16,
+    y: u16,
+) -> Option<usize> {
     if rows_table_inner.width == 0 || rows_table_inner.height == 0 {
         return None;
     }

--- a/crates/rocm-dash-tui/src/ui/tabs/chat.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/chat.rs
@@ -404,7 +404,10 @@ mod tests {
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| draw(f, f.area(), s, &s.theme)).unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+        buf.content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/tabs/chat.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/chat.rs
@@ -1,5 +1,6 @@
-//! Chat tab — a TUI-local conversation surface. Phase 1 is render-only with a
-//! local echo backend; later phases wire a Rig-built agent behind the
+//! Chat tab — a TUI-local conversation surface.
+//!
+//! Phase 1 is render-only with a local echo backend; later phases wire a Rig-built agent behind the
 //! `AgentClient` trait. The transcript and input buffer are plain TUI state on
 //! `AppState` (`rocm-dash-core` carries no chat types).
 
@@ -142,7 +143,7 @@ fn consent_gate_lines<'a>(
                 )),
                 Line::raw(""),
                 Line::from(Span::styled(
-                    endpoint.clone().unwrap_or_else(|| "(unknown)".into()),
+                    endpoint.unwrap_or_else(|| "(unknown)".into()),
                     Style::default()
                         .fg(theme.accent)
                         .add_modifier(Modifier::BOLD),
@@ -181,9 +182,7 @@ fn consent_gate_lines<'a>(
                         Style::default().fg(theme.ok).add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        endpoint
-                            .map(|e| format!("enable {e}"))
-                            .unwrap_or_else(|| "enable".into()),
+                        endpoint.map_or_else(|| "enable".into(), |e| format!("enable {e}")),
                         Style::default().fg(theme.fg),
                     ),
                 ]),
@@ -405,7 +404,7 @@ mod tests {
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| draw(f, f.area(), s, &s.theme)).unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
@@ -842,7 +842,10 @@ mod tests {
         term.draw(|f| draw(f, f.area(), state, &state.theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+        buf.content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
     }
 
     fn state_with_snapshot(snap: Snapshot) -> AppState {
@@ -1019,9 +1022,15 @@ mod tests {
         // an observed value above the floor wins
         assert_eq!(semantic_max(HEATMAP_TEMP_MAX_C, &[60.0, 110.0]), 110.0);
         // power: below critical → floor (POWER_CRIT_W)
-        assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[400.0, 690.0]), 700.0);
+        assert_eq!(
+            semantic_max(f64::from(POWER_CRIT_W), &[400.0, 690.0]),
+            700.0
+        );
         // power: above critical → observed
-        assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[400.0, 760.0]), 760.0);
+        assert_eq!(
+            semantic_max(f64::from(POWER_CRIT_W), &[400.0, 760.0]),
+            760.0
+        );
         // empty data → floor
         assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[]), 700.0);
     }
@@ -1075,7 +1084,11 @@ mod tests {
         term.draw(|f| draw_detail(f, f.area(), &s, &s.theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        let out: String = buf.content().iter().map(ratatui::buffer::Cell::symbol).collect();
+        let out: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
         assert!(out.contains("detail"), "missing detail title: {out:?}");
         assert!(out.contains("power W"), "missing power heatmap row");
     }
@@ -1088,7 +1101,10 @@ mod tests {
         rocm_dash_core::metrics::Instance {
             container_name: name.into(),
             model_name: name.into(),
-            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
+            gpu_ids: gpu_ids
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             gen_tps,
             ..Default::default()
         }

--- a/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
@@ -35,23 +35,20 @@ const GPU_HEADER_H: u16 = 1;
 const FULL_PANEL_MIN_H: u16 = 6;
 
 pub fn draw(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
-    let snap = match state.latest.as_ref() {
-        Some(s) => s,
-        None => {
-            let p = Paragraph::new(Line::from(Span::styled(
-                "waiting for first snapshot…",
-                Style::default().fg(theme.muted),
-            )))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Hardware ")
-                    .border_style(theme.border_style())
-                    .title_style(theme.title_style()),
-            );
-            f.render_widget(p, area);
-            return;
-        }
+    let Some(snap) = state.latest.as_ref() else {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "waiting for first snapshot…",
+            Style::default().fg(theme.muted),
+        )))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Hardware ")
+                .border_style(theme.border_style())
+                .title_style(theme.title_style()),
+        );
+        f.render_widget(p, area);
+        return;
     };
 
     let rows = Layout::default()
@@ -240,16 +237,16 @@ fn draw_gauge_block(
 
 fn draw_gpus(f: &mut Frame, area: Rect, state: &AppState, snap: &Snapshot, theme: &Theme) {
     if snap.gpus.is_empty() {
-        let lines: Vec<Line> = if !snap.warnings.is_empty() {
-            snap.warnings
-                .iter()
-                .map(|w| Line::from(Span::styled(w.clone(), Style::default().fg(theme.warn))))
-                .collect()
-        } else {
+        let lines: Vec<Line> = if snap.warnings.is_empty() {
             vec![Line::from(Span::styled(
                 "no GPUs reported",
                 Style::default().fg(theme.muted),
             ))]
+        } else {
+            snap.warnings
+                .iter()
+                .map(|w| Line::from(Span::styled(w.clone(), Style::default().fg(theme.warn))))
+                .collect()
         };
         let p = Paragraph::new(lines).block(
             Block::default()
@@ -311,7 +308,7 @@ fn gpu_section_header(snap: &Snapshot, theme: &Theme) -> Line<'static> {
             ));
         }
     }
-    let total_power: f64 = snap.gpus.iter().map(|g| g.power_w as f64).sum();
+    let total_power: f64 = snap.gpus.iter().map(|g| f64::from(g.power_w)).sum();
     spans.push(Span::styled(
         format!("  ·  {:.1} kW", total_power / 1000.0),
         Style::default().fg(theme.fg),
@@ -346,6 +343,7 @@ fn plan_gpu_rows(section_h: u16, n: usize) -> (bool, usize) {
 }
 
 /// Visible compact-row count for the Hardware tab given the full body height.
+///
 /// Used by `AppState` to keep `gpu_scroll` in sync on navigation. Accounts for
 /// both the rows above the GPU section and the section's own header row.
 pub fn gpu_visible_count(body_h: u16, n: usize) -> usize {
@@ -360,7 +358,7 @@ pub fn gpu_visible_count(body_h: u16, n: usize) -> usize {
 
 /// Advance/clamp a scroll offset so index `sel` lies within
 /// `[scroll, scroll + visible)`.
-pub fn scroll_to_show(sel: usize, scroll: usize, visible: usize) -> usize {
+pub const fn scroll_to_show(sel: usize, scroll: usize, visible: usize) -> usize {
     if visible == 0 {
         0
     } else if sel < scroll {
@@ -672,27 +670,25 @@ fn detail_now_line(g: &GpuMetrics, theme: &Theme) -> Line<'static> {
     ])
 }
 
-/// Full-screen detail for the currently-selected GPU. Pulls per-tick samples
-/// out of `state.history` to build a metric × time heatmap (util, temp,
+/// Full-screen detail for the currently-selected GPU.
+///
+/// Pulls per-tick samples out of `state.history` to build a metric × time heatmap (util, temp,
 /// power, vram%) alongside a summary header and a footer hint.
 pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     use crate::ui::heatmap::{Heatmap, HeatmapRow};
     use crate::ui::modal::{centered_rect, draw_popup_frame};
 
     let popup = centered_rect(85, 85, 140, 32, area);
-    let snap = match state.latest.as_ref() {
-        Some(s) => s,
-        None => {
-            let inner = draw_popup_frame(f, popup, "GPU detail", theme);
-            f.render_widget(
-                Paragraph::new(Line::from(Span::styled(
-                    "no snapshot yet",
-                    Style::default().fg(theme.muted),
-                ))),
-                inner,
-            );
-            return;
-        }
+    let Some(snap) = state.latest.as_ref() else {
+        let inner = draw_popup_frame(f, popup, "GPU detail", theme);
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "no snapshot yet",
+                Style::default().fg(theme.muted),
+            ))),
+            inner,
+        );
+        return;
     };
     if snap.gpus.is_empty() {
         let inner = draw_popup_frame(f, popup, "GPU detail", theme);
@@ -729,7 +725,7 @@ pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         .split(inner);
 
     let sysinfo = snap.gpu_system_info.as_ref();
-    let model = sysinfo.map(|si| si.gpu_model.as_str()).unwrap_or("?");
+    let model = sysinfo.map_or("?", |si| si.gpu_model.as_str());
     let rocm = sysinfo
         .and_then(|si| si.rocm_version.as_deref())
         .unwrap_or("?");
@@ -779,15 +775,15 @@ pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let history = &state.history;
     let util: Vec<f64> = history
         .iter()
-        .filter_map(|s| s.gpus.get(i).map(|gpu| gpu.gpu_utilization_pct as f64))
+        .filter_map(|s| s.gpus.get(i).map(|gpu| f64::from(gpu.gpu_utilization_pct)))
         .collect();
     let temp: Vec<f64> = history
         .iter()
-        .filter_map(|s| s.gpus.get(i).map(|gpu| gpu.temperature_c as f64))
+        .filter_map(|s| s.gpus.get(i).map(|gpu| f64::from(gpu.temperature_c)))
         .collect();
     let power: Vec<f64> = history
         .iter()
-        .filter_map(|s| s.gpus.get(i).map(|gpu| gpu.power_w as f64))
+        .filter_map(|s| s.gpus.get(i).map(|gpu| f64::from(gpu.power_w)))
         .collect();
     let vram: Vec<f64> = history
         .iter()
@@ -806,7 +802,7 @@ pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     // "near the limit", not "near the largest value seen this session". The
     // row still grows if telemetry ever exceeds the redline.
     let max_temp = semantic_max(HEATMAP_TEMP_MAX_C, &temp);
-    let max_power = semantic_max(POWER_CRIT_W as f64, &power);
+    let max_power = semantic_max(f64::from(POWER_CRIT_W), &power);
     let rows_vec = vec![
         HeatmapRow::new("util %", util, 100.0).stops(theme.ok, theme.warn, theme.err),
         HeatmapRow::new("temp °C", temp, max_temp).stops(theme.ok, theme.warn, theme.err),
@@ -846,7 +842,7 @@ mod tests {
         term.draw(|f| draw(f, f.area(), state, &state.theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        buf.content().iter().map(|c| c.symbol()).collect()
+        buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
     }
 
     fn state_with_snapshot(snap: Snapshot) -> AppState {
@@ -974,7 +970,7 @@ mod tests {
             .iter()
             .find(|s| s.content.contains("°C"))
             .unwrap();
-        let pow_span = line.spans.iter().find(|s| s.content.contains("W")).unwrap();
+        let pow_span = line.spans.iter().find(|s| s.content.contains('W')).unwrap();
         assert_eq!(temp_span.style.fg, Some(theme.err));
         assert_eq!(pow_span.style.fg, Some(theme.err));
         // wide → vram segment included
@@ -1016,17 +1012,18 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn semantic_max_uses_floor_then_grows() {
         // all temps below the redline → max is the semantic floor
         assert_eq!(semantic_max(HEATMAP_TEMP_MAX_C, &[60.0, 78.0, 95.0]), 100.0);
         // an observed value above the floor wins
         assert_eq!(semantic_max(HEATMAP_TEMP_MAX_C, &[60.0, 110.0]), 110.0);
         // power: below critical → floor (POWER_CRIT_W)
-        assert_eq!(semantic_max(POWER_CRIT_W as f64, &[400.0, 690.0]), 700.0);
+        assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[400.0, 690.0]), 700.0);
         // power: above critical → observed
-        assert_eq!(semantic_max(POWER_CRIT_W as f64, &[400.0, 760.0]), 760.0);
+        assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[400.0, 760.0]), 760.0);
         // empty data → floor
-        assert_eq!(semantic_max(POWER_CRIT_W as f64, &[]), 700.0);
+        assert_eq!(semantic_max(f64::from(POWER_CRIT_W), &[]), 700.0);
     }
 
     #[test]
@@ -1078,7 +1075,7 @@ mod tests {
         term.draw(|f| draw_detail(f, f.area(), &s, &s.theme))
             .unwrap();
         let buf = term.backend().buffer().clone();
-        let out: String = buf.content().iter().map(|c| c.symbol()).collect();
+        let out: String = buf.content().iter().map(ratatui::buffer::Cell::symbol).collect();
         assert!(out.contains("detail"), "missing detail title: {out:?}");
         assert!(out.contains("power W"), "missing power heatmap row");
     }
@@ -1091,7 +1088,7 @@ mod tests {
         rocm_dash_core::metrics::Instance {
             container_name: name.into(),
             model_name: name.into(),
-            gpu_ids: gpu_ids.iter().map(|s| s.to_string()).collect(),
+            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
             gen_tps,
             ..Default::default()
         }

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -193,7 +193,10 @@ fn clamp_sel(sel: usize, len: usize) -> usize {
     if len == 0 { 0 } else { sel.min(len - 1) }
 }
 
-const fn status_meta(status: InstanceStatus, theme: &Theme) -> (ratatui::style::Color, &'static str) {
+const fn status_meta(
+    status: InstanceStatus,
+    theme: &Theme,
+) -> (ratatui::style::Color, &'static str) {
     match status {
         InstanceStatus::Running => (theme.ok, "RUNNING"),
         InstanceStatus::Starting => (theme.warn, "STARTING"),
@@ -262,8 +265,7 @@ fn draw_card(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme, selected
         return;
     }
 
-    let port_str = inst
-        .port.map_or_else(|| "-".into(), |p| p.to_string());
+    let port_str = inst.port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus_str = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else if inst.gpu_ids.len() == 1 {
@@ -377,8 +379,7 @@ fn draw_card(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme, selected
 
 fn compact_line<'a>(inst: &'a Instance, theme: &Theme, max_w: usize) -> Line<'a> {
     let (status_color, _) = status_meta(inst.status, theme);
-    let port = inst
-        .port.map_or_else(|| "-".into(), |p| p.to_string());
+    let port = inst.port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else {
@@ -515,8 +516,7 @@ fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
     let container_id = trunc(&inst.container_id, id_w);
     let partition = inst.partition_info.as_deref().unwrap_or("-");
     let quant = inst.quantization.as_deref().unwrap_or("-");
-    let port = inst
-        .port.map_or_else(|| "-".into(), |p| p.to_string());
+    let port = inst.port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else {

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -161,7 +161,7 @@ pub(crate) fn build_kv_heatmap_rows(
                 snap.instances
                     .iter()
                     .find(|i| &i.container_id == id)
-                    .and_then(|i| i.kv_cache_usage_pct.map(|v| v as f64))
+                    .and_then(|i| i.kv_cache_usage_pct.map(f64::from))
                     .unwrap_or(0.0)
             })
             .collect();
@@ -170,7 +170,7 @@ pub(crate) fn build_kv_heatmap_rows(
     out
 }
 
-fn pick_cols(width: u16) -> usize {
+const fn pick_cols(width: u16) -> usize {
     if width >= 160 {
         3
     } else if width >= 100 {
@@ -193,7 +193,7 @@ fn clamp_sel(sel: usize, len: usize) -> usize {
     if len == 0 { 0 } else { sel.min(len - 1) }
 }
 
-fn status_meta(status: InstanceStatus, theme: &Theme) -> (ratatui::style::Color, &'static str) {
+const fn status_meta(status: InstanceStatus, theme: &Theme) -> (ratatui::style::Color, &'static str) {
     match status {
         InstanceStatus::Running => (theme.ok, "RUNNING"),
         InstanceStatus::Starting => (theme.warn, "STARTING"),
@@ -263,9 +263,7 @@ fn draw_card(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme, selected
     }
 
     let port_str = inst
-        .port
-        .map(|p| p.to_string())
-        .unwrap_or_else(|| "-".into());
+        .port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus_str = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else if inst.gpu_ids.len() == 1 {
@@ -380,9 +378,7 @@ fn draw_card(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme, selected
 fn compact_line<'a>(inst: &'a Instance, theme: &Theme, max_w: usize) -> Line<'a> {
     let (status_color, _) = status_meta(inst.status, theme);
     let port = inst
-        .port
-        .map(|p| p.to_string())
-        .unwrap_or_else(|| "-".into());
+        .port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else {
@@ -399,6 +395,7 @@ fn compact_line<'a>(inst: &'a Instance, theme: &Theme, max_w: usize) -> Line<'a>
 }
 
 /// Detail modal: summary + launch_args + env_vars + log footer.
+///
 /// Resolve a click at `(x, y)` inside the Instances tab body. Returns a
 /// `KeyAction` to dispatch, or `None` when the click misses everything
 /// actionable.
@@ -449,7 +446,7 @@ pub fn hit_test(area: Rect, x: u16, y: u16, state: &AppState) -> Option<KeyActio
                 if idx == sel {
                     return Some(KeyAction::OpenDetail);
                 }
-                let delta = idx as isize - sel as isize;
+                let delta = idx.cast_signed() - sel.cast_signed();
                 return Some(KeyAction::Move(delta));
             }
         }
@@ -459,7 +456,7 @@ pub fn hit_test(area: Rect, x: u16, y: u16, state: &AppState) -> Option<KeyActio
 
 /// Pure point-in-rect check using half-open coordinates (right/bottom edges
 /// are exclusive), matching ratatui's own rect semantics.
-fn point_in_rect(r: Rect, x: u16, y: u16) -> bool {
+const fn point_in_rect(r: Rect, x: u16, y: u16) -> bool {
     x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height
 }
 
@@ -519,9 +516,7 @@ fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
     let partition = inst.partition_info.as_deref().unwrap_or("-");
     let quant = inst.quantization.as_deref().unwrap_or("-");
     let port = inst
-        .port
-        .map(|p| p.to_string())
-        .unwrap_or_else(|| "-".into());
+        .port.map_or_else(|| "-".into(), |p| p.to_string());
     let gpus = if inst.gpu_ids.is_empty() {
         "-".to_string()
     } else {
@@ -896,6 +891,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn heatmap_rows_track_kv_cache_per_snapshot() {
         let i_a = mk_inst_kv("a", "alpha", Some(10.0));
         let i_b = mk_inst_kv("b", "beta", Some(20.0));
@@ -994,7 +990,7 @@ mod tests {
         let mut inst = mk_inst("vllm");
         inst.quantization = Some("fp8".into());
         inst.vram_used_mb = 49152;
-        inst.vram_total_mb = 196608; // mib_pair → "48.0 / 192.0 GiB"
+        inst.vram_total_mb = 196_608; // mib_pair → "48.0 / 192.0 GiB"
         let vram = format::mib_pair(inst.vram_used_mb, inst.vram_total_mb);
         assert_eq!(vram, "48.0 / 192.0 GiB"); // sanity on the expected string
 

--- a/crates/rocm-dash-tui/src/ui/tabs/overview.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/overview.rs
@@ -34,10 +34,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     draw_memory(f, left[1], state, theme);
     draw_host(f, left[2], state, theme);
 
-    let n_gpus = state
-        .latest
-        .as_ref()
-        .map_or(1, |s| s.gpus.len().max(1));
+    let n_gpus = state.latest.as_ref().map_or(1, |s| s.gpus.len().max(1));
     let gpu_height = (n_gpus as u16 * 4 + 2).clamp(8, 20);
     let right = Layout::default()
         .direction(Direction::Vertical)
@@ -320,8 +317,7 @@ fn draw_instances(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         };
         let name = trunc(&inst.container_name, 18);
         let model = trunc(&inst.model_name, 20);
-        let port = inst
-            .port.map_or_else(|| "-".into(), |p| p.to_string());
+        let port = inst.port.map_or_else(|| "-".into(), |p| p.to_string());
         let gpus = if inst.gpu_ids.is_empty() {
             "-".to_string()
         } else {

--- a/crates/rocm-dash-tui/src/ui/tabs/overview.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/overview.rs
@@ -37,8 +37,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let n_gpus = state
         .latest
         .as_ref()
-        .map(|s| s.gpus.len().max(1))
-        .unwrap_or(1);
+        .map_or(1, |s| s.gpus.len().max(1));
     let gpu_height = (n_gpus as u16 * 4 + 2).clamp(8, 20);
     let right = Layout::default()
         .direction(Direction::Vertical)
@@ -58,8 +57,7 @@ fn draw_cpu(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let n_cores = state
         .latest
         .as_ref()
-        .map(|s| s.host.cpu_per_core_pct.len())
-        .unwrap_or(0);
+        .map_or(0, |s| s.host.cpu_per_core_pct.len());
     let title = match state.latest.as_ref() {
         Some(s) => format!(
             " CPU · {} · {} cores ",
@@ -201,29 +199,26 @@ fn draw_gpu(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         return;
     }
 
-    let snap = match state.latest.as_ref() {
-        Some(s) => s,
-        None => {
-            let p = Paragraph::new(Line::from(Span::styled(
-                "waiting for first snapshot…",
-                Style::default().fg(theme.muted),
-            )));
-            f.render_widget(p, inner);
-            return;
-        }
+    let Some(snap) = state.latest.as_ref() else {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "waiting for first snapshot…",
+            Style::default().fg(theme.muted),
+        )));
+        f.render_widget(p, inner);
+        return;
     };
 
     if snap.gpus.is_empty() {
-        let lines: Vec<Line> = if !snap.warnings.is_empty() {
-            snap.warnings
-                .iter()
-                .map(|w| Line::from(Span::styled(w.clone(), Style::default().fg(theme.warn))))
-                .collect()
-        } else {
+        let lines: Vec<Line> = if snap.warnings.is_empty() {
             vec![Line::from(Span::styled(
                 "no GPUs reported",
                 Style::default().fg(theme.muted),
             ))]
+        } else {
+            snap.warnings
+                .iter()
+                .map(|w| Line::from(Span::styled(w.clone(), Style::default().fg(theme.warn))))
+                .collect()
         };
         f.render_widget(Paragraph::new(lines), inner);
         return;
@@ -326,9 +321,7 @@ fn draw_instances(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         let name = trunc(&inst.container_name, 18);
         let model = trunc(&inst.model_name, 20);
         let port = inst
-            .port
-            .map(|p| p.to_string())
-            .unwrap_or_else(|| "-".into());
+            .port.map_or_else(|| "-".into(), |p| p.to_string());
         let gpus = if inst.gpu_ids.is_empty() {
             "-".to_string()
         } else {

--- a/crates/rocm-dash-tui/src/ui/theme.rs
+++ b/crates/rocm-dash-tui/src/ui/theme.rs
@@ -92,7 +92,7 @@ pub fn theme_names() -> Vec<&'static str> {
 impl Theme {
     // --- bespoke palettes (don't fit a clean ANSI mapping) -----------------
 
-    pub fn default_dark() -> Self {
+    pub const fn default_dark() -> Self {
         Self {
             bg: rgb(0x13, 0x14, 0x16),
             surface: rgb(0x1d, 0x1f, 0x21),
@@ -108,7 +108,7 @@ impl Theme {
         }
     }
 
-    pub fn default_light() -> Self {
+    pub const fn default_light() -> Self {
         Self {
             bg: rgb(0xfa, 0xfa, 0xfb),
             surface: rgb(0xf2, 0xf3, 0xf5),
@@ -124,46 +124,46 @@ impl Theme {
         }
     }
 
-    pub fn solarized_dark() -> Self {
+    pub const fn solarized_dark() -> Self {
         Self::from_palette(&palettes::SOLARIZED_DARK)
     }
 
     // --- imported via Palette16 -------------------------------------------
 
-    pub fn tokyo_night() -> Self {
+    pub const fn tokyo_night() -> Self {
         Self::from_palette(&palettes::TOKYO_NIGHT)
     }
-    pub fn tokyo_night_light() -> Self {
+    pub const fn tokyo_night_light() -> Self {
         Self::from_palette(&palettes::TOKYO_NIGHT_LIGHT)
     }
-    pub fn dracula() -> Self {
+    pub const fn dracula() -> Self {
         Self::from_palette(&palettes::DRACULA)
     }
-    pub fn gruvbox_dark() -> Self {
+    pub const fn gruvbox_dark() -> Self {
         Self::from_palette(&palettes::GRUVBOX_DARK)
     }
-    pub fn nord() -> Self {
+    pub const fn nord() -> Self {
         Self::from_palette(&palettes::NORD)
     }
-    pub fn one_dark() -> Self {
+    pub const fn one_dark() -> Self {
         Self::from_palette(&palettes::ONE_DARK)
     }
-    pub fn monokai() -> Self {
+    pub const fn monokai() -> Self {
         Self::from_palette(&palettes::MONOKAI)
     }
-    pub fn catppuccin_mocha() -> Self {
+    pub const fn catppuccin_mocha() -> Self {
         Self::from_palette(&palettes::CATPPUCCIN_MOCHA)
     }
-    pub fn catppuccin_latte() -> Self {
+    pub const fn catppuccin_latte() -> Self {
         Self::from_palette(&palettes::CATPPUCCIN_LATTE)
     }
-    pub fn ayu_dark() -> Self {
+    pub const fn ayu_dark() -> Self {
         Self::from_palette(&palettes::AYU_DARK)
     }
-    pub fn ayu_light() -> Self {
+    pub const fn ayu_light() -> Self {
         Self::from_palette(&palettes::AYU_LIGHT)
     }
-    pub fn github_dark() -> Self {
+    pub const fn github_dark() -> Self {
         Self::from_palette(&palettes::GITHUB_DARK)
     }
 
@@ -180,7 +180,7 @@ impl Theme {
     /// - `warn` — `yellow`
     /// - `err` — `red`
     /// - `border` — `br_black`
-    pub fn from_palette(p: &Palette16) -> Self {
+    pub const fn from_palette(p: &Palette16) -> Self {
         Self {
             bg: p.bg,
             surface: p.bg,
@@ -230,7 +230,7 @@ impl Theme {
         Style::default().fg(self.muted).add_modifier(Modifier::BOLD)
     }
 
-    pub fn tone_color(&self, tone: StatusTone) -> Color {
+    pub const fn tone_color(&self, tone: StatusTone) -> Color {
         match tone {
             StatusTone::Neutral => self.fg,
             StatusTone::Muted => self.muted,

--- a/crates/rocm-dash-tui/src/ui/update_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/update_manager.rs
@@ -44,39 +44,39 @@ pub const ACTIONS: &[UpdateAction] = &[
 ];
 
 impl UpdateAction {
-    pub fn label(self) -> &'static str {
+    pub const fn label(self) -> &'static str {
         match self {
-            UpdateAction::Check => "Check for updates",
-            UpdateAction::Preview => "Preview the update (dry-run)",
-            UpdateAction::Apply => "Apply the update",
-            UpdateAction::ApplyActivate => "Apply and use as default",
+            Self::Check => "Check for updates",
+            Self::Preview => "Preview the update (dry-run)",
+            Self::Apply => "Apply the update",
+            Self::ApplyActivate => "Apply and use as default",
         }
     }
 
     /// `rocm` argv (after the binary) for this action.
     fn args(self) -> Vec<String> {
         match self {
-            UpdateAction::Check => vec!["update".into()],
-            UpdateAction::Preview => vec!["update".into(), "--apply".into(), "--dry-run".into()],
-            UpdateAction::Apply => vec!["update".into(), "--apply".into()],
-            UpdateAction::ApplyActivate => {
+            Self::Check => vec!["update".into()],
+            Self::Preview => vec!["update".into(), "--apply".into(), "--dry-run".into()],
+            Self::Apply => vec!["update".into(), "--apply".into()],
+            Self::ApplyActivate => {
                 vec!["update".into(), "--apply".into(), "--activate".into()]
             }
         }
     }
 
     /// Whether this action changes the system (and so needs approval).
-    fn is_mutating(self) -> bool {
-        matches!(self, UpdateAction::Apply | UpdateAction::ApplyActivate)
+    const fn is_mutating(self) -> bool {
+        matches!(self, Self::Apply | Self::ApplyActivate)
     }
 
     /// Stable job id (one console per action kind).
     fn job_id(self) -> String {
         match self {
-            UpdateAction::Check => "update-check",
-            UpdateAction::Preview => "update-preview",
-            UpdateAction::Apply => "update-apply",
-            UpdateAction::ApplyActivate => "update-apply-activate",
+            Self::Check => "update-check",
+            Self::Preview => "update-preview",
+            Self::Apply => "update-apply",
+            Self::ApplyActivate => "update-apply-activate",
         }
         .to_string()
     }
@@ -120,7 +120,7 @@ pub fn on_key(
                     return spawn_update(u, jobs, pending.action, pending.cmd);
                 }
             }
-            Some(ApprovalVerdict::Deny) | Some(ApprovalVerdict::Cancel) => u.approval = None,
+            Some(ApprovalVerdict::Deny | ApprovalVerdict::Cancel) => u.approval = None,
             None => {}
         }
         return Vec::new();
@@ -408,7 +408,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(|c| c.symbol())
+            .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("Update"));
         assert!(out.contains("Check for updates"));

--- a/crates/rocm-dash-tui/src/ui/widgets.rs
+++ b/crates/rocm-dash-tui/src/ui/widgets.rs
@@ -58,7 +58,7 @@ pub fn power_style(w: f32, theme: &Theme) -> Style {
 /// Trailing run of ASCII digits in `s` (e.g. `"gpu-3"` → `"3"`, `"3"` → `"3"`).
 /// Returns `None` when `s` has no trailing digits.
 fn trailing_digits(s: &str) -> Option<&str> {
-    let start = s.len() - s.chars().rev().take_while(|c| c.is_ascii_digit()).count();
+    let start = s.len() - s.chars().rev().take_while(char::is_ascii_digit).count();
     if start == s.len() {
         None
     } else {
@@ -87,13 +87,14 @@ pub fn instances_on_gpu<'a>(device_id: &str, instances: &'a [Instance]) -> Vec<&
         .collect()
 }
 
-/// Node-level energy efficiency: total generation throughput divided by total
-/// board power, in tokens per watt. `None` when there is no traffic
+/// Node-level energy efficiency: total generation throughput divided by total board power, in tokens per watt.
+///
+/// `None` when there is no traffic
 /// (`sum gen_tps == 0`) or no power telemetry (`sum power_w == 0`), or when the
 /// result is non-finite.
 pub fn node_efficiency(snap: &Snapshot) -> Option<f64> {
     let tps: f64 = snap.instances.iter().filter_map(|i| i.gen_tps).sum();
-    let power: f64 = snap.gpus.iter().map(|g| g.power_w as f64).sum();
+    let power: f64 = snap.gpus.iter().map(|g| f64::from(g.power_w)).sum();
     if tps > 0.0 && power > 0.0 {
         let eff = tps / power;
         eff.is_finite().then_some(eff)
@@ -140,7 +141,7 @@ mod tests {
         Instance {
             container_name: name.into(),
             model_name: name.into(),
-            gpu_ids: gpu_ids.iter().map(|s| s.to_string()).collect(),
+            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
             gen_tps,
             ..Default::default()
         }

--- a/crates/rocm-dash-tui/src/ui/widgets.rs
+++ b/crates/rocm-dash-tui/src/ui/widgets.rs
@@ -141,7 +141,10 @@ mod tests {
         Instance {
             container_name: name.into(),
             model_name: name.into(),
-            gpu_ids: gpu_ids.iter().map(std::string::ToString::to_string).collect(),
+            gpu_ids: gpu_ids
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
             gen_tps,
             ..Default::default()
         }

--- a/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
+++ b/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
@@ -132,7 +132,7 @@ fn render<F: FnOnce(&mut ratatui::Frame)>(cols: u16, rows: u16, draw: F) -> Stri
     let mut term = Terminal::new(backend).unwrap();
     term.draw(|f| draw(f)).unwrap();
     let buf = term.backend().buffer().clone();
-    buf.content().iter().map(|c| c.symbol()).collect()
+    buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
 }
 
 #[test]
@@ -171,7 +171,7 @@ fn approval_snapshot_renders_request_and_buttons() {
         ],
     );
     let out = render(120, 26, |f| {
-        draw_approval(f, f.area(), &req, ApprovalChoice::Approve, &theme)
+        draw_approval(f, f.area(), &req, ApprovalChoice::Approve, &theme);
     });
 
     assert!(

--- a/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
+++ b/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
@@ -132,7 +132,10 @@ fn render<F: FnOnce(&mut ratatui::Frame)>(cols: u16, rows: u16, draw: F) -> Stri
     let mut term = Terminal::new(backend).unwrap();
     term.draw(|f| draw(f)).unwrap();
     let buf = term.backend().buffer().clone();
-    buf.content().iter().map(ratatui::buffer::Cell::symbol).collect()
+    buf.content()
+        .iter()
+        .map(ratatui::buffer::Cell::symbol)
+        .collect()
 }
 
 #[test]

--- a/crates/rocm-engine-protocol/Cargo.toml
+++ b/crates/rocm-engine-protocol/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 rocm-core = { path = "../rocm-core" }
 serde.workspace = true

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
         fs::create_dir_all(first_dir.join(platform_engine_plugin_binary_name("sglang"))).unwrap();
 
         let plugins =
-            discover_engine_plugins([root.join("missing"), first_dir.clone(), second_dir]).unwrap();
+            discover_engine_plugins([root.join("missing"), first_dir, second_dir]).unwrap();
         let ids = plugins
             .iter()
             .map(|plugin| plugin.id.as_str())

--- a/engines/atom/Cargo.toml
+++ b/engines/atom/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "rocm-engine-atom"
 path = "src/main.rs"

--- a/engines/atom/src/lib.rs
+++ b/engines/atom/src/lib.rs
@@ -358,8 +358,7 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     let env_path = runtime
         .command
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     Ok(InstallResponse {
         env_id: runtime.env_id.clone(),
         env_path: env_path.display().to_string(),
@@ -764,9 +763,10 @@ fn runtime_from_python(
     let version = probe_atom_version(&python)
         .with_context(|| format!("ATOM package not found in {}", python.display()))?
         .unwrap_or_else(|| "unknown".to_owned());
-    let (command, launcher) = atom_command_from_python(&python)
-        .map(|command| (command, AtomLauncher::Command))
-        .unwrap_or_else(|| (python.clone(), AtomLauncher::PythonModule));
+    let (command, launcher) = atom_command_from_python(&python).map_or_else(
+        || (python.clone(), AtomLauncher::PythonModule),
+        |command| (command, AtomLauncher::Command),
+    );
     Ok(AtomRuntime {
         runtime_id: runtime_id.to_owned(),
         env_id: format!("external-atom-{}", stable_id_component(runtime_id)),
@@ -821,24 +821,22 @@ fn resolve_managed_runtime(runtime_id: Option<&str>) -> Result<Option<AtomRuntim
             .as_deref()
             .unwrap_or("therock-atom-runtime")
             .to_owned();
-        let source = manifest
-            .runtime_key
-            .as_deref()
-            .map(|key| format!("managed_runtime_manifest:{key}"))
-            .unwrap_or_else(|| "managed_runtime_manifest".to_owned());
+        let source = manifest.runtime_key.as_deref().map_or_else(
+            || "managed_runtime_manifest".to_owned(),
+            |key| format!("managed_runtime_manifest:{key}"),
+        );
         let (sdk_root, sdk_bin, sdk_bin_paths, sdk_library_paths) = manifest
             .rocm_sdk
             .as_ref()
             .filter(|probe| probe.import_ok)
-            .map(|probe| {
+            .map_or((None, None, Vec::new(), Vec::new()), |probe| {
                 (
                     probe.root_path.clone(),
                     probe.bin_path.clone(),
                     probe.bin_paths.clone(),
                     probe.library_paths.clone(),
                 )
-            })
-            .unwrap_or((None, None, Vec::new(), Vec::new()));
+            });
         if let Ok(runtime) = runtime_from_python(
             python,
             &runtime_id,
@@ -1243,7 +1241,7 @@ fn current_unix_millis() -> u128 {
         .as_millis()
 }
 
-fn windows_unsupported_message() -> &'static str {
+const fn windows_unsupported_message() -> &'static str {
     "ATOM ROCm serving is supported by rocm-cli only on Linux/WSL; native Windows ATOM is not enabled. No CPU fallback is used."
 }
 
@@ -1272,7 +1270,7 @@ mod tests {
             contract_version: contract_version.to_owned(),
             engine: engine.to_owned(),
             required_flags: vec!["--reasoning-parser".to_owned(), "qwen3".to_owned()],
-            parser_settings: Default::default(),
+            parser_settings: std::collections::BTreeMap::default(),
             preferred_endpoint: None,
             unsupported_combinations: Vec::new(),
             notes: vec!["test recipe".to_owned()],

--- a/engines/lemonade/Cargo.toml
+++ b/engines/lemonade/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "rocm-engine-lemonade"
 path = "src/main.rs"

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -165,7 +165,7 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
-            })?)?
+            })?)?;
         }
         CommandKind::Launch {
             service_id,
@@ -781,11 +781,11 @@ fn prepare_embeddable(
     let downloads = root.join("downloads");
     let archive = downloads.join(archive_name);
     fs::create_dir_all(&downloads)?;
-    if !archive.is_file() {
+    if archive.is_file() {
+        eprintln!("Using cached {archive_name}.");
+    } else {
         eprintln!("Downloading {archive_name}...");
         download_file(archive_url, &archive)?;
-    } else {
-        eprintln!("Using cached {archive_name}.");
     }
     let runtime_dir = runtime_dir_in(&root);
     if reinstall || !lemond_path_in(&runtime_dir).is_file() {
@@ -984,9 +984,10 @@ fn manifest_path(paths: &AppPaths) -> PathBuf {
 }
 
 fn lemonade_root(paths: &AppPaths, env_root: Option<&Path>) -> PathBuf {
-    env_root
-        .map(|root| normalize_runtime_path_for_host(root).join(ENGINE_NAME))
-        .unwrap_or_else(|| paths.engine_dir(ENGINE_NAME))
+    env_root.map_or_else(
+        || paths.engine_dir(ENGINE_NAME),
+        |root| normalize_runtime_path_for_host(root).join(ENGINE_NAME),
+    )
 }
 
 fn runtime_dir_in(root: &Path) -> PathBuf {
@@ -1024,7 +1025,7 @@ fn platform_binary_name(name: &str) -> String {
     }
 }
 
-fn embeddable_archive_name() -> &'static str {
+const fn embeddable_archive_name() -> &'static str {
     if runtime_is_windows() {
         EMBEDDABLE_WINDOWS_ARCHIVE_NAME
     } else {
@@ -1032,7 +1033,7 @@ fn embeddable_archive_name() -> &'static str {
     }
 }
 
-fn embeddable_url() -> &'static str {
+const fn embeddable_url() -> &'static str {
     if runtime_is_windows() {
         EMBEDDABLE_WINDOWS_URL
     } else {
@@ -1041,7 +1042,7 @@ fn embeddable_url() -> &'static str {
 }
 
 fn download_file(url: &str, destination: &Path) -> Result<()> {
-    download_file_to_path(url, destination, Duration::from_secs(900))
+    download_file_to_path(url, destination, Duration::from_mins(15))
 }
 
 fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
@@ -1097,7 +1098,7 @@ fn windows_child_path(path: &Path) -> String {
     raw
 }
 
-fn runtime_is_cosmopolitan_windows() -> bool {
+const fn runtime_is_cosmopolitan_windows() -> bool {
     runtime_is_windows() && std::path::MAIN_SEPARATOR == '/'
 }
 
@@ -1258,7 +1259,7 @@ struct LemondExitStatus {
 }
 
 impl LemondExitStatus {
-    fn success(&self) -> bool {
+    const fn success(&self) -> bool {
         self.success
     }
 }
@@ -1278,7 +1279,7 @@ fn hide_child_console_window(command: &mut ProcessCommand) {
 }
 
 #[cfg(not(windows))]
-fn hide_child_console_window(_command: &mut ProcessCommand) {}
+const fn hide_child_console_window(_command: &mut ProcessCommand) {}
 
 fn child_process_path(path: &Path) -> String {
     if runtime_is_windows() {
@@ -1527,7 +1528,7 @@ fn serve_direct_rocm_llama_server(
         &request.host,
         request.port,
         &request.model_ref,
-        Duration::from_secs(120),
+        Duration::from_mins(2),
     )?;
     if !query_chat_smoke_endpoint(&request.host, request.port, &request.model_ref)? {
         bail!("Lemonade packaged llama-server did not pass a chat-completion smoke test");
@@ -1700,18 +1701,15 @@ fn query_health_json(host: &str, port: u16) -> Result<Value> {
 fn query_loaded_model_endpoint(endpoint_url: &str, model_ref: &str, backend: &str) -> Result<bool> {
     let (host, port) = parse_http_endpoint(endpoint_url)
         .with_context(|| format!("unsupported endpoint URL `{endpoint_url}`"))?;
-    match query_health_json(&host, port) {
-        Ok(health) => Ok(health_has_loaded_model(&health, model_ref, backend)),
-        Err(_) => {
-            let endpoint = format_http_base_url(&host, port);
-            let body = http_get_text(&endpoint, "/v1/models", Duration::from_secs(3))
-                .with_context(|| {
-                    format!("failed to query Lemonade models at {endpoint}/v1/models")
-                })?;
-            let models = serde_json::from_str::<Value>(&body)
-                .context("failed to parse Lemonade /v1/models JSON")?;
-            Ok(models_payload_has_loaded_model(&models, model_ref))
-        }
+    if let Ok(health) = query_health_json(&host, port) {
+        Ok(health_has_loaded_model(&health, model_ref, backend))
+    } else {
+        let endpoint = format_http_base_url(&host, port);
+        let body = http_get_text(&endpoint, "/v1/models", Duration::from_secs(3))
+            .with_context(|| format!("failed to query Lemonade models at {endpoint}/v1/models"))?;
+        let models = serde_json::from_str::<Value>(&body)
+            .context("failed to parse Lemonade /v1/models JSON")?;
+        Ok(models_payload_has_loaded_model(&models, model_ref))
     }
 }
 
@@ -2016,7 +2014,7 @@ fn parse_device_policy_arg(value: Option<&str>) -> Result<DevicePolicy> {
     }
 }
 
-fn device_policy_name(policy: &DevicePolicy) -> &'static str {
+const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
     match policy {
         DevicePolicy::GpuRequired => "gpu_required",
         DevicePolicy::GpuPreferred => "gpu_preferred",

--- a/engines/llama-cpp/Cargo.toml
+++ b/engines/llama-cpp/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "rocm-engine-llama-cpp"
 path = "src/main.rs"

--- a/engines/llama-cpp/src/lib.rs
+++ b/engines/llama-cpp/src/lib.rs
@@ -194,7 +194,7 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
-            })?)?
+            })?)?;
         }
         CommandKind::Launch {
             service_id,
@@ -330,10 +330,7 @@ fn detect_response() -> DetectResponse {
     let server = resolve_llama_server().ok();
     let runtime_executable = server.as_ref().map(|server| server.program.clone());
     let runtime_env = resolve_therock_hip_runtime_env(None);
-    let rocm_gpu_available = server
-        .as_ref()
-        .map(llama_server_has_hip_backend)
-        .unwrap_or(false)
+    let rocm_gpu_available = server.as_ref().is_some_and(llama_server_has_hip_backend)
         && matches!(runtime_env.as_ref(), Ok(Some(_)));
     let mut notes = Vec::new();
     match server.as_ref() {
@@ -404,9 +401,8 @@ fn rocm_gpu_reason(
     server: Option<&LlamaServer>,
     runtime_env: Option<&Option<TheRockHipRuntimeEnv>>,
 ) -> String {
-    let server = match server {
-        Some(server) => server,
-        None => return "llama-server was not found".to_owned(),
+    let Some(server) = server else {
+        return "llama-server was not found".to_owned();
     };
     if !llama_server_has_hip_backend(server) {
         return "llama-server was found, but no sibling ggml-hip backend library was detected"
@@ -440,11 +436,8 @@ fn llama_server_has_hip_backend(server: &LlamaServer) -> bool {
 fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     let server = resolve_llama_server().ok();
     let runtime_env = resolve_therock_hip_runtime_env(Some(&request.runtime_id))?;
-    let rocm_gpu_available = server
-        .as_ref()
-        .map(llama_server_has_hip_backend)
-        .unwrap_or(false)
-        && runtime_env.is_some();
+    let rocm_gpu_available =
+        server.as_ref().is_some_and(llama_server_has_hip_backend) && runtime_env.is_some();
     let paths = AppPaths::discover()?;
     let runtime_executable = server.as_ref().map(|server| server.program.clone());
     let mut installed_packages = server
@@ -483,10 +476,10 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     Ok(InstallResponse {
         env_id: "external-llama.cpp".to_owned(),
         env_path: paths.engine_dir(ENGINE_NAME).display().to_string(),
-        python_executable: server
-            .as_ref()
-            .map(|server| server.display.clone())
-            .unwrap_or_else(|| "<external llama-server not found>".to_owned()),
+        python_executable: server.as_ref().map_or_else(
+            || "<external llama-server not found>".to_owned(),
+            |server| server.display.clone(),
+        ),
         runtime_kind: Some("external_llama_server".to_owned()),
         runtime_executable,
         managed_env: Some(false),
@@ -578,7 +571,7 @@ fn resolve_llama_model_ref(model_ref: &str, warnings: &mut Vec<String>) -> Strin
     let expanded = expand_home_path(trimmed);
     let mut candidates = Vec::new();
     if expanded.is_absolute() {
-        candidates.push(expanded.clone());
+        candidates.push(expanded);
     } else {
         if let Ok(current_dir) = std::env::current_dir() {
             candidates.push(current_dir.join(&expanded));
@@ -613,8 +606,10 @@ fn expand_home_path(value: &str) -> PathBuf {
     };
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(|home| PathBuf::from(home).join(rest))
-        .unwrap_or_else(|| PathBuf::from(value))
+        .map_or_else(
+            || PathBuf::from(value),
+            |home| PathBuf::from(home).join(rest),
+        )
 }
 
 fn launch_service(mut request: LaunchRequest) -> Result<LaunchResponse> {
@@ -1223,17 +1218,14 @@ fn validate_therock_windows_runtime_files(runtime_env: &TheRockHipRuntimeEnv) ->
     for filename in REQUIRED_WINDOWS_THEROCK_EXACT_DLLS {
         if find_runtime_bin_file(runtime_env, filename).is_none() {
             bail!(
-                "managed TheRock runtime is missing required llama.cpp HIP DLL {}; no CPU fallback is applied",
-                filename
+                "managed TheRock runtime is missing required llama.cpp HIP DLL {filename}; no CPU fallback is applied"
             );
         }
     }
     for (prefix, suffix) in REQUIRED_WINDOWS_THEROCK_VERSIONED_DLLS {
         if find_runtime_bin_file_by_prefix_suffix(runtime_env, prefix, suffix).is_none() {
             bail!(
-                "managed TheRock runtime is missing required llama.cpp HIP DLL matching {}*{}; no CPU fallback is applied",
-                prefix,
-                suffix
+                "managed TheRock runtime is missing required llama.cpp HIP DLL matching {prefix}*{suffix}; no CPU fallback is applied"
             );
         }
     }
@@ -1380,8 +1372,7 @@ fn staged_file_is_current(source: &Path, destination: &Path) -> bool {
 fn is_windows_dll(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
-        .map(|extension| extension.eq_ignore_ascii_case("dll"))
-        .unwrap_or(false)
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("dll"))
 }
 
 fn safe_path_component(value: &str) -> String {
@@ -1542,10 +1533,10 @@ fn therock_env_from_manifest(
         .clone()
         .unwrap_or_else(|| "therock-runtime".to_owned());
     let runtime_key = manifest.runtime_key.clone();
-    let source = runtime_key
-        .as_deref()
-        .map(|key| format!("managed_runtime_manifest:{key}"))
-        .unwrap_or_else(|| "managed_runtime_manifest".to_owned());
+    let source = runtime_key.as_deref().map_or_else(
+        || "managed_runtime_manifest".to_owned(),
+        |key| format!("managed_runtime_manifest:{key}"),
+    );
 
     if let Some(probe) = manifest.rocm_sdk.as_ref()
         && probe.import_ok
@@ -1567,13 +1558,13 @@ fn therock_env_from_manifest(
             .cloned()
             .collect::<Vec<_>>();
         return Ok(Some(TheRockHipRuntimeEnv {
-            runtime_id: runtime_id.clone(),
-            runtime_key: runtime_key.clone(),
+            runtime_id,
+            runtime_key,
             root_path: root_path.clone(),
             bin_path: bin_path.clone(),
             bin_paths,
             library_paths,
-            source: source.clone(),
+            source,
         }));
     }
 
@@ -1765,7 +1756,7 @@ fn terminate_pid(pid: u32, _force: bool) -> bool {
     rocm_core::terminate_process(pid).is_ok()
 }
 
-fn device_policy_name(policy: &DevicePolicy) -> &'static str {
+const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
     match policy {
         DevicePolicy::GpuRequired => "gpu_required",
         DevicePolicy::GpuPreferred => "gpu_preferred",
@@ -1814,7 +1805,7 @@ mod tests {
             contract_version: contract_version.to_owned(),
             engine: engine.to_owned(),
             required_flags: vec!["--jinja".to_owned()],
-            parser_settings: Default::default(),
+            parser_settings: std::collections::BTreeMap::default(),
             preferred_endpoint: None,
             unsupported_combinations: Vec::new(),
             notes: vec!["test recipe".to_owned()],

--- a/engines/pytorch/Cargo.toml
+++ b/engines/pytorch/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-stream.workspace = true

--- a/engines/pytorch/src/lib.rs
+++ b/engines/pytorch/src/lib.rs
@@ -168,7 +168,7 @@ enum TheRockChannel {
 }
 
 impl TheRockChannel {
-    fn as_str(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Release => "release",
             Self::Nightly => "nightly",
@@ -484,6 +484,7 @@ where
 }
 
 fn detect_response() -> DetectResponse {
+    use std::fmt::Write as _;
     let manifest = latest_env_manifest().ok().flatten();
     let installed = manifest.is_some();
     let detected_family = detect_host_therock_family();
@@ -567,13 +568,12 @@ fn detect_response() -> DetectResponse {
 
     let rocm_gpu_available = torch_probe
         .as_ref()
-        .map(|probe| probe.cuda_available)
-        .unwrap_or_else(|| detected_family.is_some());
+        .map_or_else(|| detected_family.is_some(), |probe| probe.cuda_available);
     let rocm_gpu_reason = match torch_probe.as_ref() {
         Some(probe) if probe.cuda_available => {
             let mut reason = format!("torch.cuda reports {} device(s)", probe.device_count);
             if !probe.devices.is_empty() {
-                reason.push_str(&format!(": {}", probe.devices.join(", ")));
+                let _ = write!(reason, ": {}", probe.devices.join(", "));
             }
             Some(reason)
         }
@@ -665,7 +665,7 @@ fn resolve_model_response(request: ResolveModelRequest) -> Result<ResolveModelRe
         loader: recipe.loader.to_owned(),
         trust_remote_code: recipe.trust_remote_code,
         chat_template_mode: recipe.chat_template_mode.to_owned(),
-        dtype: recipe.preferred_dtype.to_owned(),
+        dtype: recipe.preferred_dtype.clone(),
         device_policy,
         estimated_memory: recipe.estimated_memory,
         launch_defaults: json!({
@@ -909,7 +909,7 @@ fn stop_service(request: StopRequest) -> Result<StopResponse> {
         });
     let already_terminal = matches!(
         state_status.as_deref(),
-        Some("stopped") | Some("failed") | Some("exited")
+        Some("stopped" | "failed" | "exited")
     );
     let stopped = stopped_any || (had_pid && !failed_any) || (!had_pid && already_terminal);
     if stopped {
@@ -932,8 +932,7 @@ fn service_files(service_id: &str) -> Result<ServiceFiles> {
     let record_matches_engine = record
         .as_ref()
         .and_then(|record| record.engine.as_deref())
-        .map(|engine| engine == ENGINE_NAME)
-        .unwrap_or_else(|| record.is_some());
+        .map_or_else(|| record.is_some(), |engine| engine == ENGINE_NAME);
     let state_path = record
         .as_ref()
         .filter(|_| record_matches_engine)
@@ -1016,17 +1015,16 @@ fn build_healthcheck_response(
         .and_then(|value| value_string(value, "status"))
         .unwrap_or_else(|| "unknown".to_owned());
     let health_status = health_payload.and_then(|value| value_string(value, "status"));
-    let mut status = if health_status.as_deref() == Some("ok") {
-        "ready".to_owned()
-    } else {
-        state_status.clone()
-    };
-    if matches!(state_status.as_str(), "ready" | "running")
+    let status = if matches!(state_status.as_str(), "ready" | "running")
         && health_payload.is_none()
         && probe_error.is_some()
     {
-        status = "unreachable".to_owned();
-    }
+        "unreachable".to_owned()
+    } else if health_status.as_deref() == Some("ok") {
+        "ready".to_owned()
+    } else {
+        state_status
+    };
 
     let device = health_payload
         .and_then(|value| value_string(value, "device"))
@@ -1280,9 +1278,7 @@ fn remove_managed_env_dir_with_retry(env_path: &Path) -> Result<()> {
         }
     }
 
-    let error = last_error
-        .map(|error| error.to_string())
-        .unwrap_or_else(|| "unknown error".to_owned());
+    let error = last_error.map_or_else(|| "unknown error".to_owned(), |error| error.to_string());
     bail!(
         "failed to remove managed PyTorch env {} after {} attempts. Close any ROCm, Python, or model server process using this folder and try again. Last error: {error}",
         env_path.display(),
@@ -1315,22 +1311,21 @@ fn clear_readonly_recursive(path: &Path) -> Result<()> {
 }
 
 #[cfg(not(windows))]
-fn clear_readonly_recursive(_path: &Path) -> Result<()> {
+const fn clear_readonly_recursive(_path: &Path) -> Result<()> {
     Ok(())
 }
 
 fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvManifest> {
     let paths = AppPaths::discover()?;
     paths.ensure()?;
-    let engine_envs_dir = request
-        .env_root
-        .as_ref()
-        .map(|root| {
+    let engine_envs_dir = request.env_root.as_ref().map_or_else(
+        || paths.engine_envs_dir(ENGINE_NAME),
+        |root| {
             normalize_runtime_path_for_host(root)
                 .join(ENGINE_NAME)
                 .join("envs")
-        })
-        .unwrap_or_else(|| paths.engine_envs_dir(ENGINE_NAME));
+        },
+    );
     fs::create_dir_all(&engine_envs_dir)?;
     fs::create_dir_all(paths.engine_locks_dir(ENGINE_NAME))?;
     fs::create_dir_all(paths.engine_manifests_dir(ENGINE_NAME))?;
@@ -1365,7 +1360,7 @@ fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvMa
     };
 
     if !request.reinstall
-        && let Some(manifest) = existing_manifest.clone()
+        && let Some(manifest) = existing_manifest
         && manifest.env_path.is_dir()
         && (manifest_has_torch(&manifest) || therock_resolution.is_none())
     {
@@ -1391,7 +1386,11 @@ fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvMa
 
     let mut engine_dep_args = uv_pip_install_base(&python_executable);
     engine_dep_args.extend(["--only-binary".to_owned(), ":all:".to_owned()]);
-    engine_dep_args.extend(ENGINE_DEPENDENCIES.iter().map(|s| s.to_string()));
+    engine_dep_args.extend(
+        ENGINE_DEPENDENCIES
+            .iter()
+            .map(std::string::ToString::to_string),
+    );
     run_uv_progress_command(
         &uv,
         engine_dep_args.iter().map(String::as_str),
@@ -1422,7 +1421,11 @@ fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvMa
         )?;
         let mut stack_args = uv_pip_install_base(&python_executable);
         stack_args.extend(["--only-binary".to_owned(), ":all:".to_owned()]);
-        stack_args.extend(TORCH_STACK_DEPENDENCIES.iter().map(|s| s.to_string()));
+        stack_args.extend(
+            TORCH_STACK_DEPENDENCIES
+                .iter()
+                .map(std::string::ToString::to_string),
+        );
         run_uv_progress_command(
             &uv,
             stack_args.iter().map(String::as_str),
@@ -1437,7 +1440,11 @@ fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvMa
                 install_therock_torch_packages(&uv, &python_executable, &resolution)?;
                 let mut stack_args = uv_pip_install_base(&python_executable);
                 stack_args.extend(["--only-binary".to_owned(), ":all:".to_owned()]);
-                stack_args.extend(TORCH_STACK_DEPENDENCIES.iter().map(|s| s.to_string()));
+                stack_args.extend(
+                    TORCH_STACK_DEPENDENCIES
+                        .iter()
+                        .map(std::string::ToString::to_string),
+                );
                 run_uv_progress_command(
                     &uv,
                     stack_args.iter().map(String::as_str),
@@ -1515,8 +1522,7 @@ fn create_or_update_env_manifest(request: &InstallRequest) -> Result<EngineEnvMa
                     if !probe
                         .torch_rocm_init
                         .as_ref()
-                        .map(|init| init.present)
-                        .unwrap_or(false)
+                        .is_some_and(|init| init.present)
                     {
                         warnings.push(
                         "torch._rocm_init was not found; TheRock library preloading may be unavailable"
@@ -1859,19 +1865,12 @@ fn serve_http(
         let current_status = read_service_state(&state_path)
             .0
             .and_then(|value| value_string(&value, "status"));
-        if matches!(
-            current_status.as_deref(),
-            Some("stopped") | Some("stopping")
-        ) {
+        if matches!(current_status.as_deref(), Some("stopped" | "stopping")) {
             mark_json_status(&state_path, "stopped")?;
             return Ok(());
         }
         mark_json_status(&state_path, "failed")?;
-        bail!(
-            "pytorch worker exited with status {} for service {}",
-            status,
-            service_id
-        )
+        bail!("pytorch worker exited with status {status} for service {service_id}")
     }
 }
 
@@ -2240,7 +2239,7 @@ fn normalize_pytorch_device_policy(policy: DevicePolicy) -> Result<DevicePolicy>
     }
 }
 
-fn device_policy_name(policy: &DevicePolicy) -> &'static str {
+const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
     match policy {
         DevicePolicy::GpuRequired => "gpu_required",
         DevicePolicy::GpuPreferred => "gpu_preferred",
@@ -2268,7 +2267,7 @@ fn managed_env_id(runtime_id: &str, python_version: Option<&str>) -> String {
     )
 }
 
-fn default_python_version() -> &'static str {
+const fn default_python_version() -> &'static str {
     "3.12"
 }
 
@@ -2441,8 +2440,7 @@ fn pinned_torch_package_specs_from_runtime(python_executable: &str) -> Result<Ve
     }
 
     let code = format!(
-        "import importlib.metadata as md, json; names = {names:?}; print(json.dumps({{name: md.version(name) for name in names}}, sort_keys=True))",
-        names = THEROCK_TORCH_PACKAGES
+        "import importlib.metadata as md, json; names = {THEROCK_TORCH_PACKAGES:?}; print(json.dumps({{name: md.version(name) for name in names}}, sort_keys=True))"
     );
     let output = capture_command(
         python_executable,
@@ -2496,38 +2494,34 @@ fn site_packages_candidates_for_python(python_executable: &str) -> Vec<PathBuf> 
         if parent
             .file_name()
             .and_then(|value| value.to_str())
-            .map(|value| value.eq_ignore_ascii_case("scripts"))
-            .unwrap_or(false)
+            .is_some_and(|value| value.eq_ignore_ascii_case("scripts"))
             && let Some(env_root) = parent.parent()
         {
             candidates.push(env_root.join("Lib").join("site-packages"));
         }
         candidates.push(parent.join("Lib").join("site-packages"));
-    } else {
-        if parent
-            .file_name()
-            .and_then(|value| value.to_str())
-            .map(|value| value == "bin")
-            .unwrap_or(false)
-            && let Some(env_root) = parent.parent()
-        {
-            let lib_dir = env_root.join("lib");
-            if let Ok(entries) = fs::read_dir(&lib_dir) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let name = entry.file_name();
-                    let name = name.to_string_lossy();
-                    if name.starts_with("python") {
-                        candidates.push(path.join("site-packages"));
-                    }
+    } else if parent
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|value| value == "bin")
+        && let Some(env_root) = parent.parent()
+    {
+        let lib_dir = env_root.join("lib");
+        if let Ok(entries) = fs::read_dir(&lib_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("python") {
+                    candidates.push(path.join("site-packages"));
                 }
             }
-            candidates.push(
-                lib_dir
-                    .join(format!("python{}", default_python_version()))
-                    .join("site-packages"),
-            );
         }
+        candidates.push(
+            lib_dir
+                .join(format!("python{}", default_python_version()))
+                .join("site-packages"),
+        );
     }
     candidates.sort();
     candidates.dedup();
@@ -2544,8 +2538,7 @@ fn installed_package_specs_from_dist_info_dir(site_packages: &Path) -> Result<Ve
         let is_dist_info = path
             .file_name()
             .and_then(|value| value.to_str())
-            .map(|value| value.to_ascii_lowercase().ends_with(".dist-info"))
-            .unwrap_or(false);
+            .is_some_and(|value| value.to_ascii_lowercase().ends_with(".dist-info"));
         if !path.is_dir() || !is_dist_info {
             continue;
         }
@@ -2858,7 +2851,7 @@ fn ensure_service_env(runtime_id: Option<&str>, env_id: Option<&str>) -> Result<
         }
         return create_or_update_env_manifest(&InstallRequest {
             runtime_id: manifest.runtime_id.clone(),
-            python_version: manifest.requested_python_version.clone(),
+            python_version: manifest.requested_python_version,
             env_root: None,
             reinstall: true,
         });
@@ -3128,7 +3121,7 @@ fn command_path(path: &Path) -> String {
     normalize_runtime_path_text_for_host(&path.display().to_string())
 }
 
-fn cosmo_windows_host() -> bool {
+const fn cosmo_windows_host() -> bool {
     runtime_is_windows() && !cfg!(windows)
 }
 
@@ -3192,9 +3185,9 @@ fn print_json<T: Serialize>(value: &T) -> Result<()> {
 impl From<DevicePolicyArg> for DevicePolicy {
     fn from(value: DevicePolicyArg) -> Self {
         match value {
-            DevicePolicyArg::GpuRequired => DevicePolicy::GpuRequired,
-            DevicePolicyArg::GpuPreferred => DevicePolicy::GpuPreferred,
-            DevicePolicyArg::CpuOnly => DevicePolicy::CpuOnly,
+            DevicePolicyArg::GpuRequired => Self::GpuRequired,
+            DevicePolicyArg::GpuPreferred => Self::GpuPreferred,
+            DevicePolicyArg::CpuOnly => Self::CpuOnly,
         }
     }
 }
@@ -3208,7 +3201,7 @@ mod tests {
             contract_version: contract_version.to_owned(),
             engine: engine.to_owned(),
             required_flags: vec!["--trust-remote-code=false".to_owned()],
-            parser_settings: Default::default(),
+            parser_settings: BTreeMap::default(),
             preferred_endpoint: None,
             unsupported_combinations: Vec::new(),
             notes: vec!["test recipe".to_owned()],

--- a/engines/pytorch/src/python_worker.py
+++ b/engines/pytorch/src/python_worker.py
@@ -5,8 +5,9 @@ import re
 import sys
 import time
 import traceback
+from collections.abc import Iterator
 from threading import Thread
-from typing import Any, Iterator
+from typing import Any
 
 import torch
 import uvicorn

--- a/engines/sglang/Cargo.toml
+++ b/engines/sglang/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "rocm-engine-sglang"
 path = "src/main.rs"

--- a/engines/sglang/src/lib.rs
+++ b/engines/sglang/src/lib.rs
@@ -358,8 +358,7 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     let env_path = runtime
         .command
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     Ok(InstallResponse {
         env_id: runtime.env_id.clone(),
         env_path: env_path.display().to_string(),
@@ -839,24 +838,22 @@ fn resolve_managed_runtime(runtime_id: Option<&str>) -> Result<Option<SglangRunt
             .as_deref()
             .unwrap_or("therock-sglang-runtime")
             .to_owned();
-        let source = manifest
-            .runtime_key
-            .as_deref()
-            .map(|key| format!("managed_runtime_manifest:{key}"))
-            .unwrap_or_else(|| "managed_runtime_manifest".to_owned());
+        let source = manifest.runtime_key.as_deref().map_or_else(
+            || "managed_runtime_manifest".to_owned(),
+            |key| format!("managed_runtime_manifest:{key}"),
+        );
         let (sdk_root, sdk_bin, sdk_bin_paths, sdk_library_paths) = manifest
             .rocm_sdk
             .as_ref()
             .filter(|probe| probe.import_ok)
-            .map(|probe| {
+            .map_or((None, None, Vec::new(), Vec::new()), |probe| {
                 (
                     probe.root_path.clone(),
                     probe.bin_path.clone(),
                     probe.bin_paths.clone(),
                     probe.library_paths.clone(),
                 )
-            })
-            .unwrap_or((None, None, Vec::new(), Vec::new()));
+            });
         if let Ok(runtime) = runtime_from_python(
             python,
             &runtime_id,
@@ -1326,7 +1323,7 @@ fn current_unix_millis() -> u128 {
         .as_millis()
 }
 
-fn windows_unsupported_message() -> &'static str {
+const fn windows_unsupported_message() -> &'static str {
     "SGLang ROCm serving is supported by rocm-cli only on Linux/WSL; native Windows SGLang is skipped. No CPU fallback is used."
 }
 
@@ -1355,7 +1352,7 @@ mod tests {
             contract_version: contract_version.to_owned(),
             engine: engine.to_owned(),
             required_flags: vec!["--reasoning-parser".to_owned(), "qwen3".to_owned()],
-            parser_settings: Default::default(),
+            parser_settings: std::collections::BTreeMap::default(),
             preferred_endpoint: None,
             unsupported_combinations: Vec::new(),
             notes: vec!["test recipe".to_owned()],

--- a/engines/vllm/Cargo.toml
+++ b/engines/vllm/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "rocm-engine-vllm"
 path = "src/main.rs"

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -352,8 +352,7 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     let env_path = runtime
         .command
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     Ok(InstallResponse {
         env_id: runtime.env_id.clone(),
         env_path: env_path.display().to_string(),
@@ -786,24 +785,22 @@ fn resolve_managed_runtime(runtime_id: Option<&str>) -> Result<Option<VllmRuntim
             .as_deref()
             .unwrap_or("therock-vllm-runtime")
             .to_owned();
-        let source = manifest
-            .runtime_key
-            .as_deref()
-            .map(|key| format!("managed_runtime_manifest:{key}"))
-            .unwrap_or_else(|| "managed_runtime_manifest".to_owned());
+        let source = manifest.runtime_key.as_deref().map_or_else(
+            || "managed_runtime_manifest".to_owned(),
+            |key| format!("managed_runtime_manifest:{key}"),
+        );
         let (sdk_root, sdk_bin, sdk_bin_paths, sdk_library_paths) = manifest
             .rocm_sdk
             .as_ref()
             .filter(|probe| probe.import_ok)
-            .map(|probe| {
+            .map_or((None, None, Vec::new(), Vec::new()), |probe| {
                 (
                     probe.root_path.clone(),
                     probe.bin_path.clone(),
                     probe.bin_paths.clone(),
                     probe.library_paths.clone(),
                 )
-            })
-            .unwrap_or((None, None, Vec::new(), Vec::new()));
+            });
         if let Ok(runtime) = runtime_from_python(
             python,
             &runtime_id,
@@ -1216,7 +1213,7 @@ fn current_unix_millis() -> u128 {
         .as_millis()
 }
 
-fn windows_unsupported_message() -> &'static str {
+const fn windows_unsupported_message() -> &'static str {
     "vLLM ROCm serving is supported by rocm-cli only on Linux/WSL; native Windows vLLM is skipped. No CPU fallback is used."
 }
 
@@ -1245,7 +1242,7 @@ mod tests {
             contract_version: contract_version.to_owned(),
             engine: engine.to_owned(),
             required_flags: vec!["--enable-auto-tool-choice".to_owned()],
-            parser_settings: Default::default(),
+            parser_settings: std::collections::BTreeMap::default(),
             preferred_endpoint: None,
             unsupported_combinations: Vec::new(),
             notes: vec!["test recipe".to_owned()],

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ function Fail {
     exit 1
 }
 
-function Need-Command {
+function Confirm-Command {
     param([string] $Name)
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
         Fail "missing required command: $Name"
@@ -95,7 +95,7 @@ function Resolve-SigningPublicKey {
     return ""
 }
 
-function Fetch-File {
+function Save-File {
     param(
         [string] $Url,
         [string] $OutputPath,
@@ -132,14 +132,14 @@ function Fetch-File {
     }
 }
 
-function Verify-ArchiveSignature {
+function Confirm-ArchiveSignature {
     param(
         [string] $ArchivePath,
         [string] $SignaturePath,
         [string] $PublicKeyPath
     )
 
-    Need-Command openssl
+    Confirm-Command openssl
     & openssl dgst -sha256 -verify $PublicKeyPath -signature $SignaturePath $ArchivePath | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Fail "signature verification failed"
@@ -211,7 +211,7 @@ function Expand-RocmArchive {
 
     if ($ArchivePath.EndsWith(".tar.gz", [System.StringComparison]::OrdinalIgnoreCase) -or
         $ArchivePath.EndsWith(".tgz", [System.StringComparison]::OrdinalIgnoreCase)) {
-        Need-Command tar
+        Confirm-Command tar
         & tar -xzf $ArchivePath -C $ExtractDir
         if ($LASTEXITCODE -ne 0) {
             Fail "failed to extract archive with tar"
@@ -236,7 +236,7 @@ function Find-BundleDir {
     Fail "unable to locate extracted bundle directory"
 }
 
-function Test-PathListContains {
+function Test-PathInList {
     param(
         [string] $PathList,
         [string] $Path
@@ -268,7 +268,7 @@ function Add-PathListEntry {
         [string] $Path
     )
 
-    if (Test-PathListContains $PathList $Path) {
+    if (Test-PathInList $PathList $Path) {
         return $PathList
     }
 
@@ -283,13 +283,13 @@ function Add-InstallDirToUserPath {
     param([string] $Path)
 
     $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $userPathAlreadyConfigured = Test-PathListContains $userPath $Path
+    $userPathAlreadyConfigured = Test-PathInList $userPath $Path
     if (-not $userPathAlreadyConfigured) {
         $newUserPath = Add-PathListEntry $userPath $Path
         [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
     }
 
-    $processPathAlreadyConfigured = Test-PathListContains $env:Path $Path
+    $processPathAlreadyConfigured = Test-PathInList $env:Path $Path
     if (-not $processPathAlreadyConfigured) {
         $env:Path = Add-PathListEntry $env:Path $Path
     }
@@ -366,8 +366,8 @@ $archiveUrl = "$DownloadBase/$assetBase"
 $shaUrl = "$archiveUrl.sha256"
 $sigUrl = "$archiveUrl.sig"
 
-Need-Command Expand-Archive
-Need-Command Get-FileHash
+Confirm-Command Expand-Archive
+Confirm-Command Get-FileHash
 
 if ($PSVersionTable.PSEdition -eq "Desktop") {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.ServicePointManager]::SecurityProtocol
@@ -391,8 +391,8 @@ try {
     Write-Host "  install_dir: $InstallDir"
     Write-Host "  download: $archiveUrl"
 
-    Fetch-File $archiveUrl $archivePath
-    Fetch-File $shaUrl $shaPath
+    Save-File $archiveUrl $archivePath
+    Save-File $shaUrl $shaPath
 
     $expected = Get-ExpectedSha256 $shaPath
     $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLowerInvariant()
@@ -404,8 +404,8 @@ try {
         if ([string]::IsNullOrWhiteSpace($signingPublicKey)) {
             Fail "signature verification requires ROCM_CLI_SIGNING_PUBLIC_KEY_PATH, ROCM_CLI_SIGNING_PUBLIC_KEY_PEM, -SigningPublicKeyPath, or -SigningPublicKeyPem"
         }
-        Fetch-File $sigUrl $sigPath "required signature sidecar is missing or unavailable"
-        Verify-ArchiveSignature $archivePath $sigPath $signingPublicKey
+        Save-File $sigUrl $sigPath "required signature sidecar is missing or unavailable"
+        Confirm-ArchiveSignature $archivePath $sigPath $signingPublicKey
         Write-Host "signature verified"
     }
 
@@ -461,14 +461,14 @@ try {
 
     if ($updateUserPath) {
         Add-InstallDirToUserPath $InstallDir
-    } elseif (-not (Test-PathListContains $env:Path $InstallDir)) {
+    } elseif (-not (Test-PathInList $env:Path $InstallDir)) {
         Write-Host "note: $InstallDir is not on PATH"
         Write-Host "  add it to the user PATH or run:"
         Write-Host "  `$env:Path = `"$InstallDir;`$env:Path`""
     }
 
     Write-Host "run:"
-    if (Test-PathListContains $env:Path $InstallDir) {
+    if (Test-PathInList $env:Path $InstallDir) {
         Write-Host "  rocm doctor"
     } else {
         $rocmExe = Join-Path $InstallDir "rocm.exe"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 REPO="${ROCM_CLI_GITHUB_REPO:-powderluv/rocm-cli}"
 CHANNEL="${1:-release}"
-INSTALL_DIR="${ROCM_CLI_INSTALL_DIR:-$HOME/.local/bin}"
+INSTALL_DIR="${ROCM_CLI_INSTALL_DIR:-${HOME}/.local/bin}"
 UPDATE_SHELL_PATH="${ROCM_CLI_UPDATE_SHELL_PATH:-1}"
 
 fail() {
@@ -18,9 +18,9 @@ need_cmd() {
 sha256_file() {
   file="$1"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$file" | awk '{print $1}'
+    sha256sum "${file}" | awk '{print $1}'
   elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$file" | awk '{print $1}'
+    shasum -a 256 "${file}" | awk '{print $1}'
   else
     fail "missing sha256sum or shasum for checksum verification"
   fi
@@ -36,29 +36,29 @@ truthy() {
 fetch() {
   url="$1"
   output="$2"
-  failure_message="${3:-failed to download $url}"
+  failure_message="${3:-failed to download ${url}}"
   if command -v curl >/dev/null 2>&1; then
     if [ -t 2 ]; then
-      curl -fL --progress-bar "$url" -o "$output" || {
-        rm -f "$output"
-        fail "$failure_message"
+      curl -fL --progress-bar "${url}" -o "${output}" || {
+        rm -f "${output}"
+        fail "${failure_message}"
       }
     else
-      curl -fsSL "$url" -o "$output" || {
-        rm -f "$output"
-        fail "$failure_message"
+      curl -fsSL "${url}" -o "${output}" || {
+        rm -f "${output}"
+        fail "${failure_message}"
       }
     fi
   elif command -v wget >/dev/null 2>&1; then
     if [ -t 2 ]; then
-      wget --show-progress -O "$output" "$url" || {
-        rm -f "$output"
-        fail "$failure_message"
+      wget --show-progress -O "${output}" "${url}" || {
+        rm -f "${output}"
+        fail "${failure_message}"
       }
     else
-      wget -qO "$output" "$url" || {
-        rm -f "$output"
-        fail "$failure_message"
+      wget -qO "${output}" "${url}" || {
+        rm -f "${output}"
+        fail "${failure_message}"
       }
     fi
   else
@@ -74,8 +74,8 @@ signing_public_key_path() {
 
   if [ -n "${ROCM_CLI_SIGNING_PUBLIC_KEY_PEM:-}" ]; then
     key_path="${tmp_dir}/rocm-cli-signing-public-key.pem"
-    printf '%s\n' "${ROCM_CLI_SIGNING_PUBLIC_KEY_PEM}" > "$key_path"
-    printf '%s\n' "$key_path"
+    printf '%s\n' "${ROCM_CLI_SIGNING_PUBLIC_KEY_PEM}" > "${key_path}"
+    printf '%s\n' "${key_path}"
     return 0
   fi
 
@@ -87,7 +87,7 @@ verify_signature() {
   signature="$2"
   public_key="$3"
   need_cmd openssl
-  openssl dgst -sha256 -verify "$public_key" -signature "$signature" "$archive" >/dev/null 2>&1 \
+  openssl dgst -sha256 -verify "${public_key}" -signature "${signature}" "${archive}" >/dev/null 2>&1 \
     || fail "signature verification failed"
 }
 
@@ -103,14 +103,14 @@ installer_config_dir() {
 write_minimal_config_if_missing() {
   config_dir="$(installer_config_dir)"
   config_path="${config_dir}/config.json"
-  if [ -f "$config_path" ]; then
+  if [ -f "${config_path}" ]; then
     echo "config: existing ${config_path}"
     return
   fi
 
-  mkdir -p "$config_dir"
+  mkdir -p "${config_dir}"
   config_tmp="${tmp_dir}/config.json"
-  cat > "$config_tmp" <<'JSON'
+  cat > "${config_tmp}" <<'JSON'
 {
   "default_engine": "pytorch",
   "telemetry": {
@@ -124,7 +124,7 @@ write_minimal_config_if_missing() {
   }
 }
 JSON
-  install -m 0600 "$config_tmp" "$config_path"
+  install -m 0600 "${config_tmp}" "${config_path}"
   echo "config: created ${config_path}"
 }
 
@@ -143,7 +143,7 @@ shell_name() {
   fi
 
   shell_path="${SHELL:-}"
-  if [ -z "$shell_path" ]; then
+  if [ -z "${shell_path}" ]; then
     printf '%s\n' "sh"
     return
   fi
@@ -157,27 +157,27 @@ profile_path_for_shell() {
   fi
 
   case "$(shell_name)" in
-    bash) printf '%s\n' "$HOME/.bashrc" ;;
-    zsh) printf '%s\n' "$HOME/.zshrc" ;;
-    fish) printf '%s\n' "$HOME/.config/fish/config.fish" ;;
-    ksh) printf '%s\n' "$HOME/.kshrc" ;;
-    *) printf '%s\n' "$HOME/.profile" ;;
+    bash) printf '%s\n' "${HOME}/.bashrc" ;;
+    zsh) printf '%s\n' "${HOME}/.zshrc" ;;
+    fish) printf '%s\n' "${HOME}/.config/fish/config.fish" ;;
+    ksh) printf '%s\n' "${HOME}/.kshrc" ;;
+    *) printf '%s\n' "${HOME}/.profile" ;;
   esac
 }
 
 path_expr_for_profile() {
   path="$1"
-  case "$path" in
-    "$HOME")
+  case "${path}" in
+    "${HOME}")
       # Emit the literal string $HOME so the user's shell expands it later.
       # shellcheck disable=SC2016
       printf '%s\n' '$HOME'
       ;;
-    "$HOME"/*)
-      printf '%s\n' "\$HOME/${path#"$HOME"/}"
+    "${HOME}"/*)
+      printf '%s\n' "\$HOME/${path#"${HOME}"/}"
       ;;
     *)
-      printf '%s\n' "$path"
+      printf '%s\n' "${path}"
       ;;
   esac
 }
@@ -189,10 +189,10 @@ escape_for_double_quotes() {
 profile_has_path_entry() {
   profile="$1"
   path_expr="$2"
-  [ -f "$profile" ] || return 1
-  grep -F "# >>> rocm-cli path >>>" "$profile" >/dev/null 2>&1 && return 0
-  grep -F "$path_expr" "$profile" >/dev/null 2>&1 && return 0
-  grep -F "$INSTALL_DIR" "$profile" >/dev/null 2>&1 && return 0
+  [ -f "${profile}" ] || return 1
+  grep -F "# >>> rocm-cli path >>>" "${profile}" >/dev/null 2>&1 && return 0
+  grep -F "${path_expr}" "${profile}" >/dev/null 2>&1 && return 0
+  grep -F "${INSTALL_DIR}" "${profile}" >/dev/null 2>&1 && return 0
   return 1
 }
 
@@ -200,22 +200,22 @@ append_path_snippet() {
   profile="$1"
   shell_kind="$2"
   path_expr="$3"
-  escaped_path_expr="$(escape_for_double_quotes "$path_expr")"
+  escaped_path_expr="$(escape_for_double_quotes "${path_expr}")"
 
   profile_dir="${profile%/*}"
-  if [ "$profile_dir" != "$profile" ]; then
-    mkdir -p "$profile_dir"
+  if [ "${profile_dir}" != "${profile}" ]; then
+    mkdir -p "${profile_dir}"
   fi
-  [ -f "$profile" ] || : > "$profile"
+  [ -f "${profile}" ] || : > "${profile}"
 
-  if profile_has_path_entry "$profile" "$path_expr"; then
+  if profile_has_path_entry "${profile}" "${path_expr}"; then
     printf '%s\n' "unchanged:${profile}"
     return 0
   fi
 
-  case "$shell_kind" in
+  case "${shell_kind}" in
     fish)
-      cat >> "$profile" <<EOF
+      cat >> "${profile}" <<EOF
 
 # >>> rocm-cli path >>>
 if not contains -- "${escaped_path_expr}" \$PATH
@@ -225,7 +225,7 @@ end
 EOF
       ;;
     *)
-      cat >> "$profile" <<EOF
+      cat >> "${profile}" <<EOF
 
 # >>> rocm-cli path >>>
 case ":\$PATH:" in
@@ -241,7 +241,7 @@ EOF
 }
 
 ensure_installer_process_path() {
-  case ":$PATH:" in
+  case ":${PATH}:" in
     *:"${INSTALL_DIR}":*)
       return 0
       ;;
@@ -255,21 +255,21 @@ ensure_installer_process_path() {
 os="$(uname -s)"
 arch="$(uname -m)"
 
-case "$os" in
+case "${os}" in
   Linux) platform_os="linux" ;;
   *)
-    fail "unsupported OS: $os (installer currently supports Linux x86_64 only)"
+    fail "unsupported OS: ${os} (installer currently supports Linux x86_64 only)"
     ;;
 esac
 
-case "$arch" in
+case "${arch}" in
   x86_64|amd64) platform_arch="amd64" ;;
   *)
-    fail "unsupported architecture: $arch (installer currently supports Linux x86_64 only)"
+    fail "unsupported architecture: ${arch} (installer currently supports Linux x86_64 only)"
     ;;
 esac
 
-case "$CHANNEL" in
+case "${CHANNEL}" in
   nightly)
     asset_base="rocm-cli-nightly-${platform_os}-${platform_arch}.tar.gz"
     release_path="releases/download/nightly"
@@ -291,7 +291,7 @@ sig_url="${archive_url}.sig"
 
 tmp_dir="$(mktemp -d)"
 cleanup() {
-  rm -rf "$tmp_dir"
+  rm -rf "${tmp_dir}"
 }
 trap cleanup EXIT INT TERM
 
@@ -307,28 +307,28 @@ echo "  channel: ${CHANNEL}"
 echo "  install_dir: ${INSTALL_DIR}"
 echo "  download: ${archive_url}"
 
-fetch "$archive_url" "$archive_path"
-fetch "$sha_url" "$sha_path"
+fetch "${archive_url}" "${archive_path}"
+fetch "${sha_url}" "${sha_path}"
 
-expected="$(awk '{print $1}' "$sha_path" | head -n1)"
-[ -n "$expected" ] || fail "checksum file did not contain a sha256 digest"
-actual="$(sha256_file "$archive_path")"
-[ "$expected" = "$actual" ] || fail "checksum verification failed"
+expected="$(awk '{print $1}' "${sha_path}" | head -n1)"
+[ -n "${expected}" ] || fail "checksum file did not contain a sha256 digest"
+actual="$(sha256_file "${archive_path}")"
+[ "${expected}" = "${actual}" ] || fail "checksum verification failed"
 
 public_key_path="$(signing_public_key_path)"
-if truthy "${ROCM_CLI_REQUIRE_SIGNATURE:-0}" || [ -n "$public_key_path" ]; then
-  [ -n "$public_key_path" ] || fail "signature verification requires ROCM_CLI_SIGNING_PUBLIC_KEY_PATH or ROCM_CLI_SIGNING_PUBLIC_KEY_PEM"
-  fetch "$sig_url" "$sig_path" "required signature sidecar is missing or unavailable: $sig_url"
-  verify_signature "$archive_path" "$sig_path" "$public_key_path"
+if truthy "${ROCM_CLI_REQUIRE_SIGNATURE:-0}" || [ -n "${public_key_path}" ]; then
+  [ -n "${public_key_path}" ] || fail "signature verification requires ROCM_CLI_SIGNING_PUBLIC_KEY_PATH or ROCM_CLI_SIGNING_PUBLIC_KEY_PEM"
+  fetch "${sig_url}" "${sig_path}" "required signature sidecar is missing or unavailable: ${sig_url}"
+  verify_signature "${archive_path}" "${sig_path}" "${public_key_path}"
   echo "signature verified"
 fi
 
 extract_dir="${tmp_dir}/extract"
-mkdir -p "$extract_dir"
-tar -xzf "$archive_path" -C "$extract_dir"
+mkdir -p "${extract_dir}"
+tar -xzf "${archive_path}" -C "${extract_dir}"
 
-bundle_dir="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | head -n1)"
-[ -n "$bundle_dir" ] || fail "unable to locate extracted bundle directory"
+bundle_dir="$(find "${extract_dir}" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+[ -n "${bundle_dir}" ] || fail "unable to locate extracted bundle directory"
 
 [ -f "${bundle_dir}/bin/rocm" ] || fail "bundle did not contain bin/rocm"
 [ -f "${bundle_dir}/bin/rocmd" ] || fail "bundle did not contain bin/rocmd"
@@ -339,51 +339,51 @@ bundle_dir="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d | head -n1)"
 [ -f "${bundle_dir}/bin/rocm-engine-vllm" ] || fail "bundle did not contain bin/rocm-engine-vllm"
 [ -f "${bundle_dir}/bin/rocm-engine-sglang" ] || fail "bundle did not contain bin/rocm-engine-sglang"
 
-mkdir -p "$INSTALL_DIR"
+mkdir -p "${INSTALL_DIR}"
 write_minimal_config_if_missing
 
-if [ -f "$manifest_path" ]; then
+if [ -f "${manifest_path}" ]; then
   echo "removing previous rocm-cli install"
   while IFS= read -r installed_path; do
-    [ -n "$installed_path" ] || continue
-    case "$installed_path" in
-      "$INSTALL_DIR"/*)
-        rm -f "$installed_path"
+    [ -n "${installed_path}" ] || continue
+    case "${installed_path}" in
+      "${INSTALL_DIR}"/*)
+        rm -f "${installed_path}"
         ;;
       *)
-        echo "warning: skipping manifest entry outside install dir: $installed_path" >&2
+        echo "warning: skipping manifest entry outside install dir: ${installed_path}" >&2
         ;;
     esac
-  done < "$manifest_path"
-  rm -f "$manifest_path"
+  done < "${manifest_path}"
+  rm -f "${manifest_path}"
 fi
 
 manifest_tmp="${tmp_dir}/install-manifest"
-: > "$manifest_tmp"
+: > "${manifest_tmp}"
 for bin_path in "${bundle_dir}"/bin/*; do
-  [ -f "$bin_path" ] || continue
+  [ -f "${bin_path}" ] || continue
   bin_name="${bin_path##*/}"
   rm -f "${INSTALL_DIR}/${bin_name}"
-  install -m 0755 "$bin_path" "${INSTALL_DIR}/${bin_name}"
-  echo "${INSTALL_DIR}/${bin_name}" >> "$manifest_tmp"
+  install -m 0755 "${bin_path}" "${INSTALL_DIR}/${bin_name}"
+  echo "${INSTALL_DIR}/${bin_name}" >> "${manifest_tmp}"
 done
-install -m 0644 "$manifest_tmp" "$manifest_path"
+install -m 0644 "${manifest_tmp}" "${manifest_path}"
 
 echo "installed:"
 while IFS= read -r installed_path; do
-  [ -n "$installed_path" ] || continue
+  [ -n "${installed_path}" ] || continue
   echo "  ${installed_path}"
-done < "$manifest_path"
+done < "${manifest_path}"
 
 ensure_installer_process_path
 
-case ":$PATH:" in
+case ":${PATH}:" in
   *:"${INSTALL_DIR}":*)
-    if [ "$UPDATE_SHELL_PATH" = "1" ]; then
+    if [ "${UPDATE_SHELL_PATH}" = "1" ]; then
       profile_path="$(profile_path_for_shell)"
-      path_expr="$(path_expr_for_profile "$INSTALL_DIR")"
-      profile_result="$(append_path_snippet "$profile_path" "$(shell_name)" "$path_expr")" || true
-      case "$profile_result" in
+      path_expr="$(path_expr_for_profile "${INSTALL_DIR}")"
+      profile_result="$(append_path_snippet "${profile_path}" "$(shell_name)" "${path_expr}")" || true
+      case "${profile_result}" in
         updated:*)
           echo "shell profile updated:"
           echo "  profile: ${profile_result#updated:}"
@@ -410,7 +410,7 @@ case ":$PATH:" in
 esac
 
 echo "next:"
-if [ "$UPDATE_SHELL_PATH" = "1" ]; then
+if [ "${UPDATE_SHELL_PATH}" = "1" ]; then
   echo "  open a new terminal, then run: rocm doctor"
 else
   echo "  ${INSTALL_DIR}/rocm doctor"

--- a/plans/strict-linting-plan.md
+++ b/plans/strict-linting-plan.md
@@ -1,0 +1,68 @@
+# Enable strictest (practical) linting for ROCm CLI
+
+## Motivation
+
+Linting today is minimal and partly inert:
+
+- The workspace declares `[workspace.lints.rust]` with `unsafe_code = "forbid"`, but **no member crate sets `lints.workspace = true`** — so that lint (and any we add) is currently applied to *zero* crates.
+- There is no `[workspace.lints.clippy]`; CI runs `cargo clippy ... -D warnings` against only the *default* lint set.
+- Python (ruff), Shell (shellcheck), and PowerShell (PSScriptAnalyzer) run at default rule sets.
+
+Raising lint levels catches a much broader class of correctness and quality issues. Builds on the existing prek hooks (which *run* the linters) by raising *what* they enforce.
+
+## Description
+
+Adopt a **pragmatic-strict** configuration across all languages:
+
+- **Rust:** enable `clippy::all + pedantic + nursery` (warn locally, deny in CI), wired into every crate via `lints.workspace = true`. Auto-fix everything `cargo clippy --fix` handles, then hand-fix the valuable remainder. A small, **documented** allow-list suppresses high-noise/low-value lints rather than churning the codebase for them.
+- **Python:** broaden ruff to a strict, mostly-auto-fixable rule selection.
+- **Shell / PowerShell:** enable shellcheck optional checks and PSScriptAnalyzer (verified via prek + CI, since neither tool is installed locally).
+- **Integration:** prek hooks and CI enforce the new levels identically.
+
+No runtime behavior changes — this is tooling/quality-gate work, so no acceptance scenarios.
+
+## Implementation approach
+
+### 1. Rust lint config (`Cargo.toml`)
+- Add `[workspace.lints.clippy]`:
+  - `all = "warn"`, `pedantic = "warn"`, `nursery = "warn"` (priority `-1` so specific allows win).
+  - Documented allow-list (each with a one-line reason):
+    `must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`, `too_many_lines`,
+    `module_name_repetitions`, `doc_markdown`, `multiple_crate_versions`, `cargo_common_metadata`.
+    (These are the dominant noise sources; `doc_markdown` may instead be fixed if cheap.)
+- Keep `[workspace.lints.rust]` `unsafe_code = "forbid"`; add `rust_2018_idioms = "warn"` and `unreachable_pub = "warn"` (skip `missing_debug_implementations` if it proves noisy).
+- Add `lints.workspace = true` to all 10 crate manifests: `apps/{rocm,rocmd}`, `crates/{rocm-core,rocm-engine-protocol}`, `engines/{llama-cpp,atom,pytorch,lemonade,sglang,vllm}`.
+
+### 2. Burn down Rust findings
+- Run `cargo clippy --workspace --all-targets --fix --allow-dirty` iteratively (resolves the bulk: `uninlined_format_args`, `semicolon_if_nothing_returned`, `assigning_clones`, `redundant_closure_for_method_calls`, `use_self`, …).
+- Hand-fix the valuable manual tail not covered by the allow-list, e.g. `missing_const_for_fn`, `needless_pass_by_value`, `map_unwrap_or`, `match_same_arms`, `redundant_pub_crate`, `redundant_clone`, `cast_*` (annotate or restructure).
+- Use targeted in-code `#[allow(...)]` **with justification** only where a finding is a deliberate false positive — prefer global allow-list for whole-lint decisions.
+
+### 3. Python (`ruff.toml`)
+- Expand `[lint] select`/`extend-select` to a strict set: `E, F, W, I, B, UP, SIM, C4, RUF` (consider `RET`, `ARG`, `PTH`).
+- `ruff check --fix` for the ~16 auto-fixable; hand-fix the small tail (`B904` raise-from, a few `RET`/`SIM`). Decide `E501`: rely on `ruff-format` (88 col) and `# noqa`/`per-file-ignores` for the comment/string long lines rather than reflowing.
+
+### 4. Shell & PowerShell
+- shellcheck: enable a curated optional set (e.g. `enable=all` or `add-default-case,quote-safe-variables,require-variable-braces`) via prek args + CI; fix `install.sh` + `scripts/*.sh` findings.
+- PowerShell: add PSScriptAnalyzer (`Invoke-ScriptAnalyzer`) to the prek `powershell` hook and the CI PowerShell job; fix `install.ps1` + `scripts/*.ps1` findings.
+
+### 5. Wire prek + CI
+- `.pre-commit-config.yaml`: pass strict args to ruff/shellcheck; add PSScriptAnalyzer; clippy entry already `-D warnings` (now stricter via workspace lints).
+- `.github/workflows/ci.yml`: keep `cargo clippy ... -D warnings`; update ruff/shellcheck/PowerShell steps to match prek.
+
+### Verification
+- `cargo clippy --workspace --all-targets -- -D warnings` passes clean.
+- `cargo build --workspace --all-targets` + `cargo test --workspace --all-targets` pass.
+- `cargo fmt --all --check` clean.
+- `ruff check` + `ruff format --check` clean on `scripts/` + `engines/`.
+- `prek run --all-files` green (covers shellcheck/PSScriptAnalyzer, which aren't installed in this sandbox).
+
+## Tradeoffs
+
+- **Pragmatic allow-list vs maximal strictness** (chosen: pragmatic). The allow-listed lints (`must_use_candidate`, `missing_errors_doc`, `missing_panics_doc`, `too_many_lines`, `doc_markdown`, `cargo_common_metadata`, `multiple_crate_versions`) would each require large, low-value churn (doc comments on every fallible fn, metadata on internal-only crates, unactionable transitive-dep dedup). Allowing them keeps the signal-to-noise high. They're centralized in `Cargo.toml`, so any can be re-enabled later (e.g. a follow-up to burn down `missing_errors_doc`).
+
+## Risks / notes
+
+- **CI uses `rust-toolchain@stable`, not a pin** (a separate effort will pin the toolchain). `nursery` lints can shift between compiler versions; mitigated by `warn`-level workspace lints + `-D warnings` in CI, and by that future toolchain pin. Worth a heads-up that a future stable bump may surface new nursery lints.
+- shellcheck/pwsh not installed in this dev sandbox → those fixes are validated via prek/CI rather than locally. Stated assumption: the pinned prek `shellcheck-py` / a PSScriptAnalyzer image in CI is the source of truth.
+- Expect the diff to be large but mostly mechanical (clippy `--fix`). Will keep formatting-only churn out of logic commits where practical.

--- a/plans/strict-linting-plan.md
+++ b/plans/strict-linting-plan.md
@@ -31,7 +31,7 @@ No runtime behavior changes — this is tooling/quality-gate work, so no accepta
     `module_name_repetitions`, `doc_markdown`, `multiple_crate_versions`, `cargo_common_metadata`.
     (These are the dominant noise sources; `doc_markdown` may instead be fixed if cheap.)
 - Keep `[workspace.lints.rust]` `unsafe_code = "forbid"`; add `rust_2018_idioms = "warn"` and `unreachable_pub = "warn"` (skip `missing_debug_implementations` if it proves noisy).
-- Add `lints.workspace = true` to all 10 crate manifests: `apps/{rocm,rocmd}`, `crates/{rocm-core,rocm-engine-protocol}`, `engines/{llama-cpp,atom,pytorch,lemonade,sglang,vllm}`.
+- Add `lints.workspace = true` to all 14 crate manifests: `apps/{rocm,rocmd}`, `crates/{rocm-core,rocm-engine-protocol,rocm-dash-core,rocm-dash-collectors,rocm-dash-daemon,rocm-dash-tui}`, `engines/{llama-cpp,atom,pytorch,lemonade,sglang,vllm}`.
 
 ### 2. Burn down Rust findings
 - Run `cargo clippy --workspace --all-targets --fix --allow-dirty` iteratively (resolves the bulk: `uninlined_format_args`, `semicolon_if_nothing_returned`, `assigning_clones`, `redundant_closure_for_method_calls`, `use_self`, …).

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,5 +3,19 @@
 # `ruff-format` pre-commit hook enforces.
 
 [lint]
-# Ruff's default rule set (E4, E7, E9, F) plus import sorting.
-extend-select = ["I"]
+# Strict rule selection. The formatter owns code width, so E501 (line-too-long)
+# is left off — long comments/URLs are allowed and code is wrapped by the formatter.
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # import sorting
+    "B",   # flake8-bugbear (likely bugs)
+    "UP",  # pyupgrade (modern syntax)
+    "SIM", # flake8-simplify
+    "C4",  # flake8-comprehensions
+    "RUF", # Ruff-specific rules
+]
+ignore = [
+    "E501", # line length is enforced by the formatter; long comments/URLs are fine
+]

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -117,7 +117,7 @@ function Resolve-CommandPath {
     Fail "missing required command: $Name"
 }
 
-function Test-PathListContains {
+function Test-PathInList {
     param(
         [string] $PathList,
         [string] $Path
@@ -240,7 +240,7 @@ try {
         )
         Invoke-Checked "acceptance: PATH-updating install" $psExe $pathUpdateInstallArgs $PathUpdateInstallLog
         $updatedUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        if (-not (Test-PathListContains $updatedUserPath $PathUpdateInstallDir)) {
+        if (-not (Test-PathInList $updatedUserPath $PathUpdateInstallDir)) {
             Fail "installer did not add install dir to the user PATH"
         }
         if (-not (Select-String -LiteralPath $PathUpdateInstallLog -Pattern "user PATH updated" -Quiet)) {

--- a/scripts/atom_therock_gpu_test.py
+++ b/scripts/atom_therock_gpu_test.py
@@ -288,7 +288,7 @@ def wait_atom_health(host: str, port: int, timeout: int) -> dict[str, Any]:
                     "status_code": status,
                     "body": body.decode("utf-8", errors="replace"),
                 }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
         time.sleep(0.5)
     raise RuntimeError(f"ATOM server did not become healthy: {last_error}")

--- a/scripts/build_single_exe_release.py
+++ b/scripts/build_single_exe_release.py
@@ -192,12 +192,14 @@ def reset_tar_info(info: tarfile.TarInfo) -> tarfile.TarInfo:
 
 def create_tar_gz(root: Path, archive: Path) -> None:
     archive.parent.mkdir(parents=True, exist_ok=True)
-    with archive.open("wb") as raw:
-        with gzip.GzipFile(
+    with (
+        archive.open("wb") as raw,
+        gzip.GzipFile(
             filename="", mode="wb", fileobj=raw, compresslevel=9, mtime=0
-        ) as gz:
-            with tarfile.open(fileobj=gz, mode="w") as package:
-                package.add(root, arcname=root.name, filter=reset_tar_info)
+        ) as gz,
+        tarfile.open(fileobj=gz, mode="w") as package,
+    ):
+        package.add(root, arcname=root.name, filter=reset_tar_info)
 
 
 def assert_no_codex(archive: Path) -> None:

--- a/scripts/comfyui_therock_gpu_test.py
+++ b/scripts/comfyui_therock_gpu_test.py
@@ -22,8 +22,9 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -814,10 +815,8 @@ def prompt_failed(status: Any) -> bool:
         return False
     status_text = str(status.get("status_str", "")).lower()
     completed = status.get("completed")
-    return (
-        status_text in {"error", "failed"}
-        or completed is False
-        and "error" in status_text
+    return status_text in {"error", "failed"} or (
+        completed is False and "error" in status_text
     )
 
 

--- a/scripts/cosmopolitan_feasibility.py
+++ b/scripts/cosmopolitan_feasibility.py
@@ -48,8 +48,7 @@ def run_capture(
         cwd=cwd,
         env=env,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
     return CommandResult(args, completed.returncode, completed.stdout, completed.stderr)

--- a/scripts/llama_cpp_therock_gpu_test.py
+++ b/scripts/llama_cpp_therock_gpu_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import http.client
 import json
 import os
@@ -508,7 +509,7 @@ def wait_health(host: str, port: int, timeout: int) -> dict[str, Any]:
             health = get_json(host, port, "/health", timeout=3)
             if health.get("status") == "ok":
                 return health
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
         time.sleep(0.5)
     raise RuntimeError(f"llama-server did not become healthy: {last_error}")
@@ -657,10 +658,8 @@ def add_module_root(roots: set[str], value: Any) -> None:
         return
     path = Path(value)
     roots.add(str(path).lower())
-    try:
+    with contextlib.suppress(OSError):
         roots.add(str(path.resolve()).lower())
-    except OSError:
-        pass
 
 
 def stop_service(process: subprocess.Popen[bytes] | None, state_path: Path) -> None:

--- a/scripts/local_assistant_therock_gpu_test.py
+++ b/scripts/local_assistant_therock_gpu_test.py
@@ -10,6 +10,7 @@ CPU fallback.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import http.client
 import json
 import os
@@ -492,10 +493,8 @@ def wait_local_endpoint(manifest: dict[str, Any], timeout: int) -> None:
             except OSError as error:
                 last_error = str(error)
             finally:
-                try:
+                with contextlib.suppress(Exception):
                     conn.close()  # type: ignore[name-defined]
-                except Exception:
-                    pass
         time.sleep(2)
     raise RuntimeError(
         "managed service endpoint did not report the requested loaded model "
@@ -597,12 +596,13 @@ def assert_chat_output(output: str, *, require_tool_call: bool) -> None:
     for needle in forbidden:
         if needle in output:
             raise RuntimeError(f"chat output contained forbidden `{needle}`:\n{output}")
-    if require_tool_call:
-        if "ROCm checks used" not in output or "none requested" in output:
-            raise RuntimeError(
-                "local assistant did not request a ROCm tool call; retry without "
-                "--require-tool-call or choose a tool-calling model/prompt.\n" + output
-            )
+    if require_tool_call and (
+        "ROCm checks used" not in output or "none requested" in output
+    ):
+        raise RuntimeError(
+            "local assistant did not request a ROCm tool call; retry without "
+            "--require-tool-call or choose a tool-calling model/prompt.\n" + output
+        )
 
 
 def find_ready_service_id(data_dir: Path, model: str, engine: str) -> str:

--- a/scripts/pytorch_therock_gpu_test.py
+++ b/scripts/pytorch_therock_gpu_test.py
@@ -314,7 +314,7 @@ def wait_health(
             health = get_json(host, port, "/healthz", timeout=3)
             if health.get("status") == "ok":
                 return health
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
         exit_code = process.poll()
         if exit_code is not None:
@@ -381,7 +381,7 @@ def failure_context(state_path: Path, log_path: Path) -> str:
                 if key in state
             }
             parts.append("state: " + json.dumps(visible_state, indent=2))
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             parts.append(f"state could not be read: {exc}")
     if log_path.is_file():
         log_lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -870,7 +870,7 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except KeyboardInterrupt:
-        raise SystemExit(130)
-    except Exception as exc:  # noqa: BLE001
+        raise SystemExit(130) from None
+    except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from exc

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -16,7 +16,6 @@ import tarfile
 import zipfile
 from pathlib import Path
 
-
 ARCHIVE_SUFFIXES = (".tar.gz", ".zip")
 ROCM_RELEASE_ASSET_RE = re.compile(
     r"^rocm-cli-(?:(?:v[0-9][A-Za-z0-9._+-]*|nightly(?:-[0-9]{8}-[0-9A-Fa-f]+)?)-)?"
@@ -563,7 +562,7 @@ def write_sha(path: Path, *, archive_name: str | None = None) -> None:
 def add_tar_file(
     package: tarfile.TarFile, root: str, relative: str, executable: bool = False
 ) -> None:
-    data = f"test content for {relative}\n".encode("utf-8")
+    data = f"test content for {relative}\n".encode()
     info = tarfile.TarInfo(f"{root}/{relative}")
     info.size = len(data)
     info.mode = 0o755 if executable else 0o644
@@ -802,7 +801,7 @@ def run_self_test(root: Path) -> None:
         expect_failure(
             "missing production trust inputs",
             lambda: run_with_env(
-                {name: None for name in PRODUCTION_TRUST_ENV_NAMES},
+                dict.fromkeys(PRODUCTION_TRUST_ENV_NAMES),
                 lambda: validate_release(
                     dist,
                     assets=[],
@@ -834,7 +833,7 @@ def run_self_test(root: Path) -> None:
             )
         run_with_env(
             {
-                **{name: None for name in PRODUCTION_TRUST_ENV_NAMES},
+                **dict.fromkeys(PRODUCTION_TRUST_ENV_NAMES),
                 "ROCM_CLI_SIGNING_PUBLIC_KEY_PATH": release_public_key,
                 "ROCM_CLI_METADATA_PUBLIC_KEY_PATH": metadata_public_key,
                 "ROCM_CLI_MODEL_RECIPE_INDEX_PATH": recipe_index,

--- a/scripts/rust_cosmopolitan_spike.py
+++ b/scripts/rust_cosmopolitan_spike.py
@@ -22,9 +22,9 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
@@ -69,8 +69,7 @@ def run_capture(
         cwd=cwd,
         env=env,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=False,
     )
     result = CommandResult(
@@ -183,7 +182,7 @@ def write_text(path: Path, content: str) -> None:
 def target_json(linker: Path) -> str:
     # This intentionally remains a Linux-ish target. Existing Rust/Cosmo work
     # uses this shape; Windows behavior must be tested and fixed explicitly.
-    return """{
+    return f"""{{
   "llvm-target": "x86_64-unknown-linux-musl",
   "target-pointer-width": 64,
   "arch": "x86_64",
@@ -214,14 +213,14 @@ def target_json(linker: Path) -> str:
   "no-default-libraries": true,
   "max-atomic-width": 64,
   "linker-flavor": "gcc",
-  "linker": "%s",
-  "pre-link-args": {
+  "linker": "{path_text(linker)}",
+  "pre-link-args": {{
     "gcc": ["-static", "-pg", "-mnop-mcount"]
-  },
-  "stack-probes": { "kind": "none" },
+  }},
+  "stack-probes": {{ "kind": "none" }},
   "target-family": ["unix"]
-}
-""" % path_text(linker)
+}}
+"""
 
 
 def linker_wrapper() -> str:

--- a/scripts/setup-cosmocc.sh
+++ b/scripts/setup-cosmocc.sh
@@ -7,15 +7,15 @@ set -euo pipefail
 # this tool under .rocm-work so the repo and user home directory stay clean.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TOOLS_DIR="${ROCM_CLI_COSMOCC_TOOLS_DIR:-"$ROOT_DIR/.rocm-work/tools/cosmocc"}"
-WSL_ELF_DIR="${ROCM_CLI_COSMOCC_WSL_ELF_DIR:-"$ROOT_DIR/.rocm-work/tools/cosmocc-wsl-elf"}"
+TOOLS_DIR="${ROCM_CLI_COSMOCC_TOOLS_DIR:-"${ROOT_DIR}/.rocm-work/tools/cosmocc"}"
+WSL_ELF_DIR="${ROCM_CLI_COSMOCC_WSL_ELF_DIR:-"${ROOT_DIR}/.rocm-work/tools/cosmocc-wsl-elf"}"
 URL="${ROCM_CLI_COSMOCC_URL:-"https://cosmo.zip/pub/cosmocc/cosmocc.zip"}"
-ZIP_PATH="$TOOLS_DIR/cosmocc.zip"
+ZIP_PATH="${TOOLS_DIR}/cosmocc.zip"
 
 if [[ "${1:-}" == "--self-test" ]]; then
-  echo "setup-cosmocc: tools dir: $TOOLS_DIR"
-  echo "setup-cosmocc: wsl elf dir: $WSL_ELF_DIR"
-  echo "setup-cosmocc: url: $URL"
+  echo "setup-cosmocc: tools dir: ${TOOLS_DIR}"
+  echo "setup-cosmocc: wsl elf dir: ${WSL_ELF_DIR}"
+  echo "setup-cosmocc: url: ${URL}"
   exit 0
 fi
 
@@ -27,17 +27,17 @@ is_wsl() {
 is_ape_file() {
   local path="$1"
   local magic
-  magic="$(od -An -tx1 -N6 "$path" 2>/dev/null | tr -d ' \n')"
-  [[ "$magic" == "4d5a71467044" || "$magic" == "6a6172747372" ]]
+  magic="$(od -An -tx1 -N6 "${path}" 2>/dev/null | tr -d ' \n')"
+  [[ "${magic}" == "4d5a71467044" || "${magic}" == "6a6172747372" ]]
 }
 
 restore_tool_permissions() {
   local root="$1"
-  if [[ -d "$root/bin" ]]; then
-    find "$root/bin" -type f -exec chmod +x {} +
+  if [[ -d "${root}/bin" ]]; then
+    find "${root}/bin" -type f -exec chmod +x {} +
   fi
-  if [[ -d "$root/libexec" ]]; then
-    find "$root/libexec" -type f -exec chmod +x {} +
+  if [[ -d "${root}/libexec" ]]; then
+    find "${root}/libexec" -type f -exec chmod +x {} +
   fi
 }
 
@@ -45,11 +45,11 @@ needs_elf_toolchain() {
   local root="$1"
   local tool
   for tool in \
-    "$root/bin/x86_64-linux-cosmo-ar" \
-    "$root/bin/x86_64-unknown-cosmo-cc" \
-    "$root/bin/cosmocross" \
-    "$root/bin/assimilate"; do
-    if [[ -f "$tool" ]] && is_ape_file "$tool"; then
+    "${root}/bin/x86_64-linux-cosmo-ar" \
+    "${root}/bin/x86_64-unknown-cosmo-cc" \
+    "${root}/bin/cosmocross" \
+    "${root}/bin/assimilate"; do
+    if [[ -f "${tool}" ]] && is_ape_file "${tool}"; then
       return 0
     fi
   done
@@ -59,52 +59,52 @@ needs_elf_toolchain() {
 prepare_wsl_elf_toolchain() {
   local src="$1"
   local dest="$2"
-  local ape="$src/bin/ape-x86_64.elf"
-  local assimilate="$src/bin/assimilate"
-  local marker="$dest/.rocm-cosmocc-wsl-elf-source"
-  local expected="source=$src url=$URL"
+  local ape="${src}/bin/ape-x86_64.elf"
+  local assimilate="${src}/bin/assimilate"
+  local marker="${dest}/.rocm-cosmocc-wsl-elf-source"
+  local expected="source=${src} url=${URL}"
 
-  if [[ -f "$dest/bin/cosmocc" && -f "$marker" ]] && grep -qxF "$expected" "$marker"; then
-    echo "$dest/bin/cosmocc"
+  if [[ -f "${dest}/bin/cosmocc" && -f "${marker}" ]] && grep -qxF "${expected}" "${marker}"; then
+    echo "${dest}/bin/cosmocc"
     return 0
   fi
-  if [[ ! -x "$ape" || ! -f "$assimilate" ]]; then
-    echo "setup-cosmocc: missing APE loader or assimilate in $src/bin" >&2
+  if [[ ! -x "${ape}" || ! -f "${assimilate}" ]]; then
+    echo "setup-cosmocc: missing APE loader or assimilate in ${src}/bin" >&2
     exit 1
   fi
 
-  echo "setup-cosmocc: preparing executable ELF toolchain in $dest" >&2
-  rm -rf "$dest"
-  mkdir -p "$dest"
-  tar --exclude=./cosmocc.zip -C "$src" -cf - . | tar -C "$dest" -xf -
+  echo "setup-cosmocc: preparing executable ELF toolchain in ${dest}" >&2
+  rm -rf "${dest}"
+  mkdir -p "${dest}"
+  tar --exclude=./cosmocc.zip -C "${src}" -cf - . | tar -C "${dest}" -xf -
 
   while IFS= read -r -d '' file; do
-    if is_ape_file "$file"; then
-      "$ape" "$assimilate" -e -c "$file" >/dev/null
+    if is_ape_file "${file}"; then
+      "${ape}" "${assimilate}" -e -c "${file}" >/dev/null
     fi
-  done < <(find "$dest/bin" "$dest/libexec" -type f -perm /111 -print0)
+  done < <(find "${dest}/bin" "${dest}/libexec" -type f -perm /111 -print0)
 
-  printf '%s\n' "$expected" >"$marker"
-  chmod +x "$dest/bin/cosmocc"
-  echo "$dest/bin/cosmocc"
+  printf '%s\n' "${expected}" >"${marker}"
+  chmod +x "${dest}/bin/cosmocc"
+  echo "${dest}/bin/cosmocc"
 }
 
-mkdir -p "$TOOLS_DIR"
-if [[ ! -f "$TOOLS_DIR/bin/cosmocc" && ! -f "$TOOLS_DIR/bin/x86_64-unknown-cosmo-cc" ]]; then
-  echo "setup-cosmocc: downloading $URL"
+mkdir -p "${TOOLS_DIR}"
+if [[ ! -f "${TOOLS_DIR}/bin/cosmocc" && ! -f "${TOOLS_DIR}/bin/x86_64-unknown-cosmo-cc" ]]; then
+  echo "setup-cosmocc: downloading ${URL}"
   if command -v curl >/dev/null 2>&1; then
-    curl -L --fail --retry 3 -o "$ZIP_PATH" "$URL"
+    curl -L --fail --retry 3 -o "${ZIP_PATH}" "${URL}"
   elif command -v wget >/dev/null 2>&1; then
-    wget -O "$ZIP_PATH" "$URL"
+    wget -O "${ZIP_PATH}" "${URL}"
   else
     echo "setup-cosmocc: curl or wget is required" >&2
     exit 1
   fi
-  echo "setup-cosmocc: extracting into $TOOLS_DIR"
+  echo "setup-cosmocc: extracting into ${TOOLS_DIR}"
   if command -v unzip >/dev/null 2>&1; then
-    unzip -q -o "$ZIP_PATH" -d "$TOOLS_DIR"
+    unzip -q -o "${ZIP_PATH}" -d "${TOOLS_DIR}"
   else
-    python3 - "$ZIP_PATH" "$TOOLS_DIR" <<'PY'
+    python3 - "${ZIP_PATH}" "${TOOLS_DIR}" <<'PY'
 import sys
 import zipfile
 from pathlib import Path
@@ -123,20 +123,20 @@ PY
   fi
 fi
 
-restore_tool_permissions "$TOOLS_DIR"
+restore_tool_permissions "${TOOLS_DIR}"
 
-if [[ -f "$TOOLS_DIR/bin/cosmocc" ]]; then
-  COSMOCC="$TOOLS_DIR/bin/cosmocc"
-elif [[ -f "$TOOLS_DIR/bin/x86_64-unknown-cosmo-cc" ]]; then
-  COSMOCC="$TOOLS_DIR/bin/x86_64-unknown-cosmo-cc"
+if [[ -f "${TOOLS_DIR}/bin/cosmocc" ]]; then
+  COSMOCC="${TOOLS_DIR}/bin/cosmocc"
+elif [[ -f "${TOOLS_DIR}/bin/x86_64-unknown-cosmo-cc" ]]; then
+  COSMOCC="${TOOLS_DIR}/bin/x86_64-unknown-cosmo-cc"
 else
-  echo "setup-cosmocc: could not find cosmocc in $TOOLS_DIR/bin" >&2
+  echo "setup-cosmocc: could not find cosmocc in ${TOOLS_DIR}/bin" >&2
   exit 1
 fi
 
-chmod +x "$COSMOCC"
-if is_wsl || needs_elf_toolchain "$TOOLS_DIR"; then
-  prepare_wsl_elf_toolchain "$TOOLS_DIR" "$WSL_ELF_DIR"
+chmod +x "${COSMOCC}"
+if is_wsl || needs_elf_toolchain "${TOOLS_DIR}"; then
+  prepare_wsl_elf_toolchain "${TOOLS_DIR}" "${WSL_ELF_DIR}"
 else
-  echo "$COSMOCC"
+  echo "${COSMOCC}"
 fi

--- a/scripts/sglang_therock_gpu_test.py
+++ b/scripts/sglang_therock_gpu_test.py
@@ -206,7 +206,7 @@ def wait_sglang_openai_ready(host: str, port: int, timeout: int) -> dict[str, An
             models = get_json(host, port, "/v1/models", timeout=3)
             first_model_id(models)
             return {"status_code": 200, "body": "v1/models ready"}
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
         time.sleep(0.5)
     raise RuntimeError(

--- a/scripts/single_exe_release_gate.py
+++ b/scripts/single_exe_release_gate.py
@@ -9,6 +9,7 @@ opt-in because they need an already installed managed TheRock runtime.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import shutil
 import subprocess
@@ -99,10 +100,8 @@ def stage_release_artifact(source: Path, destination: Path) -> Path:
         return destination
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
-    try:
+    with contextlib.suppress(OSError):
         destination.chmod(destination.stat().st_mode | 0o755)
-    except OSError:
-        pass
     print(f"[single-exe-gate] staged release artifact: {destination}")
     return destination
 
@@ -285,4 +284,4 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except (GateError, subprocess.SubprocessError, OSError) as error:
         print(f"[single-exe-gate] failed: {error}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from error

--- a/scripts/tui_e2e_smoke.py
+++ b/scripts/tui_e2e_smoke.py
@@ -19,8 +19,8 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import pyte
 
@@ -334,4 +334,4 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except (TuiSmokeError, OSError, subprocess.SubprocessError) as error:
         print(f"[tui-e2e-smoke] failed: {error}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from error

--- a/scripts/vllm_therock_gpu_test.py
+++ b/scripts/vllm_therock_gpu_test.py
@@ -552,7 +552,7 @@ def wait_health(host: str, port: int, timeout: int) -> dict[str, Any]:
                     "status_code": status,
                     "body": body.decode("utf-8", errors="replace"),
                 }
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             last_error = exc
         time.sleep(0.5)
     raise RuntimeError(f"vLLM server did not become healthy: {last_error}")

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 rust-version.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true


### PR DESCRIPTION
## Summary

Tightens linting to the strictest *practical* level across every language in the repo, and wires prek + CI to enforce it.

- **Rust:** enable Clippy `all` + `pedantic` + `nursery` (warn locally, denied in CI via `-D warnings`), inherited by every crate through `lints.workspace = true`. A small, documented allow-list in the root `Cargo.toml` turns off the high-noise / low-value / risky lints (e.g. `assigning_clones`, `needless_pass_by_value`, the numeric-cast family, doc/metadata lints) so the signal stays high. All remaining findings are fixed.
- **`unsafe_code`:** changed from `forbid` to `deny`. It was previously declared in `[workspace.lints.rust]` but **no crate opted in**, so it was inert — and the workspace genuinely needs platform FFI (libc / Win32 / Cosmopolitan, `std::env::set_var` in edition 2024). It's now enforced everywhere, with narrow per-function `#[allow(unsafe_code)]` (each with a reason) at the real FFI sites.
- **Python:** strict Ruff rule set (`E,W,F,I,B,UP,SIM,C4,RUF`) for the helper scripts and engine workers; all findings fixed.
- **Shell:** ShellCheck `--enable=all` (excluding `SC2310`/`SC2312`, which need risky `set -e` restructuring of the setup scripts).
- **PowerShell:** PSScriptAnalyzer with a settings file (`Write-Host` allowed — these are user-facing console installers); approved-verb renames and dead-code removal.
- **Enforcement:** prek hooks and a new CI `lint` job run the same checks so local and CI results match.

## Why

Linting was minimal and partly inert: no `[workspace.lints.clippy]` at all, `lints.workspace` never set, and CI only denied the *default* Clippy set. This raises *what* the existing hooks enforce, catching a much broader class of correctness and quality issues.

## Non-obvious decisions

- **`unreachable_pub` is intentionally not enabled** — this workspace is dominated by binary crates where every `pub` item is unreachable, so it would only add noise.
- The allow-list is centralized in the root `Cargo.toml` with a one-line rationale per lint, so any entry can be re-enabled and burned down later.
- A short rationale for the approach lives in `plans/strict-linting-plan.md`.

## Risk

Low. No runtime behavior changes — tooling/quality-gate only. The diff is large but mostly mechanical (Clippy/Ruff autofixes).

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — passing (see note)
- `ruff check` + `ruff format --check` on `scripts/` + `engines/` — clean
- `shellcheck --enable=all --exclude=SC2310,SC2312` on all scripts — clean
- PSScriptAnalyzer with the bundled settings — clean

> Note: `tui::tests::assistant_comfyui_start_result_shows_url_models_and_quit_prompt` is a pre-existing flake under the full parallel `cargo test` run (it fails on a clean `main` too); it passes in isolation and single-threaded. Unrelated to this change.