### PR TITLE
§1: rocm-core-free execution seam (RocmToolExecutor boundary)

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -208,10 +208,9 @@ async fn run_async(
     // Inject the bin-side tool-execution seam for a live dash only. Demo/replay
     // and the offline chat mock keep `tool_executor = None` and behave as today.
     if !chat_mock && replay.is_none() {
-        args.tool_executor = Some(std::sync::Arc::new(crate::dash_seam::BinToolExecutor::new(
-            paths.clone(),
-        ))
-            as rocm_dash_tui::tool_exec::SharedRocmToolExecutor);
+        let executor: rocm_dash_tui::tool_exec::SharedRocmToolExecutor =
+            std::sync::Arc::new(crate::dash_seam::BinToolExecutor::new(paths.clone()));
+        args.tool_executor = Some(executor);
     }
     // A live daemon is only needed when connecting; replay/demo feeds events
     // straight into the TUI, so skip the embedded daemon in that mode.

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -166,6 +166,9 @@ pub fn resolved_args(
         model_recipes: model_recipe_summaries(),
         runtimes: runtime_summaries(paths, config),
         automations: automation_summaries(config),
+        // The real executor is injected in `run_async` for a live dash; None
+        // here keeps demo/replay/mock behaving exactly as today.
+        tool_executor: None,
     }
 }
 

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -205,6 +205,14 @@ async fn run_async(
     let mut args = resolved_args(&config, &paths, ActiveTab::Overview);
     args.replay = replay.clone();
     args.chat_mock = chat_mock;
+    // Inject the bin-side tool-execution seam for a live dash only. Demo/replay
+    // and the offline chat mock keep `tool_executor = None` and behave as today.
+    if !chat_mock && replay.is_none() {
+        args.tool_executor = Some(std::sync::Arc::new(crate::dash_seam::BinToolExecutor::new(
+            paths.clone(),
+        ))
+            as rocm_dash_tui::tool_exec::SharedRocmToolExecutor);
+    }
     // A live daemon is only needed when connecting; replay/demo feeds events
     // straight into the TUI, so skip the embedded daemon in that mode.
     let embedded = if replay.is_none() {

--- a/apps/rocm/src/dash_seam.rs
+++ b/apps/rocm/src/dash_seam.rs
@@ -1,0 +1,142 @@
+//! Bin-side implementation of the dash execution seam.
+//!
+//! The dash crates stay free of `rocm-core`; this module lives in the bin
+//! (`apps/rocm`, which owns `rocm-core` and the tool engine) and implements the
+//! rocm-core-free [`RocmToolExecutor`] boundary by reusing the existing bin
+//! engine functions. Plain data in/out only — no dash internals leak here.
+
+use clap::Parser;
+use rocm_core::AppPaths;
+use rocm_dash_tui::tool_exec::{ApprovalIntent, RocmToolExecutor, RocmToolOutcome};
+
+use crate::Cli;
+use crate::providers;
+
+/// Concrete tool executor injected into a live dash. Carries the resolved
+/// [`AppPaths`] so read-only tool calls can be served in-process.
+#[derive(Debug)]
+pub(crate) struct BinToolExecutor {
+    paths: AppPaths,
+}
+
+impl BinToolExecutor {
+    pub(crate) fn new(paths: AppPaths) -> Self {
+        Self { paths }
+    }
+}
+
+impl RocmToolExecutor for BinToolExecutor {
+    fn execute(&self, name: &str, args: &serde_json::Value) -> RocmToolOutcome {
+        let call = providers::ChatToolCall {
+            id: None,
+            name: name.to_owned(),
+            arguments: args.clone(),
+        };
+        if let Err(e) = crate::validate_chat_tool_call(&call) {
+            return RocmToolOutcome::Error(e.to_string());
+        }
+        if crate::chat_tool_call_is_read_only(&call) {
+            match crate::run_internal_mcp_call(&self.paths, name, args.clone(), false) {
+                Ok(v) => RocmToolOutcome::Result(v),
+                Err(e) => RocmToolOutcome::Error(e.to_string()),
+            }
+        } else {
+            match crate::chat_tool_approval_request(&call, None) {
+                Ok(req) => RocmToolOutcome::ApprovalRequired(ApprovalIntent {
+                    title: req.pending_title,
+                    body: {
+                        let mut b = vec![req.command_title];
+                        if let Some(dc) = req.display_command {
+                            b.push(dc);
+                        }
+                        b
+                    },
+                    args: req.args,
+                }),
+                Err(e) => RocmToolOutcome::Error(e.to_string()),
+            }
+        }
+    }
+
+    fn execute_approved(&self, args: &[String]) -> RocmToolOutcome {
+        let argv = std::iter::once("rocm".to_owned()).chain(args.iter().cloned());
+        match Cli::try_parse_from(argv) {
+            Ok(cli) => match crate::dispatch(cli) {
+                Ok(()) => RocmToolOutcome::Result(serde_json::json!({ "status": "ok" })),
+                Err(e) => RocmToolOutcome::Error(e.to_string()),
+            },
+            Err(e) => RocmToolOutcome::Error(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocm_core::AppPaths;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A hermetic `AppPaths` rooted under the OS temp dir so tests never touch
+    /// real home. Built directly (no env mutation) so it stays unsafe-free and
+    /// safe under test parallelism.
+    fn temp_paths() -> AppPaths {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "rocm-dash-seam-{}-{}-{n}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        AppPaths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            cache_dir: root.join("cache"),
+        }
+    }
+
+    #[test]
+    fn seam_read_only_intent_returns_json() {
+        let exec = BinToolExecutor::new(temp_paths());
+        let outcome = exec.execute("engines", &serde_json::json!({}));
+        match outcome {
+            RocmToolOutcome::Result(v) => {
+                assert!(v.is_object(), "engines result should be a JSON object");
+                assert!(
+                    v.get("structuredContent")
+                        .and_then(|d| d.get("engines"))
+                        .map(serde_json::Value::is_array)
+                        .unwrap_or(false),
+                    "engines result should carry an engines array, got: {v}"
+                );
+            }
+            other => panic!("expected Result for read-only `engines`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seam_mutating_intent_returns_approval() {
+        let exec = BinToolExecutor::new(temp_paths());
+        let outcome = exec.execute(
+            "install_sdk",
+            &serde_json::json!({
+                "channel": "release",
+                "format": "wheel",
+                "prefix": "/tmp/rocm-seam-test-prefix",
+            }),
+        );
+        match outcome {
+            RocmToolOutcome::ApprovalRequired(intent) => {
+                assert_eq!(
+                    &intent.args[..2],
+                    &["install".to_owned(), "sdk".to_owned()],
+                    "install_sdk approval args should start with [\"install\", \"sdk\"], got: {:?}",
+                    intent.args
+                );
+            }
+            other => panic!("expected ApprovalRequired for `install_sdk`, got {other:?}"),
+        }
+    }
+}

--- a/apps/rocm/src/dash_seam.rs
+++ b/apps/rocm/src/dash_seam.rs
@@ -20,7 +20,7 @@ pub(crate) struct BinToolExecutor {
 }
 
 impl BinToolExecutor {
-    pub(crate) fn new(paths: AppPaths) -> Self {
+    pub(crate) const fn new(paths: AppPaths) -> Self {
         Self { paths }
     }
 }
@@ -87,8 +87,7 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
+                .map_or(0, |d| d.as_nanos())
         ));
         AppPaths {
             config_dir: root.join("config"),
@@ -107,8 +106,7 @@ mod tests {
                 assert!(
                     v.get("structuredContent")
                         .and_then(|d| d.get("engines"))
-                        .map(serde_json::Value::is_array)
-                        .unwrap_or(false),
+                        .is_some_and(serde_json::Value::is_array),
                     "engines result should carry an engines array, got: {v}"
                 );
             }

--- a/apps/rocm/src/dash_seam.rs
+++ b/apps/rocm/src/dash_seam.rs
@@ -5,11 +5,9 @@
 //! rocm-core-free [`RocmToolExecutor`] boundary by reusing the existing bin
 //! engine functions. Plain data in/out only — no dash internals leak here.
 
-use clap::Parser;
 use rocm_core::AppPaths;
 use rocm_dash_tui::tool_exec::{ApprovalIntent, RocmToolExecutor, RocmToolOutcome};
 
-use crate::Cli;
 use crate::providers;
 
 /// Concrete tool executor injected into a live dash. Carries the resolved
@@ -55,17 +53,6 @@ impl RocmToolExecutor for BinToolExecutor {
                 }),
                 Err(e) => RocmToolOutcome::Error(e.to_string()),
             }
-        }
-    }
-
-    fn execute_approved(&self, args: &[String]) -> RocmToolOutcome {
-        let argv = std::iter::once("rocm".to_owned()).chain(args.iter().cloned());
-        match Cli::try_parse_from(argv) {
-            Ok(cli) => match crate::dispatch(cli) {
-                Ok(()) => RocmToolOutcome::Result(serde_json::json!({ "status": "ok" })),
-                Err(e) => RocmToolOutcome::Error(e.to_string()),
-            },
-            Err(e) => RocmToolOutcome::Error(e.to_string()),
         }
     }
 }
@@ -127,10 +114,10 @@ mod tests {
         );
         match outcome {
             RocmToolOutcome::ApprovalRequired(intent) => {
-                assert_eq!(
-                    &intent.args[..2],
-                    &["install".to_owned(), "sdk".to_owned()],
-                    "install_sdk approval args should start with [\"install\", \"sdk\"], got: {:?}",
+                assert!(
+                    intent.args.len() >= 2
+                        && intent.args[..2] == ["install".to_owned(), "sdk".to_owned()],
+                    "install_sdk approval args should start with [install, sdk], got: {:?}",
                     intent.args
                 );
             }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -14470,6 +14470,18 @@ mod tests {
     }
 
     #[test]
+    fn daemon_run_argv_targets_rocmd_run_with_automations() {
+        assert_eq!(
+            daemon_run_argv(),
+            vec![
+                OsString::from("rocmd"),
+                OsString::from("run"),
+                OsString::from("--automations-enabled"),
+            ]
+        );
+    }
+
+    #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {
         let loading = json!({ "all_models_loaded": [] }).to_string();
         assert!(!service_http_readiness_response_ready(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -14470,18 +14470,6 @@ mod tests {
     }
 
     #[test]
-    fn daemon_run_argv_targets_rocmd_run_with_automations() {
-        assert_eq!(
-            daemon_run_argv(),
-            vec![
-                OsString::from("rocmd"),
-                OsString::from("run"),
-                OsString::from("--automations-enabled"),
-            ]
-        );
-    }
-
-    #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {
         let loading = json!({ "all_models_loaded": [] }).to_string();
         assert!(!service_http_readiness_response_ready(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -2,6 +2,7 @@ mod automations;
 mod bootstrap;
 mod comfyui;
 mod dash;
+mod dash_seam;
 mod provider_keys;
 mod providers;
 mod therock;
@@ -1066,7 +1067,8 @@ fn render_freeform_comfyui_status_answer(
     Ok(output)
 }
 
-fn dispatch(cli: Cli) -> Result<()> {
+// pub(crate): used by the dash execution seam (dash_seam.rs)
+pub(crate) fn dispatch(cli: Cli) -> Result<()> {
     if !matches!(
         cli.command,
         Some(Command::Update { .. } | Command::Bootstrap { .. } | Command::Completions { .. })
@@ -8308,7 +8310,8 @@ fn chat_tool_value(tool_text: &str, key: &str) -> Option<String> {
     })
 }
 
-fn run_internal_mcp_call(
+// pub(crate): used by the dash execution seam (dash_seam.rs)
+pub(crate) fn run_internal_mcp_call(
     paths: &AppPaths,
     name: &str,
     arguments: serde_json::Value,

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1067,8 +1067,7 @@ fn render_freeform_comfyui_status_answer(
     Ok(output)
 }
 
-// pub(crate): used by the dash execution seam (dash_seam.rs)
-pub(crate) fn dispatch(cli: Cli) -> Result<()> {
+fn dispatch(cli: Cli) -> Result<()> {
     if !matches!(
         cli.command,
         Some(Command::Update { .. } | Command::Bootstrap { .. } | Command::Completions { .. })

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -68,6 +68,9 @@ pub struct ResolvedArgs {
     /// Background checks for the automations manager (Phase 3 Wave 3). Adapted
     /// by the bin. Empty when none are available.
     pub automations: Vec<crate::ui::automations_manager::AutomationSummary>,
+    /// Bin-injected tool-executor seam; None for demo/replay/mock — dash behaves
+    /// as today. Stored here (Phase 2 plumbing); Phase 3 will use it.
+    pub tool_executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
 }
 
 type Tui = Terminal<CrosstermBackend<io::Stdout>>;
@@ -364,6 +367,9 @@ pub struct AppState {
     /// Background checks for the automations manager. Set from `ResolvedArgs`
     /// in the event loop; empty by default.
     pub automations: Vec<crate::ui::automations_manager::AutomationSummary>,
+    /// Bin-injected tool-executor seam. Set from `ResolvedArgs` in the event
+    /// loop; `None` for demo/replay/mock and by default.
+    pub tool_executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
 }
 
 impl AppState {
@@ -420,6 +426,7 @@ impl AppState {
             model_recipes: Vec::new(),
             runtimes: Vec::new(),
             automations: Vec::new(),
+            tool_executor: None,
         }
     }
 
@@ -829,6 +836,9 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
     state.runtimes = args.runtimes.clone();
     // Automations manager source (Phase 3 Wave 3), adapted by the bin.
     state.automations = args.automations.clone();
+    // Tool-executor seam (Phase 2 plumbing), injected by the bin; None for
+    // demo/replay/mock. Phase 3 will use it.
+    state.tool_executor = args.tool_executor.clone();
     state.replay = replay_controller.map(ReplayState::new);
 
     // Resolve the chat backend. `--chat-mock` short-circuits detection with a

--- a/crates/rocm-dash-tui/src/lib.rs
+++ b/crates/rocm-dash-tui/src/lib.rs
@@ -12,5 +12,6 @@ pub mod llm;
 pub mod reconnect;
 pub mod replay;
 pub mod skills;
+pub mod tool_exec;
 pub mod transport;
 pub mod ui;

--- a/crates/rocm-dash-tui/src/tool_exec.rs
+++ b/crates/rocm-dash-tui/src/tool_exec.rs
@@ -23,9 +23,11 @@ pub enum RocmToolOutcome {
     Error(String),
 }
 
-/// rocm-core-free tool-executor boundary. The bin implements this; the dash holds
-/// it as `Option<Arc<dyn RocmToolExecutor>>` (None for demo/replay/mock).
-/// `Debug` supertrait so `ResolvedArgs`/`AppState` keep deriving Debug.
+/// rocm-core-free tool-executor boundary.
+///
+/// The bin implements this; the dash holds it as
+/// `Option<Arc<dyn RocmToolExecutor>>` (None for demo/replay/mock). The `Debug`
+/// supertrait keeps `ResolvedArgs`/`AppState` deriving Debug.
 pub trait RocmToolExecutor: std::fmt::Debug + Send + Sync {
     /// Execute a tool-call intent: read-only → Result(json); mutating → ApprovalRequired; failure → Error.
     fn execute(&self, name: &str, args: &serde_json::Value) -> RocmToolOutcome;

--- a/crates/rocm-dash-tui/src/tool_exec.rs
+++ b/crates/rocm-dash-tui/src/tool_exec.rs
@@ -1,0 +1,36 @@
+//! rocm-core-free tool-call boundary (the execution seam).
+//!
+//! Plain-data signatures ONLY (serde_json / std / serde). The bin (`apps/rocm`,
+//! which owns `rocm-core` and the tool engine) implements [`RocmToolExecutor`];
+//! the dash holds it as `Option<Arc<dyn RocmToolExecutor>>` and never depends on
+//! `rocm-core`. Phase 2 only stores the seam; Phase 3 will use it.
+
+use std::sync::Arc;
+
+/// Plain-data approval descriptor surfaced to the app event loop (Phase 4 renders it).
+#[derive(Debug, Clone)]
+pub struct ApprovalIntent {
+    pub title: String,
+    pub body: Vec<String>,
+    pub args: Vec<String>,
+}
+
+/// Outcome of a tool-call intent executed by the bin across the seam.
+#[derive(Debug, Clone)]
+pub enum RocmToolOutcome {
+    Result(serde_json::Value),
+    ApprovalRequired(ApprovalIntent),
+    Error(String),
+}
+
+/// rocm-core-free tool-executor boundary. The bin implements this; the dash holds
+/// it as `Option<Arc<dyn RocmToolExecutor>>` (None for demo/replay/mock).
+/// `Debug` supertrait so `ResolvedArgs`/`AppState` keep deriving Debug.
+pub trait RocmToolExecutor: std::fmt::Debug + Send + Sync {
+    /// Execute a tool-call intent: read-only → Result(json); mutating → ApprovalRequired; failure → Error.
+    fn execute(&self, name: &str, args: &serde_json::Value) -> RocmToolOutcome;
+    /// Run a previously-approved set of CLI args in-process (the mutating "execute approved" path).
+    fn execute_approved(&self, args: &[String]) -> RocmToolOutcome;
+}
+
+pub type SharedRocmToolExecutor = Arc<dyn RocmToolExecutor>;

--- a/crates/rocm-dash-tui/src/tool_exec.rs
+++ b/crates/rocm-dash-tui/src/tool_exec.rs
@@ -16,6 +16,7 @@ pub struct ApprovalIntent {
 }
 
 /// Outcome of a tool-call intent executed by the bin across the seam.
+#[must_use]
 #[derive(Debug, Clone)]
 pub enum RocmToolOutcome {
     Result(serde_json::Value),
@@ -28,11 +29,17 @@ pub enum RocmToolOutcome {
 /// The bin implements this; the dash holds it as
 /// `Option<Arc<dyn RocmToolExecutor>>` (None for demo/replay/mock). The `Debug`
 /// supertrait keeps `ResolvedArgs`/`AppState` deriving Debug.
+///
+/// NOTE: the mutating "execute approved" path is intentionally deferred to
+/// Phase 4, where it will be added alongside the approval modal with proper
+/// stdout/stderr capture (TUI-safe), spawn_blocking off the async loop, and an
+/// approval-provenance barrier so only descriptors from `execute()`'s
+/// ApprovalRequired can be run.
 pub trait RocmToolExecutor: std::fmt::Debug + Send + Sync {
     /// Execute a tool-call intent: read-only → Result(json); mutating → ApprovalRequired; failure → Error.
+    /// (Return value carries `#[must_use]` via the `RocmToolOutcome` enum.)
     fn execute(&self, name: &str, args: &serde_json::Value) -> RocmToolOutcome;
-    /// Run a previously-approved set of CLI args in-process (the mutating "execute approved" path).
-    fn execute_approved(&self, args: &[String]) -> RocmToolOutcome;
 }
 
+/// Arc-wrapped executor as stored in `ResolvedArgs`/`AppState`.
 pub type SharedRocmToolExecutor = Arc<dyn RocmToolExecutor>;

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -802,6 +802,7 @@ mod tests {
             model_recipes: Vec::new(),
             runtimes: Vec::new(),
             automations: Vec::new(),
+            tool_executor: None,
         }
     }
 


### PR DESCRIPTION
**Stack 2/10** · base: `supergoal/phase-1-daemon-wiring`

Load-bearing foundation for §1 chat parity: a plain-data tool-call boundary the dash chat uses so the bin executes ROCm tools.

- `crates/rocm-dash-tui/src/tool_exec.rs`: `RocmToolExecutor` trait + `RocmToolOutcome`/`ApprovalIntent` — **no rocm-core/tokio/ratatui** in signatures.
- Bin `dash_seam.rs::BinToolExecutor` delegates to the existing engine (`validate_chat_tool_call` → `run_internal_mcp_call`); injected via `ResolvedArgs` (None for demo/replay/mock).

Plumbing only — no behavior change yet. **Invariants:** rocm-dash-tui keeps 0 rocm-core edges; agent.rs stays the sole `rig` namer. All mandatory cargo gates green.