### PR TITLE
Fix clippy lints in rocm-dash-daemon

### DIFF
--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -68,13 +68,14 @@ async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
                 .recursive(true)
                 .mode(0o700)
                 .create(parent)
-                .with_context(|| format!("creating socket directory {parent:?}"))?;
+                .with_context(|| format!("creating socket directory {}", parent.display()))?;
             std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).with_context(
                 || {
                     format!(
-                        "restricting socket directory {parent:?} to mode 0700 — \
+                        "restricting socket directory {} to mode 0700 — \
                          check that the directory is owned by the current user \
-                         (EPERM means it is owned by another user or root)"
+                         (EPERM means it is owned by another user or root)",
+                        parent.display()
                     )
                 },
             )?;
@@ -84,11 +85,12 @@ async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
         std::fs::remove_file(&path)
             .with_context(|| format!("removing stale socket {}", path.display()))?;
     }
-    let listener = UnixListener::bind(&path).with_context(|| format!("binding {path:?}"))?;
+    let listener =
+        UnixListener::bind(&path).with_context(|| format!("binding {}", path.display()))?;
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("setting permissions on {path:?}"))?;
+            .with_context(|| format!("setting permissions on {}", path.display()))?;
     }
     info!(socket = %path.display(), "listening");
 

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -241,9 +241,10 @@ async fn socket_is_created_with_restricted_permissions() {
                 break m;
             }
         }
-        if std::time::Instant::now() >= deadline {
-            panic!("daemon did not create socket with mode 0o600 within 5 s");
-        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "daemon did not create socket with mode 0o600 within 5 s"
+        );
         tokio::time::sleep(Duration::from_millis(20)).await;
     };
 


### PR DESCRIPTION
## Summary

Fixes the `cargo clippy --workspace --all-targets -- -D warnings` failure in CI.

- `src/server.rs`: switch `{parent:?}` / `{path:?}` to `Display` formatting via `.display()` (`clippy::unnecessary_debug_formatting`, 4 sites)
- `tests/end_to_end.rs`: replace `if … { panic!(…) }` with `assert!(…)` (`clippy::manual_assert`). This one was masked in CI because the lib failed to compile first.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean locally