### PR TITLE
Nightly convenience assets + drop redundant engine binaries from the bundle

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -271,6 +271,27 @@ jobs:
             --notes "${NOTES}" \
             --prerelease \
             "${ASSET_DIR}"/*
+
+          # Convenience assets for quick curl-and-run, attached after the
+          # readiness gate (NOT part of the signed exact-asset set):
+          #   rocm / rocm.exe        - standalone CLI binaries
+          #   linux-binaries.tar.gz  - byte-identical alias of the signed
+          #                            rocm-cli-nightly-linux-amd64.tar.gz bundle
+          #   windows-binaries.zip   - byte-identical alias of the signed
+          #                            rocm-cli-nightly-windows-amd64.zip bundle
+          # Integrity-conscious users should prefer the signed *-amd64 archives.
+          EXTRA="$(mktemp -d)"
+          mkdir -p "${EXTRA}/lin" "${EXTRA}/win"
+          tar -xzf "${ASSET_DIR}/rocm-cli-nightly-linux-amd64.tar.gz" -C "${EXTRA}/lin"
+          unzip -o -q "${ASSET_DIR}/rocm-cli-nightly-windows-amd64.zip" -d "${EXTRA}/win"
+          cp "$(find "${EXTRA}/lin" -type f -name rocm)" "${EXTRA}/rocm"
+          cp "$(find "${EXTRA}/win" -type f -name rocm.exe)" "${EXTRA}/rocm.exe"
+          cp "${ASSET_DIR}/rocm-cli-nightly-linux-amd64.tar.gz" "${EXTRA}/linux-binaries.tar.gz"
+          cp "${ASSET_DIR}/rocm-cli-nightly-windows-amd64.zip" "${EXTRA}/windows-binaries.zip"
+          gh release upload nightly \
+            "${EXTRA}/rocm" "${EXTRA}/rocm.exe" \
+            "${EXTRA}/linux-binaries.tar.gz" "${EXTRA}/windows-binaries.zip" --clobber
+
           gh release delete "${STAGING_TAG}" --yes --cleanup-tag
 
   cleanup-staging-nightly:

--- a/install.ps1
+++ b/install.ps1
@@ -413,7 +413,9 @@ try {
     $bundleDir = Find-BundleDir $extractDir
     $bundleBin = Join-Path $bundleDir "bin"
 
-    foreach ($required in @("rocm.exe", "rocmd.exe", "rocm-engine-pytorch.exe", "rocm-engine-llama-cpp.exe", "rocm-engine-lemonade.exe", "rocm-engine-atom.exe", "rocm-engine-vllm.exe", "rocm-engine-sglang.exe")) {
+    # First-party engines are built into rocm.exe and run in-process; the
+    # standalone rocm-engine-*.exe binaries are an external plugin fallback.
+    foreach ($required in @("rocm.exe", "rocmd.exe")) {
         if (-not (Test-Path -LiteralPath (Join-Path $bundleBin $required) -PathType Leaf)) {
             Fail "bundle did not contain bin/$required"
         }

--- a/install.sh
+++ b/install.sh
@@ -330,14 +330,10 @@ tar -xzf "${archive_path}" -C "${extract_dir}"
 bundle_dir="$(find "${extract_dir}" -mindepth 1 -maxdepth 1 -type d | head -n1)"
 [ -n "${bundle_dir}" ] || fail "unable to locate extracted bundle directory"
 
+# First-party engines are built into rocm and run in-process; the standalone
+# rocm-engine-* binaries are an external plugin fallback, not shipped here.
 [ -f "${bundle_dir}/bin/rocm" ] || fail "bundle did not contain bin/rocm"
 [ -f "${bundle_dir}/bin/rocmd" ] || fail "bundle did not contain bin/rocmd"
-[ -f "${bundle_dir}/bin/rocm-engine-pytorch" ] || fail "bundle did not contain bin/rocm-engine-pytorch"
-[ -f "${bundle_dir}/bin/rocm-engine-llama-cpp" ] || fail "bundle did not contain bin/rocm-engine-llama-cpp"
-[ -f "${bundle_dir}/bin/rocm-engine-lemonade" ] || fail "bundle did not contain bin/rocm-engine-lemonade"
-[ -f "${bundle_dir}/bin/rocm-engine-atom" ] || fail "bundle did not contain bin/rocm-engine-atom"
-[ -f "${bundle_dir}/bin/rocm-engine-vllm" ] || fail "bundle did not contain bin/rocm-engine-vllm"
-[ -f "${bundle_dir}/bin/rocm-engine-sglang" ] || fail "bundle did not contain bin/rocm-engine-sglang"
 
 mkdir -p "${INSTALL_DIR}"
 write_minimal_config_if_missing

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -174,7 +174,7 @@ try {
     Write-Host "acceptance: build release binaries"
     Push-Location $RepoRoot
     try {
-        & $cargoExe build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang -p xtask
+        & $cargoExe build --release -p rocm -p rocmd -p xtask
         if ($LASTEXITCODE -ne 0) {
             Fail "cargo build failed"
         }
@@ -423,12 +423,6 @@ try {
     }
     Assert-File (Join-Path $InstallDir "rocm.exe")
     Assert-File (Join-Path $InstallDir "rocmd.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-pytorch.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-llama-cpp.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-lemonade.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-atom.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-vllm.exe")
-    Assert-File (Join-Path $InstallDir "rocm-engine-sglang.exe")
     Assert-File (Join-Path $InstallDir ".rocm-cli-manifest")
 
     Write-Host "acceptance: simulate stale prior install entry and reinstall"
@@ -471,12 +465,6 @@ try {
     Invoke-Checked "acceptance: uninstall from the installed binary" $rocmExe @("uninstall", "--yes", "--keep-config", "--keep-data", "--keep-cache") $UninstallLog
 
     Assert-Missing (Join-Path $InstallDir "rocmd.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-pytorch.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-llama-cpp.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-lemonade.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-atom.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-vllm.exe")
-    Assert-Missing (Join-Path $InstallDir "rocm-engine-sglang.exe")
     Assert-Missing (Join-Path $InstallDir ".rocm-cli-manifest")
     if (-not (Select-String -LiteralPath $UninstallLog -Pattern "skipping running executable on Windows" -Quiet)) {
         Fail "uninstall did not report the expected running executable skip"

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -106,7 +106,7 @@ expect_failure() {
 }
 
 echo "acceptance: build release binaries"
-(cd "${REPO_ROOT}" && cargo build --release -p rocm -p rocmd -p rocm-engine-pytorch -p rocm-engine-llama-cpp -p rocm-engine-lemonade -p rocm-engine-atom -p rocm-engine-vllm -p rocm-engine-sglang -p xtask)
+(cd "${REPO_ROOT}" && cargo build --release -p rocm -p rocmd -p xtask)
 
 echo "acceptance: generate signing key"
 (cd "${REPO_ROOT}" && cargo xtask keygen \
@@ -250,12 +250,6 @@ grep -q "shell profile updated" "${INSTALL_LOG_1}" \
   || fail "installer did not report automatic shell profile setup"
 assert_file "${INSTALL_DIR}/rocm"
 assert_file "${INSTALL_DIR}/rocmd"
-assert_file "${INSTALL_DIR}/rocm-engine-pytorch"
-assert_file "${INSTALL_DIR}/rocm-engine-llama-cpp"
-assert_file "${INSTALL_DIR}/rocm-engine-lemonade"
-assert_file "${INSTALL_DIR}/rocm-engine-atom"
-assert_file "${INSTALL_DIR}/rocm-engine-vllm"
-assert_file "${INSTALL_DIR}/rocm-engine-sglang"
 assert_file "${INSTALL_DIR}/.rocm-cli-manifest"
 assert_file "${INSTALL_CONFIG_FILE}"
 grep -q '"default_engine"[[:space:]]*:[[:space:]]*"pytorch"' "${INSTALL_CONFIG_FILE}" \
@@ -334,12 +328,6 @@ env \
 
 assert_missing "${INSTALL_DIR}/rocm"
 assert_missing "${INSTALL_DIR}/rocmd"
-assert_missing "${INSTALL_DIR}/rocm-engine-pytorch"
-assert_missing "${INSTALL_DIR}/rocm-engine-llama-cpp"
-assert_missing "${INSTALL_DIR}/rocm-engine-lemonade"
-assert_missing "${INSTALL_DIR}/rocm-engine-atom"
-assert_missing "${INSTALL_DIR}/rocm-engine-vllm"
-assert_missing "${INSTALL_DIR}/rocm-engine-sglang"
 assert_missing "${INSTALL_DIR}/.rocm-cli-manifest"
 assert_missing "${XDG_CONFIG_HOME}/rocm-cli"
 assert_missing "${XDG_DATA_HOME}/rocm-cli"

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -24,14 +24,11 @@ rm -rf "${ROOT_DIR}"
 rm -f "${ARCHIVE_PATH}" "${ARCHIVE_PATH}.sha256" "${ARCHIVE_PATH}.sig" "${TAR_PATH}"
 mkdir -p "${ROOT_DIR}/bin"
 
+# The first-party engines (pytorch/llama.cpp/lemonade/atom/vllm/sglang) are
+# compiled into `rocm` and run in-process; the standalone rocm-engine-* binaries
+# are only an external third-party plugin fallback, so they are not shipped.
 cp "${BINARY_DIR}/rocm" "${ROOT_DIR}/bin/"
 cp "${BINARY_DIR}/rocmd" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-pytorch" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-llama-cpp" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-lemonade" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-atom" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-vllm" "${ROOT_DIR}/bin/"
-cp "${BINARY_DIR}/rocm-engine-sglang" "${ROOT_DIR}/bin/"
 cp README.md LICENSE install.sh "${ROOT_DIR}/"
 
 (cd "${OUTPUT_DIR}" && tar -cf "${DIST_NAME}.tar" "${DIST_NAME}")

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -127,14 +127,11 @@ Remove-Item -LiteralPath "$archivePath.sig" -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path (Join-Path $rootDir "bin") | Out-Null
 
 $bundleBin = Join-Path $rootDir "bin"
+# First-party engines are built into rocm.exe and run in-process; the
+# standalone rocm-engine-*.exe binaries are only an external plugin fallback,
+# so they are not shipped.
 Copy-RequiredFile (Join-Path $binaryDir "rocm.exe") (Join-Path $bundleBin "rocm.exe")
 Copy-RequiredFile (Join-Path $binaryDir "rocmd.exe") (Join-Path $bundleBin "rocmd.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-pytorch.exe") (Join-Path $bundleBin "rocm-engine-pytorch.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-llama-cpp.exe") (Join-Path $bundleBin "rocm-engine-llama-cpp.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-lemonade.exe") (Join-Path $bundleBin "rocm-engine-lemonade.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-atom.exe") (Join-Path $bundleBin "rocm-engine-atom.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-vllm.exe") (Join-Path $bundleBin "rocm-engine-vllm.exe")
-Copy-RequiredFile (Join-Path $binaryDir "rocm-engine-sglang.exe") (Join-Path $bundleBin "rocm-engine-sglang.exe")
 Copy-RequiredFile (Join-Path $repoRoot "README.md") (Join-Path $rootDir "README.md")
 Copy-RequiredFile (Join-Path $repoRoot "LICENSE") (Join-Path $rootDir "LICENSE")
 Copy-RequiredFile (Join-Path $repoRoot "install.ps1") (Join-Path $rootDir "install.ps1")

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -21,15 +21,12 @@ ROCM_RELEASE_ASSET_RE = re.compile(
     r"^rocm-cli-(?:(?:v[0-9][A-Za-z0-9._+-]*|nightly(?:-[0-9]{8}-[0-9A-Fa-f]+)?)-)?"
     r"(?P<os>linux|windows)-amd64(?P<suffix>\.tar\.gz|\.zip)$"
 )
+# First-party engines are built into rocm/rocm.exe (run in-process); the
+# standalone rocm-engine-* binaries are an external plugin fallback and are not
+# part of the shipped bundle.
 LINUX_REQUIRED = (
     "bin/rocm",
     "bin/rocmd",
-    "bin/rocm-engine-pytorch",
-    "bin/rocm-engine-llama-cpp",
-    "bin/rocm-engine-lemonade",
-    "bin/rocm-engine-atom",
-    "bin/rocm-engine-vllm",
-    "bin/rocm-engine-sglang",
     "README.md",
     "LICENSE",
     "install.sh",
@@ -37,12 +34,6 @@ LINUX_REQUIRED = (
 WINDOWS_REQUIRED = (
     "bin/rocm.exe",
     "bin/rocmd.exe",
-    "bin/rocm-engine-pytorch.exe",
-    "bin/rocm-engine-llama-cpp.exe",
-    "bin/rocm-engine-lemonade.exe",
-    "bin/rocm-engine-atom.exe",
-    "bin/rocm-engine-vllm.exe",
-    "bin/rocm-engine-sglang.exe",
     "README.md",
     "LICENSE",
     "install.ps1",
@@ -50,12 +41,6 @@ WINDOWS_REQUIRED = (
 LINUX_EXECUTABLES = (
     "bin/rocm",
     "bin/rocmd",
-    "bin/rocm-engine-pytorch",
-    "bin/rocm-engine-llama-cpp",
-    "bin/rocm-engine-lemonade",
-    "bin/rocm-engine-atom",
-    "bin/rocm-engine-vllm",
-    "bin/rocm-engine-sglang",
     "install.sh",
 )
 PRODUCTION_TRUST_ENV_NAMES = (


### PR DESCRIPTION
Two related release-packaging changes.

## 1. Convenience assets on the rolling `nightly` release
For quick curl-and-run, attached after the signature/readiness gate (signed bundles + installers unchanged):

| Asset | What |
|---|---|
| `rocm` / `rocm.exe` | standalone CLI binaries |
| `linux-binaries.tar.gz` / `windows-binaries.zip` | full bundle (alias of the signed `rocm-cli-nightly-*-amd64` archives) |

Stable links: `…/releases/download/nightly/rocm`, `…/rocm.exe`, `…/linux-binaries.tar.gz`, `…/windows-binaries.zip`.

## 2. Drop the redundant `rocm-engine-*` binaries from the bundle
The six first-party engines (pytorch/llama.cpp/lemonade/atom/vllm/sglang) are **compiled into `rocm` and run in-process** — verified end-to-end:
- the stdio protocol path calls `builtin_engine_request` in-process and returns before any sibling-binary lookup;
- managed/background serve self-execs `rocm __engine-serve-http <engine>` (not a separate binary);
- the standalone `rocm-engine-*` binaries are **only** the external third-party plugin fallback and are never invoked for first-party engines.

So engine *selection* already happens at runtime (`rocm install` sets up the ROCm runtime; the in-process adapter pip-installs the chosen backend into a managed venv) — the release never needs to ship the engine binaries. Shipped bundle is now **`rocm` + `rocmd`**.

Updated everywhere the bundle is produced or verified: `package-linux-release.sh`, `package-windows-release.ps1`, `release_readiness.py` (required/executable lists), `install.sh`, `install.ps1`, and the install/uninstall acceptance scripts. These are shared with `release.yml`, so the stable bundle is slimmed too.

### Notes / follow-ups
- `scripts/build_single_exe_release.py` (a dev-only helper, not the CI/release path) still lists the engine binaries; left untouched here because PR #19 already reworks it — worth a tidy-up there.
- Validated locally: `release_readiness.py --self-test` ✓, `bash -n` on the shell scripts ✓. PowerShell scripts are syntax-checked by the Windows CI job.