### PR TITLE
oss: clean up internal developer references for OSS readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/powderluv/rocm-cli"
+repository = "https://github.com/ROCm/rocm-cli"
 rust-version = "1.96"
 
 [workspace.dependencies]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -5727,7 +5727,7 @@ pub(crate) fn render_chat_prompt_result_with_progress(
         let _ = writeln!(output, "Assistant after ROCm checks");
         let _ = writeln!(
             output,
-            "I can install ROCm/TheRock, but I need the install folder first. Type the folder you want to use, for example D:\\jam\\temp\\therock_venvs. Nothing will download until ROCm CLI shows a review card and you approve it."
+            "I can install ROCm/TheRock, but I need the install folder first. Type the folder you want to use, for example D:\\ROCm\\therock_venvs. Nothing will download until ROCm CLI shows a review card and you approve it."
         );
     }
     if tool_result.approval.is_none()
@@ -12313,8 +12313,7 @@ fn build_freeform_plan_with_recipes(
                 actions: Vec::new(),
                 notes: vec![
                     "Choose a ROCm/TheRock install folder before approving an install.".to_owned(),
-                    "Say something like: install TheRock into D:\\jam\\temp\\therock_venvs."
-                        .to_owned(),
+                    "Say something like: install TheRock into D:\\ROCm\\therock_venvs.".to_owned(),
                 ],
             };
         };
@@ -14442,7 +14441,7 @@ mod tests {
     #[test]
     fn hybrid_planner_builds_nightly_therock_install_call() {
         let plan = build_freeform_plan(
-            "install the latest TheRock nightly for this GPU into D:\\jam\\temp\\therock_venvs",
+            "install the latest TheRock nightly for this GPU into D:\\ROCm\\therock_venvs",
             &RocmCliConfig::default(),
         );
 
@@ -14451,10 +14450,10 @@ mod tests {
             plan.parsed
                 .contains(&("channel".to_owned(), "nightly".to_owned()))
         );
-        assert!(plan.parsed.contains(&(
-            "prefix".to_owned(),
-            "D:\\jam\\temp\\therock_venvs".to_owned()
-        )));
+        assert!(
+            plan.parsed
+                .contains(&("prefix".to_owned(), "D:\\ROCm\\therock_venvs".to_owned()))
+        );
         assert!(plan.actions.iter().any(|action| {
             action.title == "Install TheRock SDK"
                 && action.approval == "required"
@@ -14467,7 +14466,7 @@ mod tests {
                         "--format".to_owned(),
                         "wheel".to_owned(),
                         "--prefix".to_owned(),
-                        "D:\\jam\\temp\\therock_venvs".to_owned(),
+                        "D:\\ROCm\\therock_venvs".to_owned(),
                     ]
         }));
     }
@@ -14475,7 +14474,7 @@ mod tests {
     #[test]
     fn hybrid_planner_builds_requested_therock_build_date_install_call() {
         let plan = build_freeform_plan(
-            "install the TheRock wheel from date 06052026 into D:\\jam\\temp\\therock_venvs",
+            "install the TheRock wheel from date 06052026 into D:\\ROCm\\therock_venvs",
             &RocmCliConfig::default(),
         );
 
@@ -14496,7 +14495,7 @@ mod tests {
                         "--format".to_owned(),
                         "wheel".to_owned(),
                         "--prefix".to_owned(),
-                        "D:\\jam\\temp\\therock_venvs".to_owned(),
+                        "D:\\ROCm\\therock_venvs".to_owned(),
                         "--build-date".to_owned(),
                         "2026-06-05".to_owned(),
                     ]
@@ -14982,7 +14981,7 @@ mod tests {
             arguments: serde_json::json!({
                 "channel": "release",
                 "format": "wheel",
-                "prefix": "D:\\jam\\temp\\therock_venvs"
+                "prefix": "D:\\ROCm\\therock_venvs"
             }),
         };
 
@@ -14991,7 +14990,7 @@ mod tests {
         assert_eq!(
             rocm_chat_tool_requested_command(&call).as_deref(),
             Some(
-                "rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs"
+                "rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs"
             )
         );
         let approval = chat_tool_approval_request(
@@ -15015,7 +15014,7 @@ mod tests {
                 "--format".to_owned(),
                 "wheel".to_owned(),
                 "--prefix".to_owned(),
-                "D:\\jam\\temp\\therock_venvs".to_owned(),
+                "D:\\ROCm\\therock_venvs".to_owned(),
             ]
         );
     }
@@ -15026,7 +15025,7 @@ mod tests {
             id: Some("call-date".to_owned()),
             name: "rocm_command".to_owned(),
             arguments: serde_json::json!({
-                "args": ["install", "sdk", "--channel", "release", "--format", "wheel", "--prefix", "D:\\jam\\temp\\therock_venvs", "--build-date", "06052026"],
+                "args": ["install", "sdk", "--channel", "release", "--format", "wheel", "--prefix", "D:\\ROCm\\therock_venvs", "--build-date", "06052026"],
                 "reason": "The user asked for the TheRock build from 2026-06-05."
             }),
         };
@@ -15036,7 +15035,7 @@ mod tests {
         assert_eq!(
             rocm_chat_tool_requested_command(&call).as_deref(),
             Some(
-                "rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs --build-date 06052026"
+                "rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs --build-date 06052026"
             )
         );
         let approval =
@@ -15053,7 +15052,7 @@ mod tests {
                 "--format".to_owned(),
                 "wheel".to_owned(),
                 "--prefix".to_owned(),
-                "D:\\jam\\temp\\therock_venvs".to_owned(),
+                "D:\\ROCm\\therock_venvs".to_owned(),
                 "--build-date".to_owned(),
                 "06052026".to_owned(),
             ]
@@ -15249,8 +15248,8 @@ examine:
   legacy_rocm_status: not_detected
 runtime_state:
   active_runtime_status: ready
-  active_runtime_root: D:\\jam\\temp\\therock_venvs
-  active_runtime_pip_cache_dir: D:\\jam\\temp\\therock_venvs\\pip-cache
+  active_runtime_root: D:\\ROCm\\therock_venvs
+  active_runtime_pip_cache_dir: D:\\ROCm\\therock_venvs\\pip-cache
   active_runtime_version: 7.13.0a20260511 (build 2026-05-11)
   active_runtime_family: gfx120X-all
 ",
@@ -15260,8 +15259,8 @@ runtime_state:
         assert!(summary.contains("GPU: AMD Radeon RX 9070 XT driver 32.0.23033.1002"));
         assert!(summary.contains("ROCm/TheRock: installed and active for ROCm CLI"));
         assert!(summary.contains("gfx120X-all"));
-        assert!(summary.contains(r"Install folder: D:\jam\temp\therock_venvs"));
-        assert!(summary.contains(r"Downloads/cache: D:\jam\temp\therock_venvs\pip-cache"));
+        assert!(summary.contains(r"Install folder: D:\ROCm\therock_venvs"));
+        assert!(summary.contains(r"Downloads/cache: D:\ROCm\therock_venvs\pip-cache"));
         assert!(summary.contains("no global legacy ROCm install was found"));
     }
 
@@ -15415,11 +15414,11 @@ model recipes
                     arguments: serde_json::json!({
                         "channel": "release",
                         "format": "wheel",
-                        "prefix": "D:\\jam\\temp\\therock_venvs"
+                        "prefix": "D:\\ROCm\\therock_venvs"
                     }),
                 },
                 Some(
-                    "rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs",
+                    "rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs",
                 ),
                 false,
             ),
@@ -15851,7 +15850,7 @@ model recipes
                 arguments: serde_json::json!({
                     "channel": "release",
                     "format": "wheel",
-                    "prefix": "D:\\jam\\temp\\therock_venvs"
+                    "prefix": "D:\\ROCm\\therock_venvs"
                 }),
             }],
         };
