### PR TITLE
docs: rewrite README with install commands and full command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ TUI shows live GPU utilization, active model servers, and a chat tab.
 ```
 rocm install sdk    [--channel release|nightly] [--format wheel|tarball]
                     [--version X.Y.Z | --build-date YYYY-MM-DD]
-                    [--family gfx110X-all] [--dry-run]
+                    [--family gfx110X-all] [--prefix PATH] [--dry-run]
 
 rocm install driver [--dkms] [--yes] [--dry-run] [--reconcile]
 
@@ -108,7 +108,7 @@ Start a local OpenAI-compatible model server:
 
 ```
 rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
-                   [--device gpu_required|cpu_only]
+                   [--device gpu_required|gpu_preferred|cpu_only]
                    [--runtime-id KEY | --env-id ID]
                    [--host HOST] [--port PORT]
                    [--foreground | --managed]
@@ -173,7 +173,7 @@ rocm comfyui models-path
 
 ```
 rocm automations list
-rocm automations enable <watcher-id>  [--mode auto|review]
+rocm automations enable <watcher-id>  [--mode observe|propose|contained]
 rocm automations disable <watcher-id>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,119 +1,220 @@
 # rocm-cli
 
-ROCm AI Command Center CLI for AMD systems.
+Command-line tool for setting up and running local AI on AMD GPUs, with a
+full-screen TUI dashboard for GPU telemetry, model serving, and chat.
 
-## Quick Start
+A single prebuilt binary for Linux and Windows. No Python, Rust, or existing
+ROCm install required. Ships with inference engine adapters for PyTorch,
+llama.cpp, Lemonade, ATOM, vLLM, and SGLang.
 
-Install on Windows x86_64 from PowerShell:
+> Only nightly builds are available at this time.
+
+## Installation
+
+**Linux / WSL x86_64**:
+
+```bash
+curl -fsSL https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm -o ~/.local/bin/rocm
+chmod +x ~/.local/bin/rocm
+```
+
+**Windows x86_64** (PowerShell):
 
 ```powershell
-$script = "$env:TEMP\install-rocm-cli.ps1"; irm https://raw.githubusercontent.com/powderluv/rocm-cli/main/install.ps1 -OutFile $script; Set-ExecutionPolicy -Scope Process Bypass -Force; & $script
+irm https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm.exe -OutFile "$env:LOCALAPPDATA\Microsoft\WindowsApps\rocm.exe"
 ```
 
-The bootstrap installer downloads the prebuilt rocm-cli bundle and updates PATH.
-It does not require ROCm, Python, Rust, or Cargo to already be installed.
+Rerun the same command to upgrade to the latest nightly.
 
-Install on Linux or WSL x86_64:
+## First run
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/powderluv/rocm-cli/main/install.sh | sh
 ```
-
-Start rocm-cli:
-
-```bash
 rocm
 ```
 
-On first run, rocm-cli opens setup before the main screen. Choose where ROCm
-should be installed, approve the install, and wait for setup to finish.
+Opens the interactive TUI. On first launch it walks through setup: choose an
+install folder and let rocm-cli download and configure ROCm. After setup the
+TUI shows live GPU utilization, active model servers, and a chat tab.
 
-After setup, check the machine:
+## Quick reference
 
-```bash
-rocm doctor
+| Command | Description |
+|---|---|
+| `rocm` | Open the TUI (runs setup on first launch) |
+| `rocm doctor` | Check GPU, ROCm install, engines, and managed folders |
+| `rocm install sdk` | Install TheRock ROCm wheels into a managed Python environment |
+| `rocm install driver` | Install the AMD kernel driver on Linux |
+| `rocm serve <model>` | Start a local OpenAI-compatible model server |
+| `rocm dash` | Open the full-screen telemetry dashboard |
+| `rocm setup status` | Show first-time setup state |
+| `rocm version` | Print the rocm-cli version |
+
+## Commands
+
+### ROCm installation
+
+```
+rocm install sdk    [--channel release|nightly] [--format wheel|tarball]
+                    [--version X.Y.Z | --build-date YYYY-MM-DD]
+                    [--family gfx110X-all] [--dry-run]
+
+rocm install driver [--dkms] [--yes] [--dry-run] [--reconcile]
+
+rocm update         [--apply] [--runtime KEY] [--activate] [--dry-run]
 ```
 
-Serve a local model:
+`install sdk` downloads TheRock ROCm wheels into a Python environment managed
+by rocm-cli. `install driver` installs the AMD kernel driver on Linux (DKMS or
+native package). `update` checks for a newer ROCm package; pass `--apply` to
+install it.
 
-```bash
-rocm serve qwen --engine lemonade --managed
+### Runtime management
+
+Manage multiple side-by-side ROCm installs:
+
 ```
-
-Open the live telemetry dashboard — GPU utilization, serving instances,
-benchmarks, and a chat tab:
-
-```bash
-rocm dash
-```
-
-No GPU handy? Try the built-in demo — a deterministic synthetic session that
-needs no GPU or daemon:
-
-```bash
-rocm dash --demo
-```
-
-> The live dashboard currently requires Unix domain sockets (Linux/WSL); the
-> `--demo` and `--replay <file>` modes work on every platform.
-
-## Developer Checks
-
-Command-line ROCm install:
-
-```bash
-rocm install sdk --channel release --format wheel
 rocm runtimes list
