### PR TITLE
Enforce signed and signed-off commits via hooks and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,25 +228,37 @@ jobs:
   commit-signatures:
     name: Commit signatures + sign-off
     runs-on: ubuntu-latest
-    # Only meaningful for PRs, where a base branch defines the commit range.
-    if: github.event_name == 'pull_request'
+    # Runs on pull requests and in the merge queue. Both define a base that
+    # bounds the commit range. Handling `merge_group` matters once this is a
+    # *required* check: the queue fires `merge_group` (not `pull_request`), so a
+    # job gated to PRs only would never produce the required check and the queue
+    # entry would stall forever.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Check out the PR head commit, not the synthetic refs/pull/N/merge
-          # commit (which is unsigned and lacks a sign-off, and would otherwise
-          # appear in origin/<base>..HEAD and fail the gate on every PR).
-          ref: ${{ github.event.pull_request.head.sha }}
+          # PR: check out the PR head, not the synthetic refs/pull/N/merge commit
+          # (which is unsigned and lacks a sign-off, and would otherwise appear
+          # in origin/<base>..HEAD and fail the gate on every PR).
+          # merge_group: check out the queue head — the rebased/squashed commits
+          # GitHub built for the group. Merge commits are disabled on this repo,
+          # so these are normal commits that preserve their Signed-off-by trailer
+          # and are GitHub "Verified" (web-flow signed).
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Verify commits are signed and signed-off
         # `--require-verified` shells out to the `gh` CLI; pass the job token so
         # `gh api` is authenticated (avoids the unauthenticated rate limit).
+        # Base: the PR's base branch, or — in the queue — the exact commit the
+        # merge group was built on (`base_sha`), so the range is just the queued
+        # commits and not whatever else has since landed on the base branch.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo xtask verify-commits --base origin/${{ github.base_ref }} --require-verified
+          BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.merge_group.base_sha }}
+        run: cargo xtask verify-commits --base "$BASE" --require-verified
 
   # Hardware (real AMD GPU / WSL) smoke tests on dedicated self-hosted runners
   # are intentionally not part of this workflow yet. See

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,29 @@ jobs:
       - name: Check license headers
         uses: korandoru/hawkeye@v6
 
+  commit-signatures:
+    name: Commit signatures + sign-off
+    runs-on: ubuntu-latest
+    # Only meaningful for PRs, where a base branch defines the commit range.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # Check out the PR head commit, not the synthetic refs/pull/N/merge
+          # commit (which is unsigned and lacks a sign-off, and would otherwise
+          # appear in origin/<base>..HEAD and fail the gate on every PR).
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Verify commits are signed and signed-off
+        # `--require-verified` shells out to the `gh` CLI; pass the job token so
+        # `gh api` is authenticated (avoids the unauthenticated rate limit).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo xtask verify-commits --base origin/${{ github.base_ref }} --require-verified
+
   # Hardware (real AMD GPU / WSL) smoke tests on dedicated self-hosted runners
   # are intentionally not part of this workflow yet. See
   # docs/ci-hardware-testing.md for the planned design; they will land in a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,24 @@ repos:
       - id: shellcheck
         args: [--enable=all, --exclude=SC2310,SC2312]
 
+  # Commit trust: signing + DCO sign-off are enforced, not just policy.
+  # `--check-config` is a fast local-config assertion run on every commit;
+  # the full range verification is deferred to pre-push (and mirrored in CI).
+  - repo: local
+    hooks:
+      - id: commit-signing-configured
+        name: commit signing configured
+        entry: cargo xtask verify-commits --check-config
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: verify-commits
+        name: verify commits are signed and signed-off
+        entry: cargo xtask verify-commits
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
   # License headers: mirrors the korandoru/hawkeye CI check.
   # Requires: cargo install hawkeye
   - repo: local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ Identity requirements stay intact:
 - include DCO sign-off (`git commit -s`)
 - keep commit signing enabled when configured; do not bypass with `--no-gpg-sign`, `-n`, or `--no-verify`
 
