### PR TITLE
amd-smi path resolution

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -55,12 +55,8 @@ pub fn runner_options(
         // D7 seam consumer: managed services from `rocm serve --managed`.
         services_dir: Some(paths.services_dir()),
         // amd-smi ships inside the managed runtime wheel's bin dir, not on PATH;
-        // resolve the absolute path so the GPU collector can find it.
-        amd_smi_binary: Some(
-            rocm_core::resolve_amd_smi_binary()
-                .to_string_lossy()
-                .into_owned(),
-        ),
+        // resolve the path so the GPU collector can find it.
+        amd_smi_binary: Some(rocm_core::resolve_amd_smi_binary()),
     }
 }
 

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -54,6 +54,13 @@ pub fn runner_options(
         persist_dir: Some(paths.telemetry_state_dir()),
         // D7 seam consumer: managed services from `rocm serve --managed`.
         services_dir: Some(paths.services_dir()),
+        // amd-smi ships inside the managed runtime wheel's bin dir, not on PATH;
+        // resolve the absolute path so the GPU collector can find it.
+        amd_smi_binary: Some(
+            rocm_core::resolve_amd_smi_binary()
+                .to_string_lossy()
+                .into_owned(),
+        ),
     }
 }
 

--- a/apps/rocm/src/tui.rs
+++ b/apps/rocm/src/tui.rs
@@ -39,8 +39,8 @@ use rocm_core::{
     daemon_binary_path, default_engine_for_platform, detect_host_gpu_summary,
     find_automation_proposal, format_host_for_url, format_host_port, format_http_base_url,
     load_model_recipe_registry, load_recent_automation_proposals, managed_pip_cache_dir,
-    managed_service_endpoint_model_ready, replace_automation_proposal, runtime_directory_label,
-    runtime_drive_root_for_key, runtime_drive_roots, runtime_is_windows,
+    managed_service_endpoint_model_ready, replace_automation_proposal, resolve_amd_smi_binary,
+    runtime_directory_label, runtime_drive_root_for_key, runtime_drive_roots, runtime_is_windows,
     runtime_path_is_same_or_inside, runtime_path_sort_key, sanitize_component, unix_time_millis,
     update_automation_proposal_status,
 };