@@ -16059,10 +16058,10 @@ model recipes
     fn fallback_tool_call_preserves_requested_therock_install_prefix() {
         for (prompt, expected_prefix) in [
             (
-                "install TheRock for me in D:\\jam\\temp\\therock_venvs",
-                "D:\\jam\\temp\\therock_venvs",
+                "install TheRock for me in D:\\ROCm\\therock_venvs",
+                "D:\\ROCm\\therock_venvs",
             ),
-            ("install ROCm to D:\\jam\\temp", "D:\\jam\\temp"),
+            ("install ROCm to D:\\ROCm\\temp", "D:\\ROCm\\temp"),
         ] {
             let call = fallback_rocm_tool_call_for_prompt(prompt).unwrap();
             assert_eq!(call.name, "rocm_command");
@@ -16087,12 +16086,12 @@ model recipes
     fn fallback_tool_call_routes_requested_therock_build_date_install() {
         for (prompt, expected_prefix) in [
             (
-                "Install this specific TheRock wheel from date 06052026 into D:\\jam\\temp\\therock_venvs",
-                "D:\\jam\\temp\\therock_venvs",
+                "Install this specific TheRock wheel from date 06052026 into D:\\ROCm\\therock_venvs",
+                "D:\\ROCm\\therock_venvs",
             ),
             (
-                "install ROCm at D:\\jam\\temp with build date 2026-06-05",
-                "D:\\jam\\temp",
+                "install ROCm at D:\\ROCm\\temp with build date 2026-06-05",
+                "D:\\ROCm\\temp",
             ),
         ] {
             let call = fallback_rocm_tool_call_for_prompt(prompt).unwrap();
@@ -16240,7 +16239,7 @@ install therock";
     #[test]
     fn chat_install_intent_preserves_bare_folder_path() {
         let approval =
-            install_sdk_chat_approval_for_prompt("install therock D:\\jam\\temp\\therock_venvs")
+            install_sdk_chat_approval_for_prompt("install therock D:\\ROCm\\therock_venvs")
                 .expect("direct install prompt should be recognized");
 
         assert_eq!(
@@ -16253,7 +16252,7 @@ install therock";
                 "--format".to_owned(),
                 "wheel".to_owned(),
                 "--prefix".to_owned(),
-                "D:\\jam\\temp\\therock_venvs".to_owned(),
+                "D:\\ROCm\\therock_venvs".to_owned(),
             ]
         );
     }
@@ -16261,7 +16260,7 @@ install therock";
     #[test]
     fn fallback_tool_call_routes_requested_therock_exact_version_install() {
         let call = fallback_rocm_tool_call_for_prompt(
-            "Install the TheRock ROCm wheel version 7.13.0a20260605 into D:\\jam\\temp\\therock_venvs",
+            "Install the TheRock ROCm wheel version 7.13.0a20260605 into D:\\ROCm\\therock_venvs",
         )
         .unwrap();
         assert_eq!(call.name, "rocm_command");
@@ -16275,7 +16274,7 @@ install therock";
                 "--format".to_owned(),
                 "wheel".to_owned(),
                 "--prefix".to_owned(),
-                "D:\\jam\\temp\\therock_venvs".to_owned(),
+                "D:\\ROCm\\therock_venvs".to_owned(),
                 "--version".to_owned(),
                 "7.13.0a20260605".to_owned(),
             ]
@@ -16288,7 +16287,7 @@ install therock";
         let call = providers::ChatToolCall {
             id: Some("path-check".to_owned()),
             name: "path_exists".to_owned(),
-            arguments: serde_json::json!({ "path": "D:\\jam\\temp" }),
+            arguments: serde_json::json!({ "path": "D:\\ROCm\\temp" }),
         };
 
         validate_chat_tool_call(&call).unwrap();
@@ -16500,7 +16499,7 @@ install therock";
 
         let final_answer = providers::ChatResponse {
             tool_calls: Vec::new(),
-            content: "The runtime root is D:\\jam\\temp\\therock_venvs.".to_owned(),
+            content: "The runtime root is D:\\ROCm\\therock_venvs.".to_owned(),
             ..response
         };
         assert!(local_follow_up_content_is_final(&final_answer));
@@ -16510,9 +16509,9 @@ install therock";
     fn visible_chat_content_removes_reasoning_blocks() {
         assert_eq!(
             visible_chat_content(
-                "<think>\nchecking the tool output\n</think>\nThe runtime root is D:\\jam\\temp."
+                "<think>\nchecking the tool output\n</think>\nThe runtime root is D:\\ROCm\\temp."
             ),
-            "The runtime root is D:\\jam\\temp."
+            "The runtime root is D:\\ROCm\\temp."
         );
         assert_eq!(
             visible_chat_content("Before\n<THINK>hidden</THINK>\nAfter"),
@@ -17076,7 +17075,7 @@ install therock";
             "--format",
             "wheel",
             "--prefix",
-            "D:\\jam\\temp\\therock_venvs",
+            "D:\\ROCm\\therock_venvs",
             "--family",
             "gfx110X-all",
         ])
@@ -18915,21 +18914,21 @@ VERSION_ID="41"
     fn friendly_engine_detect_notes_hide_probe_and_path_noise() {
         let pytorch = friendly_engine_detect_notes(
             "pytorch",
-            &[r"torch probe: cuda_available=true device_count=1; managed env detected at C:\Users\jam\.rocm\engines\pytorch\envs\release; rocm_sdk: version=7.13".to_owned()],
+            &[r"torch probe: cuda_available=true device_count=1; managed env detected at C:\Users\user\.rocm\engines\pytorch\envs\release; rocm_sdk: version=7.13".to_owned()],
         )
         .expect("pytorch note");
         assert_eq!(pytorch, "PyTorch is ready on your AMD GPU.");
 
         let lemonade = friendly_engine_detect_notes(
             "lemonade",
-            &["Lemonade embeddable 10.6.0 is installed at D:/jam/temp/runtime; Lemonade is configured for llamacpp:rocm; no CPU fallback is used".to_owned()],
+            &["Lemonade embeddable 10.6.0 is installed at D:/ROCm/temp/runtime; Lemonade is configured for llamacpp:rocm; no CPU fallback is used".to_owned()],
         )
         .expect("lemonade note");
         assert_eq!(lemonade, "Lemonade is ready on your AMD GPU.");
 
         let llama = friendly_engine_detect_notes(
             "llama.cpp",
-            &["llama-server not found; TheRock HIP runtime env available: root=D:\\jam\\temp\\therock".to_owned()],
+            &["llama-server not found; TheRock HIP runtime env available: root=D:\\ROCm\\temp\\therock".to_owned()],
         )
         .expect("llama.cpp note");
         assert_eq!(llama, "llama.cpp server is not installed yet.");

--- a/apps/rocm/src/provider_keys.rs
+++ b/apps/rocm/src/provider_keys.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use keyring_core::api::CredentialStoreApi;
 use keyring_core::{Entry, Error as KeyringError};
 
-const PROVIDER_KEY_SERVICE: &str = "powderluv.rocm-cli.provider-key";
+const PROVIDER_KEY_SERVICE: &str = "org.rocm.rocm-cli.provider-key";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum ProviderKeyState {

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -3488,10 +3488,10 @@ mod tests {
 
     #[test]
     fn python_venv_args_use_python_default_linking() {
-        let args = python_venv_args(Path::new("/mnt/d/jam/rocm"));
+        let args = python_venv_args(Path::new("/mnt/d/path/to/rocm"));
 
         assert!(!args.iter().any(|arg| arg == "--copies"));
-        assert_eq!(args.last().map(String::as_str), Some("/mnt/d/jam/rocm"));
+        assert_eq!(args.last().map(String::as_str), Some("/mnt/d/path/to/rocm"));
     }
 
     #[test]
@@ -3916,6 +3916,15 @@ echo Python 3.12.10
             http_header_value(headers, "last-modified").as_deref(),
             Some("today")
         );
+    }
+
+    #[test]
+    fn windows_child_path_maps_ape_drive_paths() {
+        assert_eq!(
+            windows_child_path(Path::new("/D/path/to/rocm-cli/file.ps1")),
+            r"D:\path\to\rocm-cli\file.ps1"
+        );
+        assert_eq!(windows_child_path(Path::new("/c")), r"C:\");
     }
 
     #[test]

--- a/apps/rocm/src/tui.rs
+++ b/apps/rocm/src/tui.rs
@@ -22783,12 +22783,12 @@ fn help_topic_detail(topic: HelpTopic) -> String {
             "",
             "From a terminal:",
             "  rocm setup reset",
-            "  rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs",
+            "  rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs",
             "  rocm runtimes list",
             "  rocm runtimes activate <runtime_key>",
             "",
             "Use a full path for --prefix.",
-            "On Linux or WSL, use a Linux path such as /home/jam/rocm_venvs.",
+            "On Linux or WSL, use a Linux path such as /home/user/rocm_venvs.",
         ]
         .join("\n"),
         HelpTopic::LocalModels => [
@@ -26141,7 +26141,7 @@ fn render_local_rocm_tools_chat_intro(service: Option<&ManagedServiceRecord>) ->
     );
     let _ = writeln!(
         output,
-        "  Install the TheRock build from 06052026 into D:\\jam\\temp\\therock_venvs."
+        "  Install the TheRock build from 06052026 into D:\\ROCm\\therock_venvs."
     );
     let _ = writeln!(output, "  Start a small local model.");
     let _ = writeln!(output, "  What local models are running?");
@@ -29092,45 +29092,45 @@ mod tests {
     #[test]
     fn examine_folders_separates_app_data_from_custom_rocm_install_folder() {
         let report = [
-            r"config_dir: C:\Users\jam\.rocm",
-            r"data_dir: C:\Users\jam\.rocm",
-            r"cache_dir: C:\Users\jam\.rocm\cache",
+            r"config_dir: C:\Users\user\.rocm",
+            r"data_dir: C:\Users\user\.rocm",
+            r"cache_dir: C:\Users\user\.rocm\cache",
             r"active_runtime_status: ready",
-            r"active_runtime_root: D:\jam\temp\therock_venvs",
-            r"active_runtime_pip_cache_dir: D:\jam\temp\therock_venvs\pip-cache",
+            r"active_runtime_root: D:\ROCm\therock_venvs",
+            r"active_runtime_pip_cache_dir: D:\ROCm\therock_venvs\pip-cache",
             "model_cache_entries: 0",
         ]
         .join("\n");
 
         let rendered = super::examine_folders_text(&report);
 
-        assert!(rendered.contains(r"Settings: C:\Users\jam\.rocm"));
-        assert!(rendered.contains(r"Logs and app data: C:\Users\jam\.rocm"));
-        assert!(rendered.contains(r"App metadata cache: C:\Users\jam\.rocm\cache"));
-        assert!(rendered.contains(r"ROCm install downloads: D:\jam\temp\therock_venvs\pip-cache"));
-        assert!(rendered.contains(r"Active ROCm install: D:\jam\temp\therock_venvs"));
-        assert!(!rendered.contains(r"Downloaded files: C:\Users\jam\.rocm\cache"));
+        assert!(rendered.contains(r"Settings: C:\Users\user\.rocm"));
+        assert!(rendered.contains(r"Logs and app data: C:\Users\user\.rocm"));
+        assert!(rendered.contains(r"App metadata cache: C:\Users\user\.rocm\cache"));
+        assert!(rendered.contains(r"ROCm install downloads: D:\ROCm\therock_venvs\pip-cache"));
+        assert!(rendered.contains(r"Active ROCm install: D:\ROCm\therock_venvs"));
+        assert!(!rendered.contains(r"Downloaded files: C:\Users\user\.rocm\cache"));
         assert!(!rendered.contains("ROCm installs and logs"));
     }
 
     #[test]
     fn examine_folders_uses_setup_folder_for_rocm_downloads_before_activation() {
         let report = [
-            r"config_dir: C:\Users\jam\.rocm",
-            r"data_dir: C:\Users\jam\.rocm",
-            r"cache_dir: C:\Users\jam\.rocm\cache",
+            r"config_dir: C:\Users\user\.rocm",
+            r"data_dir: C:\Users\user\.rocm",
+            r"cache_dir: C:\Users\user\.rocm\cache",
             r"active_runtime_status: unset",
-            r"setup_runtime_root: D:\jam\temp\therock_venvs",
-            r"setup_runtime_pip_cache_dir: D:\jam\temp\therock_venvs\pip-cache",
+            r"setup_runtime_root: D:\ROCm\therock_venvs",
+            r"setup_runtime_pip_cache_dir: D:\ROCm\therock_venvs\pip-cache",
             "model_cache_entries: 0",
         ]
         .join("\n");
 
         let rendered = super::examine_folders_text(&report);
 
-        assert!(rendered.contains(r"App metadata cache: C:\Users\jam\.rocm\cache"));
-        assert!(rendered.contains(r"ROCm install downloads: D:\jam\temp\therock_venvs\pip-cache"));
-        assert!(rendered.contains(r"Active ROCm install: D:\jam\temp\therock_venvs"));
+        assert!(rendered.contains(r"App metadata cache: C:\Users\user\.rocm\cache"));
+        assert!(rendered.contains(r"ROCm install downloads: D:\ROCm\therock_venvs\pip-cache"));
+        assert!(rendered.contains(r"Active ROCm install: D:\ROCm\therock_venvs"));
     }
 
     #[test]
@@ -29721,7 +29721,7 @@ mod tests {
             super::RunningJobKind::Cli,
             Ok(super::CommandOutput {
                 ok: true,
-                rendered: "ComfyUI\n  status: running\n  URL: http://127.0.0.1:8188\n  models folder: D:\\jam\\temp\\ComfyUI\\models\n".to_owned(),
+                rendered: "ComfyUI\n  status: running\n  URL: http://127.0.0.1:8188\n  models folder: D:\\ROCm\\ComfyUI\\models\n".to_owned(),
                 chat_approval: None,
             }),
             super::StreamedOutputCounts {
@@ -29736,7 +29736,7 @@ mod tests {
         assert!(rendered.contains("Open this URL:"));
         assert!(rendered.contains("http://127.0.0.1:8188"));
         assert!(rendered.contains("Show models path"));
-        assert!(rendered.contains("D:\\jam\\temp\\ComfyUI\\models"));
+        assert!(rendered.contains("D:\\ROCm\\ComfyUI\\models"));
         assert!(rendered.contains("rocm comfyui models-path"));
         assert!(rendered.contains("Put models here:"));
         assert!(!rendered.contains("Status: ok"));
@@ -33724,7 +33724,7 @@ mod tests {
         assert!(!rendered.contains("I checked ROCm"), "{rendered}");
 
         handle_key(&mut app, key_event(KeyCode::Esc, KeyModifiers::NONE));
-        app.set_input("use D:\\jam\\temp\\therock_venvs".to_owned());
+        app.set_input("use D:\\ROCm\\therock_venvs".to_owned());
         handle_key(&mut app, key_event(KeyCode::Enter, KeyModifiers::NONE));
 
         assert!(
@@ -33747,9 +33747,9 @@ mod tests {
                     display_command: Some(display),
                     ..
                 } if args.windows(2).any(|pair| {
-                    pair[0] == "--prefix" && pair[1] == "D:\\jam\\temp\\therock_venvs"
+                    pair[0] == "--prefix" && pair[1] == "D:\\ROCm\\therock_venvs"
                 })
-                    && display.contains("D:\\jam\\temp\\therock_venvs")
+                    && display.contains("D:\\ROCm\\therock_venvs")
             ),
             "{pending:#?}"
         );
@@ -33757,10 +33757,7 @@ mod tests {
         assert!(rendered.contains("Install ROCm"), "{rendered}");
         assert!(!rendered.contains("Review this change"), "{rendered}");
         assert!(!rendered.contains("What will happen"), "{rendered}");
-        assert!(
-            rendered.contains("D:\\jam\\temp\\therock_venvs"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("D:\\ROCm\\therock_venvs"), "{rendered}");
         assert!(!rendered.contains("I checked ROCm"), "{rendered}");
         Ok(())
     }
@@ -34026,7 +34023,7 @@ mod tests {
     #[test]
     fn home_install_prompt_with_folder_opens_review_card_without_chat() {
         let mut app = test_app();
-        app.set_input("install therock into D:\\jam\\temp\\therock_venvs".to_owned());
+        app.set_input("install therock into D:\\ROCm\\therock_venvs".to_owned());
         handle_key(&mut app, key_event(KeyCode::Enter, KeyModifiers::NONE));
 
         assert!(app.install_manager.is_none());
@@ -34044,8 +34041,8 @@ mod tests {
                 display_command: Some(display),
                 ..
             } if args.windows(2).any(|pair| {
-                pair[0] == "--prefix" && pair[1] == "D:\\jam\\temp\\therock_venvs"
-            }) && display.contains("D:\\jam\\temp\\therock_venvs")
+                pair[0] == "--prefix" && pair[1] == "D:\\ROCm\\therock_venvs"
+            }) && display.contains("D:\\ROCm\\therock_venvs")
         ));
         let rendered = render_test_terminal(&app, 120, 32);
         assert!(rendered.contains("Install ROCm"), "{rendered}");
@@ -34153,7 +34150,7 @@ mod tests {
                 "rocm engines install lemonade",
             ),
             (
-                "install this specific TheRock wheel from date 06052026 into D:\\jam\\temp\\therock_venvs",
+                "install this specific TheRock wheel from date 06052026 into D:\\ROCm\\therock_venvs",
                 serde_json::json!({
                     "choices": [{
                         "message": {
@@ -34164,17 +34161,17 @@ mod tests {
                                 "type": "function",
                                 "function": {
                                     "name": "rocm_command",
-                                    "arguments": "{\"args\":[\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"pip\",\"--prefix\",\"D:\\\\jam\\\\temp\\\\therock_venvs\",\"--build-date\",\"2026-06-05\"],\"reason\":\"Install the requested TheRock build date into the user's folder.\"}"
+                                    "arguments": "{\"args\":[\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"pip\",\"--prefix\",\"D:\\\\ROCm\\\\therock_venvs\",\"--build-date\",\"2026-06-05\"],\"reason\":\"Install the requested TheRock build date into the user's folder.\"}"
                                 }
                             }]
                         }
                     }]
                 }),
                 "Install ROCm",
-                "rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs --build-date 2026-06-05",
+                "rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs --build-date 2026-06-05",
             ),
             (
-                "install TheRock version 7.13.0a20260605 into D:\\jam\\temp\\therock_venvs",
+                "install TheRock version 7.13.0a20260605 into D:\\ROCm\\therock_venvs",
                 serde_json::json!({
                     "choices": [{
                         "message": {
@@ -34185,14 +34182,14 @@ mod tests {
                                 "type": "function",
                                 "function": {
                                     "name": "rocm_command",
-                                    "arguments": "{\"args\":[\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"pip\",\"--prefix\",\"D:\\\\jam\\\\temp\\\\therock_venvs\",\"--version\",\"7.13.0a20260605\"],\"reason\":\"Install the requested exact TheRock version into the user's folder.\"}"
+                                    "arguments": "{\"args\":[\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"pip\",\"--prefix\",\"D:\\\\ROCm\\\\therock_venvs\",\"--version\",\"7.13.0a20260605\"],\"reason\":\"Install the requested exact TheRock version into the user's folder.\"}"
                                 }
                             }]
                         }
                     }]
                 }),
                 "Install ROCm",
-                "rocm install sdk --channel release --format wheel --prefix D:\\jam\\temp\\therock_venvs --version 7.13.0a20260605",
+                "rocm install sdk --channel release --format wheel --prefix D:\\ROCm\\therock_venvs --version 7.13.0a20260605",
             ),
         ] {
             let mut app = test_app();
@@ -34469,7 +34466,7 @@ mod tests {
                             "type": "function",
                             "function": {
                                 "name": "install_sdk",
-                                "arguments": "{\"channel\":\"release\",\"format\":\"pip\",\"prefix\":\"D:\\\\jam\\\\temp\\\\therock_venvs\"}"
+                                "arguments": "{\"channel\":\"release\",\"format\":\"pip\",\"prefix\":\"D:\\\\ROCm\\\\therock_venvs\"}"
                             }
                         }]
                     }
@@ -34496,7 +34493,7 @@ mod tests {
             model: Some("Qwen/Qwen3.5".to_owned()),
             messages: vec![crate::providers::ChatMessage {
                 role: "user".to_owned(),
-                content: "help me install ROCm in D:\\jam\\temp\\therock_venvs".to_owned(),
+                content: "help me install ROCm in D:\\ROCm\\therock_venvs".to_owned(),
             }],
             max_tokens: None,
             rocm_tools: true,
@@ -34604,8 +34601,8 @@ Assistant is checking ROCm first.
 ROCm checks used
   Examine: ok
     os: windows
-    data_dir: C:\\Users\\jam\\.rocm
-    cache_dir: C:\\Users\\jam\\.rocm\\cache
+    data_dir: C:\\Users\\user\\.rocm
+    cache_dir: C:\\Users\\user\\.rocm\\cache
 
 Assistant after ROCm checks
 ROCm is installed and ready.";
@@ -34633,13 +34630,13 @@ Assistant is checking ROCm first.
 ROCm checks used
   Examine: ok
     os: windows
-    data_dir: C:\\Users\\jam\\.rocm
+    data_dir: C:\\Users\\user\\.rocm
 
 ROCm CLI summary
   GPU: AMD Radeon RX 9070 XT
   ROCm/TheRock: installed and active for ROCm CLI (gfx120X-all), 7.13.0a20260511
-  Install folder: D:\\jam\\temp\\therock_venvs
-  Downloads/cache: D:\\jam\\temp\\therock_venvs\\pip-cache
+  Install folder: D:\\ROCm\\therock_venvs
+  Downloads/cache: D:\\ROCm\\therock_venvs\\pip-cache
   Note: no global legacy ROCm install was found; ROCm CLI is using its managed TheRock runtime.";
 
         let display = super::chat_session_display_text(rendered);
@@ -34647,8 +34644,8 @@ ROCm CLI summary
         assert!(display.contains("Here is what I found on this computer."));
         assert!(display.contains("AMD Radeon RX 9070 XT"));
         assert!(display.contains("installed and active for ROCm CLI"));
-        assert!(display.contains("D:\\jam\\temp\\therock_venvs"));
-        assert!(display.contains("D:\\jam\\temp\\therock_venvs\\pip-cache"));
+        assert!(display.contains("D:\\ROCm\\therock_venvs"));
+        assert!(display.contains("D:\\ROCm\\therock_venvs\\pip-cache"));
         assert!(!display.contains("I checked ROCm"));
         assert!(!display.contains("provider:"));
         assert!(!display.contains("data_dir:"));
@@ -34670,7 +34667,7 @@ Recent output
   Warning: pip is checking candidates
 
 Full log
-  C:\\Users\\jam\\.rocm\\logs\\tui\\123-install.log";
+  C:\\Users\\user\\.rocm\\logs\\tui\\123-install.log";
 
         let display = super::chat_session_command_result_text("Install", false, summary);
         let detail = super::chat_session_command_result_detail("Install", false, summary);
@@ -34680,21 +34677,21 @@ Full log
         assert!(!display.contains("Recent command output"));
         assert!(!display.contains("Output: resolving torch wheels"));
         assert!(!display.contains("Warning: pip is checking candidates"));
-        assert!(!display.contains("C:\\Users\\jam\\.rocm\\logs\\tui\\123-install.log"));
+        assert!(!display.contains("C:\\Users\\user\\.rocm\\logs\\tui\\123-install.log"));
 
         assert!(detail.contains("Error: No matching distribution found for torch"));
         assert!(detail.contains("Live output"));
         assert!(detail.contains("Output: resolving torch wheels"));
         assert!(detail.contains("Warning: pip is checking candidates"));
         assert!(detail.contains("More details are available in Logs."));
-        assert!(!detail.contains("C:\\Users\\jam\\.rocm\\logs\\tui\\123-install.log"));
+        assert!(!detail.contains("C:\\Users\\user\\.rocm\\logs\\tui\\123-install.log"));
     }
 
     #[test]
     fn chat_session_next_prompt_includes_rocm_command_result() {
         let mut app = test_app();
         app.open_local_rocm_tools_chat_session(None);
-        let summary = "Install finished.\n\nRecent output\n  Output: ROCm installed into D:\\jam\\temp\\therock_venvs\n\nFull log\n  C:\\Users\\jam\\.rocm\\logs\\tui\\123-install.log";
+        let summary = "Install finished.\n\nRecent output\n  Output: ROCm installed into D:\\ROCm\\therock_venvs\n\nFull log\n  C:\\Users\\user\\.rocm\\logs\\tui\\123-install.log";
         app.push_chat_session_turn_with_detail(
             super::ChatSessionRole::Tool,
             super::chat_session_command_result_text("Install", true, summary),
@@ -34706,10 +34703,10 @@ Full log
         let prompt = app.chat_session_request_prompt("what should I do next?");
 
         assert!(prompt.contains("ROCm command result: Install finished."));
-        assert!(prompt.contains("ROCm installed into D:\\jam\\temp\\therock_venvs"));
+        assert!(prompt.contains("ROCm installed into D:\\ROCm\\therock_venvs"));
         assert!(prompt.contains("ROCm command result details:"));
         assert!(prompt.contains("More details are available in Logs."));
-        assert!(!prompt.contains("C:\\Users\\jam\\.rocm\\logs\\tui\\123-install.log"));
+        assert!(!prompt.contains("C:\\Users\\user\\.rocm\\logs\\tui\\123-install.log"));
         assert!(prompt.contains("New message:"));
         assert!(prompt.contains("what should I do next?"));
     }
@@ -34894,7 +34891,7 @@ Full log
         sender
             .send(super::RunningJobEvent::Stream {
                 stream: super::CommandOutputStream::Stdout,
-                line: "ROCm installed into D:\\jam\\temp\\therock_venvs".to_owned(),
+                line: "ROCm installed into D:\\ROCm\\therock_venvs".to_owned(),
             })
             .unwrap();
         sender
@@ -34922,15 +34919,15 @@ Full log
         assert!(
             !tool_turn
                 .content
-                .contains("ROCm installed into D:\\jam\\temp\\therock_venvs")
+                .contains("ROCm installed into D:\\ROCm\\therock_venvs")
         );
         assert!(!tool_turn.content.contains("Choose ROCm result"));
         assert!(tool_turn.detail.as_deref().is_some_and(|detail| {
-            detail.contains("ROCm installed into D:\\jam\\temp\\therock_venvs")
+            detail.contains("ROCm installed into D:\\ROCm\\therock_venvs")
         }));
         assert!(
             super::latest_chat_session_tool_detail(session).is_some_and(
-                |detail| detail.contains("ROCm installed into D:\\jam\\temp\\therock_venvs")
+                |detail| detail.contains("ROCm installed into D:\\ROCm\\therock_venvs")
             )
         );
         assert!(
@@ -35972,7 +35969,7 @@ Full log
         sender
             .send(super::RunningJobEvent::Finished(Ok(super::CommandOutput {
                 ok: true,
-                rendered: "ComfyUI\n  status: installed\n  models path: C:\\Users\\jam\\.rocm\\apps\\comfyui\\source\\models\n  next step: rocm comfyui start\n".to_owned(),
+                rendered: "ComfyUI\n  status: installed\n  models path: C:\\Users\\user\\.rocm\\apps\\comfyui\\source\\models\n  next step: rocm comfyui start\n".to_owned(),
                 chat_approval: None,
             })))
             .unwrap();
@@ -35995,7 +35992,7 @@ Full log
         assert!(
             tool_turn
                 .content
-                .contains("C:\\Users\\jam\\.rocm\\apps\\comfyui\\source\\models")
+                .contains("C:\\Users\\user\\.rocm\\apps\\comfyui\\source\\models")
         );
         assert!(!tool_turn.content.contains("ComfyUI finished."));
     }
@@ -36013,7 +36010,7 @@ Full log
             .send(super::RunningJobEvent::Finished(Ok(super::CommandOutput {
                 ok: true,
                 rendered: format!(
-                    "ComfyUI\n  status: running\n  URL: {url}\n  models path: C:\\Users\\jam\\.rocm\\apps\\comfyui\\source\\models\n"
+                    "ComfyUI\n  status: running\n  URL: {url}\n  models path: C:\\Users\\user\\.rocm\\apps\\comfyui\\source\\models\n"
                 ),
                 chat_approval: None,
             })))
@@ -36036,7 +36033,7 @@ Full log
         assert!(
             tool_turn
                 .content
-                .contains("C:\\Users\\jam\\.rocm\\apps\\comfyui\\source\\models")
+                .contains("C:\\Users\\user\\.rocm\\apps\\comfyui\\source\\models")
         );
         assert!(!tool_turn.content.contains("ComfyUI finished."));
 
@@ -36949,7 +36946,7 @@ Full log
             gfx_target: Some("gfx1201".to_owned()),
             therock_family: Some("gfx120X-all".to_owned()),
         };
-        let folder = r"D:\jam\temp\therock_venvs";
+        let folder = r"D:\ROCm\therock_venvs";
         app.request_screen_cli_approval_with_explanation(
             "Install ROCm",
             "Install",
@@ -36992,7 +36989,7 @@ Full log
     fn full_access_still_reviews_rocm_install_and_remove() {
         let mut app = test_app();
         app.config.permissions.mode = PERMISSIONS_MODE_FULL_ACCESS.to_owned();
-        let folder = r"D:\jam\temp\therock_venvs";
+        let folder = r"D:\ROCm\therock_venvs";
 
         app.request_screen_cli_approval_with_explanation(
             "Install ROCm",
@@ -37794,17 +37791,17 @@ Full log
             ),
             ("Preparing Python 3.12...", "Checking Python..."),
             (
-                "Using existing Python 3.12 at C:\\Users\\jam\\.rocm\\tools\\python\\python.exe.",
+                "Using existing Python 3.12 at C:\\Users\\user\\.rocm\\tools\\python\\python.exe.",
                 "Checking Python...",
             ),
             (
-                "Python 3.12 is ready at C:\\Users\\jam\\.rocm\\tools\\python\\python.exe.",
+                "Python 3.12 is ready at C:\\Users\\user\\.rocm\\tools\\python\\python.exe.",
                 "Checking Python...",
             ),
             ("Finding Python 3.12...", "Checking Python..."),
             ("Installing Python 3.12 via uv...", "Installing Python..."),
             (
-                "Creating Python environment at C:\\Users\\jam\\.rocm\\envs\\default.",
+                "Creating Python environment at C:\\Users\\user\\.rocm\\envs\\default.",
                 "Setting up Python...",
             ),
             (
@@ -39048,11 +39045,11 @@ Full log
     #[test]
     fn command_parser_preserves_quoted_windows_path_backslashes() {
         let parts = super::split_command_line(
-            r#"serve "C:\Users\jam\My Models\tiny.gguf" --engine llama.cpp"#,
+            r#"serve "C:\Users\user\My Models\tiny.gguf" --engine llama.cpp"#,
         )
         .expect("quoted windows path should parse");
 
-        assert_eq!(parts[1], r"C:\Users\jam\My Models\tiny.gguf");
+        assert_eq!(parts[1], r"C:\Users\user\My Models\tiny.gguf");
     }
 
     #[test]
@@ -40086,7 +40083,7 @@ Full log
     fn chat_session_message_box_wraps_and_scrolls_long_prompt() {
         let mut app = test_app();
         app.open_local_rocm_tools_chat_session(None);
-        let prompt = "install ROCm into D:\\jam\\temp\\therock_venvs and then explain exactly what folder will be used before you do anything ".repeat(8);
+        let prompt = "install ROCm into D:\\ROCm\\therock_venvs and then explain exactly what folder will be used before you do anything ".repeat(8);
         app.set_input(prompt);
 
         assert!(
@@ -44079,12 +44076,12 @@ Full log
                 "runtime_id": "runtime",
                 "runtime_key": "release",
                 "runtime_version": "7.13.0a20260511",
-                "runtime_root": "D:\\jam\\temp\\therock_venvs",
+                "runtime_root": "D:\\ROCm\\therock_venvs",
                 "python_executable": "python",
                 "source_url": "https://github.com/comfyanonymous/ComfyUI/archive/refs/heads/master.tar.gz",
                 "source_path": source_path,
                 "requirements_path": "requirements.txt",
-                "pip_cache_dir": "D:\\jam\\temp\\therock_venvs\\pip-cache",
+                "pip_cache_dir": "D:\\ROCm\\therock_venvs\\pip-cache",
                 "log_path": log_path,
                 "torch_version": "2.10.0",
                 "torch_cuda_available": true,

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -197,7 +197,7 @@ pub(crate) fn home_rocm_dir() -> Option<PathBuf> {
 }
 
 fn project_dirs() -> Option<ProjectDirs> {
-    ProjectDirs::from("com", "powderluv", "rocm-cli")
+    ProjectDirs::from("org", "ROCm", "rocm-cli")
 }
 
 pub fn default_config_dir() -> Option<PathBuf> {
@@ -663,13 +663,13 @@ mod tests {
             return;
         }
 
-        let path = normalize_windows_runtime_path_text(r"D:\/jam/temp/therock_venvs");
+        let path = normalize_windows_runtime_path_text(r"D:\/path/to/therock_venvs");
 
         assert!(windows_runtime_path_text_is_absolute(&path));
         if std::path::MAIN_SEPARATOR == '\\' {
-            assert_eq!(path, r"D:\jam\temp\therock_venvs");
+            assert_eq!(path, r"D:\path\to\therock_venvs");
         } else {
-            assert_eq!(path, "D:/jam/temp/therock_venvs");
+            assert_eq!(path, "D:/path/to/therock_venvs");
         }
     }
 
@@ -679,13 +679,13 @@ mod tests {
             return;
         }
 
-        let path = normalize_windows_runtime_path_text("/D/jam/temp/therock_venvs");
+        let path = normalize_windows_runtime_path_text("/D/path/to/therock_venvs");
 
         assert!(windows_runtime_path_text_is_absolute(&path));
         if std::path::MAIN_SEPARATOR == '\\' {
-            assert_eq!(path, r"D:\jam\temp\therock_venvs");
+            assert_eq!(path, r"D:\path\to\therock_venvs");
         } else {
-            assert_eq!(path, "D:/jam/temp/therock_venvs");
+            assert_eq!(path, "D:/path/to/therock_venvs");
         }
     }
 
@@ -696,12 +696,12 @@ mod tests {
         }
 
         assert_eq!(
-            normalize_runtime_path_text_for_storage("/D/jam/temp/therock_venvs"),
-            r"D:\jam\temp\therock_venvs"
+            normalize_runtime_path_text_for_storage("/D/path/to/therock_venvs"),
+            r"D:\path\to\therock_venvs"
         );
         assert_eq!(
-            normalize_runtime_path_text_for_storage("D:/jam/temp/therock_venvs"),
-            r"D:\jam\temp\therock_venvs"
+            normalize_runtime_path_text_for_storage("D:/path/to/therock_venvs"),
+            r"D:\path\to\therock_venvs"
         );
     }
 
@@ -720,9 +720,9 @@ mod tests {
     #[test]
     fn runtime_path_normalization_accepts_windows_drive_forms() {
         let cases = [
-            (r"D:\jam\temp\therock_venvs", "D:/jam/temp/therock_venvs"),
-            ("D:/jam/temp/therock_venvs", "D:/jam/temp/therock_venvs"),
-            (r"D:\/jam/temp/therock_venvs", "D:/jam/temp/therock_venvs"),
+            (r"D:\path\to\therock_venvs", "D:/path/to/therock_venvs"),
+            ("D:/path/to/therock_venvs", "D:/path/to/therock_venvs"),
+            (r"D:\/path/to/therock_venvs", "D:/path/to/therock_venvs"),
         ];
         for (input, expected) in cases {
             assert_eq!(
@@ -763,7 +763,7 @@ mod tests {
 
     #[test]
     fn runtime_path_normalization_keeps_wsl_paths_linux_native() {
-        let wsl_path = "/mnt/d/jam/temp/therock_venvs";
+        let wsl_path = "/mnt/d/path/to/therock_venvs";
         assert_eq!(
             normalize_runtime_path_text_for_platform(wsl_path, RuntimePlatform::Linux),
             wsl_path
@@ -776,7 +776,7 @@ mod tests {
 
     #[test]
     fn runtime_path_normalization_does_not_treat_windows_drive_as_linux_absolute() {
-        let windows_path = r"D:\jam\temp\therock_venvs";
+        let windows_path = r"D:\path\to\therock_venvs";
         assert_eq!(
             normalize_runtime_path_text_for_platform(windows_path, RuntimePlatform::Linux),
             windows_path

--- a/docs/atom.md
+++ b/docs/atom.md
@@ -40,7 +40,7 @@ rocm-cli managed TheRock runtime:
 
 ```bash
 python3 scripts/atom_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-atom \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-atom \
   --model Qwen/Qwen3-0.6B
 ```
 

--- a/docs/current-tui-therock-correction-plan.md
+++ b/docs/current-tui-therock-correction-plan.md
@@ -6,7 +6,7 @@ history. It is retained as historical context, not as an open task list.
 
 ## Status
 
-Completed on the current `jam/updates` branch.
+Completed on the main branch.
 
 - Normal Windows users do not need to set `ROCM_CLI_THEROCK_FAMILY`; detection
   chooses the compatible TheRock family where GPU inventory is available.
@@ -120,8 +120,8 @@ git diff --check
 Historical WSL verification commands:
 
 ```powershell
-wsl.exe --cd /mnt/d/jam/rocm-cli -e env -i HOME=/home/jam PATH=/home/jam/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CARGO_TARGET_DIR=/home/jam/.cache/rocm-cli-target cargo test -p rocm --bin rocm setup
-wsl.exe --cd /mnt/d/jam/rocm-cli -e env -i HOME=/home/jam PATH=/home/jam/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CARGO_TARGET_DIR=/home/jam/.cache/rocm-cli-target cargo build --workspace
+wsl.exe --cd /mnt/d/path/to/rocm-cli -e env -i HOME=/home/user PATH=/home/user/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CARGO_TARGET_DIR=/home/user/.cache/rocm-cli-target cargo test -p rocm --bin rocm setup
+wsl.exe --cd /mnt/d/path/to/rocm-cli -e env -i HOME=/home/user PATH=/home/user/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CARGO_TARGET_DIR=/home/user/.cache/rocm-cli-target cargo build --workspace
 ```
 
 ### 7. UX Review Gate

--- a/docs/sglang.md
+++ b/docs/sglang.md
@@ -79,7 +79,7 @@ On a supported ROCm target, run the live acceptance harness from the repo root:
 
 ```bash
 python3 scripts/sglang_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-sglang \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-sglang \
   --model Qwen/Qwen2.5-1.5B-Instruct
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,7 +127,7 @@ runtime installs, model artifacts, and supported upstream GPU targets.
 WSL live examine sanity after building with a Linux target directory:
 
 ```bash
-export CARGO_TARGET_DIR=/home/jam/.cache/rocm-cli-target
+export CARGO_TARGET_DIR=/home/user/.cache/rocm-cli-target
 cargo build --workspace
 rocm examine
 ```
@@ -994,7 +994,7 @@ from the managed TheRock SDK wheel directories:
 
 ```bash
 python3 scripts/atom_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-atom \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-atom \
   --model Qwen/Qwen3-0.6B
 ```
 
@@ -1013,7 +1013,7 @@ python scripts/vllm_therock_gpu_test.py --self-test
 
 # On Linux/WSL with vLLM installed in the active rocm-cli managed TheRock venv:
 python3 scripts/vllm_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-vllm \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-vllm \
   --model facebook/opt-125m
 ```
 
@@ -1049,7 +1049,7 @@ wheel directories:
 
 ```bash
 python3 scripts/sglang_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-sglang \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-sglang \
   --model Qwen/Qwen2.5-1.5B-Instruct
 ```
 
@@ -1096,9 +1096,9 @@ WSL command shape, using the WSL-built adapter and server:
 
 ```bash
 python3 scripts/llama_cpp_therock_gpu_test.py \
-  --engine /home/jam/.cache/rocm-cli-target/debug/rocm-engine-llama-cpp \
-  --llama-server /home/jam/.cache/rocm-cli-llama.cpp-build-hip/bin/llama-server \
-  --model-path /mnt/d/jam/rocm-cli/target/models/stories260K.gguf \
+  --engine /home/user/.cache/rocm-cli-target/debug/rocm-engine-llama-cpp \
+  --llama-server /home/user/.cache/rocm-cli-llama.cpp-build-hip/bin/llama-server \
+  --model-path /mnt/d/path/to/rocm-cli/target/models/stories260K.gguf \
   --timeout 120
 ```
 

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -115,7 +115,7 @@ still useful for compatibility checks while the WSL path is being hardened.
 ## TheRock Runtime Env In WSL
 
 `rocm-cli` should continue to own the Python venv. Do not rely on an externally
-created venv such as `D:\jam\venv`.
+created venv such as `D:\ROCm\venv`.
 
 The WSL activation environment for HIP applications that do not preload ROCm
 the way PyTorch does must include the managed TheRock runtime package paths and

--- a/engines/atom/src/lib.rs
+++ b/engines/atom/src/lib.rs
@@ -1525,7 +1525,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\python.exe"
             } else {
-                "/home/jam/.venv/bin/python"
+                "/home/user/.venv/bin/python"
             }),
             launcher: AtomLauncher::Command,
             python_executable: None,
@@ -1534,12 +1534,12 @@ mod tests {
             sdk_root: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel"
             })),
             sdk_bin: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
             })),
             sdk_bin_paths: Vec::new(),
             sdk_library_paths: Vec::new(),
@@ -1592,7 +1592,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\python.exe"
             } else {
-                "/home/jam/.venv/bin/python"
+                "/home/user/.venv/bin/python"
             }),
             launcher: AtomLauncher::Command,
             python_executable: None,
@@ -1601,22 +1601,22 @@ mod tests {
             sdk_root: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel"
             })),
             sdk_bin: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
             })),
             sdk_bin_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
             })],
             sdk_library_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-lib"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
             })],
         };
 

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2201,12 +2201,21 @@ mod tests {
             data_dir: PathBuf::from("C:/Users/test/.rocm"),
             cache_dir: PathBuf::from("C:/Users/test/.rocm/cache"),
         };