+Signing and sign-off are now **enforced**, not just policy: local prek hooks
+check signing config on every commit (`commit-signing-configured`) and verify
+the full range on push (`verify-commits`), and a blocking CI gate
+(`commit-signatures`) re-checks every PR with GitHub "Verified" status. See
+`docs/commit-signatures.md`.
+
 Content restrictions for upstream surfaces:
 
 - do not include internal/proprietary names, aliases, URLs, hostnames, gateways, cluster names, or registry paths

--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ prek install -t pre-push    # heavier checks on push (clippy + tests)
 prek run --all-files        # run everything against the whole tree
 ```
 
+Commits must be both cryptographically **signed** and carry a DCO
+**`Signed-off-by`** trailer (use `git commit -s`). This is enforced by the
+prek hooks above and by a blocking CI check. Enable signing once with:
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+See `docs/commit-signatures.md` for details (GPG signing, GitHub "Verified", and troubleshooting).
+
 ## More docs
 
 - Testing and verification: `docs/testing.md`

--- a/docs/commit-signatures.md
+++ b/docs/commit-signatures.md
@@ -1,0 +1,135 @@
+# Commit Signatures and Sign-off
+
+Every commit that lands in this repository must be:
+
+1. **Cryptographically signed** — so authorship is verifiable and history
+   cannot be silently forged or impersonated.
+2. **Signed-off** — a DCO `Signed-off-by:` trailer, certifying you have the
+   right to submit the change under the project license.
+
+Both requirements are **enforced**, not advisory: local git hooks reject
+non-conforming commits before they leave your machine, and a blocking CI gate
+rejects them on every pull request.
+
+## Setting Up Signing
+
+You can sign with SSH (simplest if you already have an SSH key) or GPG.
+
+### SSH signing
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+### GPG signing
+
+```bash
+git config --global gpg.format openpgp        # the default
+git config --global user.signingkey <your-gpg-key-id>
+git config --global commit.gpgsign true
+```
+
+With `commit.gpgsign true` set, commits are signed automatically. Add the
+sign-off trailer with `-s`:
+
+```bash
+git commit -s -m "Your message"
+```
+
+To add sign-off to a range of existing commits:
+
+```bash
+git rebase --signoff <base>
+```
+
+## Registering Your Key on GitHub (required for CI)
+
+CI uses **strict** verification: it asks GitHub whether each commit's signature
+is `verified`. For GitHub to report a commit as **Verified** you must:
+
+- Add your signing key under **Settings → SSH and GPG keys** (an SSH *signing*
+  key, or your GPG public key).
+- Ensure the email in your committer identity is a **verified email** on your
+  GitHub account.
+
+If either is missing, the signature exists but GitHub will not mark it
+"Verified", and the CI gate will fail.
+
+## How Enforcement Works
+
+### Local hooks (prek)
+
+The hooks are defined in `.pre-commit-config.yaml`. Install them once:
+
+```bash
+prek install                # pre-commit
+prek install -t pre-push    # pre-push
+```
+
+- **pre-commit**: `cargo xtask verify-commits --check-config` — a fast check
+  that `commit.gpgsign` is `true` and `user.signingkey` is set, with
+  remediation if not.
+- **pre-push**: `cargo xtask verify-commits` — verifies every outgoing commit
+  in `origin/main..HEAD` is signed (signature present and not bad) and
+  signed-off.
+
+### CI gate
+
+The `commit-signatures` job in `.github/workflows/ci.yml` runs on pull requests:
+
+```bash
+cargo xtask verify-commits --base origin/<base-branch> --require-verified
+```
+
+`--require-verified` switches on strict mode (GitHub "Verified" via the `gh`
+CLI). The job checks out with `fetch-depth: 0` so the base ref and all PR
+commits are available. Mark it as a required check in branch protection / your
+repository ruleset so it blocks merges.
+
+### The xtask check
+
+`cargo xtask verify-commits` is the single source of truth for the logic:
+
+| Flag                | Meaning                                                           |
+| ------------------- | ---------------------------------------------------------------- |
+| `--base <ref>`      | Base ref; checks `<base>..HEAD`. Defaults to `GITHUB_BASE_REF` (as `origin/<branch>`) in CI, else `origin/main`. |
+| `--require-verified`| Strict mode: require GitHub's `verification.verified` (needs `gh`). |
+| `--check-config`    | Instead of checking commits, assert local signing is configured. |
+
+An empty commit range is treated as success.
+
+## Native GitHub Ruleset (Complementary)
+
+GitHub can natively **require signed commits** via a repository ruleset. Enable
+it as defense-in-depth alongside the in-repo check:
+
+```bash
+gh api -X POST /repos/<owner>/<repo>/rulesets \
+  --input - <<'JSON'
+{
+  "name": "Require signed commits",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "required_signatures" }
+  ]
+}
+JSON
+```
+
+The native ruleset is useful but has **two gaps** that the `verify-commits`
+xtask check exists to close:
+
+1. **It does not apply to pull requests from forks.** Fork PRs can carry
+   unsigned commits that the native rule will not block; the CI gate runs on
+   every PR regardless of source.
+2. **It cannot enforce DCO sign-off.** The native rule only checks signatures,
+   not the `Signed-off-by` trailer.
+
+Run both: the native ruleset for the merge-to-protected-branch path, and the
+xtask check (local hooks + CI) for signatures *and* sign-off on every PR.

--- a/docs/commit-signatures.md
+++ b/docs/commit-signatures.md
@@ -69,15 +69,18 @@ prek install -t pre-push    # pre-push
 ```
 
 - **pre-commit**: `cargo xtask verify-commits --check-config` — a fast check
