### PR TITLE
§1: lifecycle mutating commands — /update /comfyui /uninstall /setup

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -8740,6 +8740,15 @@ fn run_rocm_read_only_in_process(paths: &AppPaths, args: &[String]) -> Result<St
         {
             render_uninstall_dry_run(paths)
         }
+        [command] if command.eq_ignore_ascii_case("setup") => {
+            render_setup_status_text(paths, &config)
+        }
+        [command, subcommand]
+            if command.eq_ignore_ascii_case("setup")
+                && subcommand.eq_ignore_ascii_case("status") =>
+        {
+            render_setup_status_text(paths, &config)
+        }
         _ => bail!(
             "unsupported in-process read-only rocm command: {}",
             format_structured_tool_call("rocm", args)
@@ -16149,6 +16158,27 @@ model recipes
             Some("rocm")
         );
         assert!(mcp_tool_result_text(&result).contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn setup_status_renders_in_process() {
+        let (_root, paths) = test_paths("setup-status-in-process");
+
+        for args in [
+            vec!["setup".to_owned()],
+            vec!["setup".to_owned(), "status".to_owned()],
+        ] {
+            let text = run_rocm_read_only_in_process(&paths, &args)
+                .expect("setup status read path should render in-process");
+            assert!(
+                !text.trim().is_empty(),
+                "setup status text should be non-empty for {args:?}"
+            );
+            assert!(
+                text.contains("ROCm setup"),
+                "setup status text should be reached for {args:?}: {text}"
+            );
+        }
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -7539,6 +7539,16 @@ fn chat_rocm_command_action_from_args(mut args: Vec<String>) -> Result<ChatRocmC
                 command_title: "ComfyUI".to_owned(),
             })
         }
+        Some("setup") if second.as_deref().is_none_or(|value| value == "status") => {
+            Ok(ChatRocmCommandAction::ReadOnly(args))
+        }
+        Some("setup") if second.as_deref() == Some("reset") => {
+            Ok(ChatRocmCommandAction::Approval {
+                args,
+                pending_title: "Reset first-time setup".to_owned(),
+                command_title: "Setup".to_owned(),
+            })
+        }
         Some(command) => bail!("local assistant cannot use unsupported rocm command `{command}`"),
         None => bail!("rocm_command requires at least one argument"),
     }
@@ -15954,6 +15964,77 @@ model recipes
                 .expect("approval should be built");
         assert_eq!(approval.pending_title, "Change settings");
         assert_eq!(approval.command_title, "Config");