-        let engine_root = PathBuf::from("D:/jam/temp/therock_venvs/engines");
+        let engine_root = PathBuf::from("D:/path/to/therock_venvs/engines");
 
         assert_eq!(
             lemonade_root(&paths, Some(&engine_root)),
             normalize_runtime_path_for_host(&engine_root).join(ENGINE_NAME)
         );
+    }
+
+    #[test]
+    fn windows_child_path_maps_ape_drive_paths() {
+        assert_eq!(
+            windows_child_path(Path::new("/D/path/to/rocm-cli/file.zip")),
+            r"D:\path\to\rocm-cli\file.zip"
+        );
+        assert_eq!(windows_child_path(Path::new("/c")), r"C:\");
     }
 
     #[test]

--- a/engines/sglang/src/lib.rs
+++ b/engines/sglang/src/lib.rs
@@ -1676,7 +1676,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\sglang.exe"
             } else {
-                "/home/jam/.venv/bin/sglang"
+                "/home/user/.venv/bin/sglang"
             }),
             launcher: SglangLauncher::Command,
             python_executable: None,
@@ -1685,12 +1685,12 @@ mod tests {
             sdk_root: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel"
             })),
             sdk_bin: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
             })),
             sdk_bin_paths: Vec::new(),
             sdk_library_paths: Vec::new(),
