### PR TITLE
ci: improve build caching and cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -54,14 +58,20 @@ jobs:
 
   windows-build-and-test:
     runs-on: windows-latest
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-on-failure: true
 
       - name: Build
         shell: pwsh
-        run: cargo build --workspace --all-targets
+        run: |
+          cargo build --workspace --all-targets
+          cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang -p xtask
 
       - name: Test
         shell: pwsh
@@ -103,6 +113,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -126,7 +138,7 @@ jobs:
       - name: Install native build deps
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,21 +39,59 @@ jobs:
             echo "${COMMITS} new commit(s) since last nightly"
           fi
 
+      - name: Cache Cargo home and build artifacts
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+            ~/.cargo/rustup
+            target
+          key: Linux-manylinux-release-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            Linux-manylinux-release-
+
       - name: Build release binaries
         if: steps.check.outputs.skip != 'true'
         run: |
+          # The bind-mount source must exist and be owned by the runner user;
+          # Docker would otherwise create it as root, leaving the non-root
+          # container user unable to write into CARGO_HOME/RUSTUP_HOME.
+          mkdir -p "$HOME/.cargo"
+
+          # Install system build deps as root: yum needs to write to
+          # /var/cache/yum and the RPM db, which a non-root container user
+          # cannot do. These land in the container's ephemeral layer (not the
+          # bind mount), so this runs every time; only the Cargo/rustup state
+          # below is cached.
           docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -e HOME=/tmp/rocm-cli-home \
             -v "$PWD":/work \
             -w /work \
             quay.io/pypa/manylinux2014_x86_64 \
             /bin/bash -lc '
               set -euo pipefail
-              mkdir -p "$HOME"
               yum install -y pkgconfig libcap-devel
-              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
-              export PATH="$HOME/.cargo/bin:$PATH"
+            '
+
+          # Build as the runner user so cached Cargo/rustup files are owned by
+          # the runner (the host-side cache save step must be able to read them).
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -e CARGO_HOME=/host-cargo \
+            -e RUSTUP_HOME=/host-cargo/rustup \
+            -v "$HOME/.cargo":/host-cargo \
+            -v "$PWD":/work \
+            -w /work \
+            quay.io/pypa/manylinux2014_x86_64 \
+            /bin/bash -lc '
+              set -euo pipefail
+              if [ ! -f /host-cargo/bin/cargo ]; then
+                curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none --no-modify-path
+              fi
+              export PATH="/host-cargo/bin:$PATH"
               cargo build --release --workspace
             '
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Cargo home and build artifacts
         if: steps.check.outputs.skip != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,20 +46,57 @@ jobs:
           esac
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Cache Cargo home and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/registry/src
+            ~/.cargo/rustup
+            target
+          key: Linux-manylinux-release-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          restore-keys: |
+            Linux-manylinux-release-
+
       - name: Build release binaries
         run: |
+          # The bind-mount source must exist and be owned by the runner user;
+          # Docker would otherwise create it as root, leaving the non-root
+          # container user unable to write into CARGO_HOME/RUSTUP_HOME.
+          mkdir -p "$HOME/.cargo"
+
+          # Install system build deps as root: yum needs to write to
+          # /var/cache/yum and the RPM db, which a non-root container user
+          # cannot do. These land in the container's ephemeral layer (not the
+          # bind mount), so this runs every time; only the Cargo/rustup state
+          # below is cached.
           docker run --rm \
-            -u "$(id -u):$(id -g)" \
-            -e HOME=/tmp/rocm-cli-home \
             -v "$PWD":/work \
             -w /work \
             quay.io/pypa/manylinux2014_x86_64 \
             /bin/bash -lc '
               set -euo pipefail
-              mkdir -p "$HOME"
               yum install -y pkgconfig libcap-devel
-              curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
-              export PATH="$HOME/.cargo/bin:$PATH"
+            '
+
+          # Build as the runner user so cached Cargo/rustup files are owned by
+          # the runner (the host-side cache save step must be able to read them).
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -e CARGO_HOME=/host-cargo \
+            -e RUSTUP_HOME=/host-cargo/rustup \
+            -v "$HOME/.cargo":/host-cargo \
+            -v "$PWD":/work \
+            -w /work \
+            quay.io/pypa/manylinux2014_x86_64 \
+            /bin/bash -lc '
+              set -euo pipefail
+              if [ ! -f /host-cargo/bin/cargo ]; then
+                curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none --no-modify-path
+              fi
+              export PATH="/host-cargo/bin:$PATH"
               cargo build --release --workspace
             '
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Cargo home and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin


### PR DESCRIPTION
## Summary

- Add a concurrency group that cancels in-progress CI runs when a new push arrives on the same branch, reducing wasted runner minutes on active PRs.
- **Windows cache fix**: the acceptance script runs a second `cargo build --release` after Swatinem saves its snapshot, so each run accumulated new artifacts in a post-snapshot diff that was too large to compress and upload before the runner moved on. Pre-building the release packages in the explicit Build step ensures Swatinem captures the complete `target/` state upfront; the acceptance script's `cargo build` becomes a no-op on cache hits. Added `CARGO_INCREMENTAL=0` to reduce artifact size and `cache-on-failure` to improve reliability.
- **Manylinux caching** (`nightly` and `release` workflows): mount the host `~/.cargo` as `CARGO_HOME`/`RUSTUP_HOME` inside the Docker container and add an `actions/cache` step so the registry, toolchain, and `target/` survive between runs. Rustup install is skipped when a cached `cargo` binary is already present. Split the build into two `docker run` invocations — root for `yum install` (which needs `/var/cache/yum`), runner uid for the cargo build so cached files stay runner-owned. `mkdir -p ~/.cargo` before `docker run` to prevent Docker from creating the bind-mount source as root.
- Disable Swatinem cache on the `fmt` job — `cargo fmt` does not compile code and the cache restore/save cycle wastes bandwidth.
- Pin the `coverage` job toolchain to `1.96.0` to match `rust-toolchain.toml` (was pinned to `stable`, which can diverge).

## Test plan

- [x] CI green on this PR (verifies no YAML breakage, concurrency group fires correctly).
- [x] Windows `build-and-test` shows a cache hit on a second run (setup-rust-toolchain restore step is fast, Build step is incremental, Post Run is a no-op or near-instant).
- [x] Nightly: Linux manylinux build shows cache restore on subsequent runs (Rustup skipped, cargo build is incremental). Note: the nightly workflow runs on schedule and is not exercised by PR CI — verify on first nightly run after merge.