### PR TITLE
fix: use atomic counter for tempdir uniqueness in bench_tail tests

### DIFF
--- a/crates/rocm-dash-collectors/src/bench_tail.rs
+++ b/crates/rocm-dash-collectors/src/bench_tail.rs
@@ -142,13 +142,12 @@ mod tests {
     }
 
     fn tempdir() -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let mut p = std::env::temp_dir();
         let pid = std::process::id();
-        let ts = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        p.push(format!("rocm-dash-test-{pid}-{ts}"));
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        p.push(format!("rocm-dash-test-{pid}-{n}"));
         std::fs::create_dir_all(&p).unwrap();
         p
     }


### PR DESCRIPTION
## Summary

- Replaces the `SystemTime::now().as_nanos()` suffix in `tempdir()` with an `AtomicU64` counter
- Windows `SystemTime` has ~15ms resolution; parallel tests running within the same timer tick could collide on the same directory path, causing tests to read/write each other's `results.csv` and produce wrong deserialization results
- Observed failure: `missing_30col_fields_default_safely` got `rows[0].run == 1` (from another test's ROW2) instead of 7

## Root cause

`bench_tail::tests::tempdir()` built its path as `rocm-dash-test-{pid}-{nanos}`. Under full parallel test load on Windows CI, the three tests in the module ran within the same 15ms clock tick → same suffix → same directory → same `results.csv` → file contents from one test leaked into another.

An atomic counter increments on every call so each invocation gets a distinct suffix regardless of clock resolution.

## Test plan

- [x] `cargo test -p rocm-dash-collectors` passes (54/54)
- [x] Windows CI green

Fixes flaky failure observed in https://github.com/ROCm/rocm-cli/actions/runs/27690632058/job/81900409577