@@ -1743,7 +1743,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\sglang.exe"
             } else {
-                "/home/jam/.venv/bin/sglang"
+                "/home/user/.venv/bin/sglang"
             }),
             launcher: SglangLauncher::Command,
             python_executable: None,
@@ -1752,22 +1752,22 @@ mod tests {
             sdk_root: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel"
             })),
             sdk_bin: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_devel/bin"
             })),
             sdk_bin_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
             })],
             sdk_library_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-lib"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
             })],
         };
 

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1283,7 +1283,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\vllm.exe"
             } else {
-                "/home/jam/.venv/bin/vllm"
+                "/home/user/.venv/bin/vllm"
             }),
             python_executable: None,
             version: Some("test".to_owned()),
@@ -1572,7 +1572,7 @@ mod tests {
             command: PathBuf::from(if cfg!(windows) {
                 r"C:\venv\Scripts\vllm.exe"
             } else {
-                "/home/jam/.venv/bin/vllm"
+                "/home/user/.venv/bin/vllm"
             }),
             python_executable: None,
             version: Some("test".to_owned()),
@@ -1580,22 +1580,22 @@ mod tests {
             sdk_root: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/rocm_sdk"
+                "/home/user/.venv/lib/python/site-packages/rocm_sdk"
             })),
             sdk_bin: Some(PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/rocm_sdk/bin"
+                "/home/user/.venv/lib/python/site-packages/rocm_sdk/bin"
             })),
             sdk_bin_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-bin"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/bin"
             })],
             sdk_library_paths: vec![PathBuf::from(if cfg!(windows) {
                 r"C:\rocm-sdk\extra-lib"
             } else {
-                "/home/jam/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
+                "/home/user/.venv/lib/python/site-packages/_rocm_sdk_libraries/lib"
             })],
         };
 

