### PR TITLE
New --gpu flag for serving a model on a specific gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ not already used by another rocm-cli server (managed or foreground), falling
 back to the GPU with the most free memory. Pass a single index (`--gpu 1`) to
 pin a specific device. The
 selected GPU is exposed to the engine via `HIP_VISIBLE_DEVICES`. Serving one
-model across multiple GPUs is not supported.
+model across multiple GPUs is not supported. `--gpu` is ignored with
+`--device cpu_only` (the model runs on CPU). Because selection uses the
+`amd-smi` ordinal but is applied via `HIP_VISIBLE_DEVICES`, rocm-cli warns when
+`ROCR_VISIBLE_DEVICES` is set, since the two orderings can diverge.
 
 Show recommended models and hardware compatibility:
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
 
 `--gpu` selects which AMD GPU the server runs on. `auto` (the default) probes
 per-GPU VRAM with `amd-smi` and picks the lowest-numbered GPU that is idle and
-not already used by a rocm-cli managed service, falling back to the GPU with the
-most free memory. Pass a single index (`--gpu 1`) to pin a specific device. The
+not already used by another rocm-cli server (managed or foreground), falling
+back to the GPU with the most free memory. Pass a single index (`--gpu 1`) to
+pin a specific device. The
 selected GPU is exposed to the engine via `HIP_VISIBLE_DEVICES`. Serving one
 model across multiple GPUs is not supported.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Start a local OpenAI-compatible model server:
 ```
 rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
                    [--device gpu_required|gpu_preferred|cpu_only]
+                   [--gpu auto|<index>]
                    [--runtime-id KEY | --env-id ID]
                    [--host HOST] [--port PORT]
                    [--foreground | --managed]
@@ -137,6 +138,13 @@ rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
 
 `--managed` runs the server in the background under rocm-cli's supervision.
 `--foreground` attaches it to the current terminal.
+
+`--gpu` selects which AMD GPU the server runs on. `auto` (the default) probes
+per-GPU VRAM with `amd-smi` and picks the lowest-numbered GPU that is idle and
+not already used by a rocm-cli managed service, falling back to the GPU with the
+most free memory. Pass a single index (`--gpu 1`) to pin a specific device. The
+selected GPU is exposed to the engine via `HIP_VISIBLE_DEVICES`. Serving one
+model across multiple GPUs is not supported.
 
 Show recommended models and hardware compatibility:
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -42,7 +42,7 @@ use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
     ENGINE_RECIPE_CONTRACT_VERSION, EngineMethod, EnginePluginDescriptor, EngineRecipeEndpointHint,
     EngineRecipeHint, EngineRecipeUnsupportedCombinationHint, EngineRequestEnvelope,
-    EngineResponseEnvelope, InstallRequest, InstallResponse, ResolveModelRequest,
+    EngineResponseEnvelope, GpuSelection, InstallRequest, InstallResponse, ResolveModelRequest,
     ResolveModelResponse, StopRequest, StopResponse,
 };
 use serde::de::DeserializeOwned;
@@ -147,6 +147,8 @@ enum Command {
         port: u16,
         #[arg(long, default_value = "gpu_required")]
         device_policy: String,
+        #[arg(long)]
+        gpu: Option<String>,
         #[arg(long, conflicts_with = "env_id")]
         runtime_id: Option<String>,
         #[arg(long, conflicts_with = "runtime_id")]
@@ -278,6 +280,10 @@ rocm serve qwen2.5-7b-instruct --foreground --device gpu_required")]
         /// Device policy [possible values: gpu_required, gpu_preferred, cpu_only].
         #[arg(long)]
         device: Option<String>,
+        /// GPU device to serve on: `auto` (default; first free GPU) or a single
+        /// index like `1`.
+        #[arg(long, value_name = "INDEX|auto")]
+        gpu: Option<String>,
         /// ROCm runtime key to use for this server.
         #[arg(long, conflicts_with = "env_id")]
         runtime_id: Option<String>,
@@ -1240,6 +1246,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             host,
             port,
             device_policy,
+            gpu,
             runtime_id,
             env_id,
             state_path,
@@ -1252,6 +1259,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             host,
             port,
             &device_policy,
+            parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -1433,6 +1441,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             model,
             engine,
             device,
+            gpu,
             runtime_id,
             env_id,
             host,
@@ -1444,6 +1453,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             model,
             engine,
             device,
+            gpu,
             runtime_id,
             env_id,
             host,
@@ -3658,6 +3668,7 @@ fn serve(
     model: String,
     engine: Option<String>,
     device: Option<String>,
+    gpu: Option<String>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     host: String,
@@ -3683,6 +3694,9 @@ fn serve(
     let engine_model_ref =
         serve_model_ref_for_engine(&model, shared_recipe.as_ref(), &selected_engine);
     let device_policy = parse_device_policy(device.as_deref())?;
+    let gpu_selection = parse_gpu_selection(gpu.as_deref())?;
+    let gpu_vram = gpu_vram_usage();
+    let gpu_indices = resolve_gpu_indices(&paths, &gpu_selection, gpu_vram.as_deref())?;
     let resolved_selection = resolve_engine_selection(
         &config,
         &selected_engine,
@@ -3715,6 +3729,7 @@ fn serve(
             device_policy: Some(device_policy),
             recipe_override: None,
             engine_recipe,
+            gpu_selection: Some(gpu_selection.clone()),
         },
     )?;
     let service_id = generate_service_id(&selected_engine, &resolve.canonical_model_id);
@@ -3739,6 +3754,23 @@ fn serve(
         "  device_policy: {}",
         device_policy_name(&resolve.device_policy)
     );
+    match &gpu_selection {
+        GpuSelection::Auto => {
+            if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices) {
+                println!("  gpu: auto (selected {csv})");
+            } else {
+                println!("  gpu: auto (engine default visibility)");
+            }
+        }
+        GpuSelection::Index(_) => {
+            let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                .unwrap_or_else(|| "none".to_owned());
+            println!("  gpu: {csv}");
+        }
+    }
+    if let Some(warning) = gpu_low_memory_warning(&gpu_indices, gpu_vram.as_deref()) {
+        println!("  {warning}");
+    }
     if let Some(engine_recipe) = &resolve.engine_recipe {
         print!("{}", render_serve_engine_recipe_lines(engine_recipe));
     }
@@ -3767,6 +3799,7 @@ fn serve(
             &host,
             port,
             &resolve.device_policy,
+            &gpu_indices,
             managed_runtime_id.as_deref(),
             managed_env_id.as_deref(),
             resolve.engine_recipe.as_ref(),
@@ -3786,6 +3819,7 @@ fn serve(
         &host,
         port,
         &resolve.device_policy,
+        &gpu_indices,
         resolved_selection.runtime_id.as_deref(),
         resolved_selection.env_id.as_deref(),
         resolve.engine_recipe.as_ref(),
@@ -3843,6 +3877,7 @@ fn start_managed_service(
     host: &str,
     port: u16,
     device_policy: &DevicePolicy,
+    gpu_indices: &[u32],
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe: Option<&EngineRecipeHint>,
@@ -3893,6 +3928,7 @@ fn start_managed_service(
         env_id.map(str::to_owned),
         Some(device_policy_name(device_policy).to_owned()),
     );
+    record.gpu_indices = gpu_indices.to_vec();
     record.engine_recipe_json = engine_recipe
         .map(serde_json::to_string)
         .transpose()
@@ -3914,6 +3950,7 @@ fn start_managed_service(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         engine_recipe,
@@ -4048,6 +4085,7 @@ fn run_foreground_service(
     host: &str,
     port: u16,
     device_policy: &DevicePolicy,
+    gpu_indices: &[u32],
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe: Option<&EngineRecipeHint>,
@@ -4070,6 +4108,7 @@ fn run_foreground_service(
         env_id.map(str::to_owned),
         Some(device_policy_name(device_policy).to_owned()),
     );
+    record.gpu_indices = gpu_indices.to_vec();
     record.write()?;
 
     println!("foreground service starting");
@@ -4088,6 +4127,7 @@ fn run_foreground_service(
         host.to_owned(),
         port,
         device_policy_name(device_policy),
+        gpu_indices.to_vec(),
         runtime_id.map(str::to_owned),
         env_id.map(str::to_owned),
         record.engine_state_path.clone(),
@@ -11369,6 +11409,7 @@ fn restart_internal_managed_service(
         &record.host,
         record.port,
         &policy,
+        &record.gpu_indices,
         record.runtime_id.as_deref(),
         record.env_id.as_deref(),
         recipe.as_ref(),
@@ -14131,6 +14172,7 @@ fn run_builtin_engine_serve_http(
     host: String,
     port: u16,
     device_policy: &str,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -14145,6 +14187,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             parsed_policy,
+            gpu_indices,
             runtime_id,
             env_id,
             state_path,
@@ -14156,6 +14199,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             parsed_policy,
+            gpu_indices,
             runtime_id,
             env_id,
             state_path,
@@ -14168,6 +14212,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             Some(device_policy_name(&parsed_policy).to_owned()),
+            gpu_indices,
             runtime_id,
             env_id,
             state_path,
@@ -14180,6 +14225,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             parsed_policy,
+            gpu_indices,
             env_id,
             runtime_id,
             state_path,
@@ -14191,6 +14237,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             parsed_policy,
+            gpu_indices,
             runtime_id,
             env_id,
             state_path,
@@ -14202,6 +14249,7 @@ fn run_builtin_engine_serve_http(
             host,
             port,
             parsed_policy,
+            gpu_indices,
             runtime_id,
             env_id,
             state_path,
@@ -14219,6 +14267,7 @@ fn builtin_engine_serve_http_args(
     host: &str,
     port: u16,
     device_policy: &DevicePolicy,
+    gpu_indices: &[u32],
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe: Option<&EngineRecipeHint>,
@@ -14237,6 +14286,9 @@ fn builtin_engine_serve_http_args(
         "--device-policy".to_owned(),
         device_policy_name(device_policy).to_owned(),
     ];
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(gpu_indices) {
+        args.extend(["--gpu".to_owned(), csv]);
+    }
     if env_id.is_none() {
         args.extend(optional_arg("--runtime-id", runtime_id));
     }
@@ -14257,6 +14309,278 @@ fn parse_device_policy(value: Option<&str>) -> Result<DevicePolicy> {
         ),
         other => bail!("unsupported device policy: {other}"),
     }
+}
+
+/// Parse the user-facing `--gpu` value (`auto`, `1`, or `0,1,2`) into a
+/// `GpuSelection`. `None` defaults to `auto`.
+fn parse_gpu_selection(value: Option<&str>) -> Result<GpuSelection> {
+    let Some(raw) = value else {
+        return Ok(GpuSelection::Auto);
+    };
+    GpuSelection::parse_cli_value(raw).map_err(|message| anyhow::anyhow!(message))
+}
+
+/// Parse the internal `--gpu` csv passed to the hidden `__engine-serve-http`
+/// subcommand back into explicit device ordinals (empty when absent/`auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    match parse_gpu_selection(value)? {
+        GpuSelection::Auto => Ok(Vec::new()),
+        GpuSelection::Index(index) => Ok(vec![index]),
+    }
+}
+
+/// Resolve a `GpuSelection` to the concrete device ordinal to pin for this
+/// server. `Auto` picks the lowest-numbered GPU that is idle (high free VRAM)
+/// and not already serving a rocm-cli managed/foreground model; an explicit
+/// index is validated against the detected GPU count when it is known. The
+/// result holds at most one ordinal; serving across multiple GPUs is not
+/// supported.
+///
+/// Ordinal semantics: the index produced here is fed to engines via
+/// `HIP_VISIBLE_DEVICES`, but it is sourced from `amd-smi`'s `gpu` index
+/// (probing/busy detection). On a normal single-host ROCm install without GPU
+/// partitioning these orderings coincide, but they are not guaranteed to match
+/// when `ROCR_VISIBLE_DEVICES`, CPX/partition modes, or non-default device
+/// enumeration are in play. Validate on multi-GPU hardware before relying on a
+/// specific `--gpu <index>` mapping in those configurations.
+fn resolve_gpu_indices(
+    paths: &AppPaths,
+    selection: &GpuSelection,
+    vram: Option<&[GpuVramUsage]>,
+) -> Result<Vec<u32>> {
+    let detected = detect_gpu_count();
+    match selection {
+        GpuSelection::Index(index) => {
+            if let Some(count) = detected
+                && (*index as usize) >= count
+            {
+                bail!(
+                    "--gpu index {index} is out of range; {count} GPU(s) detected (valid indices 0..{})",
+                    count - 1
+                );
+            }
+            Ok(vec![*index])
+        }
+        GpuSelection::Auto => Ok(auto_select_gpu_indices(paths, detected, vram)),
+    }
+}
+
+/// A GPU's local VRAM occupancy as reported by `amd-smi metric --json`.
+#[derive(Debug, Clone, Copy)]
+struct GpuVramUsage {
+    index: u32,
+    used_mb: u64,
+    total_mb: u64,
+}
+
+impl GpuVramUsage {
+    /// Fraction of total VRAM that is currently free (`0.0`..=`1.0`). Returns
+    /// `None` when the total is unknown so callers do not divide by zero.
+    fn free_fraction(self) -> Option<f64> {
+        if self.total_mb == 0 {
+            return None;
+        }
+        Some(self.total_mb.saturating_sub(self.used_mb) as f64 / self.total_mb as f64)
+    }
+}
+
+/// A GPU is treated as "free" for `--gpu auto` when at least this fraction of
+/// its VRAM is unused (i.e. it is effectively idle).
+const AUTO_FREE_VRAM_FRACTION: f64 = 0.90;
+
+/// Pick a GPU ordinal for `--gpu auto`. Prefers the lowest-numbered GPU that is
+/// idle (free VRAM at or above [`AUTO_FREE_VRAM_FRACTION`]) and not pinned by a
+/// running rocm-cli service; otherwise falls back to the non-busy GPU with the
+/// most free VRAM, then to the first non-busy GPU, then to `[0]`.
+///
+/// Selection reads service state without holding a lock, so two near-concurrent
+/// `--gpu auto` launches can race onto the same idle GPU. The VRAM-occupancy
+/// fallback and the start-time low-memory warning keep this from silently
+/// overcommitting in practice; pass an explicit `--gpu <index>` to avoid the
+/// race entirely.
+fn auto_select_gpu_indices(
+    paths: &AppPaths,
+    detected: Option<usize>,
+    vram: Option<&[GpuVramUsage]>,
+) -> Vec<u32> {
+    let busy = busy_gpu_indices(paths);
+    select_auto_gpu_index(detected, &busy, vram)
+}
+
+/// Pure auto-selection used by [`auto_select_gpu_indices`], split out so the
+/// preference order can be unit-tested without amd-smi or service state.
+fn select_auto_gpu_index(
+    detected: Option<usize>,
+    busy: &[u32],
+    vram: Option<&[GpuVramUsage]>,
+) -> Vec<u32> {
+    let count = detected.unwrap_or(0);
+    if count == 0 {
+        return vec![0];
+    }
+    let candidates = || (0..count as u32).filter(|index| !busy.contains(index));
+    let usage_for = |index: u32| vram.and_then(|rows| rows.iter().find(|row| row.index == index));
+
+    if vram.is_some() {
+        // Pass 1: lowest-index idle GPU.
+        for index in candidates() {
+            if let Some(free) = usage_for(index).and_then(|usage| usage.free_fraction())
+                && free >= AUTO_FREE_VRAM_FRACTION
+            {
+                return vec![index];
+            }
+        }
+        // Pass 2: the non-busy GPU with the most free VRAM.
+        if let Some(index) = candidates().max_by(|left, right| {
+            let left_free = usage_for(*left).and_then(|usage| usage.free_fraction());
+            let right_free = usage_for(*right).and_then(|usage| usage.free_fraction());
+            left_free
+                .partial_cmp(&right_free)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                // Break ties toward the lowest index.
+                .then(right.cmp(left))
+        }) && usage_for(index)
+            .and_then(|usage| usage.free_fraction())
+            .is_some()
+        {
+            return vec![index];
+        }
+    }
+
+    // Pass 3: no VRAM telemetry; first GPU not pinned by a managed service.
+    if let Some(index) = candidates().next() {
+        return vec![index];
+    }
+    // Every detected GPU is pinned by a running service. We still return GPU 0
+    // (no CPU fallback is ever used); the caller surfaces a low-memory warning
+    // so the user can free a device or pick another `--gpu`.
+    vec![0]
+}
+
+/// Best-effort per-GPU VRAM occupancy via `amd-smi metric --json`. Returns
+/// `None` when amd-smi is unavailable or its output cannot be parsed (callers
+/// then fall back to service-state-only auto-selection).
+fn gpu_vram_usage() -> Option<Vec<GpuVramUsage>> {
+    let binary = rocm_core::resolve_amd_smi_binary();
+    let output = ProcessCommand::new(&binary)
+        .arg("metric")
+        .arg("--json")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let rows = parse_gpu_vram_usage(&value);
+    if rows.is_empty() { None } else { Some(rows) }
+}
+
+/// Parse `amd-smi metric --json` output into per-GPU VRAM usage. Accepts both
+/// the `{"gpu_data": [...]}` envelope and a bare top-level array, mirroring the
+/// schema variance handled by the dashboard amd-smi collector.
+fn parse_gpu_vram_usage(value: &serde_json::Value) -> Vec<GpuVramUsage> {
+    let entries = value
+        .get("gpu_data")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| value.as_array());
+    let Some(entries) = entries else {
+        return Vec::new();
+    };
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(position, entry)| {
+            let index = entry
+                .get("gpu")
+                .and_then(serde_json::Value::as_u64)
+                .map_or(position as u32, |id| id as u32);
+            let used_mb = entry
+                .pointer("/mem_usage/used_vram/value")
+                .and_then(serde_json::Value::as_u64)?;
+            let total_mb = entry
+                .pointer("/mem_usage/total_vram/value")
+                .and_then(serde_json::Value::as_u64)?;
+            Some(GpuVramUsage {
+                index,
+                used_mb,
+                total_mb,
+            })
+        })
+        .collect()
+}
+
+/// Build a serve-plan warning when a selected GPU is already heavily used, so
+/// the user knows to free it or pick another `--gpu` before the engine fails on
+/// insufficient VRAM. Returns `None` when telemetry is missing or the selected
+/// GPUs are comfortably free.
+fn gpu_low_memory_warning(gpu_indices: &[u32], vram: Option<&[GpuVramUsage]>) -> Option<String> {
+    let vram = vram?;
+    for &index in gpu_indices {
+        // Skip indices without telemetry rather than abandoning the whole scan,
+        // so a missing row for one GPU does not suppress warnings for others.
+        let Some(usage) = vram.iter().find(|row| row.index == index) else {
+            continue;
+        };
+        let Some(free) = usage.free_fraction() else {
+            continue;
+        };
+        if free < AUTO_FREE_VRAM_FRACTION {
+            let free_gib = (usage.total_mb.saturating_sub(usage.used_mb)) as f64 / 1024.0;
+            let total_gib = usage.total_mb as f64 / 1024.0;
+            return Some(format!(
+                "warning: GPU {index} has only {free_gib:.1} GiB of {total_gib:.1} GiB free; \
+                 serving may fail on VRAM. Free it or pick another with `--gpu <index|auto>`."
+            ));
+        }
+    }
+    None
+}
+
+/// GPU ordinals currently pinned by running rocm-cli managed/foreground
+/// services, used to skip busy devices during `--gpu auto` selection.
+fn busy_gpu_indices(paths: &AppPaths) -> Vec<u32> {
+    let Ok(records) = load_managed_services(paths) else {
+        return Vec::new();
+    };
+    let mut busy = Vec::new();
+    for record in records {
+        if !matches!(
+            record.status.as_str(),
+            "starting" | "running" | "recovering" | "ready"
+        ) {
+            continue;
+        }
+        for index in record.gpu_indices {
+            if !busy.contains(&index) {
+                busy.push(index);
+            }
+        }
+    }
+    busy
+}
+
+/// Best-effort count of local AMD GPUs via `amd-smi`. Returns `None` when
+/// amd-smi is unavailable or its output cannot be parsed (callers then fall
+/// back to conservative defaults).
+fn detect_gpu_count() -> Option<usize> {
+    let binary = rocm_core::resolve_amd_smi_binary();
+    let output = ProcessCommand::new(&binary)
+        .arg("list")
+        .arg("--json")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let count = value.as_array().map(Vec::len)?;
+    if count == 0 { None } else { Some(count) }
 }
 
 const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
