### PR TITLE
Add project banner and tech preview notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
-# rocm-cli
+# ROCm CLI
 
-Command-line tool for setting up and running local AI on AMD GPUs, with a
+![ROCm](https://img.shields.io/badge/ROCm-Enabled-green)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.TXT)
+
+```
+ ██████╗  ██████╗  ██████╗███╗   ███╗     ██████╗██╗     ██╗
+ ██╔══██╗██╔═══██╗██╔════╝████╗ ████║    ██╔════╝██║     ██║
+ ██████╔╝██║   ██║██║     ██╔████╔██║    ██║     ██║     ██║
+ ██╔══██╗██║   ██║██║     ██║╚██╔╝██║    ██║     ██║     ██║
+ ██║  ██║╚██████╔╝╚██████╗██║ ╚═╝ ██║    ╚██████╗███████╗██║
+ ╚═╝  ╚═╝ ╚═════╝  ╚═════╝╚═╝     ╚═╝     ╚═════╝╚══════╝╚═╝
+
+        Local AI on AMD GPUs — one binary, zero setup
+```
+
+ROCm CLI is a command-line tool for setting up and running local AI on AMD GPUs, with a
 full-screen TUI dashboard for GPU telemetry, model serving, and chat.
 
 A single prebuilt binary for Linux and Windows. No Python, Rust, or existing
 ROCm install required. Ships with inference engine adapters for PyTorch,
 llama.cpp, Lemonade, ATOM, vLLM, and SGLang.
+
+> [!IMPORTANT]
+> **Tech Preview** -- This software is provided as-is, without warranty or
+> guarantee of stability. APIs, commands, and behavior may change without
+> notice. Intended for experimentation and early feedback only.
 
 > Only nightly builds are available at this time.
 


### PR DESCRIPTION
Adds an ASCII art banner to the main README file, together with a Tech Preview disclaimer.

<img width="1141" height="703" alt="image" src="https://github.com/user-attachments/assets/0afeeb29-98f7-4d64-9468-a143feda6755" />
