### PR TITLE
Add SPDX license headers to all source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,14 @@ jobs:
           }
           if ($findings) { $findings | Format-Table -AutoSize; exit 1 }
 
+  license-headers:
+    name: License header check (hawkeye)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check license headers
+        uses: korandoru/hawkeye@v6
+
   # Hardware (real AMD GPU / WSL) smoke tests on dedicated self-hosted runners
   # are intentionally not part of this workflow yet. See
   # docs/ci-hardware-testing.md for the planned design; they will land in a

--- a/apps/rocm/build.rs
+++ b/apps/rocm/build.rs
@@ -1,1 +1,5 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {}

--- a/apps/rocm/src/automations.rs
+++ b/apps/rocm/src/automations.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! `rocm automations` command handler.
 //!
 //! Mechanically relocated from `main.rs` with no behavior change — the

--- a/apps/rocm/src/bootstrap.rs
+++ b/apps/rocm/src/bootstrap.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::Result;
 use clap::Subcommand;
 use rocm_core::interactive_terminal;

--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{format_structured_tool_call, runtime_usability_status, therock};
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! `rocm dash` — launch the unified telemetry dashboard.
 //!
 //! Folds the rocm-dash launch verb into the `rocm` binary. It builds the

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod automations;
 mod bootstrap;
 mod comfyui;