--- a/install.ps1
+++ b/install.ps1
@@ -313,7 +313,7 @@ function Add-InstallDirToUserPath {
 }
 
 if ([string]::IsNullOrWhiteSpace($Repo)) {
-    $Repo = "powderluv/rocm-cli"
+    $Repo = "ROCm/rocm-cli"
 }
 
 if ([string]::IsNullOrWhiteSpace($Channel)) {

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-REPO="${ROCM_CLI_GITHUB_REPO:-powderluv/rocm-cli}"
+REPO="${ROCM_CLI_GITHUB_REPO:-ROCm/rocm-cli}"
 CHANNEL="${1:-release}"
 INSTALL_DIR="${ROCM_CLI_INSTALL_DIR:-${HOME}/.local/bin}"
 UPDATE_SHELL_PATH="${ROCM_CLI_UPDATE_SHELL_PATH:-1}"

--- a/plans/rocm-cli-remaining-implementation-plan.md
+++ b/plans/rocm-cli-remaining-implementation-plan.md
@@ -167,9 +167,9 @@ Locally implemented and recently verified:
 - Live local-assistant acceptance now also passes on WSL with the `qwen` alias
   after path propagation fixes for managed child processes:
   `scripts/local_assistant_therock_gpu_test.py --rocm
-  /home/jam/.cache/rocm-cli-target/debug/rocm --model qwen --require-tool-call`
+  /home/user/.cache/rocm-cli-target/debug/rocm --model qwen --require-tool-call`
   launched the managed PyTorch GPU-required service, wrote its service
-  manifest under `/home/jam/.rocm/services`, required a ROCm tool call, and
+  manifest under `/home/user/.rocm/services`, required a ROCm tool call, and
   stopped the managed service cleanly.
 - ComfyUI TUI logs/file-location polish is now covered by regression tests:
   `/comfyui logs` and `/comfyui log-files` keep the user on a navigable
@@ -180,7 +180,7 @@ Locally implemented and recently verified:
   WSL `rocm examine`, `rocm engines list`, `rocm comfyui status`, and
   `rocm services list`. The first WSL sidecar found a stale `/mnt/d` debug
   binary that rejected newer `comfyui`/`services` subcommands; a forced rebuild
-  into `/home/jam/.cache/rocm-cli-target` fixed the artifact and verified those
+  into `/home/user/.cache/rocm-cli-target` fixed the artifact and verified those
   subcommands. Live WSL PyTorch local-assistant serving now passes, and live WSL
   ComfyUI now passes an opt-in install/start/status/logs/generate-cat/stop flow
   from the ext4 worktree.

--- a/scripts/build_single_exe_release.py
+++ b/scripts/build_single_exe_release.py
@@ -107,8 +107,8 @@ def strip_tool_for(platform: str) -> str | None:
     if platform == "windows-amd64":
         candidates.extend(
             [
-                r"D:\jam\venv\Lib\site-packages\_rocm_sdk_core\lib\llvm\bin\llvm-strip.exe",
-                r"D:\jam\venv\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\llvm-strip.exe",
+                r"D:\path\to\venv\Lib\site-packages\_rocm_sdk_core\lib\llvm\bin\llvm-strip.exe",
+                r"D:\path\to\venv\Lib\site-packages\_rocm_sdk_devel\lib\llvm\bin\llvm-strip.exe",
                 "llvm-strip",
             ]
         )


### PR DESCRIPTION
## Summary

Prepares the repository for public release by removing personal developer identifiers and placeholder paths.

### Changes

- **Keyring service ID** (`apps/rocm/src/provider_keys.rs`): replaced personal GitHub username with namespaced neutral identifier `org.rocm.rocm-cli.provider-key`
- **Package manifest** (`Cargo.toml`): updated `repository` field to `https://github.com/ROCm/rocm-cli`
- **Install scripts** (`README.md`, `install.sh`, `install.ps1`): updated download URLs to point to `ROCm/rocm-cli`
- **Project dirs** (`crates/rocm-core/src/runtime.rs`): updated `ProjectDirs` qualifier/org to `org`/`ROCm`
- **Engine test fixtures** (`engines/atom`, `engines/sglang`, `engines/vllm`, `engines/lemonade`): replaced developer home paths (`/home/jam/.venv/`, `D:/jam/...`) with generic examples
- **App test data** (`apps/rocm/src/main.rs`, `tui.rs`, `therock.rs`): replaced developer-specific Windows/WSL paths with generic examples
- **Build scripts** (`scripts/`): replaced hardcoded developer paths with portable equivalents; `single_exe_release_gate.py` now anchors the WSL `--cd` directory to `REPO_ROOT` (via the existing `wsl_path()` helper) instead of a hardcoded path
- **Docs and plans**: replaced developer-specific paths in example commands

## Breaking changes

- **Keyring service ID rename** (`powderluv.rocm-cli.provider-key` → `org.rocm.rocm-cli.provider-key`): the OS keyring stores provider API keys under this service name, so any key saved by a pre-existing install will no longer be found after upgrading. Affected users must re-save their key with `rocm config set-provider-key <provider>` (or set the provider's API-key environment variable). No data is lost; the old entry simply becomes orphaned. Acceptable for a pre-OSS-release rename, but noted here for anyone running an earlier build.

## Test Plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` — 750/751 tests pass (1 pre-existing flaky test in TUI, confirmed on main)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --check --all` — clean (formatting fix committed as part of this PR)
- [x] No `powderluv`, `jam` user references remain in any tracked file