### PR TITLE
ci: run CI on merge_group so queued PRs get checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The merge queue creates a temporary branch and fires `merge_group`; without
+  # this trigger the required checks never start and queued PRs stall forever.
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

PRs added to the merge queue (`queue/main`) never merge — their required status checks never start, so each entry stalls at "Waiting for checks to start" and eventually times out.

## Root cause

The merge queue does not re-run a PR's existing checks. It adds the PR to a temporary branch and fires a **`merge_group`** event. A workflow only runs against the queued branch if its `on:` block subscribes to that event.

The CI workflow triggers on `push` and `pull_request` only — nothing listens for `merge_group`. So when a PR enters the queue, **zero check runs are created**, the required checks (fmt, clippy, build/test, …) never report, and the queue blocks indefinitely.

## Fix

Subscribe the CI workflow to `merge_group`. The same jobs then run against the queued branch and report the required checks back to the queue. The `concurrency` group keys on `github.ref`, which is unique per queued branch, so queue runs won't cross-cancel.

This must be merged via the normal (non-queue) route, since the queue itself is currently blocked.