+rocm runtimes activate <runtime-key>
+rocm runtimes rollback
+rocm runtimes uninstall <runtime-key>
+rocm runtimes import <manifest-file> [--replace]
+rocm runtimes adopt --python <path> [--root <path>] [--runtime-id ID]
+                    [--runtime-key KEY] [--channel LABEL] [--replace]
 ```
 
-Choose one installed ROCm folder:
+### Inference engines
 
-```bash
-rocm runtimes activate <runtime_key>
+```
+rocm engines list
+rocm engines install <engine> [--runtime-id KEY] [--python-version X.Y] [--reinstall]
+rocm engines shell <engine>   [--runtime-id KEY | --env-id ID] [--shell PATH]
 ```
 
-Replace `<runtime_key>` with a key printed by `rocm runtimes list`.
+Supported engines: `lemonade`, `pytorch`, `llama.cpp`, `atom`, `vllm`, `sglang`.
 
-Install a serving engine:
+### Model serving
 
-```bash
-rocm engines install pytorch
+Start a local OpenAI-compatible model server:
+
+```
+rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
+                   [--device gpu_required|cpu_only]
+                   [--runtime-id KEY | --env-id ID]
+                   [--host HOST] [--port PORT]
+                   [--foreground | --managed]
+                   [--allow-public-bind]
+```
+
+`--managed` runs the server in the background under rocm-cli's supervision.
+`--foreground` attaches it to the current terminal.
+
+Show recommended models and hardware compatibility:
+
+```
+rocm model [--verbose]
+```
+
+Manage background servers started with `--managed`:
+
+```
+rocm services list [--all]
+rocm services logs <service-id>
+rocm services stop <service-id> [--yes]
+rocm services restart <service-id> [--yes]
+```
+
+### Dashboard
+
+```
+rocm dash [--demo] [--replay <file>]
+```
+
+Full-screen TUI with GPU utilization graphs, active serving instances,
+benchmark results, and a chat tab backed by any configured provider.
+
+- `--demo` runs a deterministic synthetic session with no GPU or daemon needed,
+  works on all platforms.
+- `--replay <file>` replays a recorded NDJSON session.
+- Live mode requires Unix domain sockets (Linux and WSL only).
+
+### Chat
+
+```
+rocm chat [--provider anthropic|openai|...] [--model NAME] [--prompt TEXT] [--tools]
+```
+
+Chat with an AI provider from the terminal. Reads from stdin when `--prompt` is
+omitted.
+
+### ComfyUI
+
+Install and manage ComfyUI for image generation (alias: `rocm comfy`):
+
+```
+rocm comfyui install    [--runtime-id KEY] [--reinstall] [--dry-run]
+rocm comfyui start      [--host HOST] [--port PORT] [--no-open-browser]
+rocm comfyui stop
+rocm comfyui status
+rocm comfyui logs       [--lines N]
+rocm comfyui models-path
+```
+
+### Automations
+
+```
+rocm automations list
+rocm automations enable <watcher-id>  [--mode auto|review]
+rocm automations disable <watcher-id>
+```
+
+Optional background checks that can propose or apply changes automatically.
+
+### Configuration
+
+```
+rocm config show
+rocm config set-default-engine <engine>
+rocm config clear-default-engine
+rocm config set-default-runtime <runtime-id>
+rocm config clear-default-runtime
+rocm config set-engine <engine> [--runtime-id KEY | --env-id ID | --clear]
+rocm config set-telemetry local|off
+rocm config set-planner-provider <provider>
+rocm config clear-planner-provider
+rocm config enable-provider <provider>
+rocm config disable-provider <provider>
+rocm config set-provider-key <provider>
+rocm config clear-provider-key <provider>
+```
+
+### Logs and cleanup
+
+```
+rocm logs [--service <service-id>] [--search TERM ...]
+
+rocm uninstall [--yes] [--dry-run]
+               [--keep-binaries] [--keep-config] [--keep-data] [--keep-cache]
 ```
 
 ## Contributing
 
-This repo uses [prek](https://github.com/j178/prek) (a fast, drop-in
+This repo uses [prek](https://github.com/j178/prek) (a fast drop-in
 replacement for `pre-commit`) to run the same checks locally that CI enforces:
-`cargo fmt`/`clippy`/`test`, `ruff` (Python), `shellcheck` (shell),
-PowerShell syntax, and assorted file hygiene.
-
-Install prek and enable the hooks once after cloning:
+`cargo fmt`, `clippy`, `cargo test`, `ruff` (Python), `shellcheck` (shell),
+and PowerShell syntax.
 
 ```bash
 uv tool install prek        # or: cargo install --locked prek