@@ -18813,6 +19137,77 @@ install therock";
         Ok(())
     }
 
+    fn vram(index: u32, used_mb: u64, total_mb: u64) -> GpuVramUsage {
+        GpuVramUsage {
+            index,
+            used_mb,
+            total_mb,
+        }
+    }
+
+    #[test]
+    fn auto_selection_prefers_lowest_index_idle_gpu() {
+        // GPU 0 busy (only 5% free), GPU 1 idle, GPU 2 idle.
+        let usage = [
+            vram(0, 182_000, 192_000),
+            vram(1, 1_000, 192_000),
+            vram(2, 500, 192_000),
+        ];
+        assert_eq!(
+            select_auto_gpu_index(Some(3), &[], Some(&usage)),
+            vec![1],
+            "should skip the busy GPU 0 and pick the lowest idle GPU"
+        );
+    }
+
+    #[test]
+    fn auto_selection_skips_managed_and_busy_gpus_then_picks_most_free() {
+        // GPU 0 pinned by a managed service; GPU 1 partly used; GPU 2 more free
+        // but none is fully idle, so pass 2 (most free) applies.
+        let usage = [
+            vram(0, 10_000, 192_000),
+            vram(1, 120_000, 192_000),
+            vram(2, 60_000, 192_000),
+        ];
+        assert_eq!(
+            select_auto_gpu_index(Some(3), &[0], Some(&usage)),
+            vec![2],
+            "with no idle GPU, pick the non-busy GPU with the most free VRAM"
+        );
+    }
+
+    #[test]
+    fn auto_selection_falls_back_to_first_non_busy_without_vram() {
+        assert_eq!(select_auto_gpu_index(Some(4), &[0, 1], None), vec![2]);
+        assert_eq!(select_auto_gpu_index(None, &[], None), vec![0]);
+    }
+
+    #[test]
+    fn parse_gpu_vram_usage_reads_gpu_data_envelope() {
+        let value = json!({
+            "gpu_data": [
+                {"gpu": 0, "mem_usage": {"used_vram": {"value": 1000}, "total_vram": {"value": 192_000}}},
+                {"gpu": 1, "mem_usage": {"used_vram": {"value": 50000}, "total_vram": {"value": 192_000}}}
+            ]
+        });
+        let rows = parse_gpu_vram_usage(&value);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].index, 0);
+        assert_eq!(rows[0].used_mb, 1000);
+        assert_eq!(rows[1].index, 1);
+        assert!((rows[1].free_fraction().unwrap() - (142_000.0 / 192_000.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn gpu_low_memory_warning_flags_busy_selected_gpu() {
+        let usage = [vram(0, 182_000, 192_000), vram(1, 1_000, 192_000)];
+        let warning = gpu_low_memory_warning(&[0], Some(&usage)).expect("warning for busy GPU 0");
+        assert!(warning.contains("GPU 0"));
+        assert!(warning.contains("free"));
+        assert!(gpu_low_memory_warning(&[1], Some(&usage)).is_none());
+        assert!(gpu_low_memory_warning(&[0], None).is_none());
+    }
+
     #[test]
     fn driver_plan_ubuntu_2404_uses_official_dkms_commands() {
         let os_release = r#"
@@ -20636,11 +21031,9 @@ VERSION_ID="41"
             capabilities: rocm_engine_protocol::EngineCapabilities {
                 cpu: false,
                 rocm_gpu: false,
-                multi_gpu: false,
                 openai_compatible: true,
                 tool_calling: false,
                 quantized_models: "sglang-supported".to_owned(),
-                distributed_serving: false,
                 reasoning_parser: false,
             },
             notes: Vec::new(),

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3695,8 +3695,20 @@ fn serve(
         serve_model_ref_for_engine(&model, shared_recipe.as_ref(), &selected_engine);
     let device_policy = parse_device_policy(device.as_deref())?;
     let gpu_selection = parse_gpu_selection(gpu.as_deref())?;
-    let gpu_vram = gpu_vram_usage();
-    let gpu_indices = resolve_gpu_indices(&paths, &gpu_selection, gpu_vram.as_deref())?;
+    // CPU-only serving never pins a GPU, so skip GPU resolution entirely and
+    // surface the explicit `--gpu` as ignored rather than printing a device the
+    // server will not use.
+    let cpu_only = matches!(device_policy, DevicePolicy::CpuOnly);
+    // `--gpu` selects by the amd-smi `gpu` ordinal but is exported via
+    // `HIP_VISIBLE_DEVICES`; those orderings can diverge when
+    // `ROCR_VISIBLE_DEVICES`/partitioning is in play, so warn at serve time.
+    let rocr_visible_devices_set = std::env::var_os("ROCR_VISIBLE_DEVICES").is_some();
+    let gpu_vram = if cpu_only { None } else { gpu_vram_usage() };
+    let gpu_indices = if cpu_only {
+        Vec::new()
+    } else {
+        resolve_gpu_indices(&paths, &gpu_selection, gpu_vram.as_deref())?
+    };
     let resolved_selection = resolve_engine_selection(
         &config,
         &selected_engine,
@@ -3729,7 +3741,6 @@ fn serve(
             device_policy: Some(device_policy),
             recipe_override: None,
             engine_recipe,
-            gpu_selection: Some(gpu_selection.clone()),
         },
     )?;
     let service_id = generate_service_id(&selected_engine, &resolve.canonical_model_id);
@@ -3754,20 +3765,35 @@ fn serve(
         "  device_policy: {}",
         device_policy_name(&resolve.device_policy)
     );
-    match &gpu_selection {
-        GpuSelection::Auto => {
-            let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
-                .unwrap_or_else(|| "none".to_owned());
-            println!("  gpu: auto (selected {csv})");
+    if cpu_only {
+        if matches!(gpu_selection, GpuSelection::Index(_)) {
+            println!(
+                "  warning: --gpu was ignored because --device cpu_only runs the model on CPU"
+            );
         }
-        GpuSelection::Index(_) => {
-            let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
-                .unwrap_or_else(|| "none".to_owned());
-            println!("  gpu: {csv}");
+    } else {
+        match &gpu_selection {
+            GpuSelection::Auto => {
+                let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                    .unwrap_or_else(|| "none".to_owned());
+                println!("  gpu: auto (selected {csv})");
+            }
+            GpuSelection::Index(_) => {
+                let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                    .unwrap_or_else(|| "none".to_owned());
+                println!("  gpu: {csv}");
+            }
         }
-    }
-    if let Some(warning) = gpu_low_memory_warning(&gpu_indices, gpu_vram.as_deref()) {
-        println!("  {warning}");
+        if rocr_visible_devices_set {
+            println!(
+                "  warning: ROCR_VISIBLE_DEVICES is set; --gpu selects by the amd-smi ordinal but \
+                 is applied via HIP_VISIBLE_DEVICES, so the chosen device may differ. Verify the \
+                 selected GPU or unset ROCR_VISIBLE_DEVICES."
+            );
+        }
+        if let Some(warning) = gpu_low_memory_warning(&gpu_indices, gpu_vram.as_deref()) {
+            println!("  {warning}");
+        }
     }
     if let Some(engine_recipe) = &resolve.engine_recipe {
         print!("{}", render_serve_engine_recipe_lines(engine_recipe));
@@ -14349,19 +14375,25 @@ fn resolve_gpu_indices(
 ) -> Result<Vec<u32>> {
     let detected = detect_gpu_count();
     match selection {
-        GpuSelection::Index(index) => {
-            if let Some(count) = detected
-                && (*index as usize) >= count
-            {
-                bail!(
-                    "--gpu index {index} is out of range; {count} GPU(s) detected (valid indices 0..{})",
-                    count - 1
-                );
-            }
-            Ok(vec![*index])
-        }
+        GpuSelection::Index(index) => validate_pinned_gpu_index(*index, detected),
         GpuSelection::Auto => Ok(auto_select_gpu_indices(paths, detected, vram)),
     }
+}
+
+/// Validate an explicit `--gpu <index>` against the detected GPU count and
+/// return the single pinned ordinal. Errors when the index is out of range for
+/// a known device count; an unknown count (amd-smi unavailable) is allowed
+/// through so serving can still proceed where GPU probing is not possible.
+fn validate_pinned_gpu_index(index: u32, detected: Option<usize>) -> Result<Vec<u32>> {
+    if let Some(count) = detected
+        && (index as usize) >= count
+    {
+        bail!(
+            "--gpu index {index} is out of range; {count} GPU(s) detected (valid indices 0..{})",
+            count - 1
+        );
+    }
+    Ok(vec![index])
 }
 
 /// A GPU's local VRAM occupancy as reported by `amd-smi metric --json`.
@@ -19199,6 +19231,23 @@ install therock";
     fn auto_selection_falls_back_to_first_non_busy_without_vram() {
         assert_eq!(select_auto_gpu_index(Some(4), &[0, 1], None), vec![2]);
         assert_eq!(select_auto_gpu_index(None, &[], None), vec![0]);
+    }
+
+    #[test]
+    fn validate_pinned_gpu_index_rejects_out_of_range() {
+        // Index equal to or beyond the detected count is rejected.
+        let error = validate_pinned_gpu_index(4, Some(4)).expect_err("index 4 is out of range");
+        assert!(error.to_string().contains("out of range"));
+        assert!(validate_pinned_gpu_index(9, Some(2)).is_err());
+    }
+
+    #[test]
+    fn validate_pinned_gpu_index_accepts_in_range_or_unknown_count() {
+        // In-range index pins exactly that ordinal.
+        assert_eq!(validate_pinned_gpu_index(0, Some(1)).unwrap(), vec![0]);
+        assert_eq!(validate_pinned_gpu_index(3, Some(4)).unwrap(), vec![3]);
+        // Unknown count (amd-smi unavailable) is allowed through unvalidated.
+        assert_eq!(validate_pinned_gpu_index(7, None).unwrap(), vec![7]);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3756,11 +3756,9 @@ fn serve(
     );
     match &gpu_selection {
         GpuSelection::Auto => {
-            if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices) {
-                println!("  gpu: auto (selected {csv})");
-            } else {
-                println!("  gpu: auto (engine default visibility)");
-            }
+            let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                .unwrap_or_else(|| "none".to_owned());
+            println!("  gpu: auto (selected {csv})");
         }
         GpuSelection::Index(_) => {
             let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
@@ -14311,8 +14309,9 @@ fn parse_device_policy(value: Option<&str>) -> Result<DevicePolicy> {
     }
 }
 
-/// Parse the user-facing `--gpu` value (`auto`, `1`, or `0,1,2`) into a
-/// `GpuSelection`. `None` defaults to `auto`.
+/// Parse the user-facing `--gpu` value (`auto` or a single index like `1`)
+/// into a `GpuSelection`. Comma lists are rejected (single-GPU serving only).
+/// `None` defaults to `auto`.
 fn parse_gpu_selection(value: Option<&str>) -> Result<GpuSelection> {
     let Some(raw) = value else {
         return Ok(GpuSelection::Auto);
@@ -14382,6 +14381,13 @@ impl GpuVramUsage {
         }
         Some(self.total_mb.saturating_sub(self.used_mb) as f64 / self.total_mb as f64)
     }
+
+    /// Absolute VRAM currently free, in MiB. Used to compare GPUs of differing
+    /// total capacity: a higher free *fraction* on a smaller GPU can still mean
+    /// less free memory than a larger GPU, so auto-selection ranks by this.
+    const fn free_mb(self) -> u64 {
+        self.total_mb.saturating_sub(self.used_mb)
+    }
 }
 
 /// A GPU is treated as "free" for `--gpu auto` when at least this fraction of
@@ -14430,18 +14436,17 @@ fn select_auto_gpu_index(
                 return vec![index];
             }
         }
-        // Pass 2: the non-busy GPU with the most free VRAM.
+        // Pass 2: the non-busy GPU with the most free VRAM in absolute terms
+        // (not free percentage, which can favor a smaller GPU on heterogeneous
+        // VRAM systems).
         if let Some(index) = candidates().max_by(|left, right| {
-            let left_free = usage_for(*left).and_then(|usage| usage.free_fraction());
-            let right_free = usage_for(*right).and_then(|usage| usage.free_fraction());
+            let left_free = usage_for(*left).map(|usage| usage.free_mb());
+            let right_free = usage_for(*right).map(|usage| usage.free_mb());
             left_free
-                .partial_cmp(&right_free)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .cmp(&right_free)
                 // Break ties toward the lowest index.
                 .then(right.cmp(left))
-        }) && usage_for(index)
-            .and_then(|usage| usage.free_fraction())
-            .is_some()
+        }) && usage_for(index).is_some()
         {
             return vec![index];
         }
@@ -19173,6 +19178,20 @@ install therock";
             select_auto_gpu_index(Some(3), &[0], Some(&usage)),
             vec![2],
             "with no idle GPU, pick the non-busy GPU with the most free VRAM"
+        );
+    }
+
+    #[test]
+    fn auto_selection_pass_two_ranks_by_absolute_free_vram() {
+        // Heterogeneous VRAM with no fully-idle GPU (so pass 2 applies):
+        // GPU 0 is a small card with a high free *fraction* (75%) but little
+        // absolute free memory; GPU 1 is large with a lower fraction (~48%)
+        // but far more free memory. Auto-selection must prefer GPU 1.
+        let usage = [vram(0, 6_000, 24_000), vram(1, 100_000, 192_000)];
+        assert_eq!(
+            select_auto_gpu_index(Some(2), &[], Some(&usage)),
+            vec![1],
+            "pass 2 should rank by absolute free VRAM, not free percentage"
         );
     }
 

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -97,6 +97,8 @@ enum Command {
         #[arg(long, default_value = "gpu_required")]
         device_policy: String,
         #[arg(long)]
+        gpu: Option<String>,
+        #[arg(long)]
         engine_recipe_json: Option<String>,
     },
     Status,
@@ -281,6 +283,7 @@ async fn run_cli(cli: Cli) -> Result<()> {
             host,
             port,
             device_policy,
+            gpu,
             engine_recipe_json,
         } => supervise_service(
             &paths,
@@ -293,6 +296,7 @@ async fn run_cli(cli: Cli) -> Result<()> {
             host,
             port,
             device_policy,
+            gpu,
             engine_recipe_json,
         )?,
         Command::Status => {
@@ -3055,6 +3059,7 @@ fn supervise_service(
     host: String,
     port: u16,
     device_policy: String,
+    gpu: Option<String>,
     engine_recipe_json: Option<String>,
 ) -> Result<()> {
     paths.ensure()?;
@@ -3062,6 +3067,7 @@ fn supervise_service(
     fs::create_dir_all(paths.engine_state_dir(&engine))?;
     fs::create_dir_all(paths.services_dir())?;
 
+    let gpu_indices = parse_gpu_indices_arg(gpu.as_deref())?;
     let _ = daemon_binary_path();
 
     let mut record = ManagedServiceRecord::new(
@@ -3078,6 +3084,7 @@ fn supervise_service(
         env_id.clone(),
         Some(device_policy.clone()),
     );
+    record.gpu_indices = gpu_indices;
     record.engine_recipe_json = engine_recipe_json.clone();
     record.write()?;
 
@@ -3097,6 +3104,7 @@ fn supervise_service(
             &record.host,
             record.port,
             &device_policy,
+            &record.gpu_indices,
             runtime_id.as_deref(),
             env_id.as_deref(),
             engine_recipe_json.as_deref(),
@@ -3146,6 +3154,7 @@ fn engine_serve_http_args(
     host: &str,
     port: u16,
     device_policy: &str,
+    gpu_indices: &[u32],
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe_json: Option<&str>,
@@ -3163,6 +3172,9 @@ fn engine_serve_http_args(
         "--device-policy".to_owned(),
         device_policy.to_owned(),
     ];
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(gpu_indices) {
+        args.extend(["--gpu".to_owned(), csv]);
+    }
     args.extend(optional_arg("--runtime-id", runtime_id));
     args.extend(optional_arg("--env-id", env_id));
     args.extend(optional_arg("--engine-recipe-json", engine_recipe_json));
@@ -4806,6 +4818,9 @@ fn recovery_supervise_args(record: &ManagedServiceRecord) -> Vec<String> {
     ];
     args.extend(optional_arg("--runtime-id", record.runtime_id.as_deref()));
     args.extend(optional_arg("--env-id", record.env_id.as_deref()));
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&record.gpu_indices) {
+        args.extend(["--gpu".to_owned(), csv]);
+    }
     args.extend(optional_arg(
         "--engine-recipe-json",
         record.engine_recipe_json.as_deref(),
@@ -4982,6 +4997,7 @@ mod tests {
             "127.0.0.1",
             11435,
             "gpu_required",
+            &[],
             Some("therock-release:gfx120X-all"),
             Some("env-1"),
             Some(engine_recipe_json),
@@ -5001,6 +5017,43 @@ mod tests {
             args.windows(2)
                 .any(|pair| pair[0] == "--state-path" && pair[1] == "state.json")
         );
+    }
+
+    #[test]
+    fn engine_serve_http_args_emit_gpu_indices_when_pinned() {
+        let args = engine_serve_http_args(
+            "vllm",
+            "svc-1",
+            "Qwen/Qwen3.5-4B",
+            "127.0.0.1",
+            11435,
+            "gpu_required",
+            &[1],
+            None,
+            None,
+            None,
+            Path::new("state.json"),
+        );
+
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "--gpu" && pair[1] == "1")
+        );
+
+        let auto = engine_serve_http_args(
+            "vllm",
+            "svc-1",
+            "Qwen/Qwen3.5-4B",
+            "127.0.0.1",
+            11435,
+            "gpu_required",
+            &[],
+            None,
+            None,
+            None,
+            Path::new("state.json"),
+        );
+        assert!(!auto.iter().any(|arg| arg == "--gpu"));
     }
 
     #[test]
@@ -8486,6 +8539,16 @@ async fn shutdown_signal() {
 #[cfg(not(unix))]
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
+}
+
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    let Some(raw) = value else {
+        return Ok(Vec::new());
+    };
+    match rocm_engine_protocol::GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg)? {
+        rocm_engine_protocol::GpuSelection::Auto => Ok(Vec::new()),
+        rocm_engine_protocol::GpuSelection::Index(index) => Ok(vec![index]),
+    }
 }
 
 fn optional_arg(flag: &str, value: Option<&str>) -> Vec<String> {

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5474,6 +5474,8 @@ pub struct ManagedServiceRecord {
     #[serde(default)]
     pub device_policy: Option<String>,
     #[serde(default)]
+    pub gpu_indices: Vec<u32>,
+    #[serde(default)]
     pub engine_recipe_json: Option<String>,
     #[serde(default)]
     pub restart_count: u32,
@@ -5522,6 +5524,7 @@ impl ManagedServiceRecord {
             runtime_id,
             env_id,
             device_policy,
+            gpu_indices: Vec::new(),
             engine_recipe_json: None,
             restart_count: 0,
             last_restart_unix_ms: None,

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -145,25 +145,6 @@ pub enum GpuSelection {
 }
 
 impl GpuSelection {
-    /// The concrete device ordinal when explicitly pinned; `None` for `Auto`.
-    #[must_use]
-    pub const fn index(&self) -> Option<u32> {
-        match self {
-            Self::Auto => None,
-            Self::Index(index) => Some(*index),
-        }
-    }
-
-    /// Render as a CLI value (`auto` or `1`) for argv round-tripping through the
-    /// hidden `__engine-serve-http` subcommand.
-    #[must_use]
-    pub fn to_cli_value(&self) -> String {
-        match self {
-            Self::Auto => "auto".to_owned(),
-            Self::Index(index) => index.to_string(),
-        }
-    }
-
     /// Parse a CLI value (`auto` or a single GPU index like `1`) into a
     /// selection. Returns an error for non-numeric input or for a comma list,
     /// since serving a model across multiple GPUs is not supported.
@@ -198,6 +179,18 @@ pub fn gpu_indices_to_csv(indices: &[u32]) -> Option<String> {
             .collect::<Vec<_>>()
             .join(","),
     )
+}
+
+/// Pin the resolved GPU ordinals onto a child process by exporting
+/// `HIP_VISIBLE_DEVICES`.
+///
+/// This is the single contract point engines use to make `--gpu`/`auto`
+/// selection visible to the spawned server; an empty slice is a no-op (the
+/// engine keeps its default device visibility, never a CPU fallback).
+pub fn apply_gpu_visibility(command: &mut std::process::Command, gpu_indices: &[u32]) {
+    if let Some(csv) = gpu_indices_to_csv(gpu_indices) {
+        command.env("HIP_VISIBLE_DEVICES", csv);
+    }
 }
 
 /// The explicit GPU ordinal carried by an optional `GpuSelection`, as a list.
@@ -283,8 +276,6 @@ pub struct ResolveModelRequest {
     pub recipe_override: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_recipe: Option<EngineRecipeHint>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gpu_selection: Option<GpuSelection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -519,25 +510,35 @@ mod tests {
     }
 
     #[test]
-    fn gpu_selection_roundtrips_through_cli_value() {
-        let selection = GpuSelection::Index(2);
-        assert_eq!(selection.to_cli_value(), "2");
-        assert_eq!(
-            GpuSelection::parse_cli_value(&selection.to_cli_value()).unwrap(),
-            selection
-        );
-        assert_eq!(GpuSelection::Auto.to_cli_value(), "auto");
-    }
-
-    #[test]
     fn gpu_indices_helpers_handle_auto_and_pinned() {
         assert_eq!(gpu_indices_to_csv(&[]), None);
         assert_eq!(gpu_indices_to_csv(&[1]), Some("1".to_owned()));
-        assert_eq!(GpuSelection::Auto.index(), None);
-        assert_eq!(GpuSelection::Index(3).index(), Some(3));
         assert!(launch_gpu_indices(None).is_empty());
         assert!(launch_gpu_indices(Some(&GpuSelection::Auto)).is_empty());
         assert_eq!(launch_gpu_indices(Some(&GpuSelection::Index(2))), vec![2]);
+    }
+
+    #[test]
+    fn apply_gpu_visibility_sets_hip_visible_devices_on_command() {
+        let mut command = std::process::Command::new("true");
+        apply_gpu_visibility(&mut command, &[2]);
+        let hip = command
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("HIP_VISIBLE_DEVICES"))
+            .and_then(|(_, value)| value)
+            .map(|value| value.to_string_lossy().into_owned());
+        assert_eq!(hip.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn apply_gpu_visibility_is_noop_without_pinned_indices() {
+        let mut command = std::process::Command::new("true");
+        apply_gpu_visibility(&mut command, &[]);
+        assert!(
+            command
+                .get_envs()
+                .all(|(key, _)| key != std::ffi::OsStr::new("HIP_VISIBLE_DEVICES"))
+        );
     }
 
     #[test]
@@ -565,7 +566,6 @@ mod tests {
                 }],
                 notes: vec!["signed recipe metadata".to_owned()],
             }),
-            gpu_selection: None,
         };
 
         let serialized = serde_json::to_string(&request).unwrap();

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -134,6 +134,85 @@ pub enum DevicePolicy {
     CpuOnly,
 }
 
+/// Which GPU device a server should run on. `Auto` lets the CLI pick the first
+/// free GPU; `Index` pins one explicit GPU ordinal. Running a single model
+/// across multiple GPUs is not supported.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuSelection {
+    Auto,
+    Index(u32),
+}
+
+impl GpuSelection {
+    /// The concrete device ordinal when explicitly pinned; `None` for `Auto`.
+    #[must_use]
+    pub const fn index(&self) -> Option<u32> {
+        match self {
+            Self::Auto => None,
+            Self::Index(index) => Some(*index),
+        }
+    }
+
+    /// Render as a CLI value (`auto` or `1`) for argv round-tripping through the
+    /// hidden `__engine-serve-http` subcommand.
+    #[must_use]
+    pub fn to_cli_value(&self) -> String {
+        match self {
+            Self::Auto => "auto".to_owned(),
+            Self::Index(index) => index.to_string(),
+        }
+    }
+
+    /// Parse a CLI value (`auto` or a single GPU index like `1`) into a
+    /// selection. Returns an error for non-numeric input or for a comma list,
+    /// since serving a model across multiple GPUs is not supported.
+    pub fn parse_cli_value(value: &str) -> Result<Self, String> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+        if trimmed.contains(',') {
+            return Err(format!(
+                "invalid --gpu value `{value}`: serving across multiple GPUs is not supported; pass a single GPU index or `auto`"
+            ));
+        }
+        let index: u32 = trimmed.parse().map_err(|_| {
+            format!("invalid --gpu value `{value}`: `{trimmed}` is not a GPU index")
+        })?;
+        Ok(Self::Index(index))
+    }
+}
+
+/// Render an explicit GPU ordinal as a comma-separated `HIP_VISIBLE_DEVICES`
+/// value. Returns `None` when the slice is empty (no pinning requested).
+#[must_use]
+pub fn gpu_indices_to_csv(indices: &[u32]) -> Option<String> {
+    if indices.is_empty() {
+        return None;
+    }
+    Some(
+        indices
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+    )
+}
+
+/// The explicit GPU ordinal carried by an optional `GpuSelection`, as a list.
+///
+/// Used by engine launch paths. `Auto` and `None` yield an empty list (engine
+/// default visibility), so engines only pin when the CLI resolved a concrete
+/// index.
+#[must_use]
+pub fn launch_gpu_indices(selection: Option<&GpuSelection>) -> Vec<u32> {
+    match selection {
+        Some(GpuSelection::Index(index)) => vec![*index],
+        _ => Vec::new(),
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineRequestEnvelope {
     pub method: EngineMethod,
@@ -204,6 +283,8 @@ pub struct ResolveModelRequest {
     pub recipe_override: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_recipe: Option<EngineRecipeHint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_selection: Option<GpuSelection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -218,6 +299,8 @@ pub struct LaunchRequest {
     pub endpoint_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_recipe: Option<EngineRecipeHint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu_selection: Option<GpuSelection>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -255,11 +338,9 @@ pub struct EngineDeviceAvailability {
 pub struct EngineCapabilities {
     pub cpu: bool,
     pub rocm_gpu: bool,
-    pub multi_gpu: bool,
     pub openai_compatible: bool,
     pub tool_calling: bool,
     pub quantized_models: String,
-    pub distributed_serving: bool,
     pub reasoning_parser: bool,
 }
 
@@ -401,6 +482,65 @@ mod tests {
     }
 
     #[test]
+    fn gpu_selection_parses_auto_variants() {
+        assert_eq!(
+            GpuSelection::parse_cli_value("auto").unwrap(),
+            GpuSelection::Auto
+        );
+        assert_eq!(
+            GpuSelection::parse_cli_value("AUTO").unwrap(),
+            GpuSelection::Auto
+        );
+        assert_eq!(
+            GpuSelection::parse_cli_value("  ").unwrap(),
+            GpuSelection::Auto
+        );
+    }
+
+    #[test]
+    fn gpu_selection_parses_single_index() {
+        assert_eq!(
+            GpuSelection::parse_cli_value("1").unwrap(),
+            GpuSelection::Index(1)
+        );
+        assert_eq!(
+            GpuSelection::parse_cli_value("  2 ").unwrap(),
+            GpuSelection::Index(2)
+        );
+    }
+
+    #[test]
+    fn gpu_selection_rejects_invalid_values() {
+        assert!(GpuSelection::parse_cli_value("gpu0").is_err());
+        assert!(GpuSelection::parse_cli_value("-1").is_err());
+        // Multiple GPUs are no longer supported.
+        assert!(GpuSelection::parse_cli_value("0,1").is_err());
+        assert!(GpuSelection::parse_cli_value("0,2,3").is_err());
+    }
+
+    #[test]
+    fn gpu_selection_roundtrips_through_cli_value() {
+        let selection = GpuSelection::Index(2);
+        assert_eq!(selection.to_cli_value(), "2");
+        assert_eq!(
+            GpuSelection::parse_cli_value(&selection.to_cli_value()).unwrap(),
+            selection
+        );
+        assert_eq!(GpuSelection::Auto.to_cli_value(), "auto");
+    }
+
+    #[test]
+    fn gpu_indices_helpers_handle_auto_and_pinned() {
+        assert_eq!(gpu_indices_to_csv(&[]), None);
+        assert_eq!(gpu_indices_to_csv(&[1]), Some("1".to_owned()));
+        assert_eq!(GpuSelection::Auto.index(), None);
+        assert_eq!(GpuSelection::Index(3).index(), Some(3));
+        assert!(launch_gpu_indices(None).is_empty());
+        assert!(launch_gpu_indices(Some(&GpuSelection::Auto)).is_empty());
+        assert_eq!(launch_gpu_indices(Some(&GpuSelection::Index(2))), vec![2]);
+    }
+
+    #[test]
     fn engine_recipe_hint_roundtrips_through_resolve_request() {
         let request = ResolveModelRequest {
             model_ref: "Qwen/Test".to_owned(),
@@ -425,6 +565,7 @@ mod tests {
                 }],
                 notes: vec!["signed recipe metadata".to_owned()],
             }),
+            gpu_selection: None,
         };
 
         let serialized = serde_json::to_string(&request).unwrap();
@@ -470,6 +611,7 @@ mod tests {
                 unsupported_combinations: Vec::new(),
                 notes: Vec::new(),
             }),
+            gpu_selection: None,
         };
 
         let serialized = serde_json::to_string(&request).unwrap();

--- a/docs/llm-tool-use.md
+++ b/docs/llm-tool-use.md
@@ -85,6 +85,14 @@ rocm-cli to start the managed `llama.cpp` engine. GPU execution is required:
 {"name":"rocm_command","arguments":{"args":["serve","D:\\models\\tiny.gguf","--engine","llama.cpp","--device","gpu_required","--managed"],"reason":"Start a local GPU llama-server for this GGUF model."}}
 ```
 
+To target a specific GPU, add `--gpu` with `auto` (default; first free GPU) or a
+single index. Serving one model across multiple GPUs is not supported. CPU
+fallback is never used when a GPU is busy or out of range:
+
+```json
+{"name":"rocm_command","arguments":{"args":["serve","D:\\models\\tiny.gguf","--engine","llama.cpp","--device","gpu_required","--gpu","1","--managed"],"reason":"Serve this GGUF model on GPU 1."}}
+```
+
 The assistant can request starting ComfyUI. rocm-cli shows the local URL and
 tries to open the browser:
 

--- a/docs/sglang.md
+++ b/docs/sglang.md
@@ -43,6 +43,21 @@ Managed serving:
 rocm serve Qwen/Qwen3.5-4B --engine sglang --device gpu_required --managed
 ```
 
+### GPU selection
+
+Use `--gpu` to choose the AMD GPU SGLang runs on:
+
+```bash
+# Default: first free GPU (auto)
+rocm serve Qwen/Qwen3.5-4B --engine sglang --managed
+
+# Pin a specific GPU
+rocm serve Qwen/Qwen3.5-4B --engine sglang --gpu 1 --managed
+```
+
+rocm-cli pins the device via `HIP_VISIBLE_DEVICES`. Serving one model across
+multiple GPUs is not supported.
+
 Native Windows SGLang serving is skipped in this adapter. Use WSL/Linux for
 SGLang ROCm serving, or choose a different engine explicitly. No CPU fallback is
 used.

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -72,6 +72,21 @@ Serving through rocm-cli:
 rocm serve Qwen/Qwen3.5-4B --engine vllm --device gpu_required --managed
 ```
 
+### GPU selection
+
+Use `--gpu` to choose the AMD GPU vLLM runs on:
+
+```bash
+# Default: first free GPU (auto)
+rocm serve Qwen/Qwen3.5-4B --engine vllm --managed
+
+# Pin a specific GPU
+rocm serve Qwen/Qwen3.5-4B --engine vllm --gpu 1 --managed
+```
+
+rocm-cli pins the device via `HIP_VISIBLE_DEVICES`. Serving one model across
+multiple GPUs is not supported.
+
 Native Windows vLLM serving is skipped in this adapter. Use WSL/Linux for vLLM
 ROCm serving, or choose a different engine explicitly. No CPU fallback is used.
 

--- a/engines/atom/src/lib.rs
+++ b/engines/atom/src/lib.rs
@@ -12,7 +12,7 @@ use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
     ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest, EndpointResponse, EngineCapabilities,
     EngineDeviceAvailability, EngineMethod, EngineRecipeHint, EngineRequestEnvelope,
-    EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse, InstallRequest,
+    EngineResponseEnvelope, GpuSelection, HealthcheckRequest, HealthcheckResponse, InstallRequest,
     InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse, ResolveModelRequest,
     ResolveModelResponse, StopRequest, StopResponse,
 };
@@ -67,6 +67,8 @@ enum CommandKind {
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
     Stdio,
     ServeHttp {
@@ -86,6 +88,8 @@ enum CommandKind {
         state_path: PathBuf,
         #[arg(long)]
         engine_recipe_json: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
 }
 
@@ -170,6 +174,7 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -179,6 +184,7 @@ pub fn run_cli() -> Result<()> {
             device_policy,
             runtime_id,
             env_id,
+            gpu,
         } => print_json(&launch_service(LaunchRequest {
             service_id,
             env_id,
@@ -189,6 +195,7 @@ pub fn run_cli() -> Result<()> {
             device_policy: Some(parse_device_policy_arg(device_policy.as_deref())?),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
         })?)?,
         CommandKind::Stdio => {
             let envelope = read_request()?;
@@ -204,12 +211,14 @@ pub fn run_cli() -> Result<()> {
             env_id,
             state_path,
             engine_recipe_json,
+            gpu,
         } => serve_http(ServeHttpRequest {
             service_id,
             model_ref,
             host,
             port,
             device_policy: parse_device_policy_arg(Some(&device_policy))?,
+            gpu_indices: parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -230,6 +239,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -241,6 +251,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         state_path,
@@ -348,11 +359,9 @@ fn capabilities() -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu: !cfg!(windows),
-        multi_gpu: !cfg!(windows),
         openai_compatible: true,
         tool_calling: false,
         quantized_models: "ATOM-supported".to_owned(),
-        distributed_serving: !cfg!(windows),
         reasoning_parser: false,
     }
 }
@@ -476,6 +485,7 @@ fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
         host: request.host.clone(),
         port: request.port,
         device_policy,
+        gpu_indices: rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref()),
         runtime_id: request.runtime_id.clone(),
         env_id: request.env_id.clone(),
         state_path: state_path.clone(),
@@ -503,6 +513,7 @@ struct ServeHttpRequest {
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -562,6 +573,9 @@ fn spawn_atom_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
+        command.env("HIP_VISIBLE_DEVICES", csv);
+    }
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -896,6 +910,20 @@ fn parse_device_policy_arg(policy: Option<&str>) -> Result<DevicePolicy> {
         "cpu" | "cpu_only" => Ok(DevicePolicy::CpuOnly),
         other => bail!("unsupported device policy: {other}"),
     }
+}
+
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
 }
 
 fn atom_command_from_python(python: &Path) -> Option<PathBuf> {
@@ -1367,6 +1395,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1384,6 +1413,7 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
+            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1398,6 +1428,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
+            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 
@@ -1585,6 +1616,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: DevicePolicy::GpuRequired,
+            gpu_indices: Vec::new(),
             runtime_id: Some("therock-release:gfx120X-all".to_owned()),
             env_id: None,
             state_path: state_path.clone(),

--- a/engines/atom/src/lib.rs
+++ b/engines/atom/src/lib.rs
@@ -174,7 +174,6 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -573,9 +572,7 @@ fn spawn_atom_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
-    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
-        command.env("HIP_VISIBLE_DEVICES", csv);
-    }
+    rocm_engine_protocol::apply_gpu_visibility(&mut command, &request.gpu_indices);
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -1395,7 +1392,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1413,7 +1409,6 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
-            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1428,7 +1423,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
-            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -13,9 +13,10 @@ use rocm_core::{
 use rocm_engine_protocol::{
     DetectRequest, DetectResponse, DevicePolicy, ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest,
     EndpointResponse, EngineCapabilities, EngineDeviceAvailability, EngineMethod, EngineRecipeHint,
-    EngineRequestEnvelope, EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse,
-    InstallRequest, InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse,
-    ResolveModelRequest, ResolveModelResponse, StopRequest, StopResponse,
+    EngineRequestEnvelope, EngineResponseEnvelope, GpuSelection, HealthcheckRequest,
+    HealthcheckResponse, InstallRequest, InstallResponse, LaunchRequest, LaunchResponse,
+    LogsRequest, LogsResponse, ResolveModelRequest, ResolveModelResponse, StopRequest,
+    StopResponse,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -84,6 +85,8 @@ enum CommandKind {
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
     Stdio,
     ServeHttp {
@@ -105,6 +108,8 @@ enum CommandKind {
         log_path: Option<PathBuf>,
         #[arg(long)]
         engine_recipe_json: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
 }
 
@@ -130,6 +135,7 @@ struct LemonadeProcessEnvironment {
     rocm_root: Option<PathBuf>,
     path_entries: Vec<PathBuf>,
     library_entries: Vec<PathBuf>,
+    gpu_indices: Vec<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -139,6 +145,7 @@ struct ServeHttpRequest {
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -173,6 +180,7 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
+                gpu_selection: None,
             })?)?;
         }
         CommandKind::Launch {
@@ -183,6 +191,7 @@ pub fn run_cli() -> Result<()> {
             device_policy,
             runtime_id,
             env_id,
+            gpu,
         } => print_json(&launch_service(LaunchRequest {
             service_id,
             env_id,
@@ -193,6 +202,7 @@ pub fn run_cli() -> Result<()> {
             device_policy: Some(parse_device_policy_arg(device_policy.as_deref())?),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
         })?)?,
         CommandKind::Stdio => {
             let envelope = read_request()?;
@@ -209,12 +219,14 @@ pub fn run_cli() -> Result<()> {
             state_path,
             log_path,
             engine_recipe_json,
+            gpu,
         } => serve_http(ServeHttpRequest {
             service_id,
             model_ref,
             host,
             port,
             device_policy: parse_device_policy_arg(device_policy.as_deref())?,
+            gpu_indices: parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -236,6 +248,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -248,6 +261,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         state_path,
@@ -320,12 +334,10 @@ fn capabilities() -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu: true,
-        multi_gpu: true,
         openai_compatible: true,
         tool_calling: true,
         quantized_models: "GGUF through Lemonade llama.cpp (ROCm/Vulkan/CPU auto-selected)"
             .to_owned(),
-        distributed_serving: false,
         reasoning_parser: false,
     }
 }
@@ -467,6 +479,7 @@ fn launch_service(mut request: LaunchRequest) -> Result<LaunchResponse> {
             .device_policy
             .clone()
             .unwrap_or(DevicePolicy::GpuRequired),
+        gpu_indices: rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref()),
         runtime_id: request.runtime_id.clone(),
         env_id: request.env_id.clone(),
         state_path: state_path.clone(),
@@ -503,7 +516,8 @@ fn launch_service(mut request: LaunchRequest) -> Result<LaunchResponse> {
 fn serve_http(request: ServeHttpRequest) -> Result<()> {
     require_gpu_required(&request.device_policy)?;
     let runtime = resolve_runtime()?;
-    let process_env = lemonade_process_environment()?;
+    let mut process_env = lemonade_process_environment()?;
+    process_env.gpu_indices = request.gpu_indices.clone();
     let log_path = request.log_path.as_deref();
     write_running_state(&request, &runtime, std::process::id(), None, "starting")?;
     if runtime_is_linux() && direct_llama_server_path(&runtime.manifest).is_file() {
@@ -1296,6 +1310,7 @@ fn lemonade_process_environment() -> Result<LemonadeProcessEnvironment> {
         rocm_root: env.rocm_root,
         path_entries: env.path_entries,
         library_entries: env.library_entries,
+        gpu_indices: Vec::new(),
     })
 }
 
@@ -1328,6 +1343,9 @@ fn lemonade_process_environment_vars(
             prepend_runtime_paths(&env.library_entries, std::env::var_os("LD_LIBRARY_PATH"))?
     {
         vars.push(("LD_LIBRARY_PATH", ld_library_path));
+    }
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&env.gpu_indices) {
+        vars.push(("HIP_VISIBLE_DEVICES", OsString::from(csv)));
     }
     Ok(vars)
 }
@@ -1829,6 +1847,9 @@ fn serve_http_command_args(request: &ServeHttpRequest) -> Vec<String> {
     if let Some(log_path) = request.log_path.as_ref() {
         args.extend(["--log-path".to_owned(), log_path.display().to_string()]);
     }
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
+        args.extend(["--gpu".to_owned(), csv]);
+    }
     if let Some(engine_recipe) = request.engine_recipe.as_ref() {
         args.extend([
             "--engine-recipe-json".to_owned(),
@@ -2067,6 +2088,20 @@ fn parse_device_policy_arg(value: Option<&str>) -> Result<DevicePolicy> {
         "cpu" | "cpu_only" => Ok(DevicePolicy::CpuOnly),
         other => bail!("unknown device policy `{other}`"),
     }
+}
+
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
 }
 
 const fn device_policy_name(policy: &DevicePolicy) -> &'static str {
@@ -2363,6 +2398,7 @@ vllm                rocm        unsupported     Requires Linux                  
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: DevicePolicy::GpuRequired,
+            gpu_indices: Vec::new(),
             runtime_id: Some("runtime".to_owned()),
             env_id: Some("env".to_owned()),
             state_path: PathBuf::from("state.json"),

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -180,7 +180,6 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
-                gpu_selection: None,
             })?)?;
         }
         CommandKind::Launch {

--- a/engines/llama-cpp/src/lib.rs
+++ b/engines/llama-cpp/src/lib.rs
@@ -11,9 +11,10 @@ use rocm_core::{
 use rocm_engine_protocol::{
     DetectRequest, DetectResponse, DevicePolicy, ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest,
     EndpointResponse, EngineCapabilities, EngineDeviceAvailability, EngineMethod, EngineRecipeHint,
-    EngineRequestEnvelope, EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse,
-    InstallRequest, InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse,
-    ResolveModelRequest, ResolveModelResponse, StopRequest, StopResponse,
+    EngineRequestEnvelope, EngineResponseEnvelope, GpuSelection, HealthcheckRequest,
+    HealthcheckResponse, InstallRequest, InstallResponse, LaunchRequest, LaunchResponse,
+    LogsRequest, LogsResponse, ResolveModelRequest, ResolveModelResponse, StopRequest,
+    StopResponse,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -81,6 +82,8 @@ enum CommandKind {
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
     Stdio,
     ServeHttp {
@@ -102,6 +105,8 @@ enum CommandKind {
         log_path: Option<PathBuf>,
         #[arg(long)]
         engine_recipe_json: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
 }
 
@@ -131,6 +136,7 @@ struct ServeHttpRequest {
     host: String,
     port: u16,
     device_policy: Option<String>,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -198,6 +204,7 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
+                gpu_selection: None,
             })?)?;
         }
         CommandKind::Launch {
@@ -208,6 +215,7 @@ pub fn run_cli() -> Result<()> {
             device_policy,
             runtime_id,
             env_id,
+            gpu,
         } => print_json(&launch_service(LaunchRequest {
             service_id,
             env_id,
@@ -218,6 +226,7 @@ pub fn run_cli() -> Result<()> {
             device_policy: Some(parse_device_policy_arg(device_policy.as_deref())?),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
         })?)?,
         CommandKind::Stdio => {
             let envelope = read_request()?;
@@ -234,12 +243,14 @@ pub fn run_cli() -> Result<()> {
             state_path,
             log_path,
             engine_recipe_json,
+            gpu,
         } => serve_http(ServeHttpRequest {
             service_id,
             model_ref,
             host,
             port,
             device_policy,
+            gpu_indices: parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -261,6 +272,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: Option<String>,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -273,6 +285,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         state_path,
@@ -392,11 +405,9 @@ fn engine_capabilities(rocm_gpu: bool) -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu,
-        multi_gpu: rocm_gpu,
         openai_compatible: true,
         tool_calling: false,
         quantized_models: "gguf".to_owned(),
-        distributed_serving: false,
         reasoning_parser: false,
     }
 }
@@ -711,6 +722,12 @@ fn serve_http_command_args(
         args.push("--log-path".to_owned());
         args.push(log_path.display().to_string());
     }
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(
+        &rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref()),
+    ) {
+        args.push("--gpu".to_owned());
+        args.push(csv);
+    }
     if let Some(engine_recipe) = request.engine_recipe.as_ref() {
         args.push("--engine-recipe-json".to_owned());
         args.push(serde_json::to_string(engine_recipe).expect("engine recipe serializes"));
@@ -798,6 +815,9 @@ fn serve_http(request: ServeHttpRequest) -> Result<()> {
     let mut command = ProcessCommand::new(&prepared_server.program);
     let server_args = llama_server_args(&request, gpu_requested);
     command.args(&server_args).stdin(Stdio::null());
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
+        command.env("HIP_VISIBLE_DEVICES", csv);
+    }
     if let Some(log_path) = request.log_path.as_ref() {
         if let Some(parent) = log_path.parent() {
             fs::create_dir_all(parent)
@@ -1777,6 +1797,20 @@ fn parse_device_policy_arg(value: Option<&str>) -> Result<DevicePolicy> {
     }
 }
 
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
+}
+
 fn current_unix_millis() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1824,6 +1858,7 @@ mod tests {
             device_policy: Some(DevicePolicy::CpuOnly),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })
         .expect_err("cpu policy should not resolve");
         assert!(error.to_string().contains("no CPU fallback is used"));
@@ -1837,6 +1872,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuPreferred),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.device_policy, DevicePolicy::GpuRequired);
@@ -1851,6 +1887,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.device_policy, DevicePolicy::GpuRequired);
@@ -1872,6 +1909,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?;
         fs::remove_file(&path).ok();
 
@@ -1888,6 +1926,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.canonical_model_id, "missing-model.gguf");
@@ -1909,6 +1948,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1926,6 +1966,7 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
+            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1940,6 +1981,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
+            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 
@@ -2441,6 +2483,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: Some("gpu_required".to_owned()),
+            gpu_indices: Vec::new(),
             runtime_id: None,
             env_id: None,
             state_path: PathBuf::from("state.json"),
@@ -2516,6 +2559,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: None,
         };
 
         let args = serve_http_command_args(
@@ -2565,6 +2609,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: Some("gpu_required".to_owned()),
+            gpu_indices: Vec::new(),
             runtime_id: Some("therock-release".to_owned()),
             env_id: None,
             state_path: PathBuf::from("state.json"),
@@ -2592,6 +2637,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: Some("gpu_required".to_owned()),
+            gpu_indices: Vec::new(),
             runtime_id: Some("therock-release".to_owned()),
             env_id: None,
             state_path: PathBuf::from("state.json"),
@@ -2615,6 +2661,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: Some("cpu_only".to_owned()),
+            gpu_indices: Vec::new(),
             runtime_id: None,
             env_id: None,
             state_path: PathBuf::from("state.json"),

--- a/engines/llama-cpp/src/lib.rs
+++ b/engines/llama-cpp/src/lib.rs
@@ -204,7 +204,6 @@ pub fn run_cli() -> Result<()> {
                 device_policy: None,
                 recipe_override: None,
                 engine_recipe: None,
-                gpu_selection: None,
             })?)?;
         }
         CommandKind::Launch {
@@ -815,9 +814,7 @@ fn serve_http(request: ServeHttpRequest) -> Result<()> {
     let mut command = ProcessCommand::new(&prepared_server.program);
     let server_args = llama_server_args(&request, gpu_requested);
     command.args(&server_args).stdin(Stdio::null());
-    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
-        command.env("HIP_VISIBLE_DEVICES", csv);
-    }
+    rocm_engine_protocol::apply_gpu_visibility(&mut command, &request.gpu_indices);
     if let Some(log_path) = request.log_path.as_ref() {
         if let Some(parent) = log_path.parent() {
             fs::create_dir_all(parent)
@@ -1858,7 +1855,6 @@ mod tests {
             device_policy: Some(DevicePolicy::CpuOnly),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })
         .expect_err("cpu policy should not resolve");
         assert!(error.to_string().contains("no CPU fallback is used"));
@@ -1872,7 +1868,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuPreferred),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.device_policy, DevicePolicy::GpuRequired);
@@ -1887,7 +1882,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.device_policy, DevicePolicy::GpuRequired);
@@ -1909,7 +1903,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?;
         fs::remove_file(&path).ok();
 
@@ -1926,7 +1919,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.canonical_model_id, "missing-model.gguf");
@@ -1948,7 +1940,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1966,7 +1957,6 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
-            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1981,7 +1971,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
-            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/engines/pytorch/src/lib.rs
+++ b/engines/pytorch/src/lib.rs
@@ -15,9 +15,10 @@ use rocm_core::{
 use rocm_engine_protocol::{
     DetectRequest, DetectResponse, DevicePolicy, ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest,
     EndpointResponse, EngineCapabilities, EngineDeviceAvailability, EngineMethod, EngineRecipeHint,
-    EngineRequestEnvelope, EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse,
-    InstallRequest, InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse,
-    ResolveModelRequest, ResolveModelResponse, StopRequest, StopResponse,
+    EngineRequestEnvelope, EngineResponseEnvelope, GpuSelection, HealthcheckRequest,
+    HealthcheckResponse, InstallRequest, InstallResponse, LaunchRequest, LaunchResponse,
+    LogsRequest, LogsResponse, ResolveModelRequest, ResolveModelResponse, StopRequest,
+    StopResponse,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -101,6 +102,8 @@ enum CommandKind {
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
     Stdio,
     #[command(hide = true)]
@@ -121,6 +124,8 @@ enum CommandKind {
         state_path: PathBuf,
         #[arg(long)]
         engine_recipe_json: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
 }
 
@@ -349,6 +354,7 @@ pub async fn run_cli() -> Result<()> {
                 device_policy: device_policy.map(Into::into),
                 recipe_override: None,
                 engine_recipe: None,
+                gpu_selection: None,
             })?;
             print_json(&response)?;
         }
@@ -360,6 +366,7 @@ pub async fn run_cli() -> Result<()> {
             device_policy,
             runtime_id,
             env_id,
+            gpu,
         } => {
             let response = launch_service(LaunchRequest {
                 service_id,
@@ -371,6 +378,7 @@ pub async fn run_cli() -> Result<()> {
                 device_policy: device_policy.map(Into::into),
                 endpoint_mode: Some("openai".to_owned()),
                 engine_recipe: None,
+                gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
             })?;
             print_json(&response)?;
         }
@@ -389,6 +397,7 @@ pub async fn run_cli() -> Result<()> {
             runtime_id,
             state_path,
             engine_recipe_json,
+            gpu,
         } => {
             serve_http(
                 service_id,
@@ -396,6 +405,7 @@ pub async fn run_cli() -> Result<()> {
                 host,
                 port,
                 parse_device_policy(&device_policy)?,
+                parse_gpu_indices_arg(gpu.as_deref())?,
                 env_id,
                 runtime_id,
                 state_path,
@@ -417,6 +427,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     env_id: Option<String>,
     runtime_id: Option<String>,
     state_path: PathBuf,
@@ -428,6 +439,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         env_id,
         runtime_id,
         state_path,
@@ -626,11 +638,9 @@ fn capabilities() -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu: true,
-        multi_gpu: true,
         openai_compatible: true,
         tool_calling: true,
         quantized_models: "limited".to_owned(),
-        distributed_serving: false,
         reasoning_parser: false,
     }
 }
@@ -754,6 +764,7 @@ fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
         .args(optional_arg("--env-id", request.env_id.as_deref()))
         .args(optional_arg("--runtime-id", request.runtime_id.as_deref()))
         .args(engine_recipe_json_arg(engine_recipe.as_ref())?)
+        .args(gpu_indices_arg(request.gpu_selection.as_ref()))
         .arg("--state-path")
         .arg(&state_path)
         .stdin(Stdio::null())
@@ -1773,6 +1784,7 @@ fn serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     env_id: Option<String>,
     runtime_id: Option<String>,
     state_path: PathBuf,
@@ -1837,6 +1849,9 @@ fn serve_http(
         .env("PYTHONUNBUFFERED", "1")
         .env("TOKENIZERS_PARALLELISM", "false")
         .stdin(Stdio::null());
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices) {
+        worker_command.env("HIP_VISIBLE_DEVICES", csv);
+    }
     worker_command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -2215,6 +2230,31 @@ fn parse_device_policy(value: &str) -> Result<DevicePolicy> {
         "gpu_preferred" => Ok(DevicePolicy::GpuPreferred),
         "cpu_only" => Ok(DevicePolicy::CpuOnly),
         _ => bail!("unknown device policy: {value}"),
+    }
+}
+
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
+}
+
+/// Re-exec `--gpu` flag for the detached serve-http worker, derived from the
+/// launch request's selection. Empty (auto) selections emit no flag.
+fn gpu_indices_arg(selection: Option<&GpuSelection>) -> Vec<String> {
+    match rocm_engine_protocol::gpu_indices_to_csv(&rocm_engine_protocol::launch_gpu_indices(
+        selection,
+    )) {
+        Some(csv) => vec!["--gpu".to_owned(), csv],
+        None => Vec::new(),
     }
 }
 
@@ -3727,6 +3767,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -3741,6 +3782,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe("vllm", ENGINE_RECIPE_CONTRACT_VERSION)),
+            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -3755,6 +3797,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
+            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/engines/pytorch/src/lib.rs
+++ b/engines/pytorch/src/lib.rs
@@ -354,7 +354,6 @@ pub async fn run_cli() -> Result<()> {
                 device_policy: device_policy.map(Into::into),
                 recipe_override: None,
                 engine_recipe: None,
-                gpu_selection: None,
             })?;
             print_json(&response)?;
         }
@@ -1849,9 +1848,7 @@ fn serve_http(
         .env("PYTHONUNBUFFERED", "1")
         .env("TOKENIZERS_PARALLELISM", "false")
         .stdin(Stdio::null());
-    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices) {
-        worker_command.env("HIP_VISIBLE_DEVICES", csv);
-    }
+    rocm_engine_protocol::apply_gpu_visibility(&mut worker_command, &gpu_indices);
     worker_command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -3767,7 +3764,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -3782,7 +3778,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe("vllm", ENGINE_RECIPE_CONTRACT_VERSION)),
-            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -3797,7 +3792,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
-            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/engines/pytorch/src/python_worker.py
+++ b/engines/pytorch/src/python_worker.py
@@ -93,18 +93,11 @@ def detect_device(
         raise RuntimeError(f"unsupported device policy {policy}")
 
     max_single_gpu_mem_gb = inventory["max_single_gpu_mem_gb"]
-    total_gpu_mem_gb = inventory["total_gpu_mem_gb"]
     if (
         min_gpu_mem_gb is not None
         and max_single_gpu_mem_gb is not None
         and max_single_gpu_mem_gb + 0.5 < min_gpu_mem_gb
     ):
-        if total_gpu_mem_gb + 1.0 >= min_gpu_mem_gb and inventory["gpu_count"] > 1:
-            message = (
-                f"single GPU has {max_single_gpu_mem_gb:.1f} GiB but aggregate visible memory is "
-                f"{total_gpu_mem_gb:.1f} GiB across {inventory['gpu_count']} GPUs"
-            )
-            return "cuda", inventory, message, "auto_multi_gpu"
         message = (
             f"detected {max_single_gpu_mem_gb:.1f} GiB GPU memory but recipe recommends "
             f"{min_gpu_mem_gb:.1f} GiB"
@@ -113,13 +106,6 @@ def detect_device(
             raise RuntimeError(f"{message}; no CPU fallback is used")
         raise RuntimeError(f"unsupported device policy {policy}")
 
-    if inventory["gpu_count"] > 1:
-        return (
-            "cuda",
-            inventory,
-            f"using auto device_map across {inventory['gpu_count']} visible GPUs",
-            "auto_multi_gpu",
-        )
     return "cuda", inventory, None, "single_gpu"
 
 
@@ -208,20 +194,6 @@ def resolve_torch_dtype(preferred_dtype: str) -> tuple[torch.dtype | None, str]:
     return torch.float16, "float16"
 
 
-def build_max_memory_map(inventory: dict[str, Any]) -> dict[Any, str] | None:
-    per_gpu_mem_gb = inventory.get("per_gpu_mem_gb") or []
-    if not per_gpu_mem_gb:
-        return None
-
-    max_memory: dict[Any, str] = {}
-    for index, total_gb in enumerate(per_gpu_mem_gb):
-        reserve_gb = 4 if total_gb >= 32 else 2
-        usable_gb = max(1, int(total_gb - reserve_gb))
-        max_memory[index] = f"{usable_gb}GiB"
-    max_memory["cpu"] = "128GiB"
-    return max_memory
-
-
 class Runtime:
     def __init__(self, args: argparse.Namespace):
         self.args = args
@@ -261,10 +233,10 @@ class Runtime:
             self.compute_dtype_label = dtype_label
             if torch_dtype is not None:
                 model_kwargs["torch_dtype"] = torch_dtype
-            model_kwargs["device_map"] = "auto"
-            max_memory = build_max_memory_map(self.gpu_inventory)
-            if max_memory is not None:
-                model_kwargs["max_memory"] = max_memory
+            # Place the entire model on the single visible GPU. HIP_VISIBLE_DEVICES
+            # pins exactly one device, which torch sees as ordinal 0. Serving a
+            # model across multiple GPUs is not supported.
+            model_kwargs["device_map"] = {"": 0}
 
         self.model = AutoModelForCausalLM.from_pretrained(
             args.model_ref, **model_kwargs

--- a/engines/sglang/src/lib.rs
+++ b/engines/sglang/src/lib.rs
@@ -12,7 +12,7 @@ use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
     ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest, EndpointResponse, EngineCapabilities,
     EngineDeviceAvailability, EngineMethod, EngineRecipeHint, EngineRequestEnvelope,
-    EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse, InstallRequest,
+    EngineResponseEnvelope, GpuSelection, HealthcheckRequest, HealthcheckResponse, InstallRequest,
     InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse, ResolveModelRequest,
     ResolveModelResponse, StopRequest, StopResponse,
 };
@@ -67,6 +67,8 @@ enum CommandKind {
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
     Stdio,
     ServeHttp {
@@ -86,6 +88,8 @@ enum CommandKind {
         state_path: PathBuf,
         #[arg(long)]
         engine_recipe_json: Option<String>,
+        #[arg(long)]
+        gpu: Option<String>,
     },
 }
 
@@ -170,6 +174,7 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -179,6 +184,7 @@ pub fn run_cli() -> Result<()> {
             device_policy,
             runtime_id,
             env_id,
+            gpu,
         } => print_json(&launch_service(LaunchRequest {
             service_id,
             env_id,
@@ -189,6 +195,7 @@ pub fn run_cli() -> Result<()> {
             device_policy: Some(parse_device_policy_arg(device_policy.as_deref())?),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
         })?)?,
         CommandKind::Stdio => {
             let envelope = read_request()?;
@@ -204,12 +211,14 @@ pub fn run_cli() -> Result<()> {
             env_id,
             state_path,
             engine_recipe_json,
+            gpu,
         } => serve_http(ServeHttpRequest {
             service_id,
             model_ref,
             host,
             port,
             device_policy: parse_device_policy_arg(Some(&device_policy))?,
+            gpu_indices: parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -230,6 +239,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -241,6 +251,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         state_path,
@@ -348,11 +359,9 @@ fn capabilities() -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu: !cfg!(windows),
-        multi_gpu: !cfg!(windows),
         openai_compatible: true,
         tool_calling: false,
         quantized_models: "sglang-supported".to_owned(),
-        distributed_serving: !cfg!(windows),
         reasoning_parser: false,
     }
 }
@@ -476,6 +485,7 @@ fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
         host: request.host.clone(),
         port: request.port,
         device_policy,
+        gpu_indices: rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref()),
         runtime_id: request.runtime_id.clone(),
         env_id: request.env_id.clone(),
         state_path: state_path.clone(),
@@ -503,6 +513,7 @@ struct ServeHttpRequest {
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -562,6 +573,9 @@ fn spawn_sglang_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
+        command.env("HIP_VISIBLE_DEVICES", csv);
+    }
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -913,6 +927,20 @@ fn parse_device_policy_arg(policy: Option<&str>) -> Result<DevicePolicy> {
         "cpu" | "cpu_only" => Ok(DevicePolicy::CpuOnly),
         other => bail!("unsupported device policy: {other}"),
     }
+}
+
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
 }
 
 fn sglang_command_from_python(python: &Path) -> Option<PathBuf> {
@@ -1364,6 +1392,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_gpu_args_map_to_indices() {
+        assert_eq!(parse_gpu_indices_arg(None).unwrap(), Vec::<u32>::new());
+        assert_eq!(
+            parse_gpu_indices_arg(Some("auto")).unwrap(),
+            Vec::<u32>::new()
+        );
+        assert_eq!(parse_gpu_indices_arg(Some("3")).unwrap(), vec![3]);
+        assert!(parse_gpu_selection_arg(Some("x")).is_err());
+        assert!(parse_gpu_selection_arg(Some("1,3")).is_err());
+    }
+
+    #[test]
     fn cpu_policy_is_rejected_without_fallback() {
         let error = normalize_sglang_device_policy(Some(DevicePolicy::CpuOnly))
             .expect_err("SGLang CPU policy must fail");
@@ -1501,6 +1541,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1518,6 +1559,7 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
+            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1532,6 +1574,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
+            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 
@@ -1736,6 +1779,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11435,
             device_policy: DevicePolicy::GpuRequired,
+            gpu_indices: Vec::new(),
             runtime_id: Some("runtime-key-gfx120x".to_owned()),
             env_id: None,
             state_path: state_path.clone(),

--- a/engines/sglang/src/lib.rs
+++ b/engines/sglang/src/lib.rs
@@ -174,7 +174,6 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -573,9 +572,7 @@ fn spawn_sglang_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
-    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
-        command.env("HIP_VISIBLE_DEVICES", csv);
-    }
+    rocm_engine_protocol::apply_gpu_visibility(&mut command, &request.gpu_indices);
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -1541,7 +1538,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1559,7 +1555,6 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
-            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1574,7 +1569,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
-            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -12,7 +12,7 @@ use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
     ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest, EndpointResponse, EngineCapabilities,
     EngineDeviceAvailability, EngineMethod, EngineRecipeHint, EngineRequestEnvelope,
-    EngineResponseEnvelope, HealthcheckRequest, HealthcheckResponse, InstallRequest,
+    EngineResponseEnvelope, GpuSelection, HealthcheckRequest, HealthcheckResponse, InstallRequest,
     InstallResponse, LaunchRequest, LaunchResponse, LogsRequest, LogsResponse, ResolveModelRequest,
     ResolveModelResponse, StopRequest, StopResponse,
 };
@@ -65,6 +65,8 @@ enum CommandKind {
         #[arg(long)]
         device_policy: Option<String>,
         #[arg(long)]
+        gpu: Option<String>,
+        #[arg(long)]
         runtime_id: Option<String>,
         #[arg(long)]
         env_id: Option<String>,
@@ -79,6 +81,8 @@ enum CommandKind {
         port: u16,
         #[arg(long, default_value = "gpu_required")]
         device_policy: String,
+        #[arg(long)]
+        gpu: Option<String>,
         #[arg(long)]
         runtime_id: Option<String>,
         #[arg(long)]
@@ -164,6 +168,7 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -171,6 +176,7 @@ pub fn run_cli() -> Result<()> {
             host,
             port,
             device_policy,
+            gpu,
             runtime_id,
             env_id,
         } => print_json(&launch_service(LaunchRequest {
@@ -183,6 +189,7 @@ pub fn run_cli() -> Result<()> {
             device_policy: Some(parse_device_policy_arg(device_policy.as_deref())?),
             endpoint_mode: Some("openai".to_owned()),
             engine_recipe: None,
+            gpu_selection: parse_gpu_selection_arg(gpu.as_deref())?,
         })?)?,
         CommandKind::Stdio => {
             let envelope = read_request()?;
@@ -194,6 +201,7 @@ pub fn run_cli() -> Result<()> {
             host,
             port,
             device_policy,
+            gpu,
             runtime_id,
             env_id,
             state_path,
@@ -204,6 +212,7 @@ pub fn run_cli() -> Result<()> {
             host,
             port,
             device_policy: parse_device_policy_arg(Some(&device_policy))?,
+            gpu_indices: parse_gpu_indices_arg(gpu.as_deref())?,
             runtime_id,
             env_id,
             state_path,
@@ -224,6 +233,7 @@ pub fn builtin_serve_http(
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -235,6 +245,7 @@ pub fn builtin_serve_http(
         host,
         port,
         device_policy,
+        gpu_indices,
         runtime_id,
         env_id,
         state_path,
@@ -342,11 +353,9 @@ fn capabilities() -> EngineCapabilities {
     EngineCapabilities {
         cpu: false,
         rocm_gpu: !cfg!(windows),
-        multi_gpu: !cfg!(windows),
         openai_compatible: true,
         tool_calling: false,
         quantized_models: "vllm-supported".to_owned(),
-        distributed_serving: !cfg!(windows),
         reasoning_parser: false,
     }
 }
@@ -461,6 +470,7 @@ fn parse_engine_recipe_json(value: Option<String>) -> Result<Option<EngineRecipe
 fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
     let device_policy = normalize_vllm_device_policy(request.device_policy)?;
     let engine_recipe = accepted_engine_recipe(request.engine_recipe)?;
+    let gpu_indices = rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref());
     let runtime = resolve_vllm_runtime(request.runtime_id.as_deref())?;
     let state_path = AppPaths::discover()?
         .engine_state_dir(ENGINE_NAME)
@@ -471,6 +481,7 @@ fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
         host: request.host.clone(),
         port: request.port,
         device_policy,
+        gpu_indices,
         runtime_id: request.runtime_id.clone(),
         env_id: request.env_id.clone(),
         state_path: state_path.clone(),
@@ -498,6 +509,7 @@ struct ServeHttpRequest {
     host: String,
     port: u16,
     device_policy: DevicePolicy,
+    gpu_indices: Vec<u32>,
     runtime_id: Option<String>,
     env_id: Option<String>,
     state_path: PathBuf,
@@ -559,6 +571,9 @@ fn spawn_vllm_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
+    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
+        command.env("HIP_VISIBLE_DEVICES", csv);
+    }
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -860,6 +875,20 @@ fn parse_device_policy_arg(policy: Option<&str>) -> Result<DevicePolicy> {
         "cpu" | "cpu_only" => Ok(DevicePolicy::CpuOnly),
         other => bail!("unsupported device policy: {other}"),
     }
+}
+
+/// Parse a `--gpu` CLI value into an optional `GpuSelection` for `LaunchRequest`.
+fn parse_gpu_selection_arg(value: Option<&str>) -> Result<Option<GpuSelection>> {
+    value
+        .map(|raw| GpuSelection::parse_cli_value(raw).map_err(anyhow::Error::msg))
+        .transpose()
+}
+
+/// Parse a `--gpu` CLI value into explicit device ordinals (empty for `auto`).
+fn parse_gpu_indices_arg(value: Option<&str>) -> Result<Vec<u32>> {
+    Ok(rocm_engine_protocol::launch_gpu_indices(
+        parse_gpu_selection_arg(value)?.as_ref(),
+    ))
 }
 
 fn vllm_command_from_python(python: &Path) -> Option<PathBuf> {
@@ -1254,6 +1283,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_gpu_args_map_to_indices() {
+        assert_eq!(parse_gpu_indices_arg(None).unwrap(), Vec::<u32>::new());
+        assert_eq!(
+            parse_gpu_indices_arg(Some("auto")).unwrap(),
+            Vec::<u32>::new()
+        );
+        assert_eq!(parse_gpu_indices_arg(Some("2")).unwrap(), vec![2]);
+        assert!(parse_gpu_selection_arg(Some("nope")).is_err());
+        assert!(parse_gpu_selection_arg(Some("0,1")).is_err());
+    }
+
+    #[test]
     fn cpu_policy_is_rejected_without_fallback() {
         let error = normalize_vllm_device_policy(Some(DevicePolicy::CpuOnly))
             .expect_err("vLLM CPU policy must fail");
@@ -1352,6 +1393,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
+            gpu_selection: None,
         })?;
 
         assert_eq!(
@@ -1373,6 +1415,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
+            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1390,6 +1433,7 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
+            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1404,6 +1448,7 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
+            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 
@@ -1565,6 +1610,7 @@ mod tests {
             host: "127.0.0.1".to_owned(),
             port: 11439,
             device_policy: DevicePolicy::GpuRequired,
+            gpu_indices: Vec::new(),
             runtime_id: Some("runtime-key-gfx120x".to_owned()),
             env_id: None,
             state_path: state_path.clone(),

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -168,7 +168,6 @@ pub fn run_cli() -> Result<()> {
                 .transpose()?,
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?)?,
         CommandKind::Launch {
             service_id,
@@ -571,9 +570,7 @@ fn spawn_vllm_server(
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
     apply_therock_env(&mut command, runtime)?;
-    if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&request.gpu_indices) {
-        command.env("HIP_VISIBLE_DEVICES", csv);
-    }
+    rocm_engine_protocol::apply_gpu_visibility(&mut command, &request.gpu_indices);
     if let Some(log_path) = log_path {
         let log = fs::File::create(log_path)
             .with_context(|| format!("failed to create {}", log_path.display()))?;
@@ -1393,7 +1390,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: None,
-            gpu_selection: None,
         })?;
 
         assert_eq!(
@@ -1415,7 +1411,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(hint.clone()),
-            gpu_selection: None,
         })?;
 
         assert_eq!(response.engine_recipe, Some(hint));
@@ -1433,7 +1428,6 @@ mod tests {
                 "pytorch",
                 ENGINE_RECIPE_CONTRACT_VERSION,
             )),
-            gpu_selection: None,
         })
         .expect_err("mismatched engine recipe should fail");
 
@@ -1448,7 +1442,6 @@ mod tests {
             device_policy: Some(DevicePolicy::GpuRequired),
             recipe_override: None,
             engine_recipe: Some(test_engine_recipe(ENGINE_NAME, "999.0.0")),
-            gpu_selection: None,
         })
         .expect_err("unsupported recipe contract should fail");
 

--- a/skills/rocm-cli-assistant/SKILL.md
+++ b/skills/rocm-cli-assistant/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when answering ROCm CLI local assistant questions.
 - vLLM, SGLang, PyTorch, Lemonade, and llama.cpp are serving engines.
 - The built-in assistant is fixed to qwen served by Lemonade with GPU required. Do not switch the built-in assistant to vLLM or SGLang.
 - Installing an engine and running a model server are different states. Answer each separately when the user asks.
-- `rocm serve` accepts `--gpu auto|<index>` to pick the AMD GPU. `auto` (default) chooses the first GPU not used by a managed service; a single index pins one GPU. Serving one model across multiple GPUs is not supported. Do not suggest CPU fallback when a GPU is busy or out of range.
+- `rocm serve` accepts `--gpu auto|<index>` to pick the AMD GPU. `auto` (default) prefers a GPU that looks idle from `amd-smi` VRAM telemetry and is not already used by another rocm-cli server (managed or foreground), falling back to the GPU with the most free memory; a single index pins one GPU. Serving one model across multiple GPUs is not supported. Do not suggest CPU fallback when a GPU is busy or out of range.
 - On native Windows, vLLM and SGLang serving/install live checks are skipped; tell the user to use WSL/Linux for those ROCm GPU engines and do not suggest CPU fallback.
 
 ## ComfyUI

--- a/skills/rocm-cli-assistant/SKILL.md
+++ b/skills/rocm-cli-assistant/SKILL.md
@@ -21,6 +21,7 @@ Use this skill when answering ROCm CLI local assistant questions.
 - vLLM, SGLang, PyTorch, Lemonade, and llama.cpp are serving engines.
 - The built-in assistant is fixed to qwen served by Lemonade with GPU required. Do not switch the built-in assistant to vLLM or SGLang.
 - Installing an engine and running a model server are different states. Answer each separately when the user asks.
+- `rocm serve` accepts `--gpu auto|<index>` to pick the AMD GPU. `auto` (default) chooses the first GPU not used by a managed service; a single index pins one GPU. Serving one model across multiple GPUs is not supported. Do not suggest CPU fallback when a GPU is busy or out of range.
 - On native Windows, vLLM and SGLang serving/install live checks are skipped; tell the user to use WSL/Linux for those ROCm GPU engines and do not suggest CPU fallback.
 
 ## ComfyUI


### PR DESCRIPTION
This pull request adds support for selecting which AMD GPU a model server runs on in the ROCm CLI, including a new `--gpu` option for both foreground and managed serving. The change allows users to specify a GPU index or use an improved `auto` selection, and ensures the selected GPU(s) are tracked and passed through the system. Documentation is updated to explain the new option and its behavior.

**User-facing improvements:**

* Added a `--gpu` option to the `rocm serve` command, allowing users to specify either `auto` (the default, which selects an idle GPU with the most free memory) or a specific GPU index. This is reflected in both the CLI and the `README.md` documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R129) [[3]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R129-R130) [[4]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R234-R237)

**Core logic and data flow:**

* Updated the main CLI and service logic in `apps/rocm/src/main.rs` to accept, parse, and propagate the `--gpu` argument throughout the service startup, including for both foreground and managed services. [[1]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R1105) [[2]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R1118) [[3]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R1300) [[4]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R1312) [[5]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3527) [[6]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3553-R3555) [[7]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3588) [[8]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3613-R3629) [[9]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3658) [[10]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3678) [[11]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3736) [[12]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3759) [[13]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3781) [[14]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3916) [[15]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3939) [[16]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R3958) [[17]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R11068)

**Engine and subprocess integration:**

* Ensured the selected GPU indices are passed to engine subprocesses by updating the argument lists and environment variables, so the correct GPU(s) are exposed via `HIP_VISIBLE_DEVICES`. [[1]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13805) [[2]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13820) [[3]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13832) [[4]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13845) [[5]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13858) [[6]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13870) [[7]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13882) [[8]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13900) [[9]](diffhunk://#diff-85923bafe93886cd11cf9fc2a11c96d715facfd36cea9a7018b79526241f40a1R13919-R13921)


---

**Breaking change (called out per review):** This PR also removes the unused `multi_gpu` and `distributed_serving` fields from the shared `EngineCapabilities` type in `rocm-engine-protocol` across all six engines. This is a serde-incompatible change to a shared contract type: any persisted/cached `EngineCapabilities` blob serialized by an older build that relied on those keys would no longer round-trip. The fields are not read by any current in-workspace consumer (capabilities are recomputed at runtime, not loaded from durable storage), so there is no functional regression for current callers; the note is here so maintainers can flag any out-of-tree consumer before merge.
