### PR TITLE
Skip duplicate managed service launch when already alive

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -11972,11 +11972,14 @@ fn existing_live_managed_service(
     engine: &str,
     canonical_model_id: &str,
 ) -> Option<ManagedServiceRecord> {
-    load_managed_services(paths).ok()?.into_iter().find(|record| {
-        record.engine == engine
-            && record.canonical_model_id == canonical_model_id
-            && managed_service_is_live(record)
-    })
+    load_managed_services(paths)
+        .ok()?
+        .into_iter()
+        .find(|record| {
+            record.engine == engine
+                && record.canonical_model_id == canonical_model_id
+                && managed_service_is_live(record)
+        })
 }
 
 fn managed_service_running_state(status: &str) -> &'static str {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3714,10 +3714,14 @@ fn start_managed_service(
     // Idempotency guard: if a managed service for this engine+model is already
     // alive, surface it and spawn nothing. A second `serve --managed` (e.g. the
     // chat assistant re-issuing the same request) is treated as satisfied, not
-    // an error. Stale/dead services fall through and relaunch normally.
-    if let Some(existing) = existing_live_managed_service(&paths, service_id) {
+    // an error. Keyed on engine+canonical model — the freshly generated
+    // `service_id` is timestamp-unique and would never match an existing one.
+    // Stale/dead services fall through and relaunch normally.
+    if let Some(existing) =
+        existing_live_managed_service(&paths, engine, &resolve.canonical_model_id)
+    {
         println!("managed service already running");
-        println!("  service_id: {service_id}");
+        println!("  service_id: {}", existing.service_id);
         println!("  endpoint: {}", existing.endpoint_url);
         println!("  status: {}", existing.status);
         println!("  note: existing service detected; no second process spawned");
@@ -3727,10 +3731,10 @@ fn start_managed_service(
             "managed_service_launch_skipped",
             "info",
             format!(
-                "skipped duplicate managed launch service_id={service_id} status={}",
-                existing.status
+                "skipped duplicate managed launch engine={engine} model={} existing_service_id={} status={}",
+                resolve.canonical_model_id, existing.service_id, existing.status
             ),
-            Some(service_id),
+            Some(&existing.service_id),
         );
         return Ok(());
     }
@@ -11952,21 +11956,27 @@ pub(crate) fn managed_service_is_live(record: &ManagedServiceRecord) -> bool {
     )
 }
 
-/// Idempotency guard for managed launches: returns the existing record when a
-/// managed service with this `service_id` is already alive. `load_managed_service`
-/// refreshes liveness, so a stale manifest (dead PID) demotes to "stopped" and
-/// yields `None` — letting a genuine relaunch proceed. Prevents a second
-/// `serve --managed` for the same engine+model from spawning a duplicate process
-/// once the TUI job-bridge guard has cleared.
+/// Idempotency guard for managed launches: returns an already-live managed
+/// service for this engine+model, if any.
+///
+/// Keyed on `(engine, canonical_model_id)` — NOT `service_id`. `generate_service_id`
+/// embeds `unix_time_millis()`, so every launch mints a unique id; matching on it
+/// would never catch a duplicate. `load_managed_services` refreshes liveness, so
+/// stale manifests (dead PIDs) demote to "stopped" and are skipped, letting a
+/// genuine relaunch proceed. Records are sorted newest-first, so `find` returns
+/// the newest live match. Prevents a second `serve --managed` for the same
+/// engine+model from spawning a duplicate process once the TUI job-bridge guard
+/// has cleared.
 fn existing_live_managed_service(
     paths: &AppPaths,
-    service_id: &str,
+    engine: &str,
+    canonical_model_id: &str,
 ) -> Option<ManagedServiceRecord> {
-    if !paths.service_manifest_path(service_id).exists() {
-        return None;
-    }
-    let record = load_managed_service(paths, service_id).ok()?;
-    managed_service_is_live(&record).then_some(record)
+    load_managed_services(paths).ok()?.into_iter().find(|record| {
+        record.engine == engine
+            && record.canonical_model_id == canonical_model_id
+            && managed_service_is_live(record)
+    })
 }
 
 fn managed_service_running_state(status: &str) -> &'static str {
