### PR TITLE
§2: wire `rocm daemon` to the real background-helper loop + on-demand autostart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,7 @@ dependencies = [
  "rocm-engine-pytorch",
  "rocm-engine-sglang",
  "rocm-engine-vllm",
+ "rocmd",
  "rpassword",
  "serde",
  "serde_json",

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -30,6 +30,7 @@ rocm-engine-llama-cpp = { path = "../../engines/llama-cpp" }
 rocm-engine-pytorch = { path = "../../engines/pytorch" }
 rocm-engine-protocol = { path = "../../crates/rocm-engine-protocol" }
 rocm-engine-sglang = { path = "../../engines/sglang" }
+rocmd = { path = "../rocmd" }
 rocm-engine-vllm = { path = "../../engines/vllm" }
 rpassword.workspace = true
 serde.workspace = true

--- a/apps/rocm/src/automations.rs
+++ b/apps/rocm/src/automations.rs
@@ -37,9 +37,7 @@ pub(crate) fn automations(command: Option<AutomationsCommand>) -> Result<()> {
                 println!("  policy: {note}");
             }
             println!("  config: {}", paths.config_path().display());
-            println!(
-                "  next step: run `rocmd run --automations-enabled` to start the persistent watcher loop"
-            );
+            crate::ensure_background_helper_running()?;
         }
         AutomationsCommand::Disable { watcher } => {
             let Some(spec) = builtin_watcher(&watcher) else {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3456,7 +3456,7 @@ fn serve(
     }
 
     if managed {
-        return start_managed_service(
+        start_managed_service(
             &selected_engine,
             &service_id,
             &model,
@@ -3467,7 +3467,9 @@ fn serve(
             managed_runtime_id.as_deref(),
             managed_env_id.as_deref(),
             resolve.engine_recipe.as_ref(),
-        );
+        )?;
+        ensure_background_helper_running()?;
+        return Ok(());
     }
 
     if !foreground {
@@ -3664,6 +3666,45 @@ fn start_managed_service(
         ),
         Some(service_id),
     );
+    Ok(())
+}
+
+/// Start the background automation helper (`rocm daemon`) detached if it is not
+/// already running. Liveness is read from the file-based automation runtime
+/// state. A spawn failure is logged but never propagated to the caller, so
+/// enabling automations or launching a managed serve never hard-fails when the
+/// helper cannot start.
+fn ensure_background_helper_running() -> Result<()> {
+    let paths = AppPaths::discover()?;
+    if let Some(state) = AutomationRuntimeState::load(&paths)?
+        && state.running
+        && rocm_core::process_is_running(state.daemon_pid)
+    {
+        return Ok(());
+    }
+
+    let exe = managed_service_launcher_path()
+        .context("failed to resolve current rocm executable path")?;
+    let args = vec!["daemon".to_owned()];
+    #[cfg(windows)]
+    let spawn_result = {
+        let env_values = app_path_env_var_values(&paths, None);
+        let env_refs = app_path_env_var_refs(&env_values);
+        rocm_core::spawn_detached_no_inherit(&exe, &args, &env_refs).map(|_| ())
+    };
+    #[cfg(not(windows))]
+    let spawn_result = {
+        let mut command = managed_service_process_command(&exe, &args);
+        command.stdin(Stdio::null());
+        attach_background_stdio(&mut command, None)?;
+        detach_background_command(&mut command);
+        apply_app_path_env(&mut command, &paths);
+        command.spawn().map(|_| ())
+    };
+    match spawn_result {
+        Ok(()) => println!("  helper: started background automation daemon"),
+        Err(error) => println!("  helper: could not start background automation daemon: {error}"),
+    }
     Ok(())
 }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -14170,6 +14170,18 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn daemon_run_argv_targets_rocmd_run_with_automations() {
+        assert_eq!(
+            daemon_run_argv(),
+            vec![
+                OsString::from("rocmd"),
+                OsString::from("run"),
+                OsString::from("--automations-enabled"),
+            ]
+        );
+    }
+
+    #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {
         let loading = json!({ "all_models_loaded": [] }).to_string();
         assert!(!service_http_readiness_response_ready(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3669,12 +3669,13 @@ fn start_managed_service(
     Ok(())
 }
 
-/// Start the background automation helper (`rocm daemon`) detached if it is not
-/// already running. Liveness is read from the file-based automation runtime
-/// state. A spawn failure is logged but never propagated to the caller, so
-/// enabling automations or launching a managed serve never hard-fails when the
-/// helper cannot start.
-fn ensure_background_helper_running() -> Result<()> {
+/// Shared daemon-lifecycle entrypoint: ensures the background automation helper
+/// (`rocm daemon`) is running, spawning it detached if not. Liveness is read from
+/// the file-based automation runtime state. Intentionally `pub(crate)` — reused by
+/// both the `serve --managed` path and `automations enable`. Only the spawn result
+/// itself (`command.spawn()` / `spawn_detached_no_inherit`) is logged rather than
+/// propagated; setup errors (path discovery, stdio attach) still return `Err`.
+pub(crate) fn ensure_background_helper_running() -> Result<()> {
     let paths = AppPaths::discover()?;
     if let Some(state) = AutomationRuntimeState::load(&paths)?
         && state.running
@@ -14169,17 +14170,16 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn daemon_run_argv_targets_rocmd_run_with_automations() {
-        assert_eq!(
-            daemon_run_argv(),
-            vec![
-                OsString::from("rocmd"),
-                OsString::from("run"),
-                OsString::from("--automations-enabled"),
-            ]
-        );
-    }
+    // The previous `daemon_run_argv_targets_rocmd_run_with_automations` unit test
+    // only re-asserted the literals `daemon_run_argv()` returns, so it tested
+    // nothing real. The intended real behavior — that this argv actually drives
+    // `rocmd` into its `run --automations-enabled` foreground loop — is proven
+    // end-to-end by the `daemon_runs_real_foreground_loop` integration test in
+    // tests/daemon_run.rs. A non-tautological unit test would require parsing the
+    // argv through `rocmd::Cli`/`rocmd::Command`, but those clap structs are
+    // crate-private in rocmd and exposing them (plus their private field types
+    // like `SandboxToolArg`) is more than a trivial visibility change, so the
+    // tautological unit test is removed in favor of the integration coverage.
 
     #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -248,7 +248,11 @@ enum Command {
         query: Vec<String>,
     },
     /// Start the background helper in the foreground.
-    Daemon,
+    Daemon {
+        /// Print the automation status panel instead of running the helper loop.
+        #[arg(long)]
+        status: bool,
+    },
     /// Launch the unified telemetry dashboard (TUI) with an embedded daemon.
     Dash {
         /// Replay a recorded session NDJSON instead of connecting to a live daemon.
@@ -1295,11 +1299,15 @@ fn dispatch(cli: Cli) -> Result<()> {
             }
             Ok(())
         }
-        Some(Command::Daemon) => {
-            let paths = AppPaths::discover()?;
-            let config = RocmCliConfig::load(&paths)?;
-            print!("{}", render_daemon_text(&paths, &config));
-            Ok(())
+        Some(Command::Daemon { status }) => {
+            if status {
+                let paths = AppPaths::discover()?;
+                let config = RocmCliConfig::load(&paths)?;
+                print!("{}", render_daemon_text(&paths, &config));
+                Ok(())
+            } else {
+                rocmd::run_from_args(daemon_run_argv())
+            }
         }
         Some(Command::Dash {
             replay,
@@ -13869,6 +13877,16 @@ fn app_path_env_var_refs<'a>(vars: &'a [(&'static str, PathBuf)]) -> Vec<(&'stat
     vars.iter()
         .map(|(key, value)| (*key, value.as_path()))
         .collect()
+}
+
+/// Argv passed to the embedded `rocmd` library to run the real foreground
+/// automation loop (the same path as `rocmd run --automations-enabled`).
+fn daemon_run_argv() -> Vec<OsString> {
+    vec![
+        OsString::from("rocmd"),
+        OsString::from("run"),
+        OsString::from("--automations-enabled"),
+    ]
 }
 
 fn managed_service_launcher_path() -> Result<PathBuf> {

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -1,0 +1,87 @@
+//! Integration test proving `rocm daemon` runs the real foreground automation
+//! loop (embedded `rocmd`) instead of only printing the status panel.
+//!
+//! The real loop prints the `rocmd run` banner and then blocks forever, so we
+//! spawn the built binary, read stdout until the banner appears (or a short
+//! timeout elapses), then kill the process.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Resolve a writable temp directory unique to this test run.
+fn temp_state_dir() -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let unique = format!(
+        "rocm-daemon-run-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_nanos()
+    );
+    dir.push(unique);
+    std::fs::create_dir_all(&dir).expect("create temp state dir");
+    dir
+}
+
+#[test]
+fn daemon_runs_real_foreground_loop() {
+    let state_dir = temp_state_dir();
+    let config_dir = state_dir.join("config");
+    let data_dir = state_dir.join("data");
+    let cache_dir = state_dir.join("cache");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rocm"))
+        .arg("daemon")
+        // Point AppPaths::discover at the temp dirs so the daemon never touches
+        // the real user environment.
+        .env("ROCM_CLI_CONFIG_DIR", &config_dir)
+        .env("ROCM_CLI_DATA_DIR", &data_dir)
+        .env("ROCM_CLI_CACHE_DIR", &cache_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("spawn rocm daemon");
+
+    let stdout = child.stdout.take().expect("capture daemon stdout");
+    let (tx, rx) = mpsc::channel::<bool>();
+    let reader = thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break, // EOF: process exited.
+                Ok(_) => {
+                    if line.trim_end() == "rocmd run" {
+                        let _ = tx.send(true);
+                        return;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = tx.send(false);
+    });
+
+    let saw_banner = rx
+        .recv_timeout(Duration::from_secs(20))
+        .unwrap_or(false);
+
+    // The foreground loop blocks; terminate it regardless of outcome.
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+    let _ = std::fs::remove_dir_all(&state_dir);
+
+    assert!(
+        saw_banner,
+        "expected `rocm daemon` to print the rocmd run banner (real foreground loop), \
+         but it did not appear before timeout"
+    );
+}

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -69,9 +69,7 @@ fn daemon_runs_real_foreground_loop() {
         let _ = tx.send(false);
     });
 
-    let saw_banner = rx
-        .recv_timeout(Duration::from_secs(20))
-        .unwrap_or(false);
+    let saw_banner = rx.recv_timeout(Duration::from_secs(20)).unwrap_or(false);
 
     // The foreground loop blocks; terminate it regardless of outcome.
     let _ = child.kill();


### PR DESCRIPTION
**Stack 1/10** · base: `main`

Fixes ROADMAP §2 (daemon regression). `rocm daemon` only printed a status panel; the real loop lived in the separate `rocmd` crate.

- Adds `rocmd` path-dep to `apps/rocm` (acyclic); `rocm daemon` now runs the real foreground loop via `rocmd::run_from_args(["rocmd","run","--automations-enabled"])`.
- `rocm daemon --status` preserves the old status panel.
- `ensure_background_helper_running()`: on-demand **detached** autostart (double-spawn-guarded via `AutomationRuntimeState.daemon_pid` + `process_is_running`) on `automations enable` and `serve --managed`.

**Test plan:** `cargo build/test/clippy -D warnings/fmt --check` (workspace, all-targets) green; integration test `daemon_runs_real_foreground_loop`. Reviewed: rust + security + maintainability, zero unresolved CRITICAL/HIGH.