### PR TITLE
Add missing Apache-2.0 license headers

### DIFF
--- a/apps/rocm/src/dash_seam.rs
+++ b/apps/rocm/src/dash_seam.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Bin-side implementation of the dash execution seam.
 //!
 //! The dash crates stay free of `rocm-core`; this module lives in the bin

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Integration test proving `rocm daemon` runs the real foreground automation
 //! loop (embedded `rocmd`) instead of only printing the status panel.
 //!

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! ROCm failure-mode diagnosis.
 //!
 //! Rust port of the `rocm-doctor` skill's `diagnose.py`. It matches an

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Host examination probe.
 //!
 //! Rust port of the `rocm-doctor` skill's `examine.py`. It gathers the host

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Apply remediations for diagnosed ROCm failure modes.
 //!
 //! Rust port of the `rocm-doctor` skill's `apply_fix.py`. Only small, safe,

--- a/crates/rocm-dash-tui/src/tool_exec.rs
+++ b/crates/rocm-dash-tui/src/tool_exec.rs
@@ -1,3 +1,7 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! rocm-core-free tool-call boundary (the execution seam).
 //!
 //! Plain-data signatures ONLY (serde_json / std / serde). The bin (`apps/rocm`,


### PR DESCRIPTION
## Problem

The hawkeye **License header check** is red across the repo. Six source files already on `main` are missing the SPDX header that `licenserc.toml` mandates, so the check fails on `main` and on every open PR (hawkeye scans the whole tree, not just the diff).

Affected files:
- `apps/rocm/src/dash_seam.rs`
- `apps/rocm/tests/daemon_run.rs`
- `crates/rocm-core/src/diagnose.rs`
- `crates/rocm-core/src/examine.rs`
- `crates/rocm-core/src/fix.rs`
- `crates/rocm-dash-tui/src/tool_exec.rs`

## Fix

Prepend the standard header (per `licenserc.toml`) to each file:

```rust
// Copyright Advanced Micro Devices, Inc.
//
// SPDX-License-Identifier: Apache-2.0
```

Header-only change — no code touched. After merge, rebasing open PRs clears the license check for them too.