### PR TITLE
§1: reroute bare rocm/chat → dash chat + parity gate (tui.rs RETAINED)

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -217,7 +217,20 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
         .enable_all()
         .build()
         .context("building tokio runtime for the dashboard")?;
-    rt.block_on(run_async(config, paths, replay, chat_mock))
+    rt.block_on(run_async(config, paths, replay, chat_mock, ActiveTab::Overview))
+}
+
+/// Entry point for bare `rocm` and interactive `rocm chat`. Opens the unified
+/// dashboard with the Chat tab focused. Thin wrapper over the same runtime/
+/// `run_async` path as [`run`]; no replay/demo, embedded daemon as usual.
+pub fn run_chat(chat_mock: bool) -> Result<()> {
+    let paths = AppPaths::discover()?;
+    let config = RocmCliConfig::load(&paths)?;
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for the dashboard")?;
+    rt.block_on(run_async(config, paths, None, chat_mock, ActiveTab::Chat))
 }
 
 async fn run_async(
@@ -225,8 +238,9 @@ async fn run_async(
     paths: AppPaths,
     replay: Option<PathBuf>,
     chat_mock: bool,
+    initial_tab: ActiveTab,
 ) -> Result<()> {
-    let mut args = resolved_args(&config, &paths, ActiveTab::Overview);
+    let mut args = resolved_args(&config, &paths, initial_tab);
     args.replay = replay.clone();
     args.chat_mock = chat_mock;
     // Inject the bin-side tool-execution seam for a live dash only. Demo/replay

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -165,10 +165,16 @@ fn automation_summaries(config: &RocmCliConfig) -> Vec<AutomationSummary> {
 }
 
 /// Resolve the TUI args from the unified config + environment.
+///
+/// `anthropic_api_key` is resolved by the caller *before* any tokio runtime is
+/// entered: the secure-store fallback uses a blocking zbus client that spins its
+/// own runtime, which panics ("cannot start a runtime from within a runtime") if
+/// invoked from inside `run_async`. See [`anthropic_api_key_for_dash`].
 pub fn resolved_args(
     config: &RocmCliConfig,
     paths: &AppPaths,
     initial_tab: ActiveTab,
+    anthropic_api_key: Option<String>,
 ) -> ResolvedArgs {
     let t = &config.dashboard.tui;
     ResolvedArgs {
@@ -184,7 +190,7 @@ pub fn resolved_args(
             .ok()
             .filter(|v| !v.is_empty()),
         chat_api_key: chat_api_key_from_env(),
-        anthropic_api_key: anthropic_api_key_for_dash(),
+        anthropic_api_key,
         chat_auto_consent: false,
         chat_mock: false,
         model_recipes: model_recipe_summaries(),
@@ -213,6 +219,9 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
     } else {
         replay
     };
+    // Resolve the Anthropic key before the runtime exists; the secure-store
+    // fallback blocks on its own zbus runtime and would panic inside `run_async`.
+    let anthropic_api_key = anthropic_api_key_for_dash();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -223,6 +232,7 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
         replay,
         chat_mock,
         ActiveTab::Overview,
+        anthropic_api_key,
     ))
 }
 
@@ -232,11 +242,21 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
 pub fn run_chat(chat_mock: bool) -> Result<()> {
     let paths = AppPaths::discover()?;
     let config = RocmCliConfig::load(&paths)?;
+    // Resolve the Anthropic key before the runtime exists; the secure-store
+    // fallback blocks on its own zbus runtime and would panic inside `run_async`.
+    let anthropic_api_key = anthropic_api_key_for_dash();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("building tokio runtime for the dashboard")?;
-    rt.block_on(run_async(config, paths, None, chat_mock, ActiveTab::Chat))
+    rt.block_on(run_async(
+        config,
+        paths,
+        None,
+        chat_mock,
+        ActiveTab::Chat,
+        anthropic_api_key,
+    ))
 }
 
 async fn run_async(
@@ -245,8 +265,9 @@ async fn run_async(
     replay: Option<PathBuf>,
     chat_mock: bool,
     initial_tab: ActiveTab,
+    anthropic_api_key: Option<String>,
 ) -> Result<()> {
-    let mut args = resolved_args(&config, &paths, initial_tab);
+    let mut args = resolved_args(&config, &paths, initial_tab, anthropic_api_key);
     args.replay = replay.clone();
     args.chat_mock = chat_mock;
     // Inject the bin-side tool-execution seam for a live dash only. Demo/replay
@@ -354,7 +375,7 @@ mod tests {
     #[test]
     fn resolved_args_take_connect_and_theme_from_config() {
         let c = cfg();
-        let args = resolved_args(&c, &paths(), ActiveTab::Overview);
+        let args = resolved_args(&c, &paths(), ActiveTab::Overview, None);
         assert_eq!(args.connect, c.dashboard.tui.connect);
         assert_eq!(args.theme, c.dashboard.tui.theme);
         assert!(!args.chat_mock);

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -217,7 +217,13 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
         .enable_all()
         .build()
         .context("building tokio runtime for the dashboard")?;
-    rt.block_on(run_async(config, paths, replay, chat_mock, ActiveTab::Overview))
+    rt.block_on(run_async(
+        config,
+        paths,
+        replay,
+        chat_mock,
+        ActiveTab::Overview,
+    ))
 }
 
 /// Entry point for bare `rocm` and interactive `rocm chat`. Opens the unified

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -22203,9 +22203,11 @@ VERSION_ID="41"
     #[test]
     fn dash_run_chat_is_the_bare_and_chat_dispatch_target() {
         // Symbol exists with the expected signature (bare `rocm` / `rocm chat`
-        // interactive target). Taking the fn pointer fails to compile if the
-        // entrypoint is removed or its signature drifts.
-        let _target: fn(bool) -> Result<()> = dash::run_chat;
+        // interactive target). Coercing to the fn pointer fails to compile if
+        // the entrypoint is removed or its signature drifts; casting the pointer
+        // to an address gives the binding a real effect (no underscore-bind).
+        let target: fn(bool) -> Result<()> = dash::run_chat;
+        assert_ne!(target as usize, 0);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -13,6 +13,12 @@ mod therock;
 mod tui;
 mod uninstall;
 
+// tui.rs is RETAINED pending human go/no-go deletion (see docs/tui-retirement-checklist.md).
+// bare `rocm` and `rocm chat` now route to the dash chat (parity reached, Phases 3-8).
+// This anchor keeps the frozen module compiling (referenced, never invoked) until deletion.
+#[allow(dead_code)]
+const _RETAINED_TUI_ENTRY: fn(Option<String>) -> anyhow::Result<()> = tui::run;
+
 // Per-command handler fns mechanically relocated into modules.
 // Dispatch call sites stay byte-identical via these re-imports (upstream-sync
 // mergeability); only the fn definitions moved out of main.rs.
@@ -216,6 +222,9 @@ echo \"Summarize this\" | rocm chat --provider anthropic")]
             help = "Allow an OpenAI-compatible provider to request ROCm tool calls."
         )]
         tools: bool,
+        /// Use the offline chat mock when launching the interactive dash chat.
+        #[arg(long)]
+        chat_mock: bool,
     },
     /// Install ROCm, drivers, or related local AI components.
     Install {
@@ -849,7 +858,10 @@ fn maybe_migrate_legacy_dashboard_config() {
 fn launch_default() -> Result<()> {
     refresh_startup_update_check_quietly();
     if interactive_terminal() {
-        return tui::run(None);
+        // Bare `rocm` routes to the unified dash chat (parity reached, Phases
+        // 3-8); the legacy `tui::run` assistant is retained but no longer the
+        // interactive entrypoint (see docs/tui-retirement-checklist.md).
+        return dash::run_chat(false);
     }
 
     let paths = AppPaths::discover()?;
@@ -1325,10 +1337,17 @@ fn dispatch(cli: Cli) -> Result<()> {
             model,
             prompt,
             tools,
+            chat_mock,
         }) => {
             let paths = AppPaths::discover()?;
             if interactive_terminal() && prompt.is_none() {
-                return tui::run(provider.map(provider_name).map(str::to_owned));
+                // Interactive `rocm chat` routes to the unified dash chat
+                // (parity reached, Phases 3-8). The dash auto-detects the
+                // provider and supports `/provider` switching; --provider is
+                // honored only on the non-interactive render path below. The
+                // legacy `tui::run` assistant is retained but no longer invoked
+                // here (see docs/tui-retirement-checklist.md).
+                return dash::run_chat(chat_mock);
             }
             match prompt {
                 Some(prompt) => print!(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -22096,4 +22096,191 @@ VERSION_ID="41"
             },
         )
     }
+
+    // ---- Phase 9: reroute dispatch (bare `rocm` + interactive `rocm chat`) ----
+    //
+    // The interactive branches require a real TTY (`interactive_terminal()`),
+    // which is unavailable in CI, and the dash visuals are trust-prior. These
+    // tests instead PROVE the dispatch TARGET changed: the two interactive
+    // handlers now call `dash::run_chat` and no longer call `tui::run`. We read
+    // this source file at test time and assert on the handler bodies.
+
+    fn main_rs_source() -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("main.rs");
+        fs::read_to_string(path).expect("read apps/rocm/src/main.rs")
+    }
+
+    /// Extract the body of `fn launch_default()` (brace-balanced).
+    fn launch_default_body(src: &str) -> String {
+        slice_braced_block(src, "fn launch_default() -> Result<()> {")
+    }
+
+    /// Extract the whole `Some(Command::Chat { .. }) => { .. }` handler arm,
+    /// brace-balanced from the destructure pattern through the block body, so
+    /// both the destructured fields (e.g. `chat_mock`) and the dispatch code are
+    /// visible. Restricts to the production handler (the `=> {` form), not the
+    /// variant declaration which has no `=>`.
+    fn command_chat_handler_body(src: &str) -> String {
+        // Anchor on the handler arm specifically: the destructure that is
+        // immediately followed (after the closing `}` + `)`) by `=> {`.
+        let arm = "Some(Command::Chat {";
+        let arm_at = src.find(arm).expect("Command::Chat handler present");
+        // Balance from the `{` of the destructure to capture the full arm,
+        // including the `=> { ... }` block that follows.
+        slice_braced_to_arm_end(&src[arm_at..])
+    }
+
+    /// Given a slice beginning at `Some(Command::Chat {`, return the text from
+    /// that point through the end of the arm's `=> { .. }` block.
+    fn slice_braced_to_arm_end(src: &str) -> String {
+        // 1. balance the destructure `{ .. }`.
+        let pat_open = src.find('{').expect("destructure open brace");
+        let bytes = src.as_bytes();
+        let mut depth = 0usize;
+        let mut pat_end = pat_open;
+        for (i, &b) in bytes.iter().enumerate().skip(pat_open) {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        pat_end = i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        // 2. find the `=> {` block opener after the destructure and balance it.
+        let after = &src[pat_end..];
+        let block_rel = after.find("=> {").expect("arm block opener `=> {`");
+        let block_body = slice_braced_block(after, &after[block_rel..block_rel + 4]);
+        // Return destructure + block body together.
+        format!("{}{}", &src[pat_open..pat_end], block_body)
+    }
+
+    /// Return the brace-balanced block that follows `opener` (which must end in
+    /// `{`), including the contents but excluding the trailing brace's tail.
+    fn slice_braced_block(src: &str, opener: &str) -> String {
+        let start = src.find(opener).unwrap_or_else(|| {
+            panic!("opener not found: {opener}");
+        });
+        let brace_start = start + opener.len() - 1; // index of the `{`
+        let bytes = src.as_bytes();
+        let mut depth = 0usize;
+        let mut end = brace_start;
+        for (i, &b) in bytes.iter().enumerate().skip(brace_start) {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = i + 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        src[brace_start..end].to_string()
+    }
+
+    /// Strip `//` line comments so assertions key on real code, not the prose
+    /// comments that still mention `tui::run` for documentation.
+    fn strip_line_comments(block: &str) -> String {
+        block
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(idx) => &line[..idx],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn dash_run_chat_is_the_bare_and_chat_dispatch_target() {
+        // Symbol exists with the expected signature (bare `rocm` / `rocm chat`
+        // interactive target). Taking the fn pointer fails to compile if the
+        // entrypoint is removed or its signature drifts.
+        let _target: fn(bool) -> Result<()> = dash::run_chat;
+    }
+
+    #[test]
+    fn launch_default_routes_to_dash_run_chat_not_tui() {
+        let src = main_rs_source();
+        let body = strip_line_comments(&launch_default_body(&src));
+        assert!(
+            body.contains("dash::run_chat(false)"),
+            "bare `rocm` interactive branch must route to dash::run_chat; body:\n{body}"
+        );
+        assert!(
+            !body.contains("tui::run"),
+            "launch_default must NOT call tui::run after the reroute; body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn command_chat_interactive_routes_to_dash_run_chat_not_tui() {
+        let src = main_rs_source();
+        let body = strip_line_comments(&command_chat_handler_body(&src));
+        assert!(
+            body.contains("dash::run_chat(chat_mock)"),
+            "interactive `rocm chat` must route to dash::run_chat(chat_mock); body:\n{body}"
+        );
+        assert!(
+            !body.contains("tui::run"),
+            "Command::Chat handler must NOT call tui::run after the reroute; body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn command_chat_honors_chat_mock_and_keeps_prompt_passthrough() {
+        let src = main_rs_source();
+        let body = strip_line_comments(&command_chat_handler_body(&src));
+        // --chat-mock is forwarded into the dash reroute.
+        assert!(
+            body.contains("chat_mock,") || body.contains("chat_mock\n"),
+            "Command::Chat must destructure the --chat-mock field; body:\n{body}"
+        );
+        assert!(
+            body.contains("dash::run_chat(chat_mock)"),
+            "--chat-mock must drive run_chat(chat_mock); body:\n{body}"
+        );
+        // The scriptable prompt passthrough stays on the text render path,
+        // NOT the dash/TUI.
+        assert!(
+            body.contains("render_chat_prompt_text("),
+            "prompt passthrough must still call render_chat_prompt_text; body:\n{body}"
+        );
+        assert!(
+            body.contains("render_chat_text("),
+            "non-interactive no-prompt path must still call render_chat_text; body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn tui_run_is_referenced_only_by_the_retention_anchor() {
+        // tui.rs is RETAINED (not deleted). The ONLY non-comment reference to
+        // `tui::run` in the PRODUCTION part of main.rs (before `mod tests`) must
+        // be the retention anchor; the interactive handlers must not invoke it.
+        // (The test module itself names `tui::run` in assertion strings.)
+        let full = main_rs_source();
+        let prod = full
+            .split("mod tests {")
+            .next()
+            .expect("production source before the tests module");
+        let src = strip_line_comments(prod);
+        let count = src.matches("tui::run").count();
+        assert_eq!(
+            count, 1,
+            "expected exactly one tui::run reference (the retention anchor), found {count}"
+        );
+        assert!(
+            src.contains("_RETAINED_TUI_ENTRY"),
+            "the retention anchor _RETAINED_TUI_ENTRY must keep tui::run reachable"
+        );
+    }
 }

--- a/apps/rocm/src/provider_keys.rs
+++ b/apps/rocm/src/provider_keys.rs
@@ -229,9 +229,45 @@ impl ProviderKeyStore for NativeProviderKeyStore {
     }
 }
 
-fn with_native_entry<T>(provider: &str, action: impl FnOnce(&Entry) -> Result<T>) -> Result<T> {
-    let entry = native_entry(provider)?;
-    action(&entry)
+/// Build the native credential entry and run `action` against it.
+///
+/// The native stores drive their own blocking runtime — notably the Linux Secret
+/// Service via `zbus::blocking`, which calls `block_on` internally. If a tokio
+/// runtime *context* is already entered on the calling thread, that nested
+/// `block_on` panics with "Cannot start a runtime from within a runtime". The
+/// dash resolves keys off-runtime, but this is the single chokepoint for every
+/// store op (get/set/clear) and for `resolve_provider_api_key` /
+/// `provider_key_status`, so guard the whole class here: when a runtime is
+/// active, run the entry build *and* the action on a fresh OS thread that has no
+/// runtime entered.
+///
+/// `tokio::task::block_in_place` is deliberately NOT used — it keeps the runtime
+/// context entered (and panics outright on a current-thread runtime), so the
+/// nested `block_on` would still panic. Only a thread with no entered runtime
+/// escapes. `Handle::try_current()` also returns `Ok` on tokio's blocking-pool
+/// threads (where the context is not actually entered and no panic would occur),
+/// so this is a conservative over-trigger: at worst one short-lived thread.
+fn with_native_entry<T: Send>(
+    provider: &str,
+    action: impl FnOnce(&Entry) -> Result<T> + Send,
+) -> Result<T> {
+    let run = move || {
+        let entry = native_entry(provider)?;
+        action(&entry)
+    };
+    if tokio::runtime::Handle::try_current().is_ok() {
+        // Must `join()` the handle and convert a worker panic into an `Err`:
+        // otherwise `thread::scope` re-propagates the panic when the scope ends,
+        // which would defeat the guard by aborting the process anyway.
+        std::thread::scope(|scope| {
+            scope
+                .spawn(run)
+                .join()
+                .map_err(|_| anyhow!("secure key-store access thread panicked"))?
+        })
+    } else {
+        run()
+    }
 }
 
 fn native_entry(provider: &str) -> Result<Entry> {
@@ -393,5 +429,32 @@ mod tests {
         assert!(error.contains("requires a saved API key"));
         assert!(error.contains("rocm config set-provider-key anthropic"));
         assert!(error.contains("ANTHROPIC_API_KEY"));
+    }
+
+    /// Regression for the "Cannot start a runtime from within a runtime" panic:
+    /// the native store reaches a blocking `block_on` (Linux Secret Service via
+    /// zbus). Accessing it from inside a live tokio runtime must NOT panic — the
+    /// `with_native_entry` guard reroutes the blocking work onto a fresh thread.
+    ///
+    /// This validates the no-panic / graceful-`Err` contract, not successful
+    /// retrieval: CI has no Secret Service, so the store returns `Ok(None)` (no
+    /// entry) or an `Err` (unavailable). Either is fine; a panic is not. Pre-fix
+    /// this aborted with the nested-runtime panic.
+    #[test]
+    fn native_store_access_inside_tokio_runtime_does_not_panic() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        let outcome = rt.block_on(async {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                // Read-only: never writes to a real keychain on dev machines.
+                NativeProviderKeyStore.get_secret("anthropic")
+            }))
+        });
+        assert!(
+            outcome.is_ok(),
+            "native key-store access panicked inside a tokio runtime (runtime-in-runtime)"
+        );
     }
 }

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -1568,13 +1568,17 @@ pub async fn run(args: ResolvedArgs) -> color_eyre::Result<()> {
 
     let res = event_loop(&mut terminal, &args).await;
 
-    disable_raw_mode()?;
-    execute!(
+    // Best-effort terminal restoration: never let teardown failures override the
+    // session result. If the controlling terminal already went away (e.g. the
+    // PTY closed on quit), these writes can fail with a broken pipe — that must
+    // not turn a clean exit into a non-zero one.
+    let _ = disable_raw_mode();
+    let _ = execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
         DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
+    );
+    let _ = terminal.show_cursor();
     res
 }
 
@@ -1929,7 +1933,18 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                         }
                     }
                     Some(Ok(CtEvent::Resize(_, _))) => { /* repaint */ }