@@ -27792,7 +27792,8 @@ fn load_gpu_monitor_cards_from_json(output: &str) -> Result<BTreeMap<u32, GpuMon
 }
 
 fn run_amd_smi_json(args: &[&str]) -> Result<String> {
-    let mut child = ProcessCommand::new("amd-smi")
+    let amd_smi_binary = resolve_amd_smi_binary();
+    let mut child = ProcessCommand::new(&amd_smi_binary)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -16,8 +16,8 @@ use rocm_core::{
     ModelRecipeArtifactRecord, RocmCliConfig, WatcherMode, WatcherRuntimeSnapshot,
     append_audit_event, append_automation_event, append_automation_proposal, builtin_watcher,
     builtin_watchers, daemon_binary_path, default_engine_for_platform, format_host_port,
-    load_recent_automation_events, model_artifact_cache_status, resolve_model_recipe_artifact,
-    unix_time_millis,
+    load_recent_automation_events, model_artifact_cache_status, resolve_amd_smi_binary,
+    resolve_model_recipe_artifact, unix_time_millis,
 };
 #[cfg(test)]
 use rocm_engine_protocol::EnginePluginDescriptor;
@@ -1328,7 +1328,8 @@ fn gather_gpu_snapshot_for_config(config: &RocmCliConfig) -> CodexBridgeGpuSnaps
 }
 
 fn capture_amd_smi_json(args: &[&str]) -> Result<Value> {
-    let mut command = ProcessCommand::new("amd-smi");
+    let amd_smi_binary = resolve_amd_smi_binary();
+    let mut command = ProcessCommand::new(&amd_smi_binary);
     command
         .args(args)
         .stdin(Stdio::null())

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5870,6 +5870,79 @@ pub fn daemon_binary_path() -> Result<PathBuf> {
     Ok(current_exe)
 }
 
+pub fn resolve_amd_smi_binary() -> OsString {
+    if let Some(path) = default_data_dir()
+        .map(|data_dir| data_dir.join("runtimes").join("registry"))
+        .and_then(|registry_dir| resolve_amd_smi_binary_in_registry(&registry_dir))
+    {
+        return path;
+    }
+    resolve_amd_smi_binary_in_home(runtime_home_dir().as_deref())
+}
+
+/// Locate `amd-smi` inside the bin directories of the newest managed ROCm SDK
+/// runtime recorded in the registry. The binary ships with the TheRock wheel
+/// (under the SDK `bin_path` and/or the venv `install_root/bin`) and is not on
+/// `PATH`, so the home-directory fallbacks below never find it.
+fn resolve_amd_smi_binary_in_registry(registry_dir: &Path) -> Option<OsString> {
+    let mut records = managed_therock_environment_records(registry_dir);
+    records.sort_by_key(|(_, record)| std::cmp::Reverse(record.installed_at_unix_ms.unwrap_or(0)));
+    records.into_iter().find_map(|(_, record)| {
+        amd_smi_bin_dirs_for_record(&record)
+            .iter()
+            .find_map(|bin_dir| managed_sdk_tool_path(bin_dir, "amd-smi"))
+            .map(PathBuf::into_os_string)
+    })
+}
+
+fn amd_smi_bin_dirs_for_record(record: &TheRockFamilyManifest) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(sdk) = record.rocm_sdk.as_ref() {
+        if let Some(bin_path) = sdk.bin_path.as_ref() {
+            dirs.push(bin_path.clone());
+        }
+        for bin_path in &sdk.bin_paths {
+            if !dirs.contains(bin_path) {
+                dirs.push(bin_path.clone());
+            }
+        }
+    }
+    if let Some(install_root) = record.install_root.as_ref() {
+        let install_bin = install_root.join("bin");
+        if !dirs.contains(&install_bin) {
+            dirs.push(install_bin);
+        }
+    }
+    dirs
+}
+
+fn resolve_amd_smi_binary_in_home(home_dir: Option<&Path>) -> OsString {
+    if let Some(home_rocm_dir) = home_dir.map(Path::to_path_buf).map(|dir| dir.join(".rocm")) {
+        let amd_smi_path = home_rocm_dir.join("bin").join("amd-smi");
+        if amd_smi_path.is_file() {
+            return amd_smi_path.into();
+        }
+    }
+
+    if let Some(home_dir) = home_dir {
+        let amd_smi_path = home_dir
+            .join("rocm_venvs")
+            .join("default")
+            .join("bin")
+            .join("amd-smi");
+        if amd_smi_path.is_file() {
+            return amd_smi_path.into();
+        }
+
+        let legacy_rocm_path = home_dir.join(".rocm").join("bin").join("amd-smi");
+        if legacy_rocm_path.is_file() {
+            return legacy_rocm_path.into();
+        }
+    }
+
+    "amd-smi".into()
+}
+
 pub fn generate_service_id(engine: &str, model_ref: &str) -> String {
     let model_slug = sanitize_component(model_ref)
         .trim_matches('-')
@@ -5904,6 +5977,8 @@ pub fn unix_time_millis() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::path::Path;
 
     #[test]
     fn openai_models_endpoint_has_model_checks_loaded_model_ids() -> Result<()> {
@@ -5944,6 +6019,68 @@ mod tests {
 
         let request = server.join().expect("server thread should not panic")?;
         assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_amd_smi_binary_prefers_home_rocm_venv_path() -> Result<()> {
+        let temp_root = std::env::temp_dir().join(format!("rocm-cli-amd-smi-{}", unix_time_millis()));
+        let bin_dir = temp_root.join("rocm_venvs/default/bin");
+        fs::create_dir_all(&bin_dir)?;
+        let amd_smi_path = bin_dir.join("amd-smi");
+        fs::write(&amd_smi_path, b"#!/bin/sh\nexit 0\n")?;
+
+        let resolved = resolve_amd_smi_binary_in_home(Some(Path::new(&temp_root)));
+
+        let _ = fs::remove_file(&amd_smi_path);
+        let _ = fs::remove_dir_all(&temp_root);
+
+        assert_eq!(resolved, amd_smi_path.into_os_string());
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_amd_smi_binary_in_registry_uses_newest_runtime_sdk_bin() -> Result<()> {
+        let temp_root = std::env::temp_dir()
+            .join(format!("rocm-cli-amd-smi-registry-{}", unix_time_millis()));
+        let registry_dir = temp_root.join("runtimes/registry");
+        fs::create_dir_all(&registry_dir)?;
+
+        // Older runtime: amd-smi only under the venv install_root/bin.
+        let old_root = temp_root.join("release-wheel-gfx94x-dcgpu-7-13-0");
+        let old_bin = old_root.join("bin");
+        fs::create_dir_all(&old_bin)?;
+        fs::write(old_bin.join("amd-smi"), b"#!/bin/sh\nexit 0\n")?;
+        fs::write(
+            registry_dir.join("old.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "runtime_id": "therock-stable:gfx94X-dcgpu",
+                "install_root": old_root,
+                "installed_at_unix_ms": 1_000_u128,
+                "rocm_sdk": { "import_ok": true },
+            }))?,
+        )?;
+
+        // Newer runtime: amd-smi under the SDK devel bin_path.
+        let new_bin = temp_root
+            .join("release-wheel-gfx94x-dcgpu-7-14-0a20260611/_rocm_sdk_devel/bin");
+        fs::create_dir_all(&new_bin)?;
+        let new_amd_smi = new_bin.join("amd-smi");
+        fs::write(&new_amd_smi, b"#!/bin/sh\nexit 0\n")?;
+        fs::write(
+            registry_dir.join("new.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "runtime_id": "therock-stable:gfx94X-dcgpu",
+                "installed_at_unix_ms": 2_000_u128,
+                "rocm_sdk": { "import_ok": true, "bin_path": new_bin },
+            }))?,
+        )?;
+
+        let resolved = resolve_amd_smi_binary_in_registry(&registry_dir);
+
+        let _ = fs::remove_dir_all(&temp_root);
+
+        assert_eq!(resolved, Some(new_amd_smi.into_os_string()));
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5917,26 +5917,15 @@ fn amd_smi_bin_dirs_for_record(record: &TheRockFamilyManifest) -> Vec<PathBuf> {
 }
 
 fn resolve_amd_smi_binary_in_home(home_dir: Option<&Path>) -> OsString {
-    if let Some(home_rocm_dir) = home_dir.map(Path::to_path_buf).map(|dir| dir.join(".rocm")) {
-        let amd_smi_path = home_rocm_dir.join("bin").join("amd-smi");
-        if amd_smi_path.is_file() {
-            return amd_smi_path.into();
-        }
-    }
-
     if let Some(home_dir) = home_dir {
-        let amd_smi_path = home_dir
-            .join("rocm_venvs")
-            .join("default")
-            .join("bin")
-            .join("amd-smi");
-        if amd_smi_path.is_file() {
-            return amd_smi_path.into();
+        let venv_bin = home_dir.join("rocm_venvs").join("default").join("bin");
+        if let Some(path) = managed_sdk_tool_path(&venv_bin, "amd-smi") {
+            return path.into_os_string();
         }
 
-        let legacy_rocm_path = home_dir.join(".rocm").join("bin").join("amd-smi");
-        if legacy_rocm_path.is_file() {
-            return legacy_rocm_path.into();
+        let legacy_bin = home_dir.join(".rocm").join("bin");
+        if let Some(path) = managed_sdk_tool_path(&legacy_bin, "amd-smi") {
+            return path.into_os_string();
         }
     }
 
@@ -6024,8 +6013,9 @@ mod tests {
 
     #[test]
     fn resolve_amd_smi_binary_prefers_home_rocm_venv_path() -> Result<()> {
-        let temp_root = std::env::temp_dir().join(format!("rocm-cli-amd-smi-{}", unix_time_millis()));
-        let bin_dir = temp_root.join("rocm_venvs/default/bin");
+        let temp_root =
+            std::env::temp_dir().join(format!("rocm-cli-amd-smi-{}", unix_time_millis()));
+        let bin_dir = temp_root.join("rocm_venvs").join("default").join("bin");
         fs::create_dir_all(&bin_dir)?;
         let amd_smi_path = bin_dir.join("amd-smi");
         fs::write(&amd_smi_path, b"#!/bin/sh\nexit 0\n")?;
@@ -6041,8 +6031,8 @@ mod tests {
 
     #[test]
     fn resolve_amd_smi_binary_in_registry_uses_newest_runtime_sdk_bin() -> Result<()> {
-        let temp_root = std::env::temp_dir()
-            .join(format!("rocm-cli-amd-smi-registry-{}", unix_time_millis()));
+        let temp_root =
+            std::env::temp_dir().join(format!("rocm-cli-amd-smi-registry-{}", unix_time_millis()));
         let registry_dir = temp_root.join("runtimes/registry");
         fs::create_dir_all(&registry_dir)?;
 
@@ -6062,8 +6052,8 @@ mod tests {
         )?;
 
         // Newer runtime: amd-smi under the SDK devel bin_path.
-        let new_bin = temp_root
-            .join("release-wheel-gfx94x-dcgpu-7-14-0a20260611/_rocm_sdk_devel/bin");
+        let new_bin =
+            temp_root.join("release-wheel-gfx94x-dcgpu-7-14-0a20260611/_rocm_sdk_devel/bin");
         fs::create_dir_all(&new_bin)?;
         let new_amd_smi = new_bin.join("amd-smi");
         fs::write(&new_amd_smi, b"#!/bin/sh\nexit 0\n")?;

--- a/crates/rocm-dash-collectors/src/amd_smi.rs
+++ b/crates/rocm-dash-collectors/src/amd_smi.rs
@@ -3,6 +3,7 @@
 //! Field paths and the KFD pre-flight check are vendored from the TypeScript
 //! `AmdSmiProvider` in instinct-dash. See `../wiki/entities/amd-smi.md`.
 
+use std::ffi::OsString;
 use std::io;
 use std::time::Duration;
 
@@ -20,7 +21,7 @@ const RUN_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 pub struct AmdSmiCollector {
-    binary: String,
+    binary: OsString,
 }
 
 impl AmdSmiCollector {
@@ -35,9 +36,9 @@ impl AmdSmiCollector {
     /// Like [`detect`](Self::detect) but uses an explicit `amd-smi` binary path.
     ///
     /// The managed ROCm SDK ships `amd-smi` inside the runtime wheel's bin
-    /// directory rather than on `PATH`, so callers resolve the absolute path
-    /// (via `rocm_core::resolve_amd_smi_binary`) and pass it here.
-    pub async fn detect_with_binary(binary: impl Into<String>) -> Option<Self> {
+    /// directory rather than on `PATH`, so callers resolve the path or command
+    /// name (via `rocm_core::resolve_amd_smi_binary`) and pass it here.
+    pub async fn detect_with_binary(binary: impl Into<OsString>) -> Option<Self> {
         if !kfd_accessible() {
             return None;
         }
@@ -47,11 +48,11 @@ impl AmdSmiCollector {
         match timeout(DETECT_TIMEOUT, me.run(&["version"])).await {
             Ok(Ok(_)) => Some(me),
             Ok(Err(e)) => {
-                warn!(error = %e, binary = %me.binary, "amd-smi present but `version` failed");
+                warn!(error = %e, binary = ?me.binary, "amd-smi present but `version` failed");
                 None
             }
             Err(_) => {
-                warn!(binary = %me.binary, "amd-smi `version` timed out");
+                warn!(binary = ?me.binary, "amd-smi `version` timed out");
                 None
             }
         }

--- a/crates/rocm-dash-collectors/src/amd_smi.rs
+++ b/crates/rocm-dash-collectors/src/amd_smi.rs
@@ -29,20 +29,29 @@ impl AmdSmiCollector {
     /// The KFD pre-flight is mandatory: without it, `amd-smi` blocks in
     /// uninterruptible kernel sleep (D-state) that no signal can escape.
     pub async fn detect() -> Option<Self> {
+        Self::detect_with_binary("amd-smi").await
+    }
+
+    /// Like [`detect`](Self::detect) but uses an explicit `amd-smi` binary path.
+    ///
+    /// The managed ROCm SDK ships `amd-smi` inside the runtime wheel's bin
+    /// directory rather than on `PATH`, so callers resolve the absolute path
+    /// (via `rocm_core::resolve_amd_smi_binary`) and pass it here.
+    pub async fn detect_with_binary(binary: impl Into<String>) -> Option<Self> {
         if !kfd_accessible() {
             return None;
         }
         let me = Self {
-            binary: "amd-smi".into(),
+            binary: binary.into(),
         };
         match timeout(DETECT_TIMEOUT, me.run(&["version"])).await {
             Ok(Ok(_)) => Some(me),
             Ok(Err(e)) => {
-                warn!(error = %e, "amd-smi present but `version` failed");
+                warn!(error = %e, binary = %me.binary, "amd-smi present but `version` failed");
                 None
             }
             Err(_) => {
-                warn!("amd-smi `version` timed out");
+                warn!(binary = %me.binary, "amd-smi `version` timed out");
                 None
             }
         }

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -58,6 +58,11 @@ pub struct RunnerOptions {
     /// served via `rocm serve` appears in the dashboard with live `gen_tps`
     /// without Docker discovery. Off by default.
     pub services_dir: Option<PathBuf>,
+    /// Absolute path to the `amd-smi` binary. The managed ROCm SDK ships it
+    /// inside the runtime wheel's bin directory rather than on `PATH`, so the
+    /// caller resolves it (via `rocm_core::resolve_amd_smi_binary`) and passes
+    /// it here. `None` falls back to looking up `amd-smi` on `PATH`.
+    pub amd_smi_binary: Option<String>,
 }
 
 impl Default for RunnerOptions {
@@ -76,6 +81,7 @@ impl Default for RunnerOptions {
             lemonade_port: rocm_dash_collectors::lemonade::LEMONADE_PORT,
             persist_dir: None,
             services_dir: None,
+            amd_smi_binary: None,
         }
     }
 }
@@ -166,7 +172,10 @@ pub async fn run_loop(
     // stable between scrapes (mirrors how GPU power drives tokens_per_watt).
     let mut per_container_used: HashMap<String, u64> = HashMap::new();
 
-    let gpu = AmdSmiCollector::detect().await;
+    let gpu = match opts.amd_smi_binary.clone() {
+        Some(binary) => AmdSmiCollector::detect_with_binary(binary).await,
+        None => AmdSmiCollector::detect().await,
+    };
     let mut gpu_system_info: Option<GpuSystemInfo> = if let Some(g) = &gpu {
         let info = g.system_info().await;
         info!(

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -1,6 +1,7 @@
 //! Owner task: drives collectors on tick cadences and broadcasts Snapshots.
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -58,11 +59,11 @@ pub struct RunnerOptions {
     /// served via `rocm serve` appears in the dashboard with live `gen_tps`
     /// without Docker discovery. Off by default.
     pub services_dir: Option<PathBuf>,
-    /// Absolute path to the `amd-smi` binary. The managed ROCm SDK ships it
-    /// inside the runtime wheel's bin directory rather than on `PATH`, so the
-    /// caller resolves it (via `rocm_core::resolve_amd_smi_binary`) and passes
-    /// it here. `None` falls back to looking up `amd-smi` on `PATH`.
-    pub amd_smi_binary: Option<String>,
+    /// Path or command name for the `amd-smi` binary. The managed ROCm SDK
+    /// ships it inside the runtime wheel's bin directory rather than on `PATH`,
+    /// so the caller resolves it (via `rocm_core::resolve_amd_smi_binary`) and
+    /// passes it here. `None` falls back to looking up `amd-smi` on `PATH`.
+    pub amd_smi_binary: Option<OsString>,
 }
 
 impl Default for RunnerOptions {


### PR DESCRIPTION
`rocm dash` assumes that `amd-smi` is in path (for displaying GPU info), which it is not for default installation. This PR adds logic for amd-smi path resolution.