### PR TITLE
ci: cache pinned, checksum-verified hawkeye for license headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,43 @@ jobs:
   license-headers:
     name: License header check (hawkeye)
     runs-on: ubuntu-latest
+    env:
+      # Install a pinned prebuilt hawkeye binary instead of pulling the
+      # korandoru/hawkeye Docker image on every run, and verify it against a
+      # sha256 recorded here. The hash lives in-repo, out of band from the
+      # release: GitHub release assets are mutable, so a republished/tampered
+      # artifact (and its co-published .sha256) would pass an upstream-only
+      # check — pinning the hash here makes that fail instead. To upgrade, bump
+      # the version and replace the hash with the new release's published
+      # .sha256 (confirm the bytes first).
+      HAWKEYE_VERSION: v6.5.1
+      HAWKEYE_SHA256: d6eb0505a45a15244f4f789158aafe5e3f1a7dc86c9dc1d7651f3cb1e1b321e0
+      HAWKEYE_INSTALL_DIR: ${{ github.workspace }}/.hawkeye-bin
     steps:
       - uses: actions/checkout@v6
+
+      - name: Cache hawkeye binary
+        id: cache-hawkeye
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.HAWKEYE_INSTALL_DIR }}
+          key: ${{ runner.os }}-hawkeye-${{ env.HAWKEYE_VERSION }}-${{ env.HAWKEYE_SHA256 }}
+
+      - name: Install hawkeye
+        if: steps.cache-hawkeye.outputs.cache-hit != 'true'
+        run: |
+          tarball="hawkeye-x86_64-unknown-linux-gnu.tar.xz"
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/korandoru/hawkeye/releases/download/${HAWKEYE_VERSION}/${tarball}" \
+            -o "${tarball}"
+          echo "${HAWKEYE_SHA256}  ${tarball}" | sha256sum -c -
+          mkdir -p "${HAWKEYE_INSTALL_DIR}"
+          tar -xJf "${tarball}" -C "${HAWKEYE_INSTALL_DIR}" --strip-components=1
+          rm -f "${tarball}"
+
       - name: Check license headers
-        uses: korandoru/hawkeye@v6
+        run: |
+          "${HAWKEYE_INSTALL_DIR}/hawkeye" check
 
   # Hardware (real AMD GPU / WSL) smoke tests on dedicated self-hosted runners
   # are intentionally not part of this workflow yet. See


### PR DESCRIPTION
## What

Make the `license-headers` CI job install a pinned, checksum-verified hawkeye binary instead of pulling the Docker image on every run.

Previously the job used `korandoru/hawkeye@v6`, a Docker action that re-pulls the container image each run (effectively uncached). Now it:

- **Pins** hawkeye to `v6.5.1`.
- **Downloads** the prebuilt `x86_64-unknown-linux-gnu` binary directly from the GitHub release.
- **Verifies** it against a SHA256 recorded in the workflow before use.
- **Caches** the verified binary via `actions/cache@v5`, keyed on OS + version + hash; downloads only on a cache miss.
- Runs `hawkeye check` from the cached path.

## Why

Warm runs skip the network entirely; cold runs fetch a few-MB binary instead of a Docker image, and the pinned version makes the gate reproducible.

The checksum is recorded **in-repo**, out of band from the release. GitHub release assets are mutable, so verifying only against the checksum a release publishes alongside the artifact would still trust a republished or tampered binary (the attacker republishes a matching checksum too). Pinning the hash here makes that case fail instead.

## Notes

- No behavior change to the check itself — same `licenserc.toml`, same `hawkeye check`.
- To upgrade: bump the version and replace the hash with the new release's published `.sha256` (confirm the bytes first).