-  that `commit.gpgsign` is `true` and `user.signingkey` is set, with
-  remediation if not.
+  that commit signing is enabled (`commit.gpgsign`, in any of git's truthy
+  spellings) and `user.signingkey` is set, with remediation if not.
 - **pre-push**: `cargo xtask verify-commits` — verifies every outgoing commit
   in `origin/main..HEAD` is signed (signature present and not bad) and
-  signed-off.
+  signed-off. The base is fixed at `origin/main`, so keep it fetched
+  (`git fetch origin main`); on a branch targeting a different base, run the
+  check manually with `--base <ref>` for an accurate range.
 
 ### CI gate
 
-The `commit-signatures` job in `.github/workflows/ci.yml` runs on pull requests:
+The `commit-signatures` job in `.github/workflows/ci.yml` runs on pull requests
+and in the merge queue:
 
 ```bash
 cargo xtask verify-commits --base origin/<base-branch> --require-verified
@@ -85,7 +88,10 @@ cargo xtask verify-commits --base origin/<base-branch> --require-verified
 
 `--require-verified` switches on strict mode (GitHub "Verified" via the `gh`
 CLI). The job checks out with `fetch-depth: 0` so the base ref and all PR
-commits are available. Mark it as a required check in branch protection / your
+commits are available. On a `merge_group` event it verifies the queued commits
+against the queue's base (`merge_group.base_sha..head_sha`) instead of a PR
+base — so the check still runs in the queue and can safely be made *required*
+without stalling it. Mark it as a required check in branch protection / your
 repository ruleset so it blocks merges.
 
 ### The xtask check

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,8 @@
 //! project's signing, CI verification, and test keygen no longer depend on the
 //! `openssl` CLI. Run via the workspace alias `cargo xtask <command>`.
 
+mod verify_commits;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitCode};
@@ -67,6 +69,22 @@ enum Command {
         /// Verify the table is up to date without writing; exit non-zero if it would change.
         #[arg(long)]
         check: bool,
+    },
+    /// Verify that commits in a range are cryptographically signed and carry a
+    /// DCO `Signed-off-by` trailer.
+    VerifyCommits {
+        /// Base ref for the `<base>..HEAD` range. Defaults to the PR base branch
+        /// (`origin/$GITHUB_BASE_REF`) in CI, otherwise `origin/main`.
+        #[arg(long)]
+        base: Option<String>,
+        /// Strict mode: require GitHub to report each signature as "Verified"
+        /// (shells out to the `gh` CLI). Mutually exclusive with `--check-config`.
+        #[arg(long, conflicts_with = "check_config")]
+        require_verified: bool,
+        /// Assert only that commit signing is configured locally, without
+        /// inspecting any commits. Mutually exclusive with `--base`/`--require-verified`.
+        #[arg(long, conflicts_with_all = ["base", "require_verified"])]
+        check_config: bool,
     },
 }
 
@@ -263,6 +281,20 @@ fn run() -> Result<()> {
             verify_rsa_pkcs1_sha256_signature(&public_pem, &payload, &signature_bytes, &label)?;
         }
         Command::Manifest { check } => run_manifest(check)?,
+        Command::VerifyCommits {
+            base,
+            require_verified,
+            check_config,
+        } => {
+            // `--check-config` is declared `conflicts_with_all = ["base",
+            // "require_verified"]`, so clap rejects those combinations before we
+            // get here.
+            if check_config {
+                verify_commits::check_config()?;
+            } else {
+                verify_commits::run(base, require_verified)?;
+            }
+        }
     }
     Ok(())
 }

