### PR TITLE
Rename LICENSE to LICENSE.TXT and add AMD copyright

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,3 +1,9 @@
+Copyright Advanced Micro Devices, Inc.
+
+Third-party component licenses are maintained in THIRD_PARTY_NOTICES.txt.
+The following Apache-2.0 license applies to the rocm-cli source code
+authored by Advanced Micro Devices, Inc.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/scripts/build_single_exe_release.py
+++ b/scripts/build_single_exe_release.py
@@ -247,7 +247,7 @@ def stage_platform_release(
         if strip_binaries:
             maybe_strip(destination, platform=platform)
 
-    for name in ["README.md", "LICENSE", platform_install_script(platform)]:
+    for name in ["README.md", "LICENSE.TXT", platform_install_script(platform)]:
         copy_required(repo_root / name, staging_root / name)
 
     archive = output_dir / (
@@ -319,7 +319,7 @@ def run_self_test(root: Path) -> None:
                 path.write_bytes(b"fake release binary\n")
                 if platform == "linux-amd64":
                     path.chmod(path.stat().st_mode | stat.S_IXUSR)
-            for name in ["README.md", "LICENSE", "install.ps1", "install.sh"]:
+            for name in ["README.md", "LICENSE.TXT", "install.ps1", "install.sh"]:
                 (fake_repo / name).write_text(f"fake {name}\n", encoding="utf-8")
             standalone = build_standalone_release(
                 repo_root=fake_repo,

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -29,7 +29,7 @@ mkdir -p "${ROOT_DIR}/bin"
 # are only an external third-party plugin fallback, so they are not shipped.
 cp "${BINARY_DIR}/rocm" "${ROOT_DIR}/bin/"
 cp "${BINARY_DIR}/rocmd" "${ROOT_DIR}/bin/"
-cp README.md LICENSE install.sh "${ROOT_DIR}/"
+cp README.md LICENSE.TXT install.sh "${ROOT_DIR}/"
 
 (cd "${OUTPUT_DIR}" && tar -cf "${DIST_NAME}.tar" "${DIST_NAME}")
 gzip -c "${TAR_PATH}" > "${ARCHIVE_PATH}"

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -133,7 +133,7 @@ $bundleBin = Join-Path $rootDir "bin"
 Copy-RequiredFile (Join-Path $binaryDir "rocm.exe") (Join-Path $bundleBin "rocm.exe")
 Copy-RequiredFile (Join-Path $binaryDir "rocmd.exe") (Join-Path $bundleBin "rocmd.exe")
 Copy-RequiredFile (Join-Path $repoRoot "README.md") (Join-Path $rootDir "README.md")
-Copy-RequiredFile (Join-Path $repoRoot "LICENSE") (Join-Path $rootDir "LICENSE")
+Copy-RequiredFile (Join-Path $repoRoot "LICENSE.TXT") (Join-Path $rootDir "LICENSE.TXT")
 Copy-RequiredFile (Join-Path $repoRoot "install.ps1") (Join-Path $rootDir "install.ps1")
 
 Compress-Archive -LiteralPath $rootDir -DestinationPath $archivePath -Force

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -28,14 +28,14 @@ LINUX_REQUIRED = (
     "bin/rocm",
     "bin/rocmd",
     "README.md",
-    "LICENSE",
+    "LICENSE.TXT",
     "install.sh",
 )
 WINDOWS_REQUIRED = (
     "bin/rocm.exe",
     "bin/rocmd.exe",
     "README.md",
-    "LICENSE",
+    "LICENSE.TXT",
     "install.ps1",
 )
 LINUX_EXECUTABLES = (


### PR DESCRIPTION
## Summary

- Renames the root license file from `LICENSE` to `LICENSE.TXT` as required by AMD OSS policy.
- Adds AMD (`Advanced Micro Devices, Inc.`) as copyright holder at the top of the file.
- Adds a note that third-party component notices will be maintained separately in `THIRD_PARTY_NOTICES.txt` (to be provided in a follow-up).
- Updates all packaging and release-readiness scripts that referenced the old filename.

## Test plan

- `cargo check` passes (no build impact — this is a file rename only).
- `cargo fmt --check` passes.
- Manually verified that all script references to `LICENSE` have been updated to `LICENSE.TXT`:
  - `scripts/package-linux-release.sh`
  - `scripts/package-windows-release.ps1`
  - `scripts/build_single_exe_release.py`
  - `scripts/release_readiness.py`
- GitHub recognizes both `LICENSE` and `LICENSE.TXT` for automatic license detection, so renaming has no impact on GitHub's license badge.