-                    Some(Err(e)) => return Err(e.into()),
+                    // A terminal event-source error means the controlling
+                    // terminal went away (e.g. the PTY/stdin closed) — the
+                    // session is over, so quit cleanly rather than propagating a
+                    // fatal error. Propagating it made `rocm chat` exit non-zero
+                    // when its terminal closed before the first key was read
+                    // (e.g. the acceptance PTY smoke under the embedded-daemon
+                    // start delay); the legacy blocking reader treated this as
+                    // end-of-session too. Mirrors the `None => break` EOF arm.
+                    Some(Err(e)) => {
+                        tracing::debug!(error = %e, "terminal event stream ended; quitting");
+                        break;
+                    }
                     None => break,
                     _ => {}
                 }

--- a/docs/dash-parity-checklist.md
+++ b/docs/dash-parity-checklist.md
@@ -1,0 +1,22 @@
+# Dash parity checklist — accept/retire gate
+
+ROADMAP §1, step 1: the accept/retire gate for retiring the legacy `tui.rs`
+assistant. One row per legacy **capability bucket** (not per command — the
+per-command map is [dash-parity-map.md](dash-parity-map.md)). Every bucket must
+be **ACCEPTED** with a concrete test/artifact pointer before the human deletion
+gate ([tui-retirement-checklist.md](tui-retirement-checklist.md)) is opened.
+
+**Zero unaccepted rows.** As of Phase 9, bare `rocm` and interactive `rocm chat`
+route to the dash chat (`dash::run_chat` → `ActiveTab::Chat`).
+
+| # | Capability bucket | Legacy surface | Dash mechanism | Status | Evidence |
+|---|-------------------|----------------|----------------|--------|----------|
+| 1 | Read-only inspection (doctor, engines, services, gpu, model, config, logs, daemon, runtimes, paths) | `tui.rs` read-only tool-calls + slash commands | Phase 3 read-only `rocm_command` tools via the bin-side seam (`dash_seam::BinToolExecutor`) + nav/overlay slash commands | ACCEPTED | `read_only_tool_round_trips_to_json` (agent); `slash_doctor_opens_overlay`, `slash_runtimes_opens_overlay`, `slash_gpu_switches_to_hardware`, `slash_daemon_raises_executor_request` (app); map rows B |
+| 2 | Mutating ops + in-chat approval (install, engine, serve, services, update, comfyui, uninstall, setup) | `tui.rs` `ChatToolApprovalRequest` + `execute_approved` | Phase 4/5 mutating tools → approval modal → `execute_approved` (validator-gated, captured subprocess) | ACCEPTED | `approve_path_runs_execute_approved`, `slash_install_raises_install_sdk_request`, `slash_serve_raises_launch_server_request`, `slash_update_apply_is_mutating`, `slash_uninstall_defaults_to_dry_run` (app); `seam_execute_approved_rejects_unsafe_call_via_validator` (seam); map rows D |
+| 3 | Automations / reviews / permissions | `tui.rs` automations + proposal + permissions flows | Phase 6 `watcher_enable/disable`, `proposal_action {show,approve,reject}`, `config set-permissions` → approval modal (escalation gated) | ACCEPTED | `slash_automations_enable_raises_watcher_enable`, `slash_approve_id_raises_proposal_approve`, `proposal_action_approve_updates_status`, `slash_permissions_full_access_is_mutating`, `config_set_permissions_classifies_as_approval` (app); map rows C, E |
+| 4 | Natural-language `/plan` (Ask → Plan → Review → Run) | `tui.rs` `FreeformPlanAction` planner | Phase 7 `/plan` edge → read-only `natural_language_plan` tool → `PlanReady` → `on_plan_ready` (complete mutating action hands off to the Phase-4 approval modal; placeholder/non-mutating stays plan-only) | ACCEPTED | `plan_request_set_by_slash`, `on_plan_ready_complete_mutating_hands_off_to_approval`, `on_plan_ready_placeholder_stays_plan_only` (app); `natural_language_plan_returns_structured_mutating_action` (bin) |
+| 5 | 30 slash commands | `tui.rs` slash command set | Phases 3-8 dash slash router (nav / overlay / slash-tool / approval) | ACCEPTED | [dash-parity-map.md](dash-parity-map.md) — 30 rows, all `covered`, 0 pending-status |
+| 6 | Providers: local + openai + anthropic | `tui.rs` provider switching | Phase 8 `/provider` edge → `build_chat_agent` rebuilds the live agent (local auto-detect / `RigAgentClient` / `AnthropicAgentClient`); keys env-first then secure store, never argv; same ROCm read+mutating tools on every backend | ACCEPTED | `slash_provider_switches_backend`, `build_chat_agent_anthropic_with_key`, `build_chat_agent_anthropic_without_key_is_none` (app); `anthropic_backend_constructs_and_is_agentclient`, `anthropic_requires_key`, `all_backends_register_same_rocm_tools` (agent) |
+
+All six capability buckets are ACCEPTED. The accept/retire gate is **GO** for the
+human deletion steps in [tui-retirement-checklist.md](tui-retirement-checklist.md).

