### PR TITLE
Sync Lemonade ROCm channel with installed ROCm

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -2356,10 +2356,31 @@ pub fn active_managed_therock_environment(
     paths: &AppPaths,
     config: &RocmCliConfig,
 ) -> Result<Option<ManagedRuntimeEnvironment>> {
+    Ok(select_active_managed_therock_record(paths, config)
+        .map(|record| managed_therock_environment_from_record(&record)))
+}
+
+/// Channel (`"release"`/`"nightly"`) of the active managed TheRock runtime.
+///
+/// Reflects the channel recorded at install time. Returns `None` when there is no managed
+/// runtime (system or legacy ROCm) or the registry record predates channel recording.
+pub fn active_managed_therock_channel(
+    paths: &AppPaths,
+    config: &RocmCliConfig,
+) -> Result<Option<String>> {
+    Ok(select_active_managed_therock_record(paths, config).and_then(|record| record.channel))
+}
+
+/// Pick the active managed TheRock runtime record: the one matching
+/// `config.active_runtime_key`, falling back to the most recently installed.
+fn select_active_managed_therock_record(
+    paths: &AppPaths,
+    config: &RocmCliConfig,
+) -> Option<TheRockFamilyManifest> {
     let registry_dir = paths.data_dir.join("runtimes").join("registry");
     let mut records = managed_therock_environment_records(&registry_dir);
     if records.is_empty() {
-        return Ok(None);
+        return None;
     }
 
     if let Some(active_key) = config.active_runtime_key.as_deref()
@@ -2374,13 +2395,11 @@ pub fn active_managed_therock_environment(
                     .is_some_and(|id| id.eq_ignore_ascii_case(active_key))
         })
     {
-        return Ok(Some(managed_therock_environment_from_record(record)));
+        return Some(record.clone());
     }
 
     records.sort_by_key(|(_, record)| std::cmp::Reverse(record.installed_at_unix_ms.unwrap_or(0)));
