### PR TITLE
§1: read-only ROCm tools + nav/session slash commands + parity map

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -7135,6 +7135,10 @@ pub(crate) fn validate_chat_tool_call(call: &providers::ChatToolCall) -> Result<
     }
     match call.name.as_str() {
         "examine"
+        // `doctor` is the dash-side LLM tool + `/doctor` overlay name for the
+        // same machine inspection the bin exposes as `examine`. Accept it as an
+        // alias so a model-issued `doctor` call resolves end-to-end.
+        | "doctor"
         | "bridge_snapshot"
         | "gpu_snapshot"
         | "engines"
@@ -7706,6 +7710,7 @@ pub(crate) fn chat_tool_call_is_read_only(call: &providers::ChatToolCall) -> boo
     matches!(
         call.name.as_str(),
         "examine"
+            | "doctor"
             | "bridge_snapshot"
             | "gpu_snapshot"
             | "engines"
@@ -8334,7 +8339,7 @@ pub(crate) fn run_internal_mcp_call(
     }
 
     match name {
-        "examine" => {
+        "examine" | "doctor" => {
             let examine = ExamineSummary::gather()?;
             let text = render_examine_text()?;
             Ok(internal_mcp_tool_success(text, serde_json::json!(examine)))
@@ -16199,6 +16204,33 @@ model recipes
             };
             let error = validate_chat_tool_call(&call).unwrap_err().to_string();
             assert!(error.contains(expected), "unexpected error: {error}");
+        }
+    }
+
+    /// Guard: every read-only tool the dash side registers must have a home in
+    /// the bin's accept-list. A name-only tool (the `doctor` regression caught
+    /// in review) would otherwise fail end-to-end as "unsupported ROCm tool"
+    /// while passing the dash-side, name-against-itself completeness checks.
+    ///
+    /// We assert the NAME is accepted — not that empty args validate — so the
+    /// check stays hermetic (no real `BinToolExecutor::execute` / live I/O) and
+    /// independent of each tool's argument schema.
+    #[test]
+    fn read_tool_names_are_subset_of_bin_accept_list() {
+        for name in rocm_dash_tui::agent::ROCM_READ_TOOL_NAMES {
+            let call = providers::ChatToolCall {
+                id: None,
+                name: name.to_owned(),
+                arguments: serde_json::json!({}),
+            };
+            if let Err(error) = validate_chat_tool_call(&call) {
+                let message = error.to_string();
+                assert!(
+                    !message.contains("unsupported ROCm tool"),
+                    "ROCM_READ_TOOL_NAMES advertises `{name}` but the bin rejects \
+                     the name as unsupported: {message}"
+                );
+            }
         }
     }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -14476,18 +14476,6 @@ mod tests {
     }
 
     #[test]
-    fn daemon_run_argv_targets_rocmd_run_with_automations() {
-        assert_eq!(
-            daemon_run_argv(),
-            vec![
-                OsString::from("rocmd"),
-                OsString::from("run"),
-                OsString::from("--automations-enabled"),
-            ]
-        );
-    }
-
-    #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {
         let loading = json!({ "all_models_loaded": [] }).to_string();
         assert!(!service_http_readiness_response_ready(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1071,8 +1071,7 @@ fn render_freeform_comfyui_status_answer(
     Ok(output)
 }
 
-// pub(crate): used by the dash execution seam (dash_seam.rs)
-pub(crate) fn dispatch(cli: Cli) -> Result<()> {
+fn dispatch(cli: Cli) -> Result<()> {
     if !matches!(
         cli.command,
         Some(Command::Update { .. } | Command::Bootstrap { .. } | Command::Completions { .. })

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -14476,6 +14476,18 @@ mod tests {
     }
 
     #[test]
+    fn daemon_run_argv_targets_rocmd_run_with_automations() {
+        assert_eq!(
+            daemon_run_argv(),
+            vec![
+                OsString::from("rocmd"),
+                OsString::from("run"),
+                OsString::from("--automations-enabled"),
+            ]
+        );
+    }
+
+    #[test]
     fn service_http_readiness_requires_loaded_lemonade_model() {
         let loading = json!({ "all_models_loaded": [] }).to_string();
         assert!(!service_http_readiness_response_ready(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1071,7 +1071,8 @@ fn render_freeform_comfyui_status_answer(
     Ok(output)
 }
 
-fn dispatch(cli: Cli) -> Result<()> {
+// pub(crate): used by the dash execution seam (dash_seam.rs)
+pub(crate) fn dispatch(cli: Cli) -> Result<()> {
     if !matches!(
         cli.command,
         Some(Command::Update { .. } | Command::Bootstrap { .. } | Command::Completions { .. })

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -73,7 +73,9 @@ fn daemon_runs_real_foreground_loop() {
         let _ = tx.send(false);
     });
 
-    let saw_banner = rx.recv_timeout(Duration::from_secs(20)).unwrap_or(false);
+    let saw_banner = rx
+        .recv_timeout(Duration::from_secs(20))
+        .unwrap_or(false);
 
     // The foreground loop blocks; terminate it regardless of outcome.
     let _ = child.kill();

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -73,9 +73,7 @@ fn daemon_runs_real_foreground_loop() {
         let _ = tx.send(false);
     });
 
-    let saw_banner = rx
-        .recv_timeout(Duration::from_secs(20))
-        .unwrap_or(false);
+    let saw_banner = rx.recv_timeout(Duration::from_secs(20)).unwrap_or(false);
 
     // The foreground loop blocks; terminate it regardless of outcome.
     let _ = child.kill();

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -1280,6 +1280,72 @@ mod tests {
         assert!(SKILL_NAMES.contains(&"skill_plan"));
     }
 
+    /// Minimal executor that echoes a fixed JSON value for any tool call.
+    #[derive(Debug)]
+    struct FakeExec(serde_json::Value);
+    impl crate::tool_exec::RocmToolExecutor for FakeExec {
+        fn execute(&self, _name: &str, _args: &Value) -> RocmToolOutcome {
+            RocmToolOutcome::Result(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn read_only_tool_round_trips_to_json() {
+        // chat → tool → executor → JSON: the tool forwards across the seam and
+        // returns the executor's payload verbatim.
+        let exec: SharedRocmToolExecutor = Arc::new(FakeExec(json!({ "ok": true })));
+        let tool = DoctorRocmTool {
+            executor: Some(exec),
+            fired: Arc::new(Mutex::new(Vec::new())),
+        };
+        let out = tool.call(json!({})).await.expect("tool call ok");
+        assert_eq!(out, json!({ "ok": true }));
+        // The fired log records that the tool ran.
+        assert_eq!(tool.fired.lock().unwrap().as_slice(), &["doctor".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn read_only_tool_none_executor_is_graceful() {
+        // No seam (demo/replay/mock): a clear error object, never a panic.
+        let tool = EnginesRocmTool {
+            executor: None,
+            fired: Arc::new(Mutex::new(Vec::new())),
+        };
+        let out = tool.call(json!({})).await.expect("tool call ok");
+        assert!(out.get("error").and_then(Value::as_str).is_some());
+    }
+
+    #[test]
+    fn rocm_read_tool_names_are_complete_and_disjoint_from_skills() {
+        // Every expected read-only tool is registered…
+        for expected in [
+            "doctor",
+            "engines",
+            "services",
+            "service_logs",
+            "bridge_snapshot",
+            "gpu_snapshot",
+            "automations",
+            "path_exists",
+            "port_status",
+            "update_check",
+            "install_sdk_dry_run",
+            "rocm_command",
+        ] {
+            assert!(
+                ROCM_READ_TOOL_NAMES.contains(&expected),
+                "missing read tool: {expected}"
+            );
+        }
+        // …no mutating / planning tool leaked in (later phases).
+        assert!(!ROCM_READ_TOOL_NAMES.contains(&"natural_language_plan"));
+        // The telemetry/skill tools are still present and disjoint from the new set.
+        assert!(SKILL_NAMES.contains(&"gpu_status"));
+        for n in ROCM_READ_TOOL_NAMES {
+            assert!(!SKILL_NAMES.contains(&n), "name collision: {n}");
+        }
+    }
+
     #[test]
     fn annotate_reply_appends_deduped_skills() {
         let r = annotate_reply("hi".into(), &["gpu_status".into(), "gpu_status".into()]);

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -640,7 +640,10 @@ pub struct RigAgentClient {
 }
 
 impl RigAgentClient {
-    pub fn new(cfg: LlmConfig, executor: Option<SharedRocmToolExecutor>) -> Result<Self, AgentError> {
+    pub fn new(
+        cfg: LlmConfig,
+        executor: Option<SharedRocmToolExecutor>,
+    ) -> Result<Self, AgentError> {
         // Custom-auth gateway (e.g. Azure APIM `Ocp-Apim-Subscription-Key`):
         // the key goes in a custom header, NOT `Authorization: Bearer`. Rig
         // still requires an api_key, so pass a dummy Bearer the gateway ignores.
@@ -1301,7 +1304,10 @@ mod tests {
         let out = tool.call(json!({})).await.expect("tool call ok");
         assert_eq!(out, json!({ "ok": true }));
         // The fired log records that the tool ran.
-        assert_eq!(tool.fired.lock().unwrap().as_slice(), &["doctor".to_string()]);
+        assert_eq!(
+            tool.fired.lock().unwrap().as_slice(),
+            &["doctor".to_string()]
+        );
     }
 
     #[tokio::test]
@@ -1454,16 +1460,15 @@ mod tests {
         // key invariant is structurally preserved on the no-key path.
         let fired = Arc::new(Mutex::new(Vec::<String>::new()));
         let sink = fired.clone();
-        let client =
-            ChatGptAgentClient::new(
-                Some("gpt-5.3-codex".to_string()),
-                move |url, code| {
-                    // Would surface in the chat tab during a real device-code login.
-                    sink.lock().unwrap().push(format!("{url}|{code}"));
-                },
-                None,
-            )
-            .expect("build chatgpt oauth client");
+        let client = ChatGptAgentClient::new(
+            Some("gpt-5.3-codex".to_string()),
+            move |url, code| {
+                // Would surface in the chat tab during a real device-code login.
+                sink.lock().unwrap().push(format!("{url}|{code}"));
+            },
+            None,
+        )
+        .expect("build chatgpt oauth client");
         assert_eq!(client.model, "gpt-5.3-codex");
         // No network happened, so the handler has not fired yet.
         assert!(fired.lock().unwrap().is_empty());
@@ -1471,9 +1476,8 @@ mod tests {
 
     #[test]
     fn chatgpt_oauth_client_defaults_model_when_none() {
-        let client =
-            ChatGptAgentClient::new(None, |_url, _code| {}, None)
-                .expect("build chatgpt oauth client");
+        let client = ChatGptAgentClient::new(None, |_url, _code| {}, None)
+            .expect("build chatgpt oauth client");
         assert_eq!(
             client.model,
             rig::providers::chatgpt::GPT_5_3_CODEX,

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -30,6 +30,7 @@ use rocm_dash_core::metrics::{GpuMetrics, Instance, Snapshot};
 
 use crate::app::{ChatRole, ChatTurn};
 use crate::llm::LlmConfig;
+use crate::tool_exec::{RocmToolOutcome, SharedRocmToolExecutor};
 
 /// One-shot request budget. A hung backend becomes a timeout error turn, never
 /// a frozen pane.
@@ -432,6 +433,201 @@ pub const SKILL_NAMES: [&str; 6] = [
     SkillPlanTool::NAME,
 ];
 
+// ---------------------------------------------------------------------------
+// Read-only ROCm machine-inspection tools (group B). These forward the model's
+// tool-call intent across the rocm-core-free [`crate::tool_exec`] seam to the
+// bin-supplied executor (live dash only). They are READ-ONLY: no mutating tool
+// is registered here (mutating tools + the approval UI land in Phase 4). The
+// boundary type (`SharedRocmToolExecutor`) is plain data — importing it does NOT
+// pull `rocm-core` into this crate; agent.rs stays the sole `rig` namer.
+// ---------------------------------------------------------------------------
+
+/// Shared body for every read-only ROCm tool: forward the intent to the injected
+/// executor (None ⇒ a clear "not available in this mode" message; ApprovalRequired
+/// ⇒ a "needs approval" note — read-only tools shouldn't hit it, handled defensively).
+fn run_rocm_read_tool(exec: Option<&SharedRocmToolExecutor>, name: &str, args: &Value) -> Value {
+    match exec {
+        None => json!({ "error": "ROCm tools are unavailable in this mode (demo/replay/mock)." }),
+        Some(e) => match e.execute(name, args) {
+            RocmToolOutcome::Result(v) => v,
+            RocmToolOutcome::Error(s) => json!({ "error": s }),
+            RocmToolOutcome::ApprovalRequired(_) => {
+                json!({ "error": "this action requires approval (interactive chat only)" })
+            }
+        },
+    }
+}
+
+/// Declare one zero-cost read-only ROCm tool type. Rig requires a `const NAME`
+/// per type, so a macro generates one struct per tool to keep them DRY: each
+/// holds the optional executor + the shared `fired` log and routes `call()`
+/// through [`run_rocm_read_tool`]. Args are accepted as raw JSON (the bin
+/// validates them), so every tool shares `type Args = serde_json::Value`.
+macro_rules! rocm_read_tool {
+    ($ty:ident, $name:literal, $desc:literal, $params:tt) => {
+        pub struct $ty {
+            pub executor: Option<SharedRocmToolExecutor>,
+            pub fired: FiredLog,
+        }
+        impl Tool for $ty {
+            const NAME: &'static str = $name;
+            type Error = ToolError;
+            type Args = serde_json::Value;
+            type Output = Value;
+            async fn definition(&self, _p: String) -> ToolDefinition {
+                ToolDefinition {
+                    name: $name.to_string(),
+                    description: $desc.to_string(),
+                    parameters: json!($params),
+                }
+            }
+            async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+                record(&self.fired, $name);
+                Ok(run_rocm_read_tool(self.executor.as_ref(), $name, &args))
+            }
+        }
+    };
+}
+
+rocm_read_tool!(
+    DoctorRocmTool,
+    "doctor",
+    "Run the rocm-dash environment doctor: detected AMD GPU/driver, active ROCm \
+     runtime status, and readiness checks. Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    EnginesRocmTool,
+    "engines",
+    "List the available inference engines (e.g. vLLM, llama.cpp, ComfyUI) and \
+     their install/availability status. Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    ServicesRocmTool,
+    "services",
+    "List managed services / serving instances and their current status. \
+     Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    ServiceLogsRocmTool,
+    "service_logs",
+    "Fetch recent log lines for a managed service by id. Read-only.",
+    {
+        "type": "object",
+        "properties": {
+            "service_id": { "type": "string", "description": "Service identifier whose logs to read." }
+        },
+        "required": ["service_id"]
+    }
+);
+rocm_read_tool!(
+    BridgeSnapshotRocmTool,
+    "bridge_snapshot",
+    "Return the current job-bridge state snapshot (background jobs and their \
+     status). Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    GpuSnapshotRocmTool,
+    "gpu_snapshot",
+    "Return a point-in-time hardware snapshot of the AMD GPUs as seen by the \
+     machine (distinct from the live telemetry gpu_status). Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    AutomationsRocmTool,
+    "automations",
+    "List the configured background automations / scheduled checks and their \
+     last status. Read-only.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    PathExistsRocmTool,
+    "path_exists",
+    "Check whether a filesystem path exists on the machine. Read-only.",
+    {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Absolute or relative path to test." }
+        },
+        "required": ["path"]
+    }
+);
+rocm_read_tool!(
+    PortStatusRocmTool,
+    "port_status",
+    "Check whether a local TCP port is open / in use. Read-only.",
+    {
+        "type": "object",
+        "properties": {
+            "port": { "type": "integer", "description": "TCP port number to probe." }
+        },
+        "required": ["port"]
+    }
+);
+rocm_read_tool!(
+    UpdateCheckRocmTool,
+    "update_check",
+    "Check for an available rocm-cli update (current vs latest version). \
+     Read-only — does not install anything.",
+    { "type": "object", "properties": {} }
+);
+rocm_read_tool!(
+    InstallSdkDryRunRocmTool,
+    "install_sdk_dry_run",
+    "Show what installing the TheRock ROCm SDK WOULD do (the resolved wheels / \
+     steps) WITHOUT installing anything. Read-only dry run.",
+    {
+        "type": "object",
+        "properties": {
+            "channel": { "type": "string", "description": "Release channel, e.g. 'release'." },
+            "format": { "type": "string", "description": "Artifact format, e.g. 'wheel'." },
+            "prefix": { "type": "string", "description": "Optional install prefix to evaluate." },
+            "version": { "type": "string", "description": "Optional explicit version selector." },
+            "build_date": { "type": "string", "description": "Optional build-date selector." }
+        }
+    }
+);
+rocm_read_tool!(
+    RocmCommandRocmTool,
+    "rocm_command",
+    "Run a READ-ONLY rocm CLI subcommand and return its output. Allowed: \
+     model/models, config show, runtimes (list), logs, daemon status. Pass the \
+     argv as `args`, e.g. [\"model\"] or [\"config\",\"show\"]. Mutating \
+     subcommands are rejected.",
+    {
+        "type": "object",
+        "properties": {
+            "args": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Argv for the rocm subcommand, e.g. [\"model\"]."
+            }
+        },
+        "required": ["args"]
+    }
+);
+
+/// All read-only ROCm tool names (mirrors [`SKILL_NAMES`]). Used for
+/// uniqueness/registration checks and the parity map. Mutating tools and
+/// `natural_language_plan` are intentionally absent (later phases).
+pub const ROCM_READ_TOOL_NAMES: [&str; 12] = [
+    DoctorRocmTool::NAME,
+    EnginesRocmTool::NAME,
+    ServicesRocmTool::NAME,
+    ServiceLogsRocmTool::NAME,
+    BridgeSnapshotRocmTool::NAME,
+    GpuSnapshotRocmTool::NAME,
+    AutomationsRocmTool::NAME,
+    PathExistsRocmTool::NAME,
+    PortStatusRocmTool::NAME,
+    UpdateCheckRocmTool::NAME,
+    InstallSdkDryRunRocmTool::NAME,
+    RocmCommandRocmTool::NAME,
+];
+
 /// Live Rig-backed client for an OpenAI-compatible endpoint. The Rig client is
 /// constructed once; the agent + tools are rebuilt per request from the
 /// captured snapshot.
@@ -439,10 +635,12 @@ pub struct RigAgentClient {
     client: rig::providers::openai::CompletionsClient,
     model: String,
     preamble: String,
+    /// Bin-injected read-only tool executor (None for tests / no live seam).
+    executor: Option<SharedRocmToolExecutor>,
 }
 
 impl RigAgentClient {
-    pub fn new(cfg: LlmConfig) -> Result<Self, AgentError> {
+    pub fn new(cfg: LlmConfig, executor: Option<SharedRocmToolExecutor>) -> Result<Self, AgentError> {
         // Custom-auth gateway (e.g. Azure APIM `Ocp-Apim-Subscription-Key`):
         // the key goes in a custom header, NOT `Authorization: Bearer`. Rig
         // still requires an api_key, so pass a dummy Bearer the gateway ignores.
@@ -473,6 +671,7 @@ impl RigAgentClient {
             client,
             model: cfg.model,
             preamble: DEFAULT_PREAMBLE.to_string(),
+            executor,
         })
     }
 }
@@ -535,8 +734,9 @@ impl AgentClient for RigAgentClient {
             })
             .tool(SkillPlanTool {
                 fired: fired.clone(),
-            })
-            .build();
+            });
+        // Read-only ROCm machine-inspection tools (forward across the seam).
+        let agent = register_rocm_read_tools(agent, self.executor.as_ref(), &fired).build();
 
         let req = agent
             .prompt(last.content.clone())
@@ -554,6 +754,72 @@ impl AgentClient for RigAgentClient {
     }
 }
 
+/// Register every read-only ROCm tool on a Rig `AgentBuilder`, cloning the
+/// optional executor + the shared `fired` log into each. Kept generic over the
+/// builder's completion model + preamble so both the OpenAI-compatible and
+/// ChatGPT paths reuse one registration site (DRY — the tool list lives in
+/// exactly one place). The builder is already in the `WithBuilderTools` state
+/// because the telemetry/skill tools were registered first.
+fn register_rocm_read_tools<M, P>(
+    builder: rig::agent::AgentBuilder<M, P, rig::agent::WithBuilderTools>,
+    executor: Option<&SharedRocmToolExecutor>,
+    fired: &FiredLog,
+) -> rig::agent::AgentBuilder<M, P, rig::agent::WithBuilderTools>
+where
+    M: rig::completion::CompletionModel,
+    P: rig::agent::PromptHook<M>,
+{
+    builder
+        .tool(DoctorRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(EnginesRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(ServicesRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(ServiceLogsRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(BridgeSnapshotRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(GpuSnapshotRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(AutomationsRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(PathExistsRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(PortStatusRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(UpdateCheckRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(InstallSdkDryRunRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(RocmCommandRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+}
+
 /// No-key ChatGPT backend over Rig's native `chatgpt` OAuth provider.
 ///
 /// This is the no-key default that restores the ChatGPT device-login the vendored Codex
@@ -566,6 +832,8 @@ pub struct ChatGptAgentClient {
     client: rig::providers::chatgpt::Client,
     model: String,
     preamble: String,
+    /// Bin-injected read-only tool executor (None for tests / no live seam).
+    executor: Option<SharedRocmToolExecutor>,
 }
 
 impl ChatGptAgentClient {
@@ -573,7 +841,11 @@ impl ChatGptAgentClient {
     /// `on_device_code(verification_uri, user_code)` is invoked during the first
     /// `authorize()` (device-code flow). No network I/O happens here — login is
     /// deferred to the first `complete()`.
-    pub fn new<F>(model: Option<String>, on_device_code: F) -> Result<Self, AgentError>
+    pub fn new<F>(
+        model: Option<String>,
+        on_device_code: F,
+        executor: Option<SharedRocmToolExecutor>,
+    ) -> Result<Self, AgentError>
     where
         F: Fn(String, String) + Send + Sync + 'static,
     {
@@ -632,6 +904,7 @@ impl ChatGptAgentClient {
             client,
             model: model.unwrap_or_else(|| chatgpt::GPT_5_3_CODEX.to_string()),
             preamble: DEFAULT_PREAMBLE.to_string(),
+            executor,
         })
     }
 }
@@ -688,8 +961,9 @@ impl AgentClient for ChatGptAgentClient {
             })
             .tool(SkillPlanTool {
                 fired: fired.clone(),
-            })
-            .build();
+            });
+        // Read-only ROCm machine-inspection tools (forward across the seam).
+        let agent = register_rocm_read_tools(agent, self.executor.as_ref(), &fired).build();
 
         let req = agent
             .prompt(last.content.clone())
@@ -1066,7 +1340,7 @@ mod tests {
             api_key: None,
             auth_header: None,
         };
-        let client = RigAgentClient::new(cfg).expect("build rig client");
+        let client = RigAgentClient::new(cfg, None).expect("build rig client");
         let history = vec![ChatTurn::user("What's GPU-2 doing? Use the tools.")];
         let reply = client
             .complete(&history, fixture_snapshot())
@@ -1097,7 +1371,7 @@ mod tests {
             api_key: Some(key),
             auth_header,
         };
-        let client = RigAgentClient::new(cfg).expect("build rig client");
+        let client = RigAgentClient::new(cfg, None).expect("build rig client");
         let history = vec![ChatTurn::user("Reply with exactly: gateway ok")];
         let reply = client
             .complete(&history, fixture_snapshot())
@@ -1115,10 +1389,14 @@ mod tests {
         let fired = Arc::new(Mutex::new(Vec::<String>::new()));
         let sink = fired.clone();
         let client =
-            ChatGptAgentClient::new(Some("gpt-5.3-codex".to_string()), move |url, code| {
-                // Would surface in the chat tab during a real device-code login.
-                sink.lock().unwrap().push(format!("{url}|{code}"));
-            })
+            ChatGptAgentClient::new(
+                Some("gpt-5.3-codex".to_string()),
+                move |url, code| {
+                    // Would surface in the chat tab during a real device-code login.
+                    sink.lock().unwrap().push(format!("{url}|{code}"));
+                },
+                None,
+            )
             .expect("build chatgpt oauth client");
         assert_eq!(client.model, "gpt-5.3-codex");
         // No network happened, so the handler has not fired yet.
@@ -1128,7 +1406,8 @@ mod tests {
     #[test]
     fn chatgpt_oauth_client_defaults_model_when_none() {
         let client =
-            ChatGptAgentClient::new(None, |_url, _code| {}).expect("build chatgpt oauth client");
+            ChatGptAgentClient::new(None, |_url, _code| {}, None)
+                .expect("build chatgpt oauth client");
         assert_eq!(
             client.model,
             rig::providers::chatgpt::GPT_5_3_CODEX,
@@ -1143,9 +1422,13 @@ mod tests {
     #[tokio::test]
     #[ignore = "interactive ChatGPT OAuth device-code login + network"]
     async fn chatgpt_oauth_round_trip() {
-        let client = ChatGptAgentClient::new(None, |url, code| {
-            eprintln!("Sign in: open {url} and enter code {code}");
-        })
+        let client = ChatGptAgentClient::new(
+            None,
+            |url, code| {
+                eprintln!("Sign in: open {url} and enter code {code}");
+            },
+            None,
+        )
         .expect("build chatgpt oauth client");
         let history = vec![ChatTurn::user("Reply with exactly: oauth ok")];
         let reply = client

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -260,7 +260,7 @@ pub fn format_mmss(secs: u64) -> String {
 
 /// Result of routing a chat-input line through the slash-command handler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SlashOutcome {
+pub(crate) enum SlashOutcome {
     /// The line was a slash command and was handled in-reducer (state mutated,
     /// or a slash-tool request raised). It must NOT be sent to the LLM.
     Handled,
@@ -271,7 +271,7 @@ pub enum SlashOutcome {
 /// A pending read-only slash command that needs the bin executor (no overlay).
 /// `submit_chat` sets it; the event loop drains it once, off the async thread.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SlashToolRequest {
+pub(crate) struct SlashToolRequest {
     /// Tool name to execute across the seam (e.g. `rocm_command`).
     pub name: String,
     /// JSON args for the tool (e.g. `{"args":["model"]}`).
@@ -397,10 +397,10 @@ pub struct AppState {
     /// loop; `None` for demo/replay/mock and by default.
     pub tool_executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
     /// Set by a `/quit` (or `/exit`) slash command; the event loop breaks on it.
-    pub should_quit: bool,
+    pub(crate) should_quit: bool,
     /// Edge: a pending executor-backed read-only slash command. Raised by
     /// `handle_slash_command`, drained once by the event loop (spawn_blocking).
-    pub slash_tool: Option<SlashToolRequest>,
+    pub(crate) slash_tool: Option<SlashToolRequest>,
 }
 
 impl AppState {
@@ -644,7 +644,7 @@ impl AppState {
     /// agent); otherwise handles it in-reducer and returns
     /// [`SlashOutcome::Handled`]. Stays I/O-free: executor-backed commands raise
     /// the `slash_tool` edge for the event loop to drain off-thread.
-    pub fn handle_slash_command(&mut self, text: &str) -> SlashOutcome {
+    pub(crate) fn handle_slash_command(&mut self, text: &str) -> SlashOutcome {
         let trimmed = text.trim();
         let Some(rest) = trimmed.strip_prefix('/') else {
             return SlashOutcome::NotCommand;
@@ -726,6 +726,15 @@ impl AppState {
     pub fn on_chat_error(&mut self, message: String) {
         self.chat.push(ChatTurn::error(message));
         self.chat_sending = false;
+    }
+
+    /// Handle an executor-backed slash-tool reply (`/model`, `/daemon`): append
+    /// the summary as an agent-role turn WITHOUT touching `chat_sending`. The
+    /// slash-tool path is independent of the agent in-flight state machine, so
+    /// this must never clear/modify that flag (proven by
+    /// `slash_tool_reply_does_not_disturb_chat_sending`).
+    pub(crate) fn on_slash_tool_reply(&mut self, text: String) {
+        self.chat.push(ChatTurn::agent(text));
     }
 
     /// Apply the currently-highlighted picker entry and close the modal.
@@ -1049,6 +1058,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                         }
                     }
                     Some(ClientMsg::ChatReply { text }) => state.on_chat_reply(text),
+                    Some(ClientMsg::SlashToolReply { text }) => state.on_slash_tool_reply(text),
                     Some(ClientMsg::ChatError { message }) => state.on_chat_error(message),
                     Some(ClientMsg::ChatDetectResult { offer }) => state.set_detect_result(offer),
                     None => break,
@@ -1221,7 +1231,8 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
         // Drain a pending executor-backed read-only slash command (`/model`,
         // `/daemon`). Off-thread (spawn_blocking) so the seam's synchronous
         // execute() never blocks the async event loop; the concise summary
-        // returns as a normal chat turn via ClientMsg::ChatReply.
+        // returns via ClientMsg::SlashToolReply — its own message variant, so
+        // the slash-tool path never disturbs the agent's `chat_sending` flag.
         if let Some(req) = state.slash_tool.take() {
             match state.tool_executor.clone() {
                 Some(executor) => {
@@ -1229,10 +1240,12 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                     tokio::task::spawn_blocking(move || {
                         let outcome = executor.execute(&req.name, &req.args);
                         let text = summarize_slash_tool(&req.label, &outcome);
-                        let _ = reply_tx.send(ClientMsg::ChatReply { text });
+                        let _ = reply_tx.send(ClientMsg::SlashToolReply { text });
                     });
                 }
-                None => state.on_chat_error("ROCm tools unavailable in this mode".to_string()),
+                None => {
+                    state.on_slash_tool_reply("ROCm tools unavailable in this mode".to_string());
+                }
             }
         }
 
@@ -1333,6 +1346,10 @@ fn persist_chat_endpoint(base_url: &str, model: &str) -> Result<std::path::PathB
 /// raw JSON transcript dump (per docs/ux-guidelines.md). Errors and approval
 /// notes are surfaced plainly; a success object is reduced to a short headline
 /// plus a few key/value lines, with arrays/objects collapsed to counts.
+/// Max object fields a slash-tool summary surfaces before truncating with an
+/// ellipsis line. Keeps `summarize_json_value` output terse and length-bounded.
+const SUMMARY_MAX_FIELDS: usize = 8;
+
 fn summarize_slash_tool(label: &str, outcome: &crate::tool_exec::RocmToolOutcome) -> String {
     use crate::tool_exec::RocmToolOutcome;
     match outcome {
@@ -1356,16 +1373,17 @@ fn summarize_slash_tool(label: &str, outcome: &crate::tool_exec::RocmToolOutcome
 /// counts); arrays show a length. Keeps slash-tool output terse and scannable.
 fn summarize_json_value(v: &serde_json::Value) -> String {
     use serde_json::Value;
-    /// Max object fields to surface before truncating with an ellipsis line.
-    const MAX_FIELDS: usize = 8;
     match v {
         Value::Object(map) => {
             let mut lines = Vec::new();
-            for (k, val) in map.iter().take(MAX_FIELDS) {
+            for (k, val) in map.iter().take(SUMMARY_MAX_FIELDS) {
                 lines.push(format!("  {k}: {}", scalar_or_shape(val)));
             }
-            if map.len() > MAX_FIELDS {
-                lines.push(format!("  … ({} more fields)", map.len() - MAX_FIELDS));
+            if map.len() > SUMMARY_MAX_FIELDS {
+                lines.push(format!(
+                    "  … ({} more fields)",
+                    map.len() - SUMMARY_MAX_FIELDS
+                ));
             }
             lines.join("\n")
         }
@@ -2796,6 +2814,44 @@ mod tests {
             req.args,
             serde_json::json!({ "args": ["daemon", "status"] })
         );
+    }
+
+    #[test]
+    fn slash_tool_reply_does_not_disturb_chat_sending() {
+        // The slash-tool reply path is decoupled from the agent state machine:
+        // appending a slash-tool summary must NOT touch `chat_sending`, even if
+        // an agent request happens to be in flight at the same time.
+        let mut s = st();
+        s.chat_sending = true;
+        let before = s.chat.len();
+        s.on_slash_tool_reply("x".into());
+        assert_eq!(s.chat.len(), before + 1, "slash-tool turn appended");
+        assert_eq!(s.chat.last().unwrap().role, ChatRole::Agent);
+        assert!(
+            s.chat_sending,
+            "chat_sending untouched by slash-tool reply (decoupled)"
+        );
+    }
+
+    #[test]
+    fn summarize_slash_tool_is_concise_not_raw_json() {
+        // A representative Result(json) must summarize to a terse, labelled,
+        // length-bounded blurb — never a raw JSON dump with braces-spam.
+        let outcome = crate::tool_exec::RocmToolOutcome::Result(serde_json::json!({
+            "status": "ok",
+            "model": "llama3",
+            "nested": { "a": 1, "b": 2, "c": 3 },
+        }));
+        let out = summarize_slash_tool("model", &outcome);
+        assert!(out.contains("/model"), "carries the slash label");
+        assert!(out.contains("status: ok"), "scalars shown inline");
+        // Nested containers collapse to a shape hint, not an inlined subtree.
+        assert!(out.contains("{3 fields}"), "nested object shown as shape");
+        assert!(
+            !out.contains("\"nested\""),
+            "no raw JSON keys / braces-spam in summary"
+        );
+        assert!(out.len() < 200, "summary stays length-bounded");
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -1014,14 +1014,13 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
         } else {
             // A build failure leaves `agent` None; a submit surfaces an error turn.
             match &state.chat_llm {
-                Some(cfg) => crate::agent::RigAgentClient::new(
-                    cfg.clone(),
-                    state.tool_executor.clone(),
-                )
-                    .ok()
-                    .map(|c| {
-                        std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>
-                    }),
+                Some(cfg) => {
+                    crate::agent::RigAgentClient::new(cfg.clone(), state.tool_executor.clone())
+                        .ok()
+                        .map(|c| {
+                            std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>
+                        })
+                }
                 None => None,
             }
         }
@@ -1233,8 +1232,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                         let _ = reply_tx.send(ClientMsg::ChatReply { text });
                     });
                 }
-                None => state
-                    .on_chat_error("ROCm tools unavailable in this mode".to_string()),
+                None => state.on_chat_error("ROCm tools unavailable in this mode".to_string()),
             }
         }
 
@@ -2794,7 +2792,10 @@ mod tests {
         assert_eq!(s.handle_slash_command("/daemon"), SlashOutcome::Handled);
         let req = s.slash_tool.expect("daemon raises a slash_tool request");
         assert_eq!(req.name, "rocm_command");
-        assert_eq!(req.args, serde_json::json!({ "args": ["daemon", "status"] }));
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["daemon", "status"] })
+        );
     }
 
     #[test]
@@ -2822,7 +2823,10 @@ mod tests {
         s.chat_input = "/help".into();
         s.submit_chat();
         assert_eq!(s.modal, Modal::Help);
-        assert!(!s.chat_dispatch, "slash command never dispatches to the LLM");
+        assert!(
+            !s.chat_dispatch,
+            "slash command never dispatches to the LLM"
+        );
         assert!(!s.chat_sending);
         assert!(s.chat_input.is_empty());
     }

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -2693,6 +2693,140 @@ mod tests {
         assert!(s.chat_dispatch);
     }
 
+    // --- Slash-command dispatch (Phase 3 nav/session + read-only) ---
+
+    fn st() -> AppState {
+        AppState::new("t".into(), "default-dark".into())
+    }
+
+    #[test]
+    fn slash_help_opens_help_modal() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/help"), SlashOutcome::Handled);
+        assert_eq!(s.modal, Modal::Help);
+    }
+
+    #[test]
+    fn slash_question_mark_opens_help_modal() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/?"), SlashOutcome::Handled);
+        assert_eq!(s.modal, Modal::Help);
+    }
+
+    #[test]
+    fn slash_clear_empties_transcript() {
+        let mut s = st();
+        s.chat.push(ChatTurn::user("hi"));
+        s.chat.push(ChatTurn::agent("hello"));
+        assert_eq!(s.handle_slash_command("/clear"), SlashOutcome::Handled);
+        assert!(s.chat.is_empty());
+    }
+
+    #[test]
+    fn slash_quit_sets_should_quit() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/quit"), SlashOutcome::Handled);
+        assert!(s.should_quit);
+    }
+
+    #[test]
+    fn slash_exit_sets_should_quit() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/exit"), SlashOutcome::Handled);
+        assert!(s.should_quit);
+    }
+
+    #[test]
+    fn slash_home_switches_to_overview() {
+        let mut s = st();
+        s.active_tab = ActiveTab::Bench;
+        assert_eq!(s.handle_slash_command("/home"), SlashOutcome::Handled);
+        assert_eq!(s.active_tab, ActiveTab::Overview);
+    }
+
+    #[test]
+    fn slash_gpu_switches_to_hardware() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/gpu"), SlashOutcome::Handled);
+        assert_eq!(s.active_tab, ActiveTab::Hardware);
+    }
+
+    #[test]
+    fn slash_doctor_opens_overlay() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/doctor"), SlashOutcome::Handled);
+        assert!(s.examine_manager.is_some());
+    }
+
+    #[test]
+    fn slash_runtimes_opens_overlay() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/runtimes"), SlashOutcome::Handled);
+        assert!(s.runtime_manager.is_some());
+    }
+
+    #[test]
+    fn slash_config_opens_overlay() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/config"), SlashOutcome::Handled);
+        assert!(s.config_manager.is_some());
+    }
+
+    #[test]
+    fn slash_logs_opens_overlay() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/logs"), SlashOutcome::Handled);
+        assert!(s.logs_view.is_some());
+    }
+
+    #[test]
+    fn slash_model_raises_executor_request() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/model"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("model raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(req.args, serde_json::json!({ "args": ["model"] }));
+    }
+
+    #[test]
+    fn slash_daemon_raises_executor_request() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/daemon"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("daemon raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(req.args, serde_json::json!({ "args": ["daemon", "status"] }));
+    }
+
+    #[test]
+    fn slash_unknown_appends_error_turn_and_is_handled() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/zzz"), SlashOutcome::Handled);
+        assert_eq!(s.chat.len(), 1);
+        assert_eq!(s.chat[0].role, ChatRole::Error);
+        assert!(s.chat[0].content.contains("/zzz"));
+    }
+
+    #[test]
+    fn plain_text_is_not_a_command() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("what's GPU-2 doing?"),
+            SlashOutcome::NotCommand
+        );
+    }
+
+    #[test]
+    fn submit_routes_slash_command_away_from_the_agent() {
+        // A slash line through submit_chat must NOT raise the agent dispatch edge.
+        let mut s = st();
+        s.chat_input = "/help".into();
+        s.submit_chat();
+        assert_eq!(s.modal, Modal::Help);
+        assert!(!s.chat_dispatch, "slash command never dispatches to the LLM");
+        assert!(!s.chat_sending);
+        assert!(s.chat_input.is_empty());
+    }
+
     #[tokio::test]
     async fn chat_reply_path_appends_agent_turn_and_clears_sending() {
         // The wired ChatSubmit→reply path using the MockAgentClient (no LLM).

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -897,19 +897,26 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             && args.chat_env_url.is_none();
         if no_key_no_endpoint {
             let oauth_tx = chat_tx.clone();
-            crate::agent::ChatGptAgentClient::new(args.chat_model.clone(), move |url, code| {
-                let _ = oauth_tx.send(ClientMsg::ChatReply {
-                    text: format!(
-                        "To enable chat, sign in to ChatGPT: open {url} and enter the code {code}"
-                    ),
-                });
-            })
+            crate::agent::ChatGptAgentClient::new(
+                args.chat_model.clone(),
+                move |url, code| {
+                    let _ = oauth_tx.send(ClientMsg::ChatReply {
+                        text: format!(
+                            "To enable chat, sign in to ChatGPT: open {url} and enter the code {code}"
+                        ),
+                    });
+                },
+                state.tool_executor.clone(),
+            )
             .ok()
             .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         } else {
             // A build failure leaves `agent` None; a submit surfaces an error turn.
             match &state.chat_llm {
-                Some(cfg) => crate::agent::RigAgentClient::new(cfg.clone())
+                Some(cfg) => crate::agent::RigAgentClient::new(
+                    cfg.clone(),
+                    state.tool_executor.clone(),
+                )
                     .ok()
                     .map(|c| {
                         std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -629,7 +629,7 @@ impl AppState {
         // Slash commands are handled locally (nav/overlays/read-only tools) and
         // never reach the LLM. A `/`-prefixed line is ALWAYS consumed here, even
         // when unknown (it gets an error turn) — only non-slash text is sent on.
-        if let SlashOutcome::Handled = self.handle_slash_command(&text) {
+        if self.handle_slash_command(&text) == SlashOutcome::Handled {
             self.chat_input.clear();
             return;
         }

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -258,6 +258,28 @@ pub fn format_mmss(secs: u64) -> String {
     }
 }
 
+/// Result of routing a chat-input line through the slash-command handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlashOutcome {
+    /// The line was a slash command and was handled in-reducer (state mutated,
+    /// or a slash-tool request raised). It must NOT be sent to the LLM.
+    Handled,
+    /// The line is not a slash command — fall through to normal agent dispatch.
+    NotCommand,
+}
+
+/// A pending read-only slash command that needs the bin executor (no overlay).
+/// `submit_chat` sets it; the event loop drains it once, off the async thread.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashToolRequest {
+    /// Tool name to execute across the seam (e.g. `rocm_command`).
+    pub name: String,
+    /// JSON args for the tool (e.g. `{"args":["model"]}`).
+    pub args: serde_json::Value,
+    /// Human label for the chat turn header (e.g. `model`).
+    pub label: String,
+}
+
 /// Modal overlays. Only one is shown at a time, on top of the active tab body.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Modal {
@@ -374,6 +396,11 @@ pub struct AppState {
     /// Bin-injected tool-executor seam. Set from `ResolvedArgs` in the event
     /// loop; `None` for demo/replay/mock and by default.
     pub tool_executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
+    /// Set by a `/quit` (or `/exit`) slash command; the event loop breaks on it.
+    pub should_quit: bool,
+    /// Edge: a pending executor-backed read-only slash command. Raised by
+    /// `handle_slash_command`, drained once by the event loop (spawn_blocking).
+    pub slash_tool: Option<SlashToolRequest>,
 }
 
 impl AppState {
@@ -431,6 +458,8 @@ impl AppState {
             runtimes: Vec::new(),
             automations: Vec::new(),
             tool_executor: None,
+            should_quit: false,
+            slash_tool: None,
         }
     }
 
@@ -597,10 +626,82 @@ impl AppState {
         if text.is_empty() {
             return;
         }
+        // Slash commands are handled locally (nav/overlays/read-only tools) and
+        // never reach the LLM. A `/`-prefixed line is ALWAYS consumed here, even
+        // when unknown (it gets an error turn) — only non-slash text is sent on.
+        if let SlashOutcome::Handled = self.handle_slash_command(&text) {
+            self.chat_input.clear();
+            return;
+        }
         self.chat.push(ChatTurn::user(text));
         self.chat_input.clear();
         self.chat_sending = true;
         self.chat_dispatch = true;
+    }
+
+    /// Route a chat-input line that may be a slash command. Returns
+    /// [`SlashOutcome::NotCommand`] for plain text (caller dispatches to the
+    /// agent); otherwise handles it in-reducer and returns
+    /// [`SlashOutcome::Handled`]. Stays I/O-free: executor-backed commands raise
+    /// the `slash_tool` edge for the event loop to drain off-thread.
+    pub fn handle_slash_command(&mut self, text: &str) -> SlashOutcome {
+        let trimmed = text.trim();
+        let Some(rest) = trimmed.strip_prefix('/') else {
+            return SlashOutcome::NotCommand;
+        };
+        // First whitespace-delimited word after '/', lowercased.
+        let cmd = rest.split_whitespace().next().unwrap_or("").to_lowercase();
+
+        match cmd.as_str() {
+            // --- Group A: nav / session (deterministic, no executor) ---
+            "home" => self.active_tab = ActiveTab::Overview,
+            "gpu" => self.active_tab = ActiveTab::Hardware,
+            "help" | "?" => self.modal = Modal::Help,
+            "clear" => self.chat.clear(),
+            "quit" | "exit" => self.should_quit = true,
+            // --- Group B: read-only overlays (mirror the keybind handlers) ---
+            "doctor" => {
+                self.close_overlays();
+                self.examine_manager =
+                    Some(crate::ui::examine_manager::ExamineManagerState::default());
+            }
+            "runtimes" => {
+                self.close_overlays();
+                self.runtime_manager =
+                    Some(crate::ui::runtime_manager::RuntimeManagerState::default());
+            }
+            "config" => {
+                self.close_overlays();
+                self.config_manager =
+                    Some(crate::ui::config_manager::ConfigManagerState::default());
+            }
+            "logs" => {
+                self.close_overlays();
+                self.logs_view = Some(crate::ui::logs_view::LogsViewState::default());
+            }
+            // --- Group B: read-only executor-backed (no overlay; off-thread) ---
+            "model" => {
+                self.slash_tool = Some(SlashToolRequest {
+                    name: "rocm_command".to_string(),
+                    args: serde_json::json!({ "args": ["model"] }),
+                    label: "model".to_string(),
+                });
+            }
+            "daemon" => {
+                self.slash_tool = Some(SlashToolRequest {
+                    name: "rocm_command".to_string(),
+                    args: serde_json::json!({ "args": ["daemon", "status"] }),
+                    label: "daemon status".to_string(),
+                });
+            }
+            // Unknown slash command: an error turn, never sent to the LLM.
+            other => {
+                self.chat.push(ChatTurn::error(format!(
+                    "unknown command: /{other} (try /help)"
+                )));
+            }
+        }
+        SlashOutcome::Handled
     }
 
     /// Capture a read-only telemetry snapshot for the chat tools. Plain owned
@@ -1112,6 +1213,31 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             }
         }
 
+        // A `/quit` (or `/exit`) slash command sets `should_quit` from inside
+        // the reducer; honor it here (mirrors the `KeyAction::Quit` break).
+        if state.should_quit {
+            break;
+        }
+
+        // Drain a pending executor-backed read-only slash command (`/model`,
+        // `/daemon`). Off-thread (spawn_blocking) so the seam's synchronous
+        // execute() never blocks the async event loop; the concise summary
+        // returns as a normal chat turn via ClientMsg::ChatReply.
+        if let Some(req) = state.slash_tool.take() {
+            match state.tool_executor.clone() {
+                Some(executor) => {
+                    let reply_tx = chat_tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let outcome = executor.execute(&req.name, &req.args);
+                        let text = summarize_slash_tool(&req.label, &outcome);
+                        let _ = reply_tx.send(ClientMsg::ChatReply { text });
+                    });
+                }
+                None => state
+                    .on_chat_error("ROCm tools unavailable in this mode".to_string()),
+            }
+        }
+
         // Spawn the agent round-trip on the submit edge — keeps `apply_action`
         // I/O-free. `chat_dispatch` is raised once by `submit_chat`; consume it
         // so the in-flight request is spawned exactly once (not every tick).
@@ -1203,6 +1329,65 @@ fn persist_chat_endpoint(base_url: &str, model: &str) -> Result<std::path::PathB
     let toml = toml::to_string_pretty(&next).map_err(|e| e.to_string())?;
     std::fs::write(&path, toml).map_err(|e| e.to_string())?;
     Ok(path)
+}
+
+/// Render a CONCISE, human summary of a read-only slash-tool outcome — never a
+/// raw JSON transcript dump (per docs/ux-guidelines.md). Errors and approval
+/// notes are surfaced plainly; a success object is reduced to a short headline
+/// plus a few key/value lines, with arrays/objects collapsed to counts.
+fn summarize_slash_tool(label: &str, outcome: &crate::tool_exec::RocmToolOutcome) -> String {
+    use crate::tool_exec::RocmToolOutcome;
+    match outcome {
+        RocmToolOutcome::Error(e) => format!("/{label} failed: {e}"),
+        RocmToolOutcome::ApprovalRequired(_) => {
+            format!("/{label}: this action needs approval (read-only command did not expect it)")
+        }
+        RocmToolOutcome::Result(v) => {
+            let body = summarize_json_value(v);
+            if body.is_empty() {
+                format!("/{label}: done")
+            } else {
+                format!("/{label}:\n{body}")
+            }
+        }
+    }
+}
+
+/// Collapse a JSON value into at most a handful of readable lines. Scalars print
+/// inline; objects list their top-level fields (nested containers shown as
+/// counts); arrays show a length. Keeps slash-tool output terse and scannable.
+fn summarize_json_value(v: &serde_json::Value) -> String {
+    use serde_json::Value;
+    /// Max object fields to surface before truncating with an ellipsis line.
+    const MAX_FIELDS: usize = 8;
+    match v {
+        Value::Object(map) => {
+            let mut lines = Vec::new();
+            for (k, val) in map.iter().take(MAX_FIELDS) {
+                lines.push(format!("  {k}: {}", scalar_or_shape(val)));
+            }
+            if map.len() > MAX_FIELDS {
+                lines.push(format!("  … ({} more fields)", map.len() - MAX_FIELDS));
+            }
+            lines.join("\n")
+        }
+        Value::Array(arr) => format!("  {} item(s)", arr.len()),
+        other => format!("  {}", scalar_or_shape(other)),
+    }
+}
+
+/// A scalar's plain text, or a shape hint (`{N fields}` / `[N items]`) for a
+/// nested container — used so summaries never inline a whole subtree.
+fn scalar_or_shape(v: &serde_json::Value) -> String {
+    use serde_json::Value;
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::Array(a) => format!("[{} items]", a.len()),
+        Value::Object(o) => format!("{{{} fields}}", o.len()),
+    }
 }
 
 /// Pure immutable transform: return a copy of `cfg` with the chat endpoint set

--- a/crates/rocm-dash-tui/src/client.rs
+++ b/crates/rocm-dash-tui/src/client.rs
@@ -51,6 +51,12 @@ pub enum ClientMsg {
     ChatError {
         message: String,
     },
+    /// Result of an executor-backed read-only slash command (`/model`,
+    /// `/daemon`). Appended as a plain chat turn; decoupled from the agent
+    /// in-flight state machine so it never touches `chat_sending`.
+    SlashToolReply {
+        text: String,
+    },
     /// Result of an in-TUI local-engine detect: `Some` base_url+model when an
     /// endpoint was reachable and queried, `None` when nothing was found.
     ChatDetectResult {

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -807,6 +807,8 @@ mod tests {
             runtimes: Vec::new(),
             automations: Vec::new(),
             tool_executor: None,
+            should_quit: false,
+            slash_tool: None,
         }
     }
 

--- a/docs/dash-parity-map.md
+++ b/docs/dash-parity-map.md
@@ -1,0 +1,43 @@
+# Dash parity map
+
+Tracks the 30 legacy `rocm chat` slash commands as they are re-homed into the
+dash TUI, so `tui.rs` can be retired without regression. One row per legacy
+command. `Status` is per phase; `Dash mechanism` is the concrete surface (tab /
+overlay / modal / tool + slash command); `Evidence` points at the test that
+locks the behavior.
+
+Groups: **A** nav/session · **B** read-only · **C** approvals/automations ·
+**D** mutating ops · **E** permissions · **F** planning · **G** provider/chat.
+
+| Command | Group | Status | Dash mechanism | Evidence |
+|---------|-------|--------|----------------|----------|
+| home | A | covered (Phase 3) | `/home` slash → `ActiveTab::Overview` | `slash_home_switches_to_overview` |
+| help | A | covered (Phase 3) | `/help` slash → `Modal::Help` | `slash_help_opens_help_modal` |
+| ? | A | covered (Phase 3) | `/?` slash → `Modal::Help` | `slash_question_mark_opens_help_modal` |
+| clear | A | covered (Phase 3) | `/clear` slash → empties `chat` transcript | `slash_clear_empties_transcript` |
+| quit | A | covered (Phase 3) | `/quit` slash → `should_quit` (event loop breaks) | `slash_quit_sets_should_quit` |
+| exit | A | covered (Phase 3) | `/exit` slash → `should_quit` (event loop breaks) | `slash_exit_sets_should_quit` |
+| doctor | B | covered (Phase 3) | `/doctor` slash → doctor overlay; tool `doctor` via seam | `slash_doctor_opens_overlay` / `read_only_tool_round_trips_to_json` |
+| runtimes | B | covered (Phase 3) | `/runtimes` slash → runtime-manager overlay | `slash_runtimes_opens_overlay` |
+| model | B | covered (Phase 3) | `/model` slash → `slash_tool` `rocm_command ["model"]` (off-thread) | `slash_model_raises_executor_request` |
+| config | B | covered (Phase 3) | `/config` slash → config-manager overlay | `slash_config_opens_overlay` |
+| logs | B | covered (Phase 3) | `/logs` slash → logs overlay; tool `service_logs` via seam | `slash_logs_opens_overlay` |
+| gpu | B | covered (Phase 3) | `/gpu` slash → `ActiveTab::Hardware`; tool `gpu_snapshot` via seam | `slash_gpu_switches_to_hardware` |
+| daemon | B | covered (Phase 3) | `/daemon` slash → `slash_tool` `rocm_command ["daemon","status"]` (off-thread) | `slash_daemon_raises_executor_request` |
+| install | D | pending (Phase 4) | install overlay + mutating tool (approval-gated) | — |
+| engine | D | pending (Phase 4) | engine-manager overlay + mutating tool (approval-gated) | — |
+| serve | D | pending (Phase 4) | serve wizard + mutating tool (approval-gated) | — |
+| services | D | pending (Phase 4) | services-manager overlay + mutating actions (approval-gated) | — |
+| update | D | pending (Phase 5) | update overlay + mutating apply (approval-gated) | — |
+| comfyui | D | pending (Phase 5) | ComfyUI serve/launch flow (approval-gated) | — |
+| uninstall | D | pending (Phase 5) | uninstall flow (approval-gated) | — |
+| setup | D | pending (Phase 5) | onboarding wizard (deterministic first-run) | — |
+| automations | C | pending (Phase 6) | automations-manager overlay + run/approve actions | — |
+| reviews | C | pending (Phase 6) | approval/review queue surface | — |
+| approve | C | pending (Phase 6) | approval-queue accept action | — |
+| reject | C | pending (Phase 6) | approval-queue reject action | — |
+| edit | C | pending (Phase 6) | approval-queue edit action | — |
+| permissions | E | pending (Phase 6) | permissions/full-access toggle surface | — |
+| plan | F | pending (Phase 7) | `natural_language_plan` tool + plan review surface | — |
+| provider | G | pending (Phase 8) | config & provider manager (provider switch) | — |
+| chat | G | pending (Phase 8) | Chat tab + provider/Anthropic backend selection | — |

--- a/docs/dash-parity-map.md
+++ b/docs/dash-parity-map.md
@@ -17,11 +17,11 @@ Groups: **A** nav/session · **B** read-only · **C** approvals/automations ·
 | clear | A | covered (Phase 3) | `/clear` slash → empties `chat` transcript | `slash_clear_empties_transcript` |
 | quit | A | covered (Phase 3) | `/quit` slash → `should_quit` (event loop breaks) | `slash_quit_sets_should_quit` |
 | exit | A | covered (Phase 3) | `/exit` slash → `should_quit` (event loop breaks) | `slash_exit_sets_should_quit` |
-| doctor | B | covered (Phase 3) | `/doctor` slash → doctor overlay; tool `doctor` via seam | `slash_doctor_opens_overlay` / `read_only_tool_round_trips_to_json` |
+| doctor | B | covered (Phase 3) | `/doctor` slash → opens the doctor overlay (`doctor_manager`); the read-only `doctor` tool is covered separately via the LLM tool-call seam | `slash_doctor_opens_overlay` / `read_only_tool_round_trips_to_json` |
 | runtimes | B | covered (Phase 3) | `/runtimes` slash → runtime-manager overlay | `slash_runtimes_opens_overlay` |
 | model | B | covered (Phase 3) | `/model` slash → `slash_tool` `rocm_command ["model"]` (off-thread) | `slash_model_raises_executor_request` |
 | config | B | covered (Phase 3) | `/config` slash → config-manager overlay | `slash_config_opens_overlay` |
-| logs | B | covered (Phase 3) | `/logs` slash → logs overlay; tool `service_logs` via seam | `slash_logs_opens_overlay` |
+| logs | B | covered (Phase 3) | `/logs` slash → opens the logs overlay (`logs_view`); the read-only `service_logs` tool is covered separately via the LLM tool-call seam | `slash_logs_opens_overlay` / `read_only_tool_round_trips_to_json` |
 | gpu | B | covered (Phase 3) | `/gpu` slash → `ActiveTab::Hardware`; tool `gpu_snapshot` via seam | `slash_gpu_switches_to_hardware` |
 | daemon | B | covered (Phase 3) | `/daemon` slash → `slash_tool` `rocm_command ["daemon","status"]` (off-thread) | `slash_daemon_raises_executor_request` |
 | install | D | pending (Phase 4) | install overlay + mutating tool (approval-gated) | — |


### PR DESCRIPTION
**Stack 3/10** · base: `supergoal/phase-2-execution-seam`

- 12 read-only ROCm tools (doctor/engines/services/gpu/…) via a `rocm_read_tool!` macro, delegating through the Phase-2 seam; registered in both Rig + ChatGPT backends.
- Nav/session + read-only slash commands (`/home /help /clear /quit /doctor /runtimes /config /logs /gpu /model /daemon`).
- Seeds `docs/dash-parity-map.md` (30 legacy commands).

All cargo gates green; mock round-trip + slash-dispatch tests. Reviewed clean.