--- a/apps/rocm/src/provider_keys.rs
+++ b/apps/rocm/src/provider_keys.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, anyhow, bail};
 use keyring_core::api::CredentialStoreApi;
 use keyring_core::{Entry, Error as KeyringError};

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use rocm_core::{
     AppPaths, AuditEventRecord, ManagedServiceRecord, RocmCliConfig, append_audit_event,

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use rocm_core::{
     AppPaths, ManagedToolConfig, RocmCliConfig, detect_host_gpu_diagnostics,

--- a/apps/rocm/src/tui.rs
+++ b/apps/rocm/src/tui.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::providers::{self, ChatMessage, ChatRequest};
 use crate::{
     ChatToolApprovalRequest, FreeformPlanAction, activate_runtime, engine_inventory,

--- a/apps/rocm/src/uninstall.rs
+++ b/apps/rocm/src/uninstall.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! `rocm uninstall` command handler.
 //!
 //! Mechanically relocated from `main.rs` with no behavior change — the

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(clippy::items_after_test_module)]
 
 use anyhow::{Context, Result, bail};

--- a/apps/rocmd/src/main.rs
+++ b/apps/rocmd/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocmd::run_bin_cli()
 }

--- a/crates/rocm-core/build.rs
+++ b/crates/rocm-core/build.rs
@@ -1,1 +1,5 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {}

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use directories::{BaseDirs, ProjectDirs};
 use std::ffi::{OsStr, OsString};

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Acquisition and invocation helpers for the [`uv`](https://github.com/astral-sh/uv)
 //! package manager.
 //!

--- a/crates/rocm-dash-collectors/src/amd_smi.rs
+++ b/crates/rocm-dash-collectors/src/amd_smi.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! amd-smi subprocess + JSON parse.
 //!
 //! Field paths and the KFD pre-flight check are vendored from the TypeScript

--- a/crates/rocm-dash-collectors/src/bench_tail.rs
+++ b/crates/rocm-dash-collectors/src/bench_tail.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tail a normalized benchmark CSV from instinct-agent-bench.
 //!
 //! Strategy: every `drain()` re-reads the entire file and yields rows we haven't

--- a/crates/rocm-dash-collectors/src/cgroup.rs
+++ b/crates/rocm-dash-collectors/src/cgroup.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! PID → docker container id resolution via `/proc/<pid>/cgroup`.
 //!
 //! amd-smi reports the **host** PIDs of GPU compute processes. For a

--- a/crates/rocm-dash-collectors/src/docker.rs
+++ b/crates/rocm-dash-collectors/src/docker.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Docker service discovery via `bollard`.
 //!
 //! Field-extraction logic is vendored from instinct-dash `DockerService.ts`

--- a/crates/rocm-dash-collectors/src/engine_registry.rs
+++ b/crates/rocm-dash-collectors/src/engine_registry.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Engine registry seam — one place that maps a discovered serving engine to its per-engine sample parser.
 //!
 //! The daemon can pick a backend per service instead

--- a/crates/rocm-dash-collectors/src/host.rs
+++ b/crates/rocm-dash-collectors/src/host.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Host system metrics via sysinfo. Backs the daemon's per-tick `SystemMetrics`.
 
 use rocm_dash_core::metrics::SystemMetrics;

--- a/crates/rocm-dash-collectors/src/lemonade.rs
+++ b/crates/rocm-dash-collectors/src/lemonade.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Lemonade Server collector — pure parsers over the Lemonade REST API.
 //!
 //! Schema verified against the official docs (lemonade-server.ai/docs/api):

--- a/crates/rocm-dash-collectors/src/lib.rs
+++ b/crates/rocm-dash-collectors/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! IO-heavy collector implementations. Used by `rocm-dash-daemon`.
 //!
 //! Every collector implements one of the traits in `rocm_dash_core::traits`.

--- a/crates/rocm-dash-collectors/src/llama_slots.rs
+++ b/crates/rocm-dash-collectors/src/llama_slots.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! llama-server /slots collector. Stub.
 
 use rocm_dash_core::traits::{

--- a/crates/rocm-dash-collectors/src/parallel.rs
+++ b/crates/rocm-dash-collectors/src/parallel.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared primitives for async collectors that scrape N targets concurrently.
 //!
 //! Today: [[VllmPrometheusCollector]] uses this pattern hand-rolled in the

--- a/crates/rocm-dash-collectors/src/proc_scan.rs
+++ b/crates/rocm-dash-collectors/src/proc_scan.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! /proc scan for non-container deployments (Strix Halo). Stub.
 
 use rocm_dash_core::traits::{CollectorError, DiscoveredService, Result, ServiceDiscovery};

--- a/crates/rocm-dash-collectors/src/sysfs.rs
+++ b/crates/rocm-dash-collectors/src/sysfs.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! sysfs/hwmon collector for Strix Halo (gfx1151). Stub.
 
 use rocm_dash_core::metrics::{GpuMetrics, GpuSystemInfo};

--- a/crates/rocm-dash-collectors/src/vllm_log.rs
+++ b/crates/rocm-dash-collectors/src/vllm_log.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! vLLM log slicer — verbatim port of `inspect_bench/log_slicer.py`.
 //! See `../wiki/entities/log-slicer.md` and `../wiki/concepts/log-derived-metrics.md`.
 

--- a/crates/rocm-dash-collectors/src/vllm_prom.rs
+++ b/crates/rocm-dash-collectors/src/vllm_prom.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! vLLM Prometheus `/metrics` scraper.
 //!
 //! Field paths and the kv-cache 0..1 → 0..100 scaling are vendored from

--- a/crates/rocm-dash-collectors/tests/vllm_prom_http.rs
+++ b/crates/rocm-dash-collectors/tests/vllm_prom_http.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! End-to-end test for VllmPrometheusCollector: spins up a tiny HTTP server
 //! on a random local port, serves a canned `/metrics` payload, asserts that
 //! `fetch_async` returns the expected parsed sample.

--- a/crates/rocm-dash-core/src/bench_rollup.rs
+++ b/crates/rocm-dash-core/src/bench_rollup.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Pass^N / Pass@N trial-group rollups over benchmark rows.
 //!
 //! Pure: no rendering, no async. The rollup is cheap, so the TUI recomputes

--- a/crates/rocm-dash-core/src/bench_schema.rs
+++ b/crates/rocm-dash-core/src/bench_schema.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Benchmark row schema, vendored from instinct-agent-bench.
 //! See `../wiki/concepts/benchmark-result-schema.md` and `../wiki/entities/csv-emitter.md`.
 

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! TOML config loaded from `~/.config/rocm-dash/config.toml`. Missing = defaults.
 
 use serde::{Deserialize, Serialize};

--- a/crates/rocm-dash-core/src/efficiency.rs
+++ b/crates/rocm-dash-core/src/efficiency.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Pure efficiency derivations (tokens-per-watt). No I/O, no rendering.
 //!
 //! This is the join that turns vLLM throughput + amd-smi power into a

--- a/crates/rocm-dash-core/src/lib.rs
+++ b/crates/rocm-dash-core/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! rocm-dash-core
 //!
 //! Pure types, traits, schemas, and the reducer for rocm-dash.

--- a/crates/rocm-dash-core/src/metrics.rs
+++ b/crates/rocm-dash-core/src/metrics.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Live metric types. snake_case + units encoded in field names.
 //! See `../wiki/concepts/metric-registry.md` and `../wiki/data/metric-field-index.md`.
 

--- a/crates/rocm-dash-core/src/partition.rs
+++ b/crates/rocm-dash-core/src/partition.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! GPU partition mode enums. See `../wiki/concepts/gpu-partition-modes.md`.
 
 use serde::{Deserialize, Serialize};

--- a/crates/rocm-dash-core/src/persist.rs
+++ b/crates/rocm-dash-core/src/persist.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! On-disk session format. Used by the daemon to write each broadcast Event
 //! and by the TUI replay mode to read them back.
 //!

--- a/crates/rocm-dash-core/src/protocol.rs
+++ b/crates/rocm-dash-core/src/protocol.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! NDJSON command/event protocol between rocmdashd and rocmdash.
 //! See `../wiki/comparisons/ctux-vs-rocm-dash.md` (resolved decisions).
 

--- a/crates/rocm-dash-core/src/state.rs
+++ b/crates/rocm-dash-core/src/state.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Pure reducer. `State::apply(StateEvent) -> Vec<SideEffect>`.
 //! See `../wiki/concepts/tea-reducer-pattern.md`.
 

--- a/crates/rocm-dash-core/src/traits.rs
+++ b/crates/rocm-dash-core/src/traits.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Collector traits. Impls live in `rocm-dash-collectors`.
 //! These are sync + `Send` so collector code can decide its own async/blocking strategy.
 

--- a/crates/rocm-dash-core/src/vram.rs
+++ b/crates/rocm-dash-core/src/vram.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Pure VRAM attribution helpers. No I/O, no rendering.
 //!
 //! The `/proc` read and the amd-smi subprocess that feed these live in the

--- a/crates/rocm-dash-daemon/src/bench_ring.rs
+++ b/crates/rocm-dash-daemon/src/bench_ring.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Rolling benchmark-row history kept by the daemon so late-joining clients can hydrate.
 
 use std::collections::VecDeque;

--- a/crates/rocm-dash-daemon/src/demo.rs
+++ b/crates/rocm-dash-daemon/src/demo.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Synthetic-session generator (single source of truth for demo data).
 //!
 //! Simulates a single 8× AMD Instinct MI355X node serving inference traffic

--- a/crates/rocm-dash-daemon/src/lib.rs
+++ b/crates/rocm-dash-daemon/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! rocm-dash-daemon — daemon library.
 //!
 //! Runs on the GPU host and serves NDJSON snapshot/bench streams to `rocm`

--- a/crates/rocm-dash-daemon/src/persist.rs
+++ b/crates/rocm-dash-daemon/src/persist.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Append-only NDJSON session writer.
 //!
 //! Each daemon session opens exactly one file under `--persist-dir`, named

--- a/crates/rocm-dash-daemon/src/registry.rs
+++ b/crates/rocm-dash-daemon/src/registry.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Managed-service registry → scrape-target seam.
 //!
 //! The rocm-cli `serve` lifecycle records every managed engine as a

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Owner task: drives collectors on tick cadences and broadcasts Snapshots.
 
 use std::collections::{HashMap, HashSet};

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Listener + per-client task loop + runner-to-clients broadcast.
 
 // On Windows the listener/handler are #[cfg(unix)] stubs, so these imports are

--- a/crates/rocm-dash-daemon/src/snapshot_ring.rs
+++ b/crates/rocm-dash-daemon/src/snapshot_ring.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Rolling snapshot history kept by the daemon so late-joining clients can hydrate.
 
 use std::collections::VecDeque;

--- a/crates/rocm-dash-daemon/src/transport.rs
+++ b/crates/rocm-dash-daemon/src/transport.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! NDJSON framing helpers.
 
 use std::io;

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! End-to-end integration test: spawn the runner with a CSV, drive a broadcast
 //! subscriber from the same process, and assert Snapshot + BenchmarkRowsAppended
 //! events arrive.

--- a/crates/rocm-dash-tui/examples/gen_cast.rs
+++ b/crates/rocm-dash-tui/examples/gen_cast.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Render the TUI against a synthetic session NDJSON to an asciicast v2
 //! recording. The marketing page replays it as a real animated terminal
 //! demo — no live terminal, no external capture tools, no drift.

--- a/crates/rocm-dash-tui/examples/gen_screenshots.rs
+++ b/crates/rocm-dash-tui/examples/gen_screenshots.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Render the TUI against a synthetic session NDJSON and dump each view to
 //! a standalone SVG. The screenshots embed cleanly in the marketing page
 //! and demo decks — no live terminal, no manual capture, no drift.

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! The chat agent backend, built on **Rig**, plus the read-only "Skills"
 //! (Rig Tools) the agent calls over cached telemetry.
 //!

--- a/crates/rocm-dash-tui/src/app.rs
+++ b/crates/rocm-dash-tui/src/app.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Event loop. Sets up the terminal, spawns the client task, drives renders.
 
 use std::collections::VecDeque;

--- a/crates/rocm-dash-tui/src/client.rs
+++ b/crates/rocm-dash-tui/src/client.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! NDJSON client task. Owns the connection, handshakes, reads events, and
 //! forwards everything (including connect/disconnect transitions) to the app loop
 //! via an mpsc channel.

--- a/crates/rocm-dash-tui/src/jobs.rs
+++ b/crates/rocm-dash-tui/src/jobs.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Async job-bridge runtime (Phase 3 Wave 0).
 //!
 //! Interprets [`SideEffect::SpawnJob`]: launches the child process, streams its

--- a/crates/rocm-dash-tui/src/lib.rs
+++ b/crates/rocm-dash-tui/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! rocm-dash TUI client library.
 //!
 //! The composition-root binary (`rocm`) is a thin wrapper over `app::run`;

--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Chat LLM configuration: a pure precedence resolver plus a std-only TCP liveness probe.
 //!
 //! No HTTP client here — the Rig-built `AgentClient` (Phase 3)

--- a/crates/rocm-dash-tui/src/reconnect.rs
+++ b/crates/rocm-dash-tui/src/reconnect.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Exponential backoff helper for reconnect loops. Ported from ctux pattern.
 
 use std::time::Duration;

--- a/crates/rocm-dash-tui/src/replay.rs
+++ b/crates/rocm-dash-tui/src/replay.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Offline replay source.
 //!
 //! Reads a daemon-produced session file (NDJSON of `PersistedEntry`) into

--- a/crates/rocm-dash-tui/src/skills.rs
+++ b/crates/rocm-dash-tui/src/skills.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Skills — declarative manifest + plan model for rocm-dash's auto-config /
 //! auto-install mechanism.
 //!

--- a/crates/rocm-dash-tui/src/transport.rs
+++ b/crates/rocm-dash-tui/src/transport.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! NDJSON helpers. (Mirror of the daemon's transport module — duplicated here so we
 //! don't add a circular dep on the daemon crate. Refactor to a shared crate later.)
 

--- a/crates/rocm-dash-tui/src/ui/approval.rs
+++ b/crates/rocm-dash-tui/src/ui/approval.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Approval-gate seam (Phase 3 Wave 0).
 //!
 //! This is a **render + event seam ONLY**. The decision *logic* — what an

--- a/crates/rocm-dash-tui/src/ui/automations_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/automations_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Automations manager overlay (Phase 3 Wave 3).
 //!
 //! Lists the background checks ("watchers", plumbed in from the bin which owns

--- a/crates/rocm-dash-tui/src/ui/bench.rs
+++ b/crates/rocm-dash-tui/src/ui/bench.rs
@@ -1,1 +1,5 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Benchmark result table + filters. Stub.

--- a/crates/rocm-dash-tui/src/ui/command_screen.rs
+++ b/crates/rocm-dash-tui/src/ui/command_screen.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Command runner overlay (Phase 3 Wave 3).
 //!
 //! A general escape hatch: type any `rocm …` subcommand and run it through the

--- a/crates/rocm-dash-tui/src/ui/config_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/config_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Config + provider manager overlay (Phase 3 Wave 3).
 //!
 //! Folds the frozen `config_manager` and `provider_manager` into one screen:

--- a/crates/rocm-dash-tui/src/ui/core_bars.rs
+++ b/crates/rocm-dash-tui/src/ui/core_bars.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Per-CPU-core vertical braille bars.
 //!
 //! Each core renders as one character column (2 dots wide) showing its current

--- a/crates/rocm-dash-tui/src/ui/engine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/engine_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Engine manager overlay (Phase 3 Wave 1).
 //!
 //! Lists the serving engines ROCm CLI knows about and runs use/install/reinstall

--- a/crates/rocm-dash-tui/src/ui/examine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/examine_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Examine overlay (Phase 3 Wave 2).
 //!
 //! Runs `rocm examine` — a read-only environment check — through the job-bridge

--- a/crates/rocm-dash-tui/src/ui/exec.rs
+++ b/crates/rocm-dash-tui/src/ui/exec.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Shared helpers for launching `rocm` sub-commands from operational screens (Phase 3 Wave 1).
 //!
 //! Every screen that routes a mutating action through the

--- a/crates/rocm-dash-tui/src/ui/folder_browser.rs
+++ b/crates/rocm-dash-tui/src/ui/folder_browser.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Reusable folder browser (Phase 3 Wave 0).
 //!
 //! A shared input primitive: pick (or create-under) a directory. Dependency of

--- a/crates/rocm-dash-tui/src/ui/format.rs
+++ b/crates/rocm-dash-tui/src/ui/format.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Humanized number / unit formatters.
 //!
 //! Pure functions, no rendering deps. Used by every tab to keep numeric

--- a/crates/rocm-dash-tui/src/ui/gradient.rs
+++ b/crates/rocm-dash-tui/src/ui/gradient.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Three-stop horizontal gradient gauge (ok → warn → err by default).
 //!
 //! ratatui's built-in `Gauge` only supports a single color. This widget

--- a/crates/rocm-dash-tui/src/ui/heatmap.rs
+++ b/crates/rocm-dash-tui/src/ui/heatmap.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! 2-D heatmap widget.
 //!
 //! Each row is a series of `f64` values. Each cell renders as a single

--- a/crates/rocm-dash-tui/src/ui/install_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/install_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Install overlay (Phase 3 Wave 2).
 //!
 //! A compact form that builds a `rocm install sdk …` invocation (TheRock ROCm

--- a/crates/rocm-dash-tui/src/ui/instance_list.rs
+++ b/crates/rocm-dash-tui/src/ui/instance_list.rs
@@ -1,1 +1,5 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! j/k-navigable instance list with status badges. Stub.

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Job console widget (Phase 3 Wave 0).
 //!
 //! Renders a [`JobState`] from the reducer: a status header, the streamed

--- a/crates/rocm-dash-tui/src/ui/logs_view.rs
+++ b/crates/rocm-dash-tui/src/ui/logs_view.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Logs overlay (Phase 3 Wave 3).
 //!
 //! Browses recent ROCm CLI logs via `rocm logs [--search WORDS]` — read-only, so

--- a/crates/rocm-dash-tui/src/ui/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/mod.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod approval;
 pub mod automations_manager;
 pub mod bench;

--- a/crates/rocm-dash-tui/src/ui/modal.rs
+++ b/crates/rocm-dash-tui/src/ui/modal.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Centered popup helpers + the Help overlay.
 //!
 //! Modal content is rendered by the active tab (`detail_modal` from the tab

--- a/crates/rocm-dash-tui/src/ui/model_picker.rs
+++ b/crates/rocm-dash-tui/src/ui/model_picker.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Model picker (Phase 3 Wave 1).
 //!
 //! A reusable, filterable list of model recipes — the sub-step the serve wizard

--- a/crates/rocm-dash-tui/src/ui/onboarding.rs
+++ b/crates/rocm-dash-tui/src/ui/onboarding.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Onboarding wizard (Phase 3 Wave 2, minimal).
 //!
 //! The first-run flow, rebuilt on the Wave-0 primitives. This is the **minimal**

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Runtime manager overlay (Phase 3 Wave 2).
 //!
 //! Lists the registered ROCm runtimes (plumbed in from the bin, which owns

--- a/crates/rocm-dash-tui/src/ui/serve_wizard.rs
+++ b/crates/rocm-dash-tui/src/ui/serve_wizard.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Serve wizard overlay (Phase 3 Wave 1).
 //!
 //! The headline operational screen rebuilt on the Wave-0 primitives: a compact

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Services manager overlay (Phase 3 Wave 1).
 //!
 //! The first operational screen rebuilt on the Wave-0 primitives: it lists the

--- a/crates/rocm-dash-tui/src/ui/sparkline.rs
+++ b/crates/rocm-dash-tui/src/ui/sparkline.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Braille sparkline widget.
 //!
 //! One character cell = 2 cols × 4 rows of dots. We pack two consecutive

--- a/crates/rocm-dash-tui/src/ui/tabs/bench.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/bench.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Bench tab — full-screen bench browser with Pass^N / Pass@N rollups + sparkline.
 
 use ratatui::Frame;

--- a/crates/rocm-dash-tui/src/ui/tabs/chat.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/chat.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Chat tab — a TUI-local conversation surface.
 //!
 //! Phase 1 is render-only with a local echo backend; later phases wire a Rig-built agent behind the

--- a/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/hardware.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Hardware tab — full-screen detail of host CPU/memory + per-GPU panels.
 //!
 //! Layout (vertical):

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Instances tab — full-screen instance grid with kv-cache / requests / args,
 //! plus a detail modal showing model / partition / launch_args / env / log.
 

--- a/crates/rocm-dash-tui/src/ui/tabs/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/mod.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Tabbed view modes. Each tab module exposes a single
 //! `pub fn draw(f, area, state, theme)` so they can be implemented in parallel
 //! without touching shared files.

--- a/crates/rocm-dash-tui/src/ui/tabs/overview.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/overview.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Overview tab — the original 60/40 split layout. Preserved verbatim so
 //! switching tabs always lands back on the familiar view.
 

--- a/crates/rocm-dash-tui/src/ui/theme.rs
+++ b/crates/rocm-dash-tui/src/ui/theme.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Semantic theme.
 //!
 //! Two construction paths:

--- a/crates/rocm-dash-tui/src/ui/update_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/update_manager.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Update overlay (Phase 3 Wave 2).
 //!
 //! Wraps `rocm update`: a read-only check (and a `--apply --dry-run` preview)

--- a/crates/rocm-dash-tui/src/ui/widgets.rs
+++ b/crates/rocm-dash-tui/src/ui/widgets.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Small UI helpers shared across tabs.
 
 use ratatui::style::Style;

--- a/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
+++ b/crates/rocm-dash-tui/tests/wave0_job_bridge.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Wave 0 exit gate.
 //!
 //! Proves the job-bridge spine end-to-end: a real long-running child process is

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;

--- a/engines/atom/src/lib.rs
+++ b/engines/atom/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{

--- a/engines/atom/src/main.rs
+++ b/engines/atom/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_atom::run_cli()
 }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{

--- a/engines/lemonade/src/main.rs
+++ b/engines/lemonade/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_lemonade::run_cli()
 }

--- a/engines/llama-cpp/src/lib.rs
+++ b/engines/llama-cpp/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{

--- a/engines/llama-cpp/src/main.rs
+++ b/engines/llama-cpp/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_llama_cpp::run_cli()
 }

--- a/engines/pytorch/src/lib.rs
+++ b/engines/pytorch/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum};
 use rocm_core::{

--- a/engines/pytorch/src/main.rs
+++ b/engines/pytorch/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_pytorch::run_cli()
 }

--- a/engines/pytorch/src/python_worker.py
+++ b/engines/pytorch/src/python_worker.py
@@ -1,3 +1,7 @@
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 import os

--- a/engines/sglang/src/lib.rs
+++ b/engines/sglang/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{

--- a/engines/sglang/src/main.rs
+++ b/engines/sglang/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_sglang::run_cli()
 }

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{

--- a/engines/vllm/src/main.rs
+++ b/engines/vllm/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> anyhow::Result<()> {
     rocm_engine_vllm::run_cli()
 }

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -eu
 
 REPO="${ROCM_CLI_GITHUB_REPO:-ROCm/rocm-cli}"

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,21 @@
+## hawkeye license-header enforcement configuration.
+## Run locally: hawkeye check
+## Docs: https://github.com/korandoru/hawkeye
+
+inlineHeader = """
+Copyright Advanced Micro Devices, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+includes = [
+  "**/*.rs",
+  "**/*.py",
+  "**/*.sh",
+]
+
+excludes = [
+  "target/**",
+  ".claude/**",
+  "third_party/**",
+]

--- a/scripts/acceptance-install-upgrade-tui-uninstall.sh
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/atom_therock_gpu_test.py
+++ b/scripts/atom_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end ATOM ROCm GPU smoke test for rocm-cli managed TheRock runtimes."""
 
 from __future__ import annotations

--- a/scripts/build_single_exe_release.py
+++ b/scripts/build_single_exe_release.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Build platform-native rocm-cli release artifacts.
 
 This helper copies or archives the native `rocm`/`rocm.exe` binary for the

--- a/scripts/check_powershell_syntax.py
+++ b/scripts/check_powershell_syntax.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Validate PowerShell script syntax for the pre-commit/prek hook.
 
 Mirrors the syntax check CI runs on Windows, but works as a local hook on any

--- a/scripts/comfyui_therock_gpu_test.py
+++ b/scripts/comfyui_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end ComfyUI GPU smoke test for rocm-cli managed TheRock runtimes.
 
 This opt-in test installs or reuses the rocm-cli managed ComfyUI app, starts it

--- a/scripts/llama_cpp_therock_gpu_test.py
+++ b/scripts/llama_cpp_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end llama.cpp GPU smoke test for rocm-cli managed TheRock runtimes."""
 
 from __future__ import annotations

--- a/scripts/local_assistant_therock_gpu_test.py
+++ b/scripts/local_assistant_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Live local-assistant acceptance for rocm-cli managed GPU services.
 
 This opt-in test starts a managed Lemonade service with GPU-required policy,

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 if [[ $# -lt 1 || $# -gt 3 ]]; then

--- a/scripts/pytorch_therock_gpu_test.py
+++ b/scripts/pytorch_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end PyTorch GPU smoke test for rocm-cli managed TheRock runtimes."""
 
 from __future__ import annotations

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Verify rocm-cli release dist assets before publication."""
 
 from __future__ import annotations

--- a/scripts/setup-wsl-portable-build-deps.sh
+++ b/scripts/setup-wsl-portable-build-deps.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/sglang_therock_gpu_test.py
+++ b/scripts/sglang_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end SGLang ROCm GPU smoke test for rocm-cli managed TheRock runtimes."""
 
 from __future__ import annotations

--- a/scripts/smoke_local.py
+++ b/scripts/smoke_local.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Cross-platform local smoke tests for rocm-cli debug/release binaries."""
 
 from __future__ import annotations

--- a/scripts/therock_sdk_install_test.py
+++ b/scripts/therock_sdk_install_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Opt-in acceptance test for managed TheRock SDK wheel installs.
 
 This test creates an isolated rocm-cli state root, creates a local bootstrap

--- a/scripts/tui_e2e_smoke.py
+++ b/scripts/tui_e2e_smoke.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """PTY-driven ROCm CLI TUI smoke tests.
 
 These checks exercise the real terminal UI in an isolated temporary ROCm CLI

--- a/scripts/vllm_therock_gpu_test.py
+++ b/scripts/vllm_therock_gpu_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end vLLM ROCm GPU smoke test for rocm-cli managed TheRock runtimes."""
 
 from __future__ import annotations

--- a/scripts/wsl_preflight.py
+++ b/scripts/wsl_preflight.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Read-only WSL/ROCDXG preflight for rocm-cli.
 
 This script intentionally does not install packages or modify global WSL state.

--- a/scripts/wsl_setup_rocdxg.sh
+++ b/scripts/wsl_setup_rocdxg.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 ROCDXG_VERSION="${ROCDXG_VERSION:-1.2.0}"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Repository task runner.
 //!
 //! Currently provides the release-artifact signing toolchain in pure Rust so the


### PR DESCRIPTION
## Summary
- Added a standard header to every Rust, Python, and shell source file in the repo:
  ```
  Copyright Advanced Micro Devices, Inc.

  SPDX-License-Identifier: Apache-2.0
  ```
- Headers use each language's comment syntax and are placed after shebang lines where present.
- Why: establish clear, machine-readable license provenance across all source files ahead of broader open-source consumption.
- Risk: low — header-only additions, no logic changes.

## CI enforcement
- Added `licenserc.toml` configuring [hawkeye](https://github.com/korandoru/hawkeye) to enforce the header on `**/*.rs`, `**/*.py`, and `**/*.sh` (excluding `target/`, `third_party/`).
- Added a `license-headers` job to the CI workflow that runs the `korandoru/hawkeye` action so missing or malformed headers fail CI.
- Run locally with `hawkeye check`.

## Test plan
- `hawkeye check` passes across the tree.
- CI `license-headers` job is expected to pass on this branch.