+    }
+
+    #[test]
+    fn setup_status_is_read_only() {
+        for args in [
+            vec!["setup".to_owned()],
+            vec!["setup".to_owned(), "status".to_owned()],
+        ] {
+            let action =
+                chat_rocm_command_action_from_args(args.clone()).expect("setup status classifies");
+            assert!(
+                matches!(action, ChatRocmCommandAction::ReadOnly(_)),
+                "setup {args:?} should be read-only, got {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn setup_reset_requires_approval() {
+        let action =
+            chat_rocm_command_action_from_args(vec!["setup".to_owned(), "reset".to_owned()])
+                .expect("setup reset classifies");
+        match action {
+            ChatRocmCommandAction::Approval {
+                pending_title,
+                command_title,
+                ..
+            } => {
+                assert_eq!(pending_title, "Reset first-time setup");
+                assert_eq!(command_title, "Setup");
+            }
+            other @ ChatRocmCommandAction::ReadOnly(_) => {
+                panic!("setup reset should require approval, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn lifecycle_read_mutate_split_is_honest() {
+        let read_only = [
+            vec!["update".to_owned()],
+            vec!["comfyui".to_owned(), "status".to_owned()],
+            vec!["comfyui".to_owned(), "logs".to_owned()],
+            vec!["uninstall".to_owned(), "--dry-run".to_owned()],
+            vec!["setup".to_owned(), "status".to_owned()],
+        ];
+        for args in read_only {
+            let action = chat_rocm_command_action_from_args(args.clone())
+                .unwrap_or_else(|err| panic!("{args:?} should classify: {err}"));
+            assert!(
+                matches!(action, ChatRocmCommandAction::ReadOnly(_)),
+                "{args:?} should be read-only, got {action:?}"
+            );
+        }
+
+        let mutating = [
+            vec!["update".to_owned(), "--apply".to_owned()],
+            vec!["comfyui".to_owned(), "install".to_owned()],
+            vec!["comfyui".to_owned(), "start".to_owned()],
+            vec!["comfyui".to_owned(), "stop".to_owned()],
+            vec!["uninstall".to_owned()],
+            vec!["setup".to_owned(), "reset".to_owned()],
+        ];
+        for args in mutating {
+            let action = chat_rocm_command_action_from_args(args.clone())
+                .unwrap_or_else(|err| panic!("{args:?} should classify: {err}"));
+            assert!(
+                matches!(action, ChatRocmCommandAction::Approval { .. }),
+                "{args:?} should require approval, got {action:?}"
+            );
+        }
     }
 
     #[test]

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -2389,6 +2389,10 @@ fn ensure_rocm_command_is_read_only(args: &[String]) -> Result<()> {
             .as_deref()
             .is_none_or(|value| matches!(value, "status" | "logs" | "log")),
         Some("uninstall") => args.iter().any(|arg| arg == "--dry-run"),
+        // `setup status` reports first-time setup state (read-only); `setup reset`
+        // re-arms it and is mutating. Mirrors the bin's rocm_command classifier so
+        // the read-only allowlist is consistent across binaries.
+        Some("setup") => second.as_deref().is_none_or(|value| value == "status"),
         _ => false,
     };
     if read_only {
@@ -5160,6 +5164,35 @@ mod tests {
         )?;
         let error = ensure_rocm_command_is_read_only(&shell_args)
             .expect_err("non-rocm shell commands should be rejected");
+        assert!(error.to_string().contains("approval UI"));
+        Ok(())
+    }
+
+    #[test]
+    fn rocm_command_helper_treats_setup_status_as_read_only_and_reset_as_mutating() -> Result<()> {
+        // Mirrors the bin's rocm_command classifier so `setup status` is read-only
+        // on every binary's tool surface while `setup reset` stays approval-gated.
+        let bare_args = normalized_rocm_command_args(
+            serde_json::json!({ "args": ["setup"] })
+                .as_object()
+                .expect("json object"),
+        )?;
+        ensure_rocm_command_is_read_only(&bare_args).expect("bare setup should be read-only");
+
+        let status_args = normalized_rocm_command_args(
+            serde_json::json!({ "args": ["setup", "status"] })
+                .as_object()
+                .expect("json object"),
+        )?;
+        ensure_rocm_command_is_read_only(&status_args).expect("setup status should be read-only");
+
+        let reset_args = normalized_rocm_command_args(
+            serde_json::json!({ "args": ["setup", "reset"] })
+                .as_object()
+                .expect("json object"),
+        )?;
+        let error = ensure_rocm_command_is_read_only(&reset_args)
+            .expect_err("setup reset must go through approval");
         assert!(error.to_string().contains("approval UI"));
         Ok(())
     }

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -860,25 +860,28 @@ impl AppState {
             }
             "uninstall" => {
                 // SAFE default: bare `/uninstall` is a dry-run (read-only). A real
-                // uninstall needs `/uninstall --apply` (or now/real) and is
-                // approval-gated (the bin auto-adds --yes on approval).
-                let real = matches!(
-                    rest.split_whitespace().nth(1),
-                    Some("--apply" | "now" | "real")
-                );
-                let argv: Vec<&str> = if real {
-                    vec!["uninstall"]
+                // uninstall needs `/uninstall --apply` and is approval-gated (the
+                // bin auto-adds --yes on approval).
+                let flags: Vec<&str> = rest.split_whitespace().skip(1).collect();
+                let saw_apply = flags.iter().any(|flag| *flag == "--apply");
+                let saw_dry_run = flags.iter().any(|flag| *flag == "--dry-run");
+                if saw_apply && saw_dry_run {
+                    self.chat.push(ChatTurn::error(
+                        "conflicting /uninstall flags: choose either --dry-run (safe) or --apply (real uninstall)"
+                            .to_string(),
+                    ));
                 } else {
-                    vec!["uninstall", "--dry-run"]
-                };
-                self.slash_tool = Some(rocm_cmd_request(
-                    &argv,
-                    if real {
-                        "uninstall"
+                    let real = saw_apply;
+                    let argv: Vec<&str> = if real {
+                        vec!["uninstall"]
                     } else {
-                        "uninstall --dry-run"
-                    },
-                ));
+                        vec!["uninstall", "--dry-run"]
+                    };
+                    self.slash_tool = Some(rocm_cmd_request(
+                        &argv,
+                        if real { "uninstall" } else { "uninstall --dry-run" },
+                    ));
+                }
             }
             "setup" => {
                 // Bare `/setup` (or `/setup status`) reports first-time setup

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -824,8 +824,9 @@ impl AppState {
             // mutating paths classify as ApprovalRequired and open the Phase-4 modal.
             "update" => {
                 // `/update` reports available updates (read-only); `/update --apply`
-                // (or `/update apply`) applies them (approval-gated).
-                let apply = matches!(rest.split_whitespace().nth(1), Some("--apply" | "apply"));
+                // applies them (approval-gated). The mutating trigger is the
+                // dash flag only, matching `/uninstall --apply` and `rocm update --apply`.
+                let apply = rest.split_whitespace().nth(1) == Some("--apply");
                 let argv: Vec<&str> = if apply {
                     vec!["update", "--apply"]
                 } else {

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -3378,6 +3378,20 @@ mod tests {
     }
 
     #[test]
+    fn slash_uninstall_conflicting_flags_is_guided() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/uninstall --apply --dry-run"),
+            SlashOutcome::Handled
+        );
+        assert!(
+            s.slash_tool.is_none(),
+            "conflicting uninstall flags must NOT dispatch"
+        );
+        assert_eq!(s.chat.last().unwrap().role, ChatRole::Error);
+    }
+
+    #[test]
     fn slash_setup_bare_is_status() {
         let mut s = st();
         assert_eq!(s.handle_slash_command("/setup"), SlashOutcome::Handled);

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -665,6 +665,17 @@ impl AppState {
     /// [`SlashOutcome::Handled`]. Stays I/O-free: executor-backed commands raise
     /// the `slash_tool` edge for the event loop to drain off-thread.
     pub(crate) fn handle_slash_command(&mut self, text: &str) -> SlashOutcome {
+        /// Build a `rocm_command` slash-tool request from an argv slice and a
+        /// chat-turn label. Centralizes the repeated `name: "rocm_command"` +
+        /// `{"args": argv}` construction shared by the lifecycle read/mutate arms.
+        fn rocm_cmd_request(argv: &[&str], label: impl Into<String>) -> SlashToolRequest {
+            SlashToolRequest {
+                name: "rocm_command".to_string(),
+                args: serde_json::json!({ "args": argv }),
+                label: label.into(),
+            }
+        }
+
         let trimmed = text.trim();
         let Some(rest) = trimmed.strip_prefix('/') else {
             return SlashOutcome::NotCommand;
@@ -701,18 +712,10 @@ impl AppState {
             }
             // --- Group B: read-only executor-backed (no overlay; off-thread) ---
             "model" => {
-                self.slash_tool = Some(SlashToolRequest {
-                    name: "rocm_command".to_string(),
-                    args: serde_json::json!({ "args": ["model"] }),
-                    label: "model".to_string(),
-                });
+                self.slash_tool = Some(rocm_cmd_request(&["model"], "model"));
             }
             "daemon" => {
-                self.slash_tool = Some(SlashToolRequest {
-                    name: "rocm_command".to_string(),
-                    args: serde_json::json!({ "args": ["daemon", "status"] }),
-                    label: "daemon status".to_string(),
-                });
+                self.slash_tool = Some(rocm_cmd_request(&["daemon", "status"], "daemon status"));
             }
             // --- Group D: mutating ops (approval-gated; surfaced via the modal) ---
             // Each raises a `slash_tool` request whose `execute()` returns
@@ -828,11 +831,10 @@ impl AppState {
                 } else {
                     vec!["update"]
                 };
-                self.slash_tool = Some(SlashToolRequest {
-                    name: "rocm_command".to_string(),
-                    args: serde_json::json!({ "args": argv }),
-                    label: if apply { "update --apply" } else { "update" }.to_string(),
-                });
+                self.slash_tool = Some(rocm_cmd_request(
+                    &argv,
+                    if apply { "update --apply" } else { "update" },
+                ));
             }
             "comfyui" | "comfy" => {
                 // Bare `/comfyui` is read-only status. status/logs read; install/
@@ -840,18 +842,14 @@ impl AppState {
                 let sub = rest.split_whitespace().nth(1).map(str::to_lowercase);
                 match sub.as_deref() {
                     None | Some("status") => {
-                        self.slash_tool = Some(SlashToolRequest {
-                            name: "rocm_command".to_string(),
-                            args: serde_json::json!({ "args": ["comfyui", "status"] }),
-                            label: "comfyui status".to_string(),
-                        });
+                        self.slash_tool =
+                            Some(rocm_cmd_request(&["comfyui", "status"], "comfyui status"));
                     }
                     Some(action @ ("logs" | "install" | "start" | "stop")) => {
-                        self.slash_tool = Some(SlashToolRequest {
-                            name: "rocm_command".to_string(),
-                            args: serde_json::json!({ "args": ["comfyui", action] }),
-                            label: format!("comfyui {action}"),
-                        });
+                        self.slash_tool = Some(rocm_cmd_request(
+                            &["comfyui", action],
+                            format!("comfyui {action}"),
+                        ));
                     }
                     Some(other) => {
                         self.chat.push(ChatTurn::error(format!(
@@ -873,16 +871,14 @@ impl AppState {
                 } else {
                     vec!["uninstall", "--dry-run"]
                 };
-                self.slash_tool = Some(SlashToolRequest {
-                    name: "rocm_command".to_string(),
-                    args: serde_json::json!({ "args": argv }),
-                    label: if real {
+                self.slash_tool = Some(rocm_cmd_request(
+                    &argv,
+                    if real {
                         "uninstall"
                     } else {
                         "uninstall --dry-run"
-                    }
-                    .to_string(),
-                });
+                    },
+                ));
             }
             "setup" => {
                 // Bare `/setup` (or `/setup status`) reports first-time setup
@@ -891,18 +887,12 @@ impl AppState {
                 let sub = rest.split_whitespace().nth(1).map(str::to_lowercase);
                 match sub.as_deref() {
                     None | Some("status") => {
-                        self.slash_tool = Some(SlashToolRequest {
-                            name: "rocm_command".to_string(),
-                            args: serde_json::json!({ "args": ["setup", "status"] }),
-                            label: "setup status".to_string(),
-                        });
+                        self.slash_tool =
+                            Some(rocm_cmd_request(&["setup", "status"], "setup status"));
                     }
                     Some("reset") => {
-                        self.slash_tool = Some(SlashToolRequest {
-                            name: "rocm_command".to_string(),
-                            args: serde_json::json!({ "args": ["setup", "reset"] }),
-                            label: "setup reset".to_string(),
-                        });
+                        self.slash_tool =
+                            Some(rocm_cmd_request(&["setup", "reset"], "setup reset"));
                     }
                     Some(other) => {
                         self.chat.push(ChatTurn::error(format!(
@@ -3311,6 +3301,22 @@ mod tests {
     }
 
     #[test]
+    fn slash_comfy_alias_is_status() {
+        // `/comfy` is an alias for `/comfyui` and must map to the same
+        // read-only status argv.
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/comfy"), SlashOutcome::Handled);
+        let req = s
+            .slash_tool
+            .expect("comfy alias raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["comfyui", "status"] })
+        );
+    }
+
+    #[test]
     fn slash_comfyui_start_is_mutating() {
         let mut s = st();
         assert_eq!(
@@ -3347,6 +3353,10 @@ mod tests {
             serde_json::json!({ "args": ["uninstall", "--dry-run"] }),
             "bare /uninstall MUST default to a dry-run, not a real uninstall"
         );
+        assert_eq!(
+            req.label, "uninstall --dry-run",
+            "the dry-run label is the safety-critical user-visible string"
+        );
     }
 
     #[test]
@@ -3358,6 +3368,10 @@ mod tests {
         );
         let req = s.slash_tool.expect("uninstall --apply raises a request");
         assert_eq!(req.args, serde_json::json!({ "args": ["uninstall"] }));
+        assert_eq!(
+            req.label, "uninstall",
+            "the real-uninstall label is the safety-critical user-visible string"
+        );
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -863,8 +863,8 @@ impl AppState {
                 // uninstall needs `/uninstall --apply` and is approval-gated (the
                 // bin auto-adds --yes on approval).
                 let flags: Vec<&str> = rest.split_whitespace().skip(1).collect();
-                let saw_apply = flags.iter().any(|flag| *flag == "--apply");
-                let saw_dry_run = flags.iter().any(|flag| *flag == "--dry-run");
+                let saw_apply = flags.contains(&"--apply");
+                let saw_dry_run = flags.contains(&"--dry-run");
                 if saw_apply && saw_dry_run {
                     self.chat.push(ChatTurn::error(
                         "conflicting /uninstall flags: choose either --dry-run (safe) or --apply (real uninstall)"
@@ -879,7 +879,11 @@ impl AppState {
                     };
                     self.slash_tool = Some(rocm_cmd_request(
                         &argv,
-                        if real { "uninstall" } else { "uninstall --dry-run" },
+                        if real {
+                            "uninstall"
+                        } else {
+                            "uninstall --dry-run"
+                        },
                     ));
                 }
             }

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -816,6 +816,101 @@ impl AppState {
                     }
                 }
             }
+            // --- Group D-rest: lifecycle ops (read/mutate split via rocm_command) ---
+            // Read paths classify as ReadOnly in the bin and return a result turn;
+            // mutating paths classify as ApprovalRequired and open the Phase-4 modal.
+            "update" => {
+                // `/update` reports available updates (read-only); `/update --apply`
+                // (or `/update apply`) applies them (approval-gated).
+                let apply = matches!(rest.split_whitespace().nth(1), Some("--apply" | "apply"));
+                let argv: Vec<&str> = if apply {
+                    vec!["update", "--apply"]
+                } else {
+                    vec!["update"]
+                };
+                self.slash_tool = Some(SlashToolRequest {
+                    name: "rocm_command".to_string(),
+                    args: serde_json::json!({ "args": argv }),
+                    label: if apply { "update --apply" } else { "update" }.to_string(),
+                });
+            }
+            "comfyui" | "comfy" => {
+                // Bare `/comfyui` is read-only status. status/logs read; install/
+                // start/stop mutate (approval-gated).
+                let sub = rest.split_whitespace().nth(1).map(str::to_lowercase);
+                match sub.as_deref() {
+                    None | Some("status") => {
+                        self.slash_tool = Some(SlashToolRequest {
+                            name: "rocm_command".to_string(),
+                            args: serde_json::json!({ "args": ["comfyui", "status"] }),
+                            label: "comfyui status".to_string(),
+                        });
+                    }
+                    Some(action @ ("logs" | "install" | "start" | "stop")) => {
+                        self.slash_tool = Some(SlashToolRequest {
+                            name: "rocm_command".to_string(),
+                            args: serde_json::json!({ "args": ["comfyui", action] }),
+                            label: format!("comfyui {action}"),
+                        });
+                    }
+                    Some(other) => {
+                        self.chat.push(ChatTurn::error(format!(
+                            "unknown /comfyui action `{other}` (try status, logs, install, start, stop)"
+                        )));
+                    }
+                }
+            }
+            "uninstall" => {
+                // SAFE default: bare `/uninstall` is a dry-run (read-only). A real
+                // uninstall needs `/uninstall --apply` (or now/real) and is
+                // approval-gated (the bin auto-adds --yes on approval).
+                let real = matches!(
+                    rest.split_whitespace().nth(1),
+                    Some("--apply" | "now" | "real")
+                );
+                let argv: Vec<&str> = if real {
+                    vec!["uninstall"]
+                } else {
+                    vec!["uninstall", "--dry-run"]
+                };
+                self.slash_tool = Some(SlashToolRequest {
+                    name: "rocm_command".to_string(),
+                    args: serde_json::json!({ "args": argv }),
+                    label: if real {
+                        "uninstall"
+                    } else {
+                        "uninstall --dry-run"
+                    }
+                    .to_string(),
+                });
+            }
+            "setup" => {
+                // Bare `/setup` (or `/setup status`) reports first-time setup
+                // (read-only); `/setup reset` re-arms it (approval-gated). The CLI
+                // only has status + reset — anything else is guided, not run.
+                let sub = rest.split_whitespace().nth(1).map(str::to_lowercase);
+                match sub.as_deref() {
+                    None | Some("status") => {
+                        self.slash_tool = Some(SlashToolRequest {
+                            name: "rocm_command".to_string(),
+                            args: serde_json::json!({ "args": ["setup", "status"] }),
+                            label: "setup status".to_string(),
+                        });
+                    }
+                    Some("reset") => {
+                        self.slash_tool = Some(SlashToolRequest {
+                            name: "rocm_command".to_string(),
+                            args: serde_json::json!({ "args": ["setup", "reset"] }),
+                            label: "setup reset".to_string(),
+                        });
+                    }
+                    Some(other) => {
+                        self.chat.push(ChatTurn::error(format!(
+                            "unknown /setup action `{other}` (try status or reset)"
+                        )));
+                    }
+                }
+            }
             // Unknown slash command: an error turn, never sent to the LLM.
             other => {
                 self.chat.push(ChatTurn::error(format!(
@@ -3175,6 +3270,126 @@ mod tests {
         assert_eq!(s.handle_slash_command("/services"), SlashOutcome::Handled);
         let req = s.slash_tool.expect("bare services lists managed services");
         assert_eq!(req.name, "services");
+    }
+
+    // --- Phase 5: lifecycle slash dispatch (read/mutate split via rocm_command) ---
+
+    #[test]
+    fn slash_update_is_read_only_report() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/update"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("update raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(req.args, serde_json::json!({ "args": ["update"] }));
+    }
+
+    #[test]
+    fn slash_update_apply_is_mutating() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/update --apply"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("update --apply raises a request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["update", "--apply"] })
+        );
+    }
+
+    #[test]
+    fn slash_comfyui_bare_is_status() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/comfyui"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("comfyui raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["comfyui", "status"] })
+        );
+    }
+
+    #[test]
+    fn slash_comfyui_start_is_mutating() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/comfyui start"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("comfyui start raises a request");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["comfyui", "start"] })
+        );
+    }
+
+    #[test]
+    fn slash_comfyui_logs_is_read_only() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/comfyui logs"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("comfyui logs raises a request");
+        assert_eq!(req.args, serde_json::json!({ "args": ["comfyui", "logs"] }));
+    }
+
+    #[test]
+    fn slash_uninstall_defaults_to_dry_run() {
+        // SAFETY: a bare `/uninstall` must NEVER trigger a real uninstall.
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/uninstall"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("uninstall raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["uninstall", "--dry-run"] }),
+            "bare /uninstall MUST default to a dry-run, not a real uninstall"
+        );
+    }
+
+    #[test]
+    fn slash_uninstall_apply_is_real() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/uninstall --apply"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("uninstall --apply raises a request");
+        assert_eq!(req.args, serde_json::json!({ "args": ["uninstall"] }));
+    }
+
+    #[test]
+    fn slash_setup_bare_is_status() {
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/setup"), SlashOutcome::Handled);
+        let req = s.slash_tool.expect("setup raises a slash_tool request");
+        assert_eq!(req.name, "rocm_command");
+        assert_eq!(req.args, serde_json::json!({ "args": ["setup", "status"] }));
+    }
+
+    #[test]
+    fn slash_setup_reset_is_mutating() {
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/setup reset"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("setup reset raises a request");
+        assert_eq!(req.args, serde_json::json!({ "args": ["setup", "reset"] }));
+    }
+
+    #[test]
+    fn slash_setup_unknown_sub_is_guided() {
+        // SetupCommand has only status + reset — `skip` must guide, not dispatch.
+        let mut s = st();
+        assert_eq!(s.handle_slash_command("/setup skip"), SlashOutcome::Handled);
+        assert!(
+            s.slash_tool.is_none(),
+            "unsupported /setup sub must NOT dispatch"
+        );
+        assert_eq!(s.chat.last().unwrap().role, ChatRole::Error);
     }
 
     /// Recording executor: mutating names surface `ApprovalRequired`; the

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -824,9 +824,9 @@ impl AppState {
             // mutating paths classify as ApprovalRequired and open the Phase-4 modal.
             "update" => {
                 // `/update` reports available updates (read-only); `/update --apply`
-                // applies them (approval-gated). The mutating trigger is the
-                // dash flag only, matching `/uninstall --apply` and `rocm update --apply`.
-                let apply = rest.split_whitespace().nth(1) == Some("--apply");
+                // applies them (approval-gated). Scan all tokens for the dash flag
+                // (matching `/uninstall`) so the trigger isn't position-sensitive.
+                let apply = rest.split_whitespace().skip(1).any(|tok| tok == "--apply");
                 let argv: Vec<&str> = if apply {
                     vec!["update", "--apply"]
                 } else {
@@ -3293,6 +3293,23 @@ mod tests {
         assert_eq!(
             req.args,
             serde_json::json!({ "args": ["update", "--apply"] })
+        );
+    }
+
+    #[test]
+    fn slash_update_apply_is_position_independent() {
+        // `--apply` anywhere in the args triggers the mutating path (matching
+        // `/uninstall`'s all-tokens parse), not only as the immediate second token.
+        let mut s = st();
+        assert_eq!(
+            s.handle_slash_command("/update --preview --apply"),
+            SlashOutcome::Handled
+        );
+        let req = s.slash_tool.expect("update --apply raises a request");
+        assert_eq!(
+            req.args,
+            serde_json::json!({ "args": ["update", "--apply"] }),
+            "--apply past the second token must still apply"
         );
     }
 

--- a/docs/dash-parity-map.md
+++ b/docs/dash-parity-map.md
@@ -28,10 +28,10 @@ Groups: **A** nav/session · **B** read-only · **C** approvals/automations ·
 | engine | D | covered (Phase 4) | `/engine <name>` slash → `install_engine` mutating tool → approval modal → `execute_approved`; also LLM tool-call seam | `slash_engine_raises_install_engine_request` |
 | serve | D | covered (Phase 4) | `/serve <model>` slash (loopback host) → `launch_server` mutating tool → approval modal → `execute_approved`; also LLM tool-call seam | `slash_serve_raises_launch_server_request` / `seam_execute_approved_rejects_unsafe_call_via_validator` |
 | services | D | covered (Phase 4) | `/services stop <id>` slash → `stop_server` mutating tool → approval modal → `execute_approved`; `restart` is guided (not yet wired through the chat seam — points to stop + `/serve`); bare `/services` is read-only | `slash_services_stop_raises_stop_server_request` / `slash_services_restart_is_guided_not_stop` |
-| update | D | pending (Phase 5) | update overlay + mutating apply (approval-gated) | — |
-| comfyui | D | pending (Phase 5) | ComfyUI serve/launch flow (approval-gated) | — |
-| uninstall | D | pending (Phase 5) | uninstall flow (approval-gated) | — |
-| setup | D | pending (Phase 5) | onboarding wizard (deterministic first-run) | — |
+| update | D | covered (Phase 5) | `/update` slash → `slash_tool` `rocm_command ["update"]` (read-only report); `/update --apply` → `["update","--apply"]` → approval modal | `slash_update_is_read_only_report` / `slash_update_apply_is_mutating` / `lifecycle_read_mutate_split_is_honest` |
+| comfyui | D | covered (Phase 5) | `/comfyui` slash → `rocm_command ["comfyui","status"]` (read; status/logs); `install`/`start`/`stop` → approval modal | `slash_comfyui_bare_is_status` / `slash_comfyui_start_is_mutating` / `slash_comfyui_logs_is_read_only` |
+| uninstall | D | covered (Phase 5) | `/uninstall` slash → `rocm_command ["uninstall","--dry-run"]` (SAFE read-only default); `/uninstall --apply` → `["uninstall"]` → approval modal (bin auto-adds `--yes`) | `slash_uninstall_defaults_to_dry_run` / `slash_uninstall_apply_is_real` |
+| setup | D | covered (Phase 5) | `/setup` slash → `rocm_command ["setup","status"]` (read); `/setup reset` → `["setup","reset"]` → approval modal; unsupported subs guided | `slash_setup_bare_is_status` / `slash_setup_reset_is_mutating` / `setup_status_is_read_only` / `setup_reset_requires_approval` |
 | automations | C | pending (Phase 6) | automations-manager overlay + run/approve actions | — |
 | reviews | C | pending (Phase 6) | approval/review queue surface | — |
 | approve | C | pending (Phase 6) | approval-queue accept action | — |


### PR DESCRIPTION
**Stack 5/10** · base: `supergoal/phase-4-approval-core-mutating`

Routes the remaining lifecycle commands through the Phase-4 approval modal via the `rocm_command` seam; read paths stay read-only.

- `/update` (report=read, `--apply`=approval), `/comfyui` (status/logs=read, install/start/stop=approval), `/uninstall` (**bare = dry-run safe default**, real=approval), `/setup` (status=read, reset=approval).
- One contained bin addition: `setup` classifier + in-process status renderer. DRY `rocm_cmd_request` helper.

Reviewed: rust + security (uninstall dry-run default + approval-gated) + maintainability. All cargo gates green.