### PR TITLE
Keep the telemetry daemon alive when its socket lives in /tmp

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3836,7 +3836,7 @@ fn default_dashboard_socket() -> String {
     //
     // 1. $XDG_RUNTIME_DIR  — already mode 0700 on systemd systems, ideal.
     // 2. $HOME/.rocm/data/telemetry — standard per-user data dir.
-    // 3. temp_dir()/rocmdashd-<user> — user-named subdir so the parent is
+    // 3. temp_dir()/rocm-<user> — user-named subdir so the parent is
     //    something we create and own, not /tmp itself.
     use std::path::PathBuf;
     let path = std::env::var_os("XDG_RUNTIME_DIR")
@@ -3874,7 +3874,7 @@ fn default_dashboard_socket() -> String {
                 user
             };
             std::env::temp_dir()
-                .join(format!("rocmdashd-{user}"))
+                .join(format!("rocm-{user}"))
                 .join("rocmdashd.sock")
         });
     format!("unix:{}", path.display())

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -104,36 +104,72 @@ pub struct DaemonConfig {
 
 /// Default Unix-socket address for the telemetry daemon.
 ///
-/// The socket lives in a *per-user* subdirectory of the temp dir
-/// (`/tmp/rocm-<user>/`) rather than directly in `/tmp`. The daemon creates and
-/// owns that subdirectory, so it can tighten it to mode `0o700` without the
-/// `EPERM` that results from trying to `chmod` a shared, root-owned `/tmp`
-/// (mode `1777`). Keeping it per-user also avoids collisions on multi-user hosts.
+/// Chooses a socket location whose *parent* directory is always user-owned, so
+/// the daemon can tighten it to mode `0o700` without the `EPERM` that results
+/// from trying to `chmod` a shared, root-owned `/tmp` (mode `1777`). Precedence
+/// mirrors `rocm-core`'s `default_dashboard_socket` so the canonical `rocm`
+/// config and a standalone `rocm-dash` config resolve to the same place:
+///
+/// 1. `$XDG_RUNTIME_DIR` — already mode `0700` on systemd systems, ideal.
+/// 2. `$HOME/.rocm/data/telemetry` — standard per-user data dir.
+/// 3. `temp_dir()/rocm-<user>` — user-named subdir so the parent is something
+///    the daemon creates and owns, not `/tmp` itself.
 fn default_socket() -> String {
-    let raw = std::env::var("USER")
-        .or_else(|_| std::env::var("LOGNAME"))
-        .unwrap_or_else(|_| "user".to_owned());
-    // Sanitize: keep only alphanumeric, hyphen, and underscore so a path
-    // separator or `..` in the env var cannot escape the intended subdirectory.
-    let user: String = raw
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let user = if user.is_empty() {
-        "user".to_owned()
-    } else {
-        user
-    };
-    let path = std::env::temp_dir()
-        .join(format!("rocm-{user}"))
-        .join("rocmdashd.sock");
+    let path = socket_path(
+        std::env::var_os("XDG_RUNTIME_DIR"),
+        std::env::var_os("HOME"),
+        std::env::var("USER")
+            .or_else(|_| std::env::var("LOGNAME"))
+            .ok(),
+        std::env::temp_dir(),
+    );
     format!("unix:{}", path.display())
+}
+
+/// Pure core of [`default_socket`]: resolve the socket path from explicit env
+/// inputs so the precedence is testable without mutating process-global env vars
+/// (unsafe and racy under parallel tests in edition 2024).
+fn socket_path(
+    xdg_runtime_dir: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+    user: Option<String>,
+    temp_dir: PathBuf,
+) -> PathBuf {
+    xdg_runtime_dir
+        .filter(|v| !v.is_empty())
+        .map(|d| PathBuf::from(d).join("rocmdashd.sock"))
+        .or_else(|| {
+            home.filter(|v| !v.is_empty()).map(|h| {
+                PathBuf::from(h)
+                    .join(".rocm")
+                    .join("data")
+                    .join("telemetry")
+                    .join("rocmdashd.sock")
+            })
+        })
+        .unwrap_or_else(|| {
+            let raw = user.unwrap_or_else(|| "user".to_owned());
+            // Sanitize: keep only alphanumeric, hyphen, and underscore so a path
+            // separator or `..` in the env var cannot escape the subdirectory.
+            let sanitized: String = raw
+                .chars()
+                .map(|c| {
+                    if c.is_alphanumeric() || c == '-' || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect();
+            let sanitized = if sanitized.is_empty() {
+                "user".to_owned()
+            } else {
+                sanitized
+            };
+            temp_dir
+                .join(format!("rocm-{sanitized}"))
+                .join("rocmdashd.sock")
+        })
 }
 
 impl Default for DaemonConfig {
@@ -364,11 +400,11 @@ theme = "default-dark"
     }
 
     #[test]
-    fn default_socket_uses_per_user_subdir_not_bare_tmp() {
-        // Regression: the default socket must NOT sit directly in the temp dir.
-        // A bare `/tmp/rocmdashd.sock` makes the daemon try to chmod /tmp (a
-        // shared, root-owned dir) and abort with EPERM. The parent must be a
-        // per-user subdirectory the daemon can create and own.
+    fn default_socket_never_parents_at_bare_temp_dir() {
+        // Regression: whatever tier is chosen, the default socket must NOT sit
+        // directly in the temp dir. A bare `/tmp/rocmdashd.sock` makes the daemon
+        // try to chmod /tmp (a shared, root-owned dir) and abort with EPERM. The
+        // parent must be a directory the daemon can create or already owns.
         let socket = Config::default().daemon.listen;
         let path = socket
             .strip_prefix("unix:")
@@ -381,17 +417,60 @@ theme = "default-dark"
             std::env::temp_dir(),
             "socket parent must be a subdir, not the bare temp dir: {socket}"
         );
-        assert!(
-            parent
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with("rocm-")),
-            "socket parent should be a per-user rocm-<user> dir: {socket}"
-        );
         // daemon and tui defaults must agree so a default client finds the daemon.
         assert_eq!(
             Config::default().daemon.listen,
             Config::default().tui.connect
         );
+    }
+
+    #[test]
+    fn socket_path_prefers_xdg_runtime_dir() {
+        // Tier 1: $XDG_RUNTIME_DIR is already mode 0700 on systemd systems, so it
+        // is the ideal parent and must win over $HOME and the temp dir.
+        let path = socket_path(
+            Some("/run/user/1000".into()),
+            Some("/home/alice".into()),
+            Some("alice".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(path, PathBuf::from("/run/user/1000/rocmdashd.sock"));
+    }
+
+    #[test]
+    fn socket_path_falls_back_to_home_then_temp() {
+        // Tier 2: no XDG → per-user data dir under $HOME.
+        let path = socket_path(
+            None,
+            Some("/home/alice".into()),
+            Some("alice".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/home/alice/.rocm/data/telemetry/rocmdashd.sock")
+        );
+
+        // Tier 3: no XDG and no HOME → user-named subdir of the temp dir, never
+        // the bare temp dir itself.
+        let path = socket_path(None, None, Some("alice".to_owned()), PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-alice/rocmdashd.sock"));
+    }
+
+    #[test]
+    fn socket_path_sanitizes_user_and_skips_empty_env() {
+        // An empty XDG/HOME value is treated as unset (falls through), and a user
+        // name with path separators cannot escape the intended subdirectory.
+        let path = socket_path(
+            Some("".into()),
+            Some("".into()),
+            Some("../../etc".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(path, PathBuf::from("/tmp/rocm-______etc/rocmdashd.sock"));
+
+        // No user name at all still yields a valid per-user subdir.
+        let path = socket_path(None, None, None, PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
     }
 }

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -102,10 +102,44 @@ pub struct DaemonConfig {
     pub bench_results_dir: Option<PathBuf>,
 }
 
+/// Default Unix-socket address for the telemetry daemon.
+///
+/// The socket lives in a *per-user* subdirectory of the temp dir
+/// (`/tmp/rocm-<user>/`) rather than directly in `/tmp`. The daemon creates and
+/// owns that subdirectory, so it can tighten it to mode `0o700` without the
+/// `EPERM` that results from trying to `chmod` a shared, root-owned `/tmp`
+/// (mode `1777`). Keeping it per-user also avoids collisions on multi-user hosts.
+fn default_socket() -> String {
+    let raw = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "user".to_owned());
+    // Sanitize: keep only alphanumeric, hyphen, and underscore so a path
+    // separator or `..` in the env var cannot escape the intended subdirectory.
+    let user: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let user = if user.is_empty() {
+        "user".to_owned()
+    } else {
+        user
+    };
+    let path = std::env::temp_dir()
+        .join(format!("rocm-{user}"))
+        .join("rocmdashd.sock");
+    format!("unix:{}", path.display())
+}
+
 impl Default for DaemonConfig {
     fn default() -> Self {
         Self {
-            listen: "unix:/tmp/rocmdashd.sock".into(),
+            listen: default_socket(),
             token: None,
             gpu_tick: Duration::from_secs(1),
             discovery_tick: Duration::from_secs(5),
@@ -137,7 +171,7 @@ pub struct TuiConfig {
 impl Default for TuiConfig {
     fn default() -> Self {
         Self {
-            connect: "unix:/tmp/rocmdashd.sock".into(),
+            connect: default_socket(),
             theme: "default-dark".into(),
             chat_url: None,
             chat_model: None,
@@ -327,5 +361,37 @@ theme = "default-dark"
         std::fs::write(&p, "this is = not = valid = toml").unwrap();
         assert!(Config::load(&p).is_err());
         let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn default_socket_uses_per_user_subdir_not_bare_tmp() {
+        // Regression: the default socket must NOT sit directly in the temp dir.
+        // A bare `/tmp/rocmdashd.sock` makes the daemon try to chmod /tmp (a
+        // shared, root-owned dir) and abort with EPERM. The parent must be a
+        // per-user subdirectory the daemon can create and own.
+        let socket = Config::default().daemon.listen;
+        let path = socket
+            .strip_prefix("unix:")
+            .expect("default socket must be a unix: address");
+        let parent = std::path::Path::new(path)
+            .parent()
+            .expect("socket must have a parent directory");
+        assert_ne!(
+            parent,
+            std::env::temp_dir(),
+            "socket parent must be a subdir, not the bare temp dir: {socket}"
+        );
+        assert!(
+            parent
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("rocm-")),
+            "socket parent should be a per-user rocm-<user> dir: {socket}"
+        );
+        // daemon and tui defaults must agree so a default client finds the daemon.
+        assert_eq!(
+            Config::default().daemon.listen,
+            Config::default().tui.connect
+        );
     }
 }

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -54,36 +54,71 @@ pub async fn run(listen: &str, opts: RunnerOptions) -> anyhow::Result<()> {
     }
 }
 
+/// Ensure the socket's parent directory exists and is private (mode `0o700`).
+///
+/// Directory permissions are *defense-in-depth*: the socket itself is bound with
+/// mode `0o600` (see `run_unix`), so only the owning user can ever connect. We
+/// therefore **enforce** `0o700` only on a directory we just created — a
+/// directory we own must be securable, and failing to do so is a real error.
+///
+/// For a directory that already existed and is owned by another user (the classic
+/// case is a socket parented directly at `/tmp`, which is root-owned with mode
+/// `1777`), `chmod` returns `EPERM`. Aborting there crashed the embedded
+/// telemetry daemon for any user whose configured socket lived under `/tmp`.
+/// Since the `0o600` socket already restricts access, we log a warning and carry
+/// on instead of failing.
+#[cfg(unix)]
+fn prepare_socket_dir(parent: &std::path::Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Skip an empty parent (relative socket target such as `unix:foo.sock`).
+    // Operating on `""` would target the CWD.
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    // Whether we are about to create the directory ourselves. `DirBuilder::mode`
+    // only applies to directories it creates; a pre-existing directory keeps its
+    // current permissions, which is why we tighten explicitly below.
+    let created = !parent.exists();
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(parent)
+        .with_context(|| format!("creating socket directory {}", parent.display()))?;
+
+    if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
+        if created {
+            // We created it, so we own it: inability to secure it is a real error.
+            return Err(e).with_context(|| {
+                format!(
+                    "restricting socket directory {} to mode 0700 — \
+                     check that the directory is owned by the current user \
+                     (EPERM means it is owned by another user or root)",
+                    parent.display()
+                )
+            });
+        }
+        // Pre-existing directory we do not own (e.g. /tmp, mode 1777): the
+        // 0o600 socket still keeps the endpoint private, so warn and continue.
+        warn!(
+            dir = %parent.display(),
+            error = %e,
+            "could not restrict socket directory to mode 0700; continuing because \
+             the socket is created with mode 0600 (expected for shared directories \
+             such as /tmp)"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(unix)]
 async fn run_unix(path: PathBuf, opts: RunnerOptions) -> anyhow::Result<()> {
     use tokio::net::UnixListener;
 
     if let Some(parent) = path.parent() {
-        // Skip hardening if parent is an empty path (relative socket target
-        // such as `unix:foo.sock`). Operating on `""` would target the CWD.
-        if !parent.as_os_str().is_empty() {
-            // Create the parent directory with mode 0o700 so other users cannot
-            // traverse into it. DirBuilder::mode only applies to directories it
-            // creates; pre-existing directories keep their current permissions,
-            // so we explicitly set_permissions afterwards to tighten them.
-            use std::os::unix::fs::DirBuilderExt;
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::DirBuilder::new()
-                .recursive(true)
-                .mode(0o700)
-                .create(parent)
-                .with_context(|| format!("creating socket directory {}", parent.display()))?;
-            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).with_context(
-                || {
-                    format!(
-                        "restricting socket directory {} to mode 0700 — \
-                         check that the directory is owned by the current user \
-                         (EPERM means it is owned by another user or root)",
-                        parent.display()
-                    )
-                },
-            )?;
-        }
+        prepare_socket_dir(parent)?;
     }
     if path.exists() {
         std::fs::remove_file(&path)
@@ -253,4 +288,67 @@ fn hostname() -> Option<String> {
             .ok()
             .map(|s| s.trim().to_string())
     })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use std::path::Path;
+
+    use super::prepare_socket_dir;
+
+    /// A freshly created nested parent must end up at mode 0700.
+    #[test]
+    fn creates_missing_parent_at_0700() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("nested").join("telemetry");
+        prepare_socket_dir(&parent).expect("should create and secure a new directory");
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "newly created socket dir must be private");
+    }
+
+    /// A pre-existing parent we own but with looser perms gets tightened to 0700.
+    #[test]
+    fn tightens_owned_preexisting_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("loose");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+        prepare_socket_dir(&parent).expect("should tighten a directory we own");
+        let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    /// An empty parent (relative socket target like `unix:foo.sock`) is a no-op.
+    #[test]
+    fn empty_parent_is_noop() {
+        prepare_socket_dir(Path::new("")).expect("empty parent must be skipped");
+    }
+
+    /// Regression: a socket parented at a pre-existing directory owned by another
+    /// user (e.g. `/tmp`, root-owned mode 1777) must NOT abort the daemon — the
+    /// chmod EPERM is downgraded to a warning because the 0600 socket already
+    /// protects the endpoint. Before the fix this returned an error and crashed
+    /// the embedded telemetry daemon.
+    #[test]
+    fn preexisting_unowned_parent_does_not_abort() {
+        let tmpdir = std::env::temp_dir();
+        let Ok(meta) = std::fs::metadata(&tmpdir) else {
+            return; // no temp dir to probe; nothing to assert
+        };
+        // Determine our effective uid by stat-ing a file we create ourselves.
+        let probe = tmpdir.join(format!("rocmdashd-uidprobe-{}", std::process::id()));
+        if std::fs::write(&probe, b"x").is_err() {
+            return; // cannot write a probe; skip rather than guess our uid
+        }
+        let my_uid = std::fs::metadata(&probe).map(|m| m.uid()).ok();
+        let _ = std::fs::remove_file(&probe);
+        // Only meaningful when the temp dir is owned by someone else (so chmod is
+        // guaranteed to EPERM). If we own it or are root, chmod would *succeed*
+        // and mutate a shared directory — skip to avoid side effects.
+        if my_uid != Some(meta.uid()) {
+            prepare_socket_dir(&tmpdir)
+                .expect("must not abort when it cannot chmod a pre-existing unowned parent");
+        }
+    }
 }


### PR DESCRIPTION
## Symptom

Running `rocm` (or `rocm dash`) could abort the auto-started telemetry daemon at startup with:

```
rocm: embedded telemetry daemon exited: restricting socket directory /tmp to mode 0700 — check that the directory is owned by the current user (EPERM means it is owned by another user or root): Operation not permitted (os error 1)
```

This happens whenever the daemon's Unix socket is configured to live directly under `/tmp` (for example from a config file written by an older build, or an explicit override).

## Root cause

When binding the Unix socket, the daemon creates the socket's parent directory and then unconditionally `chmod`s it to `0700` as defense-in-depth, treating a failure as fatal. `/tmp` is shared and root-owned (mode `1777`), so a normal user cannot `chmod` it and gets `EPERM` — taking the whole daemon down. The socket itself is already bound with mode `0600`, which is the actual access control, so the parent-directory tightening should not be fatal here.

## Fix

Two layers:

1. **Don't crash on a directory we don't own.** The parent-directory hardening is extracted into a helper that only treats a failed `chmod` as fatal when it *created* the directory (which it therefore owns). For a pre-existing directory it does not own (such as `/tmp`), it logs a warning and continues — the `0600` socket still restricts access to the owning user.

2. **Pick a safer default.** The default socket location no longer sits directly in `/tmp`; it uses a per-user subdirectory (`/tmp/rocm-<user>/rocmdashd.sock`) that the daemon creates and owns, so it can be secured without touching `/tmp` and without colliding with other users on shared hosts.

## Tests

Adds regression tests that fail before and pass after: the `/tmp`-parented socket no longer aborts the daemon (plus coverage for the create/tighten/empty-parent paths), and the default socket is asserted to use a per-user subdirectory rather than the bare temp dir.