--- a/xtask/src/verify_commits.rs
+++ b/xtask/src/verify_commits.rs
@@ -292,12 +292,14 @@ pub fn run(base: Option<String>, require_verified: bool) -> Result<()> {
 /// Entry point for the `--check-config` mode: assert that commit signing is
 /// configured locally (used by the fast pre-commit hook).
 pub fn check_config() -> Result<()> {
-    let gpgsign = git(&["config", "--get", "commit.gpgsign"])
-        .unwrap_or_default()
-        .to_ascii_lowercase();
+    // `--type=bool` normalizes git's truthy spellings (`true`/`1`/`yes`/`on`,
+    // any case) to the literal `true`, matching what git itself treats as
+    // "signing on". A plain `--get` would only catch the literal `true` and
+    // wrongly report e.g. `commit.gpgsign = 1` as unconfigured.
+    let gpgsign = git(&["config", "--type=bool", "--get", "commit.gpgsign"]).unwrap_or_default();
     let signingkey = git(&["config", "--get", "user.signingkey"]).unwrap_or_default();
 
-    let signing_enabled = gpgsign == "true";
+    let signing_enabled = gpgsign.trim() == "true";
     let key_set = !signingkey.trim().is_empty();
     if signing_enabled && key_set {
         return Ok(());

--- a/xtask/src/verify_commits.rs
+++ b/xtask/src/verify_commits.rs
@@ -1,0 +1,468 @@
+// Copyright Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: MIT
+
+//! Commit-trust enforcement: verify that every commit in a range is both
+//! cryptographically signed and carries a DCO `Signed-off-by` trailer.
+//!
+//! The decision logic ([`evaluate_commits`]) is pure and operates on already
+//! collected per-commit data so it can be unit-tested without git or network
+//! access. The git/`gh` I/O lives at the edges ([`collect_commits`],
+//! [`verified_via_github`]).
+
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+/// Default base ref used when none is supplied on the command line.
+const DEFAULT_BASE: &str = "origin/main";
+
+/// One commit's data, as gathered from git (and optionally GitHub), in the
+/// structured form the pure decision logic consumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitInfo {
+    /// Abbreviated commit hash, for reporting.
+    pub short_sha: String,
+    /// First line of the commit message.
+    pub subject: String,
+    /// Signature status as reported by `git log --format=%G?`.
+    ///
+    /// `N` = no signature, `B` = bad signature; any other value
+    /// (`G`/`U`/`E`/`X`/`Y`/`R`) means a signature is present.
+    pub signature_status: char,
+    /// Whether GitHub reports the signature as `verified` (strict mode only;
+    /// `None` when strict mode is not in effect).
+    pub github_verified: Option<bool>,
+    /// Whether the message carries a `Signed-off-by` trailer.
+    pub has_signoff: bool,
+}
+
+/// A single failed check for one commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitFailure {
+    pub short_sha: String,
+    pub subject: String,
+    /// Human-readable reason the commit failed.
+    pub reason: String,
+}
+
+/// Pure decision logic: given the collected commits and whether strict
+/// (GitHub "Verified") mode is requested, return the list of failures.
+///
+/// An empty input slice (empty commit range) yields no failures.
+pub fn evaluate_commits(commits: &[CommitInfo], require_verified: bool) -> Vec<CommitFailure> {
+    let mut failures = Vec::new();
+    for commit in commits {
+        if !commit.has_signoff {
+            failures.push(CommitFailure {
+                short_sha: commit.short_sha.clone(),
+                subject: commit.subject.clone(),
+                reason: "missing `Signed-off-by` trailer".to_string(),
+            });
+        }
+        if require_verified {
+            // Strict mode: GitHub must report the signature as verified.
+            if commit.github_verified != Some(true) {
+                failures.push(CommitFailure {
+                    short_sha: commit.short_sha.clone(),
+                    subject: commit.subject.clone(),
+                    reason: "signature is not GitHub-\"Verified\"".to_string(),
+                });
+            }
+        } else {
+            // Default/local mode: a signature must be present and not bad.
+            // `N` (none) and `B` (bad) fail; everything else passes.
+            match commit.signature_status {
+                'N' => failures.push(CommitFailure {
+                    short_sha: commit.short_sha.clone(),
+                    subject: commit.subject.clone(),
+                    reason: "commit is not signed".to_string(),
+                }),
+                'B' => failures.push(CommitFailure {
+                    short_sha: commit.short_sha.clone(),
+                    subject: commit.subject.clone(),
+                    reason: "commit has a bad signature".to_string(),
+                }),
+                _ => {}
+            }
+        }
+    }
+    failures
+}
+
+/// Whether a commit message body contains a `Signed-off-by` trailer.
+///
+/// We accept any line that begins (ignoring leading whitespace) with the
+/// case-insensitive `signed-off-by:` token. This is deliberately more lenient
+/// than git's own trailer-block detection (which additionally requires the
+/// trailer to sit in the final blank-line-separated paragraph): for a DCO
+/// gate the looser match is sufficient and cannot miss a real trailer.
+fn body_has_signoff(message: &str) -> bool {
+    message.lines().any(|line| {
+        line.trim_start()
+            .to_ascii_lowercase()
+            .starts_with("signed-off-by:")
+    })
+}
+
+/// Run `git` with the given args and return trimmed stdout, failing on a
+/// non-zero exit.
+fn git(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "`git {}` failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Collect the commits in `<base>..HEAD` into structured [`CommitInfo`] records.
+///
+/// When `require_verified` is set, each commit is additionally queried against
+/// the GitHub API for its `verification.verified` status.
+fn collect_commits(base: &str, require_verified: bool) -> Result<Vec<CommitInfo>> {
+    let range = format!("{base}..HEAD");
+    // One line per commit: "<short-sha> <full-sha> <signature-status>". `%h` is
+    // the abbreviated hash (for reporting), `%H` the full hash (for the API and
+    // for fetching the message/subject separately to avoid delimiter ambiguity),
+    // and `%G?` a single character.
+    let listing = git(&["log", "--format=%h %H %G?", &range])?;
+
+    let repo_slug = if require_verified {
+        Some(github_repo_slug()?)
+    } else {
+        None
+    };
+
+    let mut commits = Vec::new();
+    for line in listing.lines().filter(|line| !line.trim().is_empty()) {
+        let mut fields = line.splitn(3, ' ');
+        let (Some(short_sha), Some(full_sha), Some(status)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            return Err(anyhow!("unexpected `git log` line: {line:?}"));
+        };
+        let short_sha = short_sha.to_string();
+        let signature_status = status.trim().chars().next().unwrap_or('N');
+
+        let subject = git(&["log", "-1", "--format=%s", full_sha])?;
+        let message = git(&["log", "-1", "--format=%B", full_sha])?;
+
+        let github_verified = match &repo_slug {
+            Some(slug) => Some(verified_via_github(slug, full_sha)?),
+            None => None,
+        };
+
+        commits.push(CommitInfo {
+            short_sha,
+            subject,
+            signature_status,
+            github_verified,
+            has_signoff: body_has_signoff(&message),
+        });
+    }
+    Ok(commits)
+}
+
+/// Derive the `owner/repo` slug from `GITHUB_REPOSITORY` (set on GitHub-hosted
+/// runners) or, failing that, from the `origin` remote URL.
+fn github_repo_slug() -> Result<String> {
+    if let Ok(slug) = std::env::var("GITHUB_REPOSITORY")
+        && !slug.trim().is_empty()
+    {
+        return Ok(slug.trim().to_string());
+    }
+    let url = git(&["remote", "get-url", "origin"])?;
+    parse_repo_slug(&url)
+        .ok_or_else(|| anyhow!("could not derive owner/repo from origin URL {url:?}"))
+}
+
+/// Parse an `owner/repo` slug from a GitHub remote URL (HTTPS or SSH form).
+fn parse_repo_slug(url: &str) -> Option<String> {
+    let url = url.trim().trim_end_matches('/');
+    let tail = url
+        .rsplit_once("github.com/")
+        .map(|(_, tail)| tail)
+        .or_else(|| url.rsplit_once("github.com:").map(|(_, tail)| tail))?;
+    let tail = tail.strip_suffix(".git").unwrap_or(tail);
+    if tail.split('/').count() == 2 && !tail.contains(' ') {
+        Some(tail.to_string())
+    } else {
+        None
+    }
+}
+
+/// Query GitHub for whether a commit's signature is `verified`, via the
+/// preinstalled, token-authenticated `gh` CLI.
+fn verified_via_github(repo_slug: &str, full_sha: &str) -> Result<bool> {
+    let endpoint = format!("/repos/{repo_slug}/commits/{full_sha}");
+    let output = Command::new("gh")
+        .args(["api", &endpoint, "--jq", ".commit.verification.verified"])
+        .output()
+        .context("failed to run `gh api` (is the GitHub CLI installed and authenticated?)")?;
+    if !output.status.success() {
+        bail!(
+            "`gh api {endpoint}` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    match stdout.trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        // `null`/empty means the field was absent — typically because the commit
+        // is not (yet) visible on GitHub. Surface that distinctly rather than
+        // reporting it as an unverified signature.
+        other => bail!(
+            "`gh api {endpoint}` returned {other:?} for `verification.verified`; \
+             the commit may not be pushed to GitHub yet"
+        ),
+    }
+}
+
+/// Remediation guidance printed when commits fail, tailored to the mode.
+fn remediation(require_verified: bool) -> String {
+    let mut text = String::from(
+        "\nTo fix:\n\
+         - Sign-off: amend with `git commit -s --amend` (one commit) or\n  \
+           `git rebase --signoff <base>` (a range), then re-push.\n\
+         - Signing: enable commit signing once, e.g. SSH signing:\n      \
+           git config --global gpg.format ssh\n      \
+           git config --global user.signingkey ~/.ssh/id_ed25519.pub\n      \
+           git config --global commit.gpgsign true\n  \
+           (or GPG: set `user.signingkey` to your GPG key id and\n   \
+           `git config --global commit.gpgsign true`), then re-sign with\n   \
+           `git rebase --exec 'git commit --amend --no-edit -S' <base>`.\n",
+    );
+    if require_verified {
+        text.push_str(
+            "- GitHub \"Verified\": register your signing key on GitHub\n  \
+             (Settings > SSH and GPG keys) and make sure your committer email is\n  \
+             a verified email on your GitHub account.\n",
+        );
+    }
+    text
+}
+
+/// Entry point for the `verify-commits` subcommand.
+pub fn run(base: Option<String>, require_verified: bool) -> Result<()> {
+    let base = base.unwrap_or_else(|| {
+        // In CI, prefer the PR base branch when GitHub provides it.
+        std::env::var("GITHUB_BASE_REF")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map_or_else(
+                || DEFAULT_BASE.to_string(),
+                |branch| format!("origin/{branch}"),
+            )
+    });
+
+    let commits = collect_commits(&base, require_verified)?;
+    if commits.is_empty() {
+        println!("verify-commits: no commits in {base}..HEAD; nothing to check.");
+        return Ok(());
+    }
+
+    let failures = evaluate_commits(&commits, require_verified);
+    if failures.is_empty() {
+        println!(
+            "verify-commits: all {} commit(s) in {base}..HEAD are signed and signed-off.",
+            commits.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!("verify-commits: {} check(s) failed:\n", failures.len());
+    for failure in &failures {
+        eprintln!(
+            "  {} {}\n    -> {}",
+            failure.short_sha, failure.subject, failure.reason
+        );
+    }
+    eprint!("{}", remediation(require_verified));
+    bail!("commit signature/sign-off enforcement failed");
+}
+
+/// Entry point for the `--check-config` mode: assert that commit signing is
+/// configured locally (used by the fast pre-commit hook).
+pub fn check_config() -> Result<()> {
+    let gpgsign = git(&["config", "--get", "commit.gpgsign"])
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let signingkey = git(&["config", "--get", "user.signingkey"]).unwrap_or_default();
+
+    let signing_enabled = gpgsign == "true";
+    let key_set = !signingkey.trim().is_empty();
+    if signing_enabled && key_set {
+        return Ok(());
+    }
+
+    eprintln!("verify-commits: commit signing is not configured.");
+    if !signing_enabled {
+        eprintln!("  -> `commit.gpgsign` is not set to `true`.");
+    }
+    if !key_set {
+        eprintln!("  -> `user.signingkey` is not set.");
+    }
+    eprint!("{}", remediation(false));
+    bail!("commit signing is not configured");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commit(status: char, verified: Option<bool>, has_signoff: bool) -> CommitInfo {
+        CommitInfo {
+            short_sha: "abc1234".to_string(),
+            subject: "example commit".to_string(),
+            signature_status: status,
+            github_verified: verified,
+            has_signoff,
+        }
+    }
+
+    #[test]
+    fn empty_range_passes() {
+        assert!(evaluate_commits(&[], false).is_empty());
+        assert!(evaluate_commits(&[], true).is_empty());
+    }
+
+    #[test]
+    fn signed_and_signed_off_passes_local() {
+        let commits = [commit('G', None, true)];
+        assert!(evaluate_commits(&commits, false).is_empty());
+    }
+
+    #[test]
+    fn missing_signoff_fails() {
+        let commits = [commit('G', None, false)];
+        let failures = evaluate_commits(&commits, false);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].reason.contains("Signed-off-by"));
+    }
+
+    #[test]
+    fn no_signature_fails_local() {
+        let commits = [commit('N', None, true)];
+        let failures = evaluate_commits(&commits, false);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].reason.contains("not signed"));
+    }
+
+    #[test]
+    fn bad_signature_fails_local() {
+        let commits = [commit('B', None, true)];
+        let failures = evaluate_commits(&commits, false);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].reason.contains("bad signature"));
+    }
+
+    #[test]
+    fn lenient_signature_states_pass_local() {
+        // Local mode only rejects `N` (none) and `B` (bad). Every other `%G?`
+        // state — including expired (`X`/`Y`), revoked (`R`), and
+        // can't-verify (`E`) keys — is intentionally accepted here; strict
+        // mode (GitHub "Verified") is the gate that judges trust in CI.
+        for status in ['G', 'U', 'E', 'X', 'Y', 'R'] {
+            let commits = [commit(status, None, true)];
+            assert!(
+                evaluate_commits(&commits, false).is_empty(),
+                "status {status:?} should pass in local mode"
+            );
+        }
+    }
+
+    #[test]
+    fn unverified_fails_strict() {
+        let commits = [commit('G', Some(false), true)];
+        let failures = evaluate_commits(&commits, true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].reason.contains("Verified"));
+    }
+
+    #[test]
+    fn verified_and_signed_off_passes_strict() {
+        let commits = [commit('G', Some(true), true)];
+        assert!(evaluate_commits(&commits, true).is_empty());
+    }
+
+    #[test]
+    fn strict_missing_github_verdict_fails() {
+        // In strict mode a `None` verdict (the API was never consulted) must
+        // not slip through as verified.
+        let commits = [commit('G', None, true)];
+        let failures = evaluate_commits(&commits, true);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].reason.contains("Verified"));
+    }
+
+    #[test]
+    fn strict_ignores_local_signature_status() {
+        // In strict mode the `%G?` char is irrelevant; only GitHub's verdict
+        // and the sign-off matter.
+        let commits = [commit('N', Some(true), true)];
+        assert!(evaluate_commits(&commits, true).is_empty());
+    }
+
+    #[test]
+    fn multiple_failures_reported_per_commit() {
+        // Unsigned AND missing sign-off => two failures for one commit.
+        let commits = [commit('N', None, false)];
+        let failures = evaluate_commits(&commits, false);
+        assert_eq!(failures.len(), 2);
+    }
+
+    #[test]
+    fn signoff_detected_in_trailer() {
+        assert!(body_has_signoff(
+            "Subject\n\nBody text.\n\nSigned-off-by: Dev <dev@example.com>\n"
+        ));
+    }
+
+    #[test]
+    fn signoff_detection_is_case_insensitive() {
+        assert!(body_has_signoff(
+            "Subject\n\nsigned-off-by: Dev <dev@example.com>"
+        ));
+    }
+
+    #[test]
+    fn signoff_detected_with_leading_whitespace() {
+        assert!(body_has_signoff(
+            "Subject\n\n  Signed-off-by: Dev <dev@example.com>"
+        ));
+    }
+
+    #[test]
+    fn signoff_absent_is_detected() {
+        assert!(!body_has_signoff("Subject\n\nNo trailer here."));
+    }
+
+    #[test]
+    fn repo_slug_parsed_from_https_and_ssh() {
+        assert_eq!(
+            parse_repo_slug("https://github.com/ROCm/rocm-cli.git").as_deref(),
+            Some("ROCm/rocm-cli")
+        );
+        assert_eq!(
+            parse_repo_slug("git@github.com:ROCm/rocm-cli.git").as_deref(),
+            Some("ROCm/rocm-cli")
+        );
+        assert_eq!(
+            parse_repo_slug("https://github.com/ROCm/rocm-cli").as_deref(),
+            Some("ROCm/rocm-cli")
+        );
+        assert_eq!(
+            parse_repo_slug("ssh://git@github.com/ROCm/rocm-cli.git").as_deref(),
+            Some("ROCm/rocm-cli")
+        );
+        assert_eq!(parse_repo_slug("https://example.com/not/github"), None);
+    }
+}