-prek install                # fast checks on commit (fmt, ruff, shellcheck, ...)
-prek install -t pre-push    # heavier checks on push (clippy, cargo test)
+prek install                # fast checks on commit
+prek install -t pre-push    # heavier checks on push (clippy + tests)
+prek run --all-files        # run everything against the whole tree
 ```
 
-Run every hook against the whole tree on demand:
-
-```bash
-prek run --all-files
-```
-
-The hook configuration lives in `.pre-commit-config.yaml`; `clippy` and the test
-suite run on `pre-push` to keep commits fast.
-
-## More Docs
+## More docs
 
 - Testing and verification: `docs/testing.md`
 - Developer manual QA: `docs/manual-testing.md`
-- Current implementation audit: `docs/implementation-completion-audit.md`
 - Engine plugin policy: `docs/engine-plugins.md`
 - ATOM adapter: `docs/atom.md`
 - vLLM adapter: `docs/vllm.md`
 - SGLang adapter: `docs/sglang.md`
-- Implementation plan: `plans/rocm-cli-implementation-plan.md`
-- PyTorch engine spec: `plans/rocm-cli-pytorch-engine-spec.md`
-
-This is an early implementation, not a production release.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,28 @@ llama.cpp, Lemonade, ATOM, vLLM, and SGLang.
 
 ## Installation
 
+This repository is currently private. Install the [GitHub CLI](https://cli.github.com/) and authenticate once before downloading:
+
+```bash
+gh auth login
+```
+
 **Linux / WSL x86_64**:
 
 ```bash
-curl -fsSL https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm -o ~/.local/bin/rocm
+gh release download nightly --repo ROCm/rocm-cli --pattern rocm --output ~/.local/bin/rocm
 chmod +x ~/.local/bin/rocm
 ```
+
+Direct link: <https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm>
 
 **Windows x86_64** (PowerShell):
 
 ```powershell
-irm https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm.exe -OutFile "$env:LOCALAPPDATA\Microsoft\WindowsApps\rocm.exe"
+gh release download nightly --repo ROCm/rocm-cli --pattern rocm.exe --output "$env:LOCALAPPDATA\Microsoft\WindowsApps\rocm.exe"
 ```
+
+Direct link: <https://github.com/ROCm/rocm-cli/releases/download/nightly/rocm.exe>
 
 Rerun the same command to upgrade to the latest nightly.
 


### PR DESCRIPTION
## Summary

- Replaces the old quick-start with direct nightly download commands for Linux/WSL and Windows (no installer scripts)
- Adds a quick reference table covering the most common commands
- Documents all public commands with subcommands and key flags, grouped by area (installation, runtimes, engines, serving, dashboard, chat, ComfyUI, automations, config, logs/cleanup)
- Notes that only nightly builds are available at this time
- Removes references to stale docs (implementation audit, plans/)

## Test plan

- [x] Read through rendered README on GitHub and verify formatting
- [x] Verify download URLs resolve to the correct release assets