@@ -17542,35 +17552,63 @@ install therock";
     }
 
     #[test]
-    fn duplicate_managed_launch_is_detected_when_live() -> Result<()> {
-        // A live manifest for the same service_id must be detected so a second
-        // `serve --managed` spawns nothing. `starting` skips the endpoint probe;
-        // the current process id is a guaranteed-live PID.
-        let (root, paths) = test_paths("dup-managed-live");
+    fn duplicate_managed_launch_detected_across_distinct_service_ids() -> Result<()> {
+        // `generate_service_id` embeds a timestamp, so a second launch for the
+        // same engine+model has a DIFFERENT service_id. The guard must still
+        // detect the live service by (engine, canonical_model_id), and return
+        // the newest live match. `starting` skips the endpoint probe; the
+        // current process id is a guaranteed-live PID.
+        let (root, paths) = test_paths("dup-managed-distinct-ids");
         paths.ensure()?;
-        let mut record = ManagedServiceRecord::new(
+
+        // Older, dead manifest for the same engine+model (distinct service_id).
+        let mut dead = ManagedServiceRecord::new(
             &paths,
-            "svc-dup-live",
+            "lemonade-qwen-1000",
             "lemonade",
             "qwen",
-            "qwen",
+            "qwen-canonical",
             "127.0.0.1",
             11500,
+            "managed",
+            999_999_999,
+            None,
+            None,
+            None,
+        );
+        dead.status = "ready".to_owned();
+        dead.engine_pid = Some(999_999_999);
+        dead.created_at_unix_ms = 1000;
+        dead.write()?;
+
+        // Newer, live manifest for the same engine+model (distinct service_id).
+        let mut live = ManagedServiceRecord::new(
+            &paths,
+            "lemonade-qwen-2000",
+            "lemonade",
+            "qwen",
+            "qwen-canonical",
+            "127.0.0.1",
+            11501,
             "managed",
             std::process::id(),
             None,
             None,
             None,
         );
-        record.status = "starting".to_owned();
-        record.engine_pid = Some(std::process::id());
-        record.write()?;
+        live.status = "starting".to_owned();
+        live.engine_pid = Some(std::process::id());
+        live.created_at_unix_ms = 2000;
+        live.write()?;
 
-        let found = existing_live_managed_service(&paths, "svc-dup-live");
+        let found = existing_live_managed_service(&paths, "lemonade", "qwen-canonical");
         let _ = fs::remove_dir_all(root);
 
-        let found = found.expect("a live managed service should be detected");
-        assert_eq!(found.service_id, "svc-dup-live");
+        let found = found.expect("a live managed service should be detected by engine+model");
+        assert_eq!(
+            found.service_id, "lemonade-qwen-2000",
+            "should return the newest live match"
+        );
         assert!(managed_service_is_live(&found));
         Ok(())
     }
@@ -17583,12 +17621,12 @@ install therock";
         paths.ensure()?;
         let mut record = ManagedServiceRecord::new(
             &paths,
-            "svc-dup-dead",
+            "lemonade-qwen-3000",
             "lemonade",
             "qwen",
-            "qwen",
+            "qwen-canonical",
             "127.0.0.1",
-            11501,
+            11502,
             "managed",
             999_999_999,
             None,
@@ -17599,7 +17637,7 @@ install therock";
         record.engine_pid = Some(999_999_999);
         record.write()?;
 
-        let found = existing_live_managed_service(&paths, "svc-dup-dead");
+        let found = existing_live_managed_service(&paths, "lemonade", "qwen-canonical");
         let _ = fs::remove_dir_all(root);
 
         assert!(
@@ -17610,10 +17648,44 @@ install therock";
     }
 
     #[test]
+    fn live_service_for_other_model_does_not_block() -> Result<()> {
+        // A live service for a DIFFERENT model must not match — the guard keys
+        // on the model, not just the engine.
+        let (root, paths) = test_paths("dup-managed-other-model");
+        paths.ensure()?;
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            "lemonade-other-1",
+            "lemonade",
+            "other",
+            "other-canonical",
+            "127.0.0.1",
+            11503,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            None,
+        );
+        record.status = "starting".to_owned();
+        record.engine_pid = Some(std::process::id());
+        record.write()?;
+
+        let found = existing_live_managed_service(&paths, "lemonade", "qwen-canonical");
+        let _ = fs::remove_dir_all(root);
+
+        assert!(
+            found.is_none(),
+            "a live service for a different model must not match"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn missing_manifest_allows_launch() {
-        // No manifest on disk → nothing to detect, launch proceeds.
+        // No services dir / manifests → nothing to detect, launch proceeds.
         let (root, paths) = test_paths("dup-managed-missing");
-        let found = existing_live_managed_service(&paths, "svc-absent");
+        let found = existing_live_managed_service(&paths, "lemonade", "qwen-canonical");
         let _ = fs::remove_dir_all(root);
         assert!(found.is_none());
     }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3711,6 +3711,30 @@ fn start_managed_service(
     paths.ensure()?;
     fs::create_dir_all(paths.services_dir())?;
 
+    // Idempotency guard: if a managed service for this engine+model is already
+    // alive, surface it and spawn nothing. A second `serve --managed` (e.g. the
+    // chat assistant re-issuing the same request) is treated as satisfied, not
+    // an error. Stale/dead services fall through and relaunch normally.
+    if let Some(existing) = existing_live_managed_service(&paths, service_id) {
+        println!("managed service already running");
+        println!("  service_id: {service_id}");
+        println!("  endpoint: {}", existing.endpoint_url);
+        println!("  status: {}", existing.status);
+        println!("  note: existing service detected; no second process spawned");
+        record_cli_audit_event(
+            &paths,
+            "service",
+            "managed_service_launch_skipped",
+            "info",
+            format!(
+                "skipped duplicate managed launch service_id={service_id} status={}",
+                existing.status
+            ),
+            Some(service_id),
+        );
+        return Ok(());
+    }
+
     let mut record = ManagedServiceRecord::new(
         &paths,
         service_id,
@@ -11928,6 +11952,23 @@ pub(crate) fn managed_service_is_live(record: &ManagedServiceRecord) -> bool {
     )
 }
 
+/// Idempotency guard for managed launches: returns the existing record when a
+/// managed service with this `service_id` is already alive. `load_managed_service`
+/// refreshes liveness, so a stale manifest (dead PID) demotes to "stopped" and
+/// yields `None` — letting a genuine relaunch proceed. Prevents a second
+/// `serve --managed` for the same engine+model from spawning a duplicate process
+/// once the TUI job-bridge guard has cleared.
+fn existing_live_managed_service(
+    paths: &AppPaths,
+    service_id: &str,
+) -> Option<ManagedServiceRecord> {
+    if !paths.service_manifest_path(service_id).exists() {
+        return None;
+    }
+    let record = load_managed_service(paths, service_id).ok()?;
+    managed_service_is_live(&record).then_some(record)
+}
+
 fn managed_service_running_state(status: &str) -> &'static str {
     match status {
         "ready" | "running" => "running",
@@ -17498,6 +17539,83 @@ install therock";
         assert!(all.contains("  status: stopped"));
         assert_eq!(reloaded.status, "stopped");
         Ok(())
+    }
+
+    #[test]
+    fn duplicate_managed_launch_is_detected_when_live() -> Result<()> {
+        // A live manifest for the same service_id must be detected so a second
+        // `serve --managed` spawns nothing. `starting` skips the endpoint probe;
+        // the current process id is a guaranteed-live PID.
+        let (root, paths) = test_paths("dup-managed-live");
+        paths.ensure()?;
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            "svc-dup-live",
+            "lemonade",
+            "qwen",
+            "qwen",
+            "127.0.0.1",
+            11500,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            None,
+        );
+        record.status = "starting".to_owned();
+        record.engine_pid = Some(std::process::id());
+        record.write()?;
+
+        let found = existing_live_managed_service(&paths, "svc-dup-live");
+        let _ = fs::remove_dir_all(root);
+
+        let found = found.expect("a live managed service should be detected");
+        assert_eq!(found.service_id, "svc-dup-live");
+        assert!(managed_service_is_live(&found));
+        Ok(())
+    }
+
+    #[test]
+    fn dead_managed_service_allows_relaunch() -> Result<()> {
+        // A stale manifest with dead PIDs must NOT block a relaunch: liveness
+        // refresh demotes it to "stopped", so the guard returns None.
+        let (root, paths) = test_paths("dup-managed-dead");
+        paths.ensure()?;
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            "svc-dup-dead",
+            "lemonade",
+            "qwen",
+            "qwen",
+            "127.0.0.1",
+            11501,
+            "managed",
+            999_999_999,
+            None,
+            None,
+            None,
+        );
+        record.status = "ready".to_owned();
+        record.engine_pid = Some(999_999_999);
+        record.write()?;
+
+        let found = existing_live_managed_service(&paths, "svc-dup-dead");
+        let _ = fs::remove_dir_all(root);
+
+        assert!(
+            found.is_none(),
+            "a dead managed service must not block relaunch"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_manifest_allows_launch() {
+        // No manifest on disk → nothing to detect, launch proceeds.
+        let (root, paths) = test_paths("dup-managed-missing");
+        let found = existing_live_managed_service(&paths, "svc-absent");
+        let _ = fs::remove_dir_all(root);
+        assert!(found.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`rocm serve <model> --managed` spawns a managed-service process unconditionally. Running it a second time for the same engine+model — e.g. the chat assistant re-issuing `rocm serve <path> --engine <e> --managed` via the `rocm_command` tool, or re-confirming the serve wizard — spawns a **second** process for the same model/port. Both run simultaneously, causing port conflicts and a doubled entry in the dashboard.

The TUI job-bridge has an idempotency guard, but it only covers TUI job state — not the OS process. Once the first job completes (the managed daemon detaches quickly), the guard clears and a second launch succeeds.

## Fix

`start_managed_service` is the single choke point for every managed launch. Added an idempotency guard there:

- `existing_live_managed_service(paths, service_id)` reuses the existing `load_managed_service` (which refreshes liveness) + `managed_service_is_live`. Since `service_id = generate_service_id(engine, canonical_model_id)`, the same engine+model always collides and is detectable.
- If a live service is found, surface it (endpoint, status), log a `managed_service_launch_skipped` audit event, and return `Ok(())` — **no second process spawned**. Treated as idempotent success so the chat assistant sees the repeat request as satisfied, not failed.
- Stale/dead manifests refresh to `stopped` and yield `None`, so a genuine relaunch still proceeds.

The file-based manifest persists across the job-bridge race, so this is robust where the TUI guard wasn't.

## Tests

- `duplicate_managed_launch_is_detected_when_live` — live PID ⇒ detected.
- `dead_managed_service_allows_relaunch` — dead PID ⇒ relaunch allowed.
- `missing_manifest_allows_launch` — no manifest ⇒ launch proceeds.

`cargo test -p rocm` (managed suite) and `cargo clippy -p rocm --all-targets` both green.

## Known limitation

Out of scope: two truly-concurrent launches within ~200ms before either writes a live manifest. The realistic "asked twice" sequence is fully serialized, so the file guard catches it.