### PR DESCRIPTION
## What

Adds blocking enforcement that every commit carries a cryptographic signature and a DCO `Signed-off-by` trailer, at two layers:

- **Local (prek):** a pre-commit hook checks signing is configured; a pre-push hook verifies outgoing commits are signed and signed-off.
- **CI:** a new `commit-signatures` job fails a pull request if any of its commits is not GitHub-"Verified" or is missing a sign-off.

The check is a `cargo xtask verify-commits` subcommand (`--base`, `--require-verified`, `--check-config`), so identical logic runs locally and in CI.

## Why

The contributing guidelines already require signed, signed-off commits, but nothing enforced it. This makes the requirement self-checking and keeps unsigned commits out of the history.

## Notes

- `docs/commit-signatures.md` documents local signing setup and the complementary native GitHub "Require signed commits" ruleset — and why a repo-side check is still needed: rulesets don't apply to pull requests from forks and can't enforce DCO sign-off.
- The CI job becomes blocking once it is marked a required check in branch protection / rulesets.

## Test plan

- `cargo build`, `test`, `clippy -D warnings`, `fmt --check` all clean; 16 unit tests cover the decision logic (signed / unsigned / bad-sig / missing sign-off / strict-unverified / empty range).
- Dogfoods itself: this PR's own commit is signed + signed-off and passes `cargo xtask verify-commits`.