-    Ok(records
-        .first()
-        .map(|(_, record)| managed_therock_environment_from_record(record)))
+    records.into_iter().next().map(|(_, record)| record)
 }
 
 pub fn prepend_runtime_paths(
@@ -2601,7 +2620,7 @@ fn newer_therock_family(
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct TheRockFamilyManifest {
     #[serde(default)]
     runtime_key: Option<String>,
@@ -2611,6 +2630,8 @@ struct TheRockFamilyManifest {
     family: Option<String>,
     #[serde(default)]
     therock_family: Option<String>,
+    #[serde(default)]
+    channel: Option<String>,
     #[serde(default)]
     rocm_sdk: Option<TheRockSdkProbeManifest>,
     #[serde(default)]
@@ -6592,6 +6613,40 @@ Class Name:                Display
         )?;
 
         assert_eq!(detect_managed_therock_sdk_gfx_target(&paths), None);
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn active_managed_therock_channel_reads_recorded_channel() -> Result<()> {
+        let (root, paths) = temp_app_paths("active-therock-channel");
+        let registry = paths.data_dir.join("runtimes").join("registry");
+        fs::create_dir_all(&registry)?;
+        fs::write(
+            registry.join("runtime.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "runtime_id": "therock-nightly:gfx120X-all",
+                "family": "gfx120X-all",
+                "channel": "nightly",
+                "installed_at_unix_ms": 10,
+                "rocm_sdk": { "import_ok": true }
+            }))?,
+        )?;
+
+        let config = RocmCliConfig::default();
+        assert_eq!(
+            active_managed_therock_channel(&paths, &config)?,
+            Some("nightly".to_owned())
+        );
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn active_managed_therock_channel_is_none_without_runtime() -> Result<()> {
+        let (root, paths) = temp_app_paths("active-therock-channel-none");
+        let config = RocmCliConfig::default();
+        assert_eq!(active_managed_therock_channel(&paths, &config)?, None);
         fs::remove_dir_all(root).ok();
         Ok(())
     }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -6652,6 +6652,64 @@ Class Name:                Display
     }
 
     #[test]
+    fn active_managed_therock_channel_falls_back_to_most_recent() -> Result<()> {
+        let (root, paths) = temp_app_paths("active-therock-channel-recent");
+        let registry = paths.data_dir.join("runtimes").join("registry");
+        fs::create_dir_all(&registry)?;
+        write_therock_channel_record(&registry, "older", "release", 10)?;
+        write_therock_channel_record(&registry, "newer", "nightly", 20)?;
+
+        // No active_runtime_key set: the most recently installed runtime wins.
+        let config = RocmCliConfig::default();
+        assert_eq!(
+            active_managed_therock_channel(&paths, &config)?,
+            Some("nightly".to_owned())
+        );
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn active_managed_therock_channel_prefers_active_runtime_key() -> Result<()> {
+        let (root, paths) = temp_app_paths("active-therock-channel-active-key");
+        let registry = paths.data_dir.join("runtimes").join("registry");
+        fs::create_dir_all(&registry)?;
+        write_therock_channel_record(&registry, "older", "release", 10)?;
+        write_therock_channel_record(&registry, "newer", "nightly", 20)?;
+
+        // The active key points at the older runtime, overriding recency.
+        let config = RocmCliConfig {
+            active_runtime_key: Some("therock-release:older".to_owned()),
+            ..RocmCliConfig::default()
+        };
+        assert_eq!(
+            active_managed_therock_channel(&paths, &config)?,
+            Some("release".to_owned())
+        );
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    fn write_therock_channel_record(
+        registry: &Path,
+        name: &str,
+        channel: &str,
+        installed_at_unix_ms: u64,
+    ) -> Result<()> {
+        fs::write(
+            registry.join(format!("{name}.json")),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "runtime_id": format!("therock-{channel}:{name}"),
+                "family": "gfx120X-all",
+                "channel": channel,
+                "installed_at_unix_ms": installed_at_unix_ms,
+                "rocm_sdk": { "import_ok": true }
+            }))?,
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn examine_render_includes_driver_and_state_counts() {
         let summary = ExamineSummary {
             os: "windows".to_owned(),

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -399,7 +399,7 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     // Align Lemonade's ROCm backend channel with the ROCm the user installed via rocm-cli
     // before backend selection, so the backend is pulled from the matching channel. This is
     // best-effort: a failure here must not abort the engine install.
-    let aligned_channel = match align_lemonade_rocm_channel(&manifest) {
+    let aligned_channel = match align_lemonade_rocm_channel(&paths, &manifest) {
         Ok(channel) => channel,
         Err(error) => {
             eprintln!(
@@ -457,19 +457,24 @@ fn lemonade_rocm_channel(rocm_cli_channel: &str) -> Option<&'static str> {
 /// backend binary at Lemonade's tested default (`builtin`). Returns the Lemonade channel that
 /// was applied, or `None` when there is no rocm-cli-managed ROCm runtime to mirror (Lemonade's
 /// own default is then left untouched).
-fn align_lemonade_rocm_channel(manifest: &LemonadeInstallManifest) -> Result<Option<&'static str>> {
-    let paths = AppPaths::discover()?;
+fn align_lemonade_rocm_channel(
+    paths: &AppPaths,
+    manifest: &LemonadeInstallManifest,
+) -> Result<Option<&'static str>> {
     // Don't fall back to a default config here: an empty config would discard the active
     // runtime key and let channel selection guess the most-recent runtime, then mutate
     // Lemonade based on that guess. Surface the error so the caller leaves defaults untouched.
-    let config = RocmCliConfig::load(&paths)?;
-    let Some(rocm_cli_channel) = active_managed_therock_channel(&paths, &config)? else {
+    let config = RocmCliConfig::load(paths)?;
+    let Some(rocm_cli_channel) = active_managed_therock_channel(paths, &config)? else {
         return Ok(None);
     };
     let Some(lemonade_channel) = lemonade_rocm_channel(&rocm_cli_channel) else {
         return Ok(None);
     };
     let process_env = lemonade_process_environment()?;
+    // Best-effort and not transactional: if the second call fails after the first succeeds,
+    // `rocm_channel` is updated but `rocm_bin` is left as-is. Acceptable here — the caller
+    // treats any failure as a warning and `rocm_bin` defaults to `builtin` regardless.
     run_lemonade_config_set(manifest, "rocm_channel", lemonade_channel, &process_env)?;
     run_lemonade_config_set(manifest, "llamacpp.rocm_bin", "builtin", &process_env)?;
     Ok(Some(lemonade_channel))

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -5,10 +5,10 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{
-    AppPaths, DEFAULT_LOCAL_PORT, RocmCliConfig, active_managed_therock_environment,
-    download_file_to_path, format_host_port, format_http_base_url, http_get_text,
-    normalize_runtime_path_for_host, prepend_runtime_paths, require_nonempty, runtime_is_linux,
-    runtime_is_windows,
+    AppPaths, DEFAULT_LOCAL_PORT, RocmCliConfig, active_managed_therock_channel,
+    active_managed_therock_environment, download_file_to_path, format_host_port,
+    format_http_base_url, http_get_text, normalize_runtime_path_for_host, prepend_runtime_paths,
+    require_nonempty, runtime_is_linux, runtime_is_windows,
 };
 use rocm_engine_protocol::{
     DetectRequest, DetectResponse, DevicePolicy, ENGINE_RECIPE_CONTRACT_VERSION, EndpointRequest,
@@ -396,9 +396,33 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
         .as_deref()
         .map(normalize_runtime_path_for_host);
     let mut manifest = prepare_embeddable(&paths, env_root.as_deref(), request.reinstall)?;
+    // Align Lemonade's ROCm backend channel with the ROCm the user installed via rocm-cli
+    // before backend selection, so the backend is pulled from the matching channel. This is
+    // best-effort: a failure here must not abort the engine install.
+    let aligned_channel = match align_lemonade_rocm_channel(&manifest) {
+        Ok(channel) => channel,
+        Err(error) => {
+            eprintln!(
+                "Warning: could not align Lemonade ROCm channel with installed ROCm: {error:#}"
+            );
+            None
+        }
+    };
     eprintln!("Detecting best supported Lemonade llama.cpp backend...");
     install_best_llamacpp_backend(&mut manifest)?;
     write_manifest(&paths, &manifest)?;
+    let mut warnings = vec![
+        "Lemonade is installed as a rocm-cli managed embeddable runtime".to_owned(),
+        format!(
+            "Selected the best supported llama.cpp backend for this GPU: {}:{}",
+            manifest.backend_recipe, manifest.backend_name
+        ),
+    ];
+    if let Some(channel) = aligned_channel {
+        warnings.push(format!(
+            "Set Lemonade ROCm channel to `{channel}` to match the installed ROCm"
+        ));
+    }
     Ok(InstallResponse {
         env_id: manifest.env_id.clone(),
         env_path: manifest.runtime_dir.display().to_string(),
@@ -415,14 +439,72 @@ fn install_response(request: InstallRequest) -> Result<InstallResponse> {
         ],
         capabilities: capabilities(),
         lock_hash: manifest_lock_hash(&manifest),
-        warnings: vec![
-            "Lemonade is installed as a rocm-cli managed embeddable runtime".to_owned(),
-            format!(
-                "Selected the best supported llama.cpp backend for this GPU: {}:{}",
-                manifest.backend_recipe, manifest.backend_name
-            ),
-        ],
+        warnings,
     })
+}
+
+/// Map a rocm-cli SDK channel (`release`/`nightly`) to Lemonade's `rocm_channel`
+/// (`stable`/`nightly`). Returns `None` for channels with no Lemonade equivalent.
+fn lemonade_rocm_channel(rocm_cli_channel: &str) -> Option<&'static str> {
+    match rocm_cli_channel.trim().to_ascii_lowercase().as_str() {
+        "release" => Some("stable"),
+        "nightly" => Some("nightly"),
+        _ => None,
+    }
+}
+
+/// Point Lemonade's ROCm backend at the channel the user installed via rocm-cli, keeping the
+/// backend binary at Lemonade's tested default (`builtin`). Returns the Lemonade channel that
+/// was applied, or `None` when there is no rocm-cli-managed ROCm runtime to mirror (Lemonade's
+/// own default is then left untouched).
+fn align_lemonade_rocm_channel(manifest: &LemonadeInstallManifest) -> Result<Option<&'static str>> {
+    let paths = AppPaths::discover()?;
+    let config = RocmCliConfig::load(&paths).unwrap_or_default();
+    let Some(rocm_cli_channel) = active_managed_therock_channel(&paths, &config)? else {
+        return Ok(None);
+    };
+    let Some(lemonade_channel) = lemonade_rocm_channel(&rocm_cli_channel) else {
+        return Ok(None);
+    };
+    let process_env = lemonade_process_environment()?;
+    run_lemonade_config_set(manifest, "rocm_channel", lemonade_channel, &process_env)?;
+    run_lemonade_config_set(manifest, "llamacpp.rocm_bin", "builtin", &process_env)?;
+    Ok(Some(lemonade_channel))
+}
+
+fn lemonade_config_set_args(key: &str, value: &str) -> Vec<String> {
+    vec![
+        "config".to_owned(),
+        "set".to_owned(),
+        format!("{key}={value}"),
+    ]
+}
+
+fn run_lemonade_config_set(
+    manifest: &LemonadeInstallManifest,
+    key: &str,
+    value: &str,
+    process_env: &LemonadeProcessEnvironment,
+) -> Result<()> {
+    let mut command = ProcessCommand::new(&manifest.lemonade);
+    command
+        .args(lemonade_config_set_args(key, value))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    apply_lemonade_process_environment(&mut command, process_env)?;
+    hide_child_console_window(&mut command);
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run {}", manifest.lemonade.display()))?;
+    if !output.status.success() {
+        bail!(
+            "Lemonade config set {key}={value} failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
 }
 
 fn resolve_model_response(request: ResolveModelRequest) -> Result<ResolveModelResponse> {
@@ -2272,6 +2354,27 @@ mod tests {
                 "vulkan",
                 "--save-options",
             ]
+        );
+    }
+
+    #[test]
+    fn rocm_cli_channel_maps_to_lemonade_channel() {
+        assert_eq!(lemonade_rocm_channel("release"), Some("stable"));
+        assert_eq!(lemonade_rocm_channel("RELEASE"), Some("stable"));
+        assert_eq!(lemonade_rocm_channel(" nightly "), Some("nightly"));
+        assert_eq!(lemonade_rocm_channel("preview"), None);
+        assert_eq!(lemonade_rocm_channel(""), None);
+    }
+
+    #[test]
+    fn lemonade_config_set_builds_key_value_arg() {
+        assert_eq!(
+            lemonade_config_set_args("rocm_channel", "nightly"),
+            vec!["config", "set", "rocm_channel=nightly"]
+        );
+        assert_eq!(
+            lemonade_config_set_args("llamacpp.rocm_bin", "builtin"),
+            vec!["config", "set", "llamacpp.rocm_bin=builtin"]
         );
     }
 

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -459,7 +459,10 @@ fn lemonade_rocm_channel(rocm_cli_channel: &str) -> Option<&'static str> {
 /// own default is then left untouched).
 fn align_lemonade_rocm_channel(manifest: &LemonadeInstallManifest) -> Result<Option<&'static str>> {
     let paths = AppPaths::discover()?;
-    let config = RocmCliConfig::load(&paths).unwrap_or_default();
+    // Don't fall back to a default config here: an empty config would discard the active
+    // runtime key and let channel selection guess the most-recent runtime, then mutate
+    // Lemonade based on that guess. Surface the error so the caller leaves defaults untouched.
+    let config = RocmCliConfig::load(&paths)?;
     let Some(rocm_cli_channel) = active_managed_therock_channel(&paths, &config)? else {
         return Ok(None);
     };
@@ -498,10 +501,16 @@ fn run_lemonade_config_set(
         .output()
         .with_context(|| format!("failed to run {}", manifest.lemonade.display()))?;
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
         bail!(
-            "Lemonade config set {key}={value} failed ({}): {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
+            "Lemonade config set {key}={value} failed ({}): {detail}",
+            output.status
         );
     }
     Ok(())


### PR DESCRIPTION
## Motivation

The Lemonade engine always defaulted to its `stable` ROCm llama.cpp backend, regardless of whether the user installed ROCm from the **release** or **nightly** channel via `rocm install`. A user who deliberately picked the nightly ROCm channel still got Lemonade's stable ROCm build.

## What this does

Make Lemonade's ROCm backend **channel** follow the channel the user picked during `rocm install`:

- **rocm-core**: surface the active managed runtime's channel. `TheRockFamilyManifest` now deserializes the `channel` field (already written to the registry), and a new `active_managed_therock_channel(paths, config)` helper resolves it using the same active-key → most-recent selection as `active_managed_therock_environment` (extracted into a shared selector).
- **lemonade engine**: at engine install time, *before* backend selection, set Lemonade's `rocm_channel` to match the install (`release → stable`, `nightly → nightly`) via the bundled `lemonade config set` CLI. The applied channel is surfaced in the install warnings.

## Scope / decisions

- The backend binary is kept at Lemonade's tested default (`rocm_bin = builtin`). There is no reliable mapping from a ROCm SDK version (e.g. `6.3.0`) to a Lemonade llama.cpp build tag (e.g. `b1260`), and pinning a tag is the main source of hard `404` download failures. Mapping the channel while keeping the tested binary is the stable slice.
- Aligning the channel is **best-effort** — a failure warns and continues rather than aborting the engine install.
- No managed ROCm runtime (system/legacy ROCm) → Lemonade's own default is left untouched.

## Testing

- `cargo test -p rocm-core -p rocm-engine-lemonade` — passes, including 4 new unit tests (channel readback, channel mapping, `config set` arg builder).
- `cargo clippy` on both crates — clean.
- `cargo check --workspace` — clean.

### Not verified in CI (deferred to hardware testing)

- The exact `lemonade config set rocm_channel=<value>` argument syntax of the bundled embeddable CLI (taken from Lemonade docs; worth confirming with `lemonade config set --help`).
- End-to-end confirmation that a nightly ROCm install causes Lemonade to fetch its nightly ROCm backend (needs real ROCm + GPU + network).

## Follow-ups (out of scope)

- Re-sync an already-installed Lemonade when the user later switches ROCm channel (would require a backend reinstall).
- Make the Linux direct-serve fast path (hardcoded `rocm-stable` segment) channel-aware.