### PR TITLE
fix: daemon socket security, config panics, dead code cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,6 +3304,7 @@ dependencies = [
  "rocm-dash-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -241,15 +241,24 @@ async fn maybe_spawn_embedded_daemon(
         let opts = runner_options(config, paths, false);
         let listen = connect.to_string();
         let socket = Some(PathBuf::from(target));
-        let token = config.dashboard.daemon.token.clone();
 
         let handle = tokio::spawn(async move {
-            if let Err(e) = rocm_dash_daemon::server::run(&listen, token.as_deref(), opts).await {
+            if let Err(e) = rocm_dash_daemon::server::run(&listen, opts).await {
                 eprintln!("rocm: embedded telemetry daemon exited: {e:#}");
             }
         });
-        // Give it a moment to bind before the TUI client dials in.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Poll until the daemon has bound and is accepting connections.
+        // A fixed sleep is race-prone on slow or loaded systems.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if tokio::net::UnixStream::connect(target).await.is_ok() {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break; // Proceed anyway; the TUI client will retry with backoff.
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
         Some((handle, socket))
     }
     #[cfg(windows)]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3817,12 +3817,62 @@ pub struct RocmCliConfig {
 // Pure `with_*()` transforms are scoped to this sub-config only — rocm-cli's own
 // config keeps its in-place `&mut` mutation convention untouched.
 
+fn default_dashboard_socket() -> String {
+    // Choose a socket location whose *parent* directory is always user-owned so
+    // that run_unix can tighten it to 0o700 without EPERM. Precedence:
+    //
+    // 1. $XDG_RUNTIME_DIR  — already mode 0700 on systemd systems, ideal.
+    // 2. $HOME/.rocm/data/telemetry — standard per-user data dir.
+    // 3. temp_dir()/rocmdashd-<user> — user-named subdir so the parent is
+    //    something we create and own, not /tmp itself.
+    use std::path::PathBuf;
+    let path = std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|v| !v.is_empty())
+        .map(|d| PathBuf::from(d).join("rocmdashd.sock"))
+        .or_else(|| {
+            std::env::var_os("HOME").filter(|v| !v.is_empty()).map(|h| {
+                PathBuf::from(h)
+                    .join(".rocm")
+                    .join("data")
+                    .join("telemetry")
+                    .join("rocmdashd.sock")
+            })
+        })
+        .unwrap_or_else(|| {
+            let raw = std::env::var("USER")
+                .or_else(|_| std::env::var("LOGNAME"))
+                .unwrap_or_else(|_| "user".to_owned());
+            // Sanitize: keep only alphanumeric, hyphen, and underscore so
+            // that path separators or '..' in a user-controlled env var
+            // cannot escape the intended subdirectory.
+            let user: String = raw
+                .chars()
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect();
+            let user = if user.is_empty() {
+                "user".to_owned()
+            } else {
+                user
+            };
+            std::env::temp_dir()
+                .join(format!("rocmdashd-{user}"))
+                .join("rocmdashd.sock")
+        });
+    format!("unix:{}", path.display())
+}
+
 fn default_dashboard_listen() -> String {
-    "unix:/tmp/rocmdashd.sock".to_owned()
+    default_dashboard_socket()
 }
 
 fn default_dashboard_connect() -> String {
-    "unix:/tmp/rocmdashd.sock".to_owned()
+    default_dashboard_socket()
 }
 
 fn default_dashboard_theme() -> String {
@@ -3876,16 +3926,22 @@ impl Default for DashboardDaemonConfig {
 }
 
 impl DashboardDaemonConfig {
+    fn secs_to_duration(s: f64, fallback: Duration) -> Duration {
+        // try_from_secs_f64 rejects NaN, negative, inf, and values that
+        // overflow Duration (extremely large finite f64).
+        Duration::try_from_secs_f64(s).unwrap_or(fallback)
+    }
+
     pub fn gpu_tick(&self) -> Duration {
-        Duration::from_secs_f64(self.gpu_tick_secs)
+        Self::secs_to_duration(self.gpu_tick_secs, Duration::from_secs(1))
     }
 
     pub fn discovery_tick(&self) -> Duration {
-        Duration::from_secs_f64(self.discovery_tick_secs)
+        Self::secs_to_duration(self.discovery_tick_secs, Duration::from_secs(5))
     }
 
     pub fn instance_tick(&self) -> Duration {
-        Duration::from_secs_f64(self.instance_tick_secs)
+        Self::secs_to_duration(self.instance_tick_secs, Duration::from_secs(2))
     }
 }
 
@@ -7504,7 +7560,11 @@ Class Name:                Display
     #[allow(clippy::float_cmp)]
     fn dashboard_config_defaults_and_json_round_trip() {
         let cfg = DashboardConfig::default();
-        assert_eq!(cfg.daemon.listen, "unix:/tmp/rocmdashd.sock");
+        assert!(
+            cfg.daemon.listen.starts_with("unix:") && cfg.daemon.listen.ends_with("rocmdashd.sock"),
+            "default listen must be a unix socket path ending with rocmdashd.sock, got: {}",
+            cfg.daemon.listen
+        );
         assert_eq!(cfg.daemon.gpu_tick_secs, 1.0);
         assert_eq!(cfg.daemon.discovery_tick_secs, 5.0);
         assert_eq!(cfg.daemon.instance_tick_secs, 2.0);
@@ -7542,7 +7602,10 @@ Class Name:                Display
         assert_eq!(themed.tui.theme, "nord");
 
         let relisten = base.clone().with_daemon_listen("tcp:127.0.0.1:9000");
-        assert_eq!(base.daemon.listen, "unix:/tmp/rocmdashd.sock");
+        assert!(
+            base.daemon.listen.starts_with("unix:"),
+            "default listen must use unix scheme"
+        );
         assert_eq!(relisten.daemon.listen, "tcp:127.0.0.1:9000");
     }
 

--- a/crates/rocm-dash-collectors/src/lib.rs
+++ b/crates/rocm-dash-collectors/src/lib.rs
@@ -3,8 +3,6 @@
 //! Every collector implements one of the traits in `rocm_dash_core::traits`.
 //! Stubs return `CollectorError::Unsupported` so the daemon can start with nothing wired.
 
-#![allow(dead_code)]
-
 pub mod amd_smi;
 pub mod bench_tail;
 pub mod cgroup;

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -152,13 +152,46 @@ mod duration_secs {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
         let secs = f64::deserialize(d)?;
-        Ok(Duration::from_secs_f64(secs))
+        // try_from_secs_f64 rejects NaN, negative, inf, and overflow.
+        Duration::try_from_secs_f64(secs)
+            .map_err(|e| serde::de::Error::custom(format!("invalid duration: {e}")))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn daemon_toml_with_gpu_tick(gpu_tick: &str) -> String {
+        format!(
+            "[daemon]\nlisten = \"unix:/tmp/test.sock\"\n\
+             discovery_tick = 5.0\ninstance_tick = 2.0\ngpu_tick = {gpu_tick}\n"
+        )
+    }
+
+    #[test]
+    fn duration_rejects_negative_gpu_tick() {
+        assert!(
+            toml::from_str::<Config>(&daemon_toml_with_gpu_tick("-1.0")).is_err(),
+            "negative gpu_tick must be rejected"
+        );
+    }
+
+    #[test]
+    fn duration_rejects_negative_discovery_tick() {
+        let toml = "[daemon]\nlisten = \"unix:/tmp/test.sock\"\n\
+                    gpu_tick = 1.0\ninstance_tick = 2.0\ndiscovery_tick = -0.001\n";
+        assert!(
+            toml::from_str::<Config>(toml).is_err(),
+            "negative discovery_tick must be rejected"
+        );
+    }
+
+    #[test]
+    fn duration_accepts_valid_positive() {
+        let c: Config = toml::from_str(&daemon_toml_with_gpu_tick("0.5")).unwrap();
+        assert_eq!(c.daemon.gpu_tick, std::time::Duration::from_millis(500));
+    }
 
     #[test]
     fn defaults_serialize_and_round_trip() {

--- a/crates/rocm-dash-core/src/lib.rs
+++ b/crates/rocm-dash-core/src/lib.rs
@@ -5,8 +5,6 @@
 //!
 //! See `../wiki/concepts/tea-reducer-pattern.md` for the architectural pattern.
 
-#![allow(dead_code)] // scaffold; remove as modules flesh out
-
 pub mod bench_rollup;
 pub mod bench_schema;
 pub mod config;

--- a/crates/rocm-dash-daemon/Cargo.toml
+++ b/crates/rocm-dash-daemon/Cargo.toml
@@ -27,3 +27,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 color-eyre = "0.6"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/rocm-dash-daemon/src/lib.rs
+++ b/crates/rocm-dash-daemon/src/lib.rs
@@ -4,8 +4,6 @@
 //! TUI clients over a Unix socket. The composition-root binary (`rocm`)
 //! drives this library via its `serve` subcommand.
 
-#![allow(dead_code)]
-
 pub mod bench_ring;
 pub mod demo;
 pub mod persist;

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -22,15 +22,23 @@ use crate::transport::{read_line, write_line};
 
 /// Broadcast capacity. A slow client that lags more than this many ticks will
 /// receive `RecvError::Lagged` and skip ahead (no crash).
+#[cfg(unix)]
 const BROADCAST_CAP: usize = 64;
 
 /// Snapshot history kept for late-joining clients (~30s at 1Hz).
+#[cfg(unix)]
 const RING_CAP: usize = 30;
 
 /// Benchmark-row history kept for late-joining clients (matches TUI `BENCH_CAP`).
+#[cfg(unix)]
 const BENCH_RING_CAP: usize = 200;
 
-pub async fn run(listen: &str, _token: Option<&str>, opts: RunnerOptions) -> anyhow::Result<()> {
+/// Start the daemon on `listen` (e.g. `unix:/run/user/1000/rocmdashd.sock`).
+///
+/// Access control is enforced by filesystem permissions: the Unix socket is
+/// created with mode `0o600` so only the owning user can connect. The parent
+/// directory is created if it does not exist.
+pub async fn run(listen: &str, opts: RunnerOptions) -> anyhow::Result<()> {
     let (scheme, target) = listen
         .split_once(':')
         .ok_or_else(|| anyhow!("listen must be `unix:/path` or `tcp:host:port`"))?;
@@ -46,12 +54,42 @@ pub async fn run(listen: &str, _token: Option<&str>, opts: RunnerOptions) -> any
 async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
     use tokio::net::UnixListener;
 
+    if let Some(parent) = path.parent() {
+        // Skip hardening if parent is an empty path (relative socket target
+        // such as `unix:foo.sock`). Operating on `""` would target the CWD.
+        if !parent.as_os_str().is_empty() {
+            // Create the parent directory with mode 0o700 so other users cannot
+            // traverse into it. DirBuilder::mode only applies to directories it
+            // creates; pre-existing directories keep their current permissions,
+            // so we explicitly set_permissions afterwards to tighten them.
+            use std::os::unix::fs::DirBuilderExt;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(parent)
+                .with_context(|| format!("creating socket directory {parent:?}"))?;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).with_context(
+                || {
+                    format!(
+                        "restricting socket directory {parent:?} to mode 0700 — \
+                         check that the directory is owned by the current user \
+                         (EPERM means it is owned by another user or root)"
+                    )
+                },
+            )?;
+        }
+    }
     if path.exists() {
         std::fs::remove_file(&path)
             .with_context(|| format!("removing stale socket {}", path.display()))?;
     }
-    let listener =
-        UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
+    let listener = UnixListener::bind(&path).with_context(|| format!("binding {path:?}"))?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting permissions on {path:?}"))?;
+    }
     info!(socket = %path.display(), "listening");
 
     let (snap_tx, _) = broadcast::channel::<Event>(BROADCAST_CAP);
@@ -202,6 +240,7 @@ async fn handle_client(
     Ok(())
 }
 
+#[cfg(unix)]
 fn hostname() -> Option<String> {
     std::env::var("HOSTNAME").ok().or_else(|| {
         std::fs::read_to_string("/proc/sys/kernel/hostname")

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -209,3 +209,47 @@ async fn bench_ring_accumulates_rows_for_replay() {
 
     let _ = std::fs::remove_file(&path);
 }
+
+/// Verify the unix socket is created with mode 0o600 (not world-accessible).
+#[cfg(unix)]
+#[tokio::test]
+async fn socket_is_created_with_restricted_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock_path = dir.path().join("test.sock");
+    let listen = format!("unix:{}", sock_path.display());
+
+    let handle = tokio::spawn({
+        let listen = listen.clone();
+        async move {
+            // Run until aborted; ignore the resulting error on abort.
+            let _ =
+                rocm_dash_daemon::run(&listen, rocm_dash_daemon::runner::RunnerOptions::default())
+                    .await;
+        }
+    });
+
+    // Poll until the socket exists *and* its mode is 0o600. Polling for
+    // existence alone is racy: set_permissions runs after UnixListener::bind,
+    // so the file can appear before the mode is restricted.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mode = loop {
+        if let Ok(meta) = std::fs::metadata(&sock_path) {
+            let m = meta.permissions().mode() & 0o777;
+            if m == 0o600 {
+                break m;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("daemon did not create socket with mode 0o600 within 5 s");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    };
+
+    handle.abort();
+    // Await the handle so the task is fully cancelled and has released the
+    // socket before the TempDir destructor removes the directory.
+    let _ = handle.await;
+    assert_eq!(mode, 0o600, "socket must not be group- or world-accessible");
+}

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -574,11 +574,53 @@ impl ChatGptAgentClient {
         F: Fn(String, String) + Send + Sync + 'static,
     {
         use rig::providers::chatgpt;
+        // Store OAuth tokens in a user-owned directory so the plaintext
+        // access/refresh tokens are not readable by other local users.
+        // Refuse to fall back to a predictable temp path: a pre-existing
+        // directory there could be owned by another user.
+        let token_dir = std::env::var_os("HOME")
+            .filter(|v| !v.is_empty())
+            .or_else(|| std::env::var_os("USERPROFILE").filter(|v| !v.is_empty())) // Windows
+            .map(|h| {
+                std::path::PathBuf::from(h)
+                    .join(".rocm")
+                    .join("data")
+                    .join("chatgpt-tokens")
+            })
+            .ok_or_else(|| {
+                AgentError::Build(
+                    "home directory not found ($HOME/$USERPROFILE unset); \
+                     cannot safely store OAuth tokens"
+                        .to_string(),
+                )
+            })?;
+        #[cfg(unix)]
+        {
+            // Create with mode 0o700 up-front so the directory is never
+            // world-accessible even for the brief window before set_permissions.
+            // The subsequent set_permissions call tightens pre-existing dirs.
+            use std::os::unix::fs::DirBuilderExt;
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(&token_dir)
+                .map_err(|e| AgentError::Build(format!("cannot create token cache dir: {e}")))?;
+            if let Err(e) =
+                std::fs::set_permissions(&token_dir, std::fs::Permissions::from_mode(0o700))
+            {
+                tracing::warn!(dir = %token_dir.display(), error = %e, "could not restrict token cache dir permissions");
+            }
+        }
+        #[cfg(not(unix))]
+        std::fs::create_dir_all(&token_dir)
+            .map_err(|e| AgentError::Build(format!("cannot create token cache dir: {e}")))?;
         // The closure param is the provider's `DeviceCodePrompt` (its `auth`
         // module is private, so we let inference name it); its `verification_uri`
         // and `user_code` fields are public.
         let client = chatgpt::Client::builder()
             .oauth()
+            .token_dir(token_dir)
             .on_device_code(move |p| on_device_code(p.verification_uri, p.user_code))
             .build()
             .map_err(|e| AgentError::Build(e.to_string()))?;

--- a/crates/rocm-dash-tui/src/lib.rs
+++ b/crates/rocm-dash-tui/src/lib.rs
@@ -4,8 +4,6 @@
 //! the same modules are reachable as a library so examples (e.g. screenshot
 //! generation) can drive the UI in-process.
 
-#![allow(dead_code)]
-
 pub mod agent;
 pub mod app;
 pub mod client;

--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -20,7 +20,7 @@ pub const PROBE_TIMEOUT: Duration = Duration::from_millis(300);
 
 /// Fully-resolved chat endpoint configuration. `api_key` is sourced from the
 /// environment only — never from TOML/CLI/source (see `main.rs`).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LlmConfig {
     pub base_url: String,
     pub model: String,
@@ -28,6 +28,17 @@ pub struct LlmConfig {
     /// Custom auth header NAME (e.g. `Ocp-Apim-Subscription-Key`). When set, the
     /// `api_key` value is sent in this header instead of `Authorization: Bearer`.
     pub auth_header: Option<String>,
+}
+
+impl std::fmt::Debug for LlmConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlmConfig")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[redacted]"))
+            .field("auth_header", &self.auth_header)
+            .finish()
+    }
 }
 
 /// Resolve the chat endpoint by precedence: **CLI > config > env > probed

--- a/crates/rocm-dash-tui/src/ui/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/mod.rs
@@ -17,7 +17,6 @@ pub mod job_console;
 pub mod logs_view;
 pub mod modal;
 pub mod model_picker;
-pub mod monitor;
 pub mod onboarding;
 pub mod runtime_manager;
 pub mod serve_wizard;

--- a/crates/rocm-dash-tui/src/ui/monitor.rs
+++ b/crates/rocm-dash-tui/src/ui/monitor.rs
@@ -1,4 +1,0 @@
-//! 6-panel monitor layout placeholder. Modeled on ctux's `crates/tui/src/ui/monitor.rs`.
-
-// TODO: split the main area into 6 panels — host CPU/mem, GPU sparklines, instance list,
-// per-instance KV cache, request queue, bench-row scroll.

--- a/crates/rocm-dash-tui/src/ui/tabs/bench.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/bench.rs
@@ -489,13 +489,6 @@ fn fmt_opt<T: std::fmt::Display>(v: &Option<T>) -> String {
     }
 }
 
-fn fmt_opt_f64_4(v: Option<f64>) -> String {
-    match v {
-        Some(x) => format!("{x:.4}"),
-        None => "-".to_string(),
-    }
-}
-
 /// SI-formatted optional `u32` counter (`-` when None).
 fn fmt_opt_u32_si(v: Option<u32>) -> String {
     match v {

--- a/crates/rocm-dash-tui/src/ui/tabs/overview.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/overview.rs
@@ -386,16 +386,8 @@ fn draw_bench(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
             (p, _) => format!("{p:?}"),
         };
         let model = r.model.as_deref().unwrap_or("?");
-        let model_trunc = if model.len() > 20 {
-            &model[..20]
-        } else {
-            model
-        };
-        let cell = if r.cell.len() > 10 {
-            &r.cell[..10]
-        } else {
-            r.cell.as_str()
-        };
+        let model_trunc = trunc(model, 20);
+        let cell = trunc(&r.cell, 10);
         lines.push(Line::from(vec![
             Span::styled(
                 format!("{cell:<10} {:>3} {model_trunc:<20} ", r.run),
@@ -413,4 +405,33 @@ fn draw_bench(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         ]));
     }
     f.render_widget(Paragraph::new(lines), inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::trunc;
+
+    #[test]
+    fn trunc_does_not_panic_on_multibyte_model_name() {
+        // Each Greek letter is 2 bytes; 20-char string is 40 bytes.
+        // Before the fix, &model[..20] would panic mid-codepoint.
+        let model = "αβγδεζηθικλμνξοπρστυ"; // 20 Greek letters = 40 bytes
+        let result = trunc(model, 20);
+        assert_eq!(result.chars().count(), 20);
+    }
+
+    #[test]
+    fn trunc_clips_multibyte_at_char_boundary() {
+        let model = "αβγδεζηθικλμνξοπρστυφ"; // 21 Greek letters
+        let result = trunc(model, 20);
+        assert_eq!(result.chars().count(), 20);
+        assert!(result.is_char_boundary(result.len()));
+    }
+
+    #[test]
+    fn trunc_does_not_panic_on_multibyte_cell_name() {
+        let cell = "日本語テスト"; // 6 CJK chars, each 3 bytes; fits in 10
+        let result = trunc(cell, 10);
+        assert_eq!(result, cell);
+    }
 }


### PR DESCRIPTION
## What & Why

Follow-up to #16. Addresses the blocking and non-blocking issues raised in the review.

## Changes

**Daemon socket security (blocking)**
- Default socket path moved from `/tmp/rocmdashd.sock` to `~/.rocm/data/telemetry/rocmdashd.sock` so other local users on a shared host cannot connect to it or pre-empt the predictable `/tmp` path.
- Socket is created with mode `0600` immediately after bind; the parent directory is created with `create_dir_all` if it doesn't exist.
- Removed the unused `_token` parameter from `server::run`; filesystem permissions are the documented access control for unix sockets.

**Config panics (blocking)**
- `duration_secs::deserialize` in `rocm-dash-core` now returns a serde error for negative, NaN, or infinite values instead of panicking.
- `DashboardDaemonConfig` tick accessors in `rocm-core` clamp to safe defaults for invalid `f64` values.

**Dead code (blocking)**
- Removed crate-wide `#![allow(dead_code)]` from all four `rocm-dash-*` crates; one genuinely unused function (`fmt_opt_f64_4`) surfaced and was deleted.
- Deleted the empty `monitor` module (`monitor.rs` contained only a TODO with no implementation and was never referenced).

**Byte-slice panic (blocking)**
- Replaced `&model[..20]` / `&r.cell[..10]` in the bench overview tab with `trunc()`, the existing char-aware helper already used elsewhere in the file. The old guards checked `.len()` (bytes) and then sliced by byte index, which panics on any multibyte character straddling the boundary.

**Non-blocking**
- `LlmConfig` now implements `Debug` manually, printing `api_key` as `"[redacted]"`.
- `ChatGptAgentClient` stores OAuth tokens under `~/.rocm/data/chatgpt-tokens/` at mode `0700` instead of the provider's default which inherits the process umask.

## Testing

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace -- --test-threads=1` — all pass
- New regression tests: socket permissions (`0600` verified at runtime), negative/invalid duration config values, multibyte string truncation