--- a/docs/dash-parity-map.md
+++ b/docs/dash-parity-map.md
@@ -9,6 +9,13 @@ locks the behavior.
 Groups: **A** nav/session · **B** read-only · **C** approvals/automations ·
 **D** mutating ops · **E** permissions · **F** planning · **G** provider/chat.
 
+> **All 30 legacy commands covered as of Phase 9; bare `rocm` and `rocm chat`
+> route to the dash.** The interactive entrypoints (`launch_default` and the
+> no-prompt `Command::Chat` branch) now open the dash with the Chat tab focused
+> via `dash::run_chat`. `tui.rs` is retained but unreferenced by these
+> entrypoints, pending the human go/no-go deletion in
+> [tui-retirement-checklist.md](tui-retirement-checklist.md).
+
 | Command | Group | Status | Dash mechanism | Evidence |
 |---------|-------|--------|----------------|----------|
 | home | A | covered (Phase 3) | `/home` slash → `ActiveTab::Overview` | `slash_home_switches_to_overview` |

--- a/docs/tui-retirement-checklist.md
+++ b/docs/tui-retirement-checklist.md
@@ -1,0 +1,99 @@
+# tui.rs retirement checklist — human deletion gate
+
+The legacy chat-first assistant (`apps/rocm/src/tui.rs`) is **RETAINED, compiling
+but unreferenced** by the interactive entrypoints. As of Phase 9, bare `rocm` and
+interactive `rocm chat` route to the dash chat (`dash::run_chat` →
+`ActiveTab::Chat`). The accept/retire gate is GO — see
+[dash-parity-checklist.md](dash-parity-checklist.md) (all six capability buckets
+ACCEPTED) and [dash-parity-map.md](dash-parity-map.md) (30/30 covered).
+
+> **Do not execute these steps automatically.** This is the human go/no-go
+> deletion procedure. Run it only after an explicit human decision to delete.
+
+Until then, the module is kept reachable under `-D warnings` by a single
+retention anchor in `apps/rocm/src/main.rs` (just below `mod tui;`):
+
+```rust
+#[allow(dead_code)]
+const _RETAINED_TUI_ENTRY: fn(Option<String>) -> anyhow::Result<()> = tui::run;
+```
+
+This anchor references `tui::run`, which keeps its whole call graph reachable, so
+no `dead_code` cascade fires into the `tui.rs`-only helpers in `main.rs`.
+
+## Deletion steps (human, on go)
+
+1. **Remove the module file.**
+   ```bash
+   git rm apps/rocm/src/tui.rs
+   ```
+
+2. **Remove the module declaration + retention anchor.** In
+   `apps/rocm/src/main.rs`:
+   - delete `mod tui;` (the `mod tui;` line near the top of the file);
+   - delete the retention block: the `// tui.rs is RETAINED ...` comment, the
+     `#[allow(dead_code)]` attribute, and the
+     `const _RETAINED_TUI_ENTRY: fn(Option<String>) -> anyhow::Result<()> = tui::run;`
+     line;
+   - delete any other `#[allow(dead_code)]` attributes that were added solely for
+     tui retention (none beyond the anchor were needed at Phase 9 — grep for
+     `tui-retirement-checklist` comments to confirm: `grep -rn "tui-retirement-checklist" apps/rocm/src`).
+
+3. **Prune now-dead helpers reachable ONLY from `tui.rs`.** Once the anchor is
+   gone, `tui.rs`-only items in `main.rs` (and the `comfyui` `render_tui_*`
+   helpers, etc.) become unreferenced and rustc will flag them. Do NOT guess the
+   list by hand — let the compiler drive it:
+   ```bash
+   # Discover what tui.rs depended on from the crate root (pre-deletion survey):
+   grep -oE "crate::[A-Za-z_][A-Za-z0-9_:]*|super::[A-Za-z_][A-Za-z0-9_]*" apps/rocm/src/tui.rs | sort -u
+
+   # After steps 1-2, the build surfaces the exact dead items:
+   cargo build --workspace --all-targets
+   cargo clippy --workspace --all-targets -- -D warnings
+   ```
+   Prune each `dead_code`-flagged item that is reachable only from the deleted
+   module. Known candidate buckets (verify each is truly unreferenced before
+   removing — some are shared with the non-interactive chat render path and MUST
+   stay):
+   - `main.rs` chat-approval / sandbox-tool helpers used only by the TUI
+     (e.g. `install_sdk_chat_approval_for_prompt`,
+     `install_sdk_without_prefix_chat_approval`,
+     `chat_install_folder_from_prompt`, `format_structured_tool_call`,
+     `run_internal_sandbox_tool`, `render_chat_prompt_result_with_progress`,
+     `tui_help_text`, `SandboxToolArg`) — **confirm** each has no remaining
+     caller after deletion; keep any still used by `render_chat_prompt_text` /
+     `render_chat_text` (the scriptable passthrough that stays).
+   - `comfyui::render_tui_status`, `comfyui::render_tui_logs`,
+     `comfyui::render_models_path` — TUI-only renderers.
+   - The many `super::*` types/consts in `tui.rs` (managers, screens, menu
+     choices, running-job machinery) defined in `main.rs` — remove those with no
+     other caller.
+
+   Iterate: delete a batch, rebuild, repeat until `cargo clippy -D warnings` is
+   clean. Each pass narrows the set; the compiler is the source of truth.
+
+4. **Move or drop `tui.rs`-specific tests.** `tui.rs` carries its own
+   `#[cfg(test)] mod tests` (these are the known parallel env-race tests). They
+   are deleted with the file in step 1. If any assertion covers behavior that
+   now lives in the dash, port it to the corresponding dash test
+   (`crates/rocm-dash-tui/src/app.rs` tests); otherwise drop it.
+
+5. **Post-deletion verification (must all be green).**
+   ```bash
+   cargo build --workspace --all-targets \
+     && cargo clippy --workspace --all-targets -- -D warnings \
+     && cargo test --workspace --all-targets
+   ```
+   Run `cargo fmt --all` before committing. If `cargo test` is run in parallel,
+   the historical `tui::tests` env-races disappear with the file; remaining
+   flakes (ETXTBSY on freshly built binaries) clear under
+   `cargo test --workspace --all-targets -- --test-threads=1`.
+
+## Rollback
+
+If any step cannot be made green, restore the retained state:
+```bash
+git checkout -- apps/rocm/src/tui.rs apps/rocm/src/main.rs
+```
+The retention anchor keeps the workspace compiling indefinitely, so there is no
+time pressure to complete the deletion in one sitting.

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -301,7 +301,13 @@ tui_command="$(
     openai
 )"
 tui_command="stty rows 40 cols 120; exec ${tui_command}"
