### PR TITLE
Nightly/release: build only shipped binaries + fix draft-staging cleanup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
                 curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none --no-modify-path
               fi
               export PATH="/host-cargo/bin:$PATH"
-              cargo build --release --workspace
+              cargo build --release -p rocm -p rocmd -p xtask
             '
 
       - name: Set nightly metadata
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build release binaries
         shell: pwsh
-        run: cargo build --release --workspace
+        run: cargo build --release -p rocm -p rocmd -p xtask
 
       - name: Package Windows bundle
         shell: pwsh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -292,7 +292,9 @@ jobs:
             "${EXTRA}/rocm" "${EXTRA}/rocm.exe" \
             "${EXTRA}/linux-binaries.tar.gz" "${EXTRA}/windows-binaries.zip" --clobber
 
-          gh release delete "${STAGING_TAG}" --yes --cleanup-tag
+          # The staging release is a draft, which never creates a git tag, so
+          # --cleanup-tag would 422 on a nonexistent ref. Just delete the draft.
+          gh release delete "${STAGING_TAG}" --yes 2>/dev/null || true
 
   cleanup-staging-nightly:
     name: Clean failed nightly staging release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
                 curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none --no-modify-path
               fi
               export PATH="/host-cargo/bin:$PATH"
-              cargo build --release --workspace
+              cargo build --release -p rocm -p rocmd -p xtask
             '
 
       - name: Package release bundle
@@ -168,7 +168,7 @@ jobs:
 
       - name: Build release binaries
         shell: pwsh
-        run: cargo build --release --workspace
+        run: cargo build --release -p rocm -p rocmd -p xtask
 
       - name: Package Windows bundle
         shell: pwsh


### PR DESCRIPTION
Two nightly/release packaging fixes.

## 1. Build only shipped binaries (speed up)
The build steps ran `cargo build --release --workspace`, compiling the whole workspace in release mode inside manylinux — including the six standalone `rocm-engine-*` binaries and `rocm-dash-daemon` that are no longer shipped (bundle is `rocm` + `rocmd`), plus test/example targets. Narrowed to:

```diff
- cargo build --release --workspace
+ cargo build --release -p rocm -p rocmd -p xtask
```

Engine **library** crates still compile (linked into `rocm` for the in-process engines), so behavior is unchanged; we skip the redundant binary link/codegen. Full-workspace compilation stays covered by `ci.yml`'s `build-and-test`. (nightly.yml + release.yml, Linux + Windows.)

## 2. Fix `publish-nightly` failing on staging cleanup
The first fully-working nightly published the rolling `nightly` release with all 16 assets, then the job **failed on its last line**:

```
HTTP 422: Reference does not exist (.../git/refs/tags/nightly-staging-…)
```

`gh release delete "$STAGING_TAG" --yes --cleanup-tag` 422s because the staging release is a `--draft`, and **draft releases never create a git tag** — so there's nothing for `--cleanup-tag` to delete. Dropped `--cleanup-tag` and made it tolerant, matching the other two staging-delete sites. (`release.yml` doesn't have this pattern — it publishes via `--draft=false`.)

## Status
The convenience-asset + signing pipeline is otherwise working end-to-end — the latest manual nightly already produced a healthy `nightly` release (signed bundles + `rocm`/`rocm.exe`/`linux-binaries.tar.gz`/`windows-binaries.zip`). This PR just makes the run go fully green and trims build time.