### PR TITLE
Add missing SPDX license headers + hawkeye pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,17 @@ repos:
       - id: shellcheck
         args: [--enable=all, --exclude=SC2310,SC2312]
 
+  # License headers: mirrors the korandoru/hawkeye CI check.
+  # Requires: cargo install hawkeye
+  - repo: local
+    hooks:
+      - id: license-headers
+        name: license header check (hawkeye)
+        entry: hawkeye check --config licenserc.toml
+        language: system
+        types_or: [rust, python, shell]
+        pass_filenames: false
+
   # Rust + PowerShell: mirror the CI checks using the local toolchain.
   - repo: local
     hooks:

--- a/apps/rocm/src/dash_seam.rs
+++ b/apps/rocm/src/dash_seam.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Bin-side implementation of the dash execution seam.
 //!
 //! The dash crates stay free of `rocm-core`; this module lives in the bin

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Integration test proving `rocm daemon` runs the real foreground automation
 //! loop (embedded `rocmd`) instead of only printing the status panel.
 //!

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! ROCm failure-mode diagnosis.
 //!
 //! Rust port of the `rocm-doctor` skill's `diagnose.py`. It matches an

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Host examination probe.
 //!
 //! Rust port of the `rocm-doctor` skill's `examine.py`. It gathers the host

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Apply remediations for diagnosed ROCm failure modes.
 //!
 //! Rust port of the `rocm-doctor` skill's `apply_fix.py`. Only small, safe,

--- a/crates/rocm-dash-tui/src/tool_exec.rs
+++ b/crates/rocm-dash-tui/src/tool_exec.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! rocm-core-free tool-call boundary (the execution seam).
 //!
 //! Plain-data signatures ONLY (serde_json / std / serde). The bin (`apps/rocm`,


### PR DESCRIPTION
## Summary

- Adds the `// Copyright Advanced Micro Devices, Inc. / SPDX-License-Identifier: Apache-2.0` header to six source files introduced without it (`fix.rs`, `diagnose.rs`, `examine.rs`, `tool_exec.rs`, `dash_seam.rs`, `daemon_run.rs`), fixing the failing [hawkeye CI job](https://github.com/ROCm/rocm-cli/actions/runs/28096718158/job/83187957883).
- Wires the hawkeye check into `.pre-commit-config.yaml` as a local hook so license headers are validated before every commit going forward.

## Test plan

- [x] CI hawkeye job passes on this PR
- [x] `hawkeye check --config licenserc.toml` passes locally
- [x] `prek run --all-files` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)