-set +e
+# Assert on the TUI's OWN exit code. The dash quits immediately on `q`, so the
+# input feeder's trailing `printf 'y'` races with the child exiting and takes a
+# broken pipe (non-zero); with `pipefail` that would poison the pipeline result
+# even though `script -e` already propagates the child's real exit code. Drop
+# `pipefail` for this one pipeline so the feeder's SIGPIPE can't mask a clean
+# (or genuinely failing) TUI exit.
+set +e +o pipefail
 (
   sleep 1
   printf 'q'
@@ -309,7 +315,7 @@ set +e
   printf 'y'
 ) | timeout 20s script -q -e -f -c "${tui_command}" "${TUI_LOG}"
 tui_status=$?
-set -e
+set -e -o pipefail
 if [[ "${tui_status}" -ne 0 ]]; then
   # Surface the captured TUI session so a non-zero exit is debuggable in CI
   # (e.g. a panic or an error returned on quit) instead of failing opaquely.

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -311,6 +311,11 @@ set +e
 tui_status=$?
 set -e
 if [[ "${tui_status}" -ne 0 ]]; then
+  # Surface the captured TUI session so a non-zero exit is debuggable in CI
+  # (e.g. a panic or an error returned on quit) instead of failing opaquely.
+  echo "--- TUI smoke log (${TUI_LOG}) ---" >&2
+  cat "${TUI_LOG}" >&2 || true
+  echo "--- end TUI smoke log ---" >&2
   fail "TUI smoke exited with status ${tui_status}"
 fi
 


### PR DESCRIPTION
**Stack 9/10** · base: `supergoal/phase-8-provider-anthropic`

- Bare `rocm` and interactive `rocm chat` now route to the dash chat (`dash::run_chat`); `--chat-mock` + prompt passthrough preserved.
- **`tui.rs` RETAINED** (parity then gate) via a single `#[allow(dead_code)]` retention anchor — deletion is a human step in `docs/tui-retirement-checklist.md` (NOT performed here).
- Finalizes `docs/dash-parity-map.md` (30 covered) + adds `docs/dash-parity-checklist.md`.

Reviewed: rust + maintainability. All cargo gates green.