### PR TITLE
fix(dash): chat /v1 404 + Esc closes a running serve modal

### DIFF
--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -17,7 +17,9 @@ use std::time::Duration;
 /// The `/v1` suffix is required: the Rig OpenAI client appends `chat/completions`
 /// directly to `base_url` (`base_url + "/" + path`), so a base without `/v1`
 /// POSTs to `/chat/completions` and a vLLM/Lemonade server answers `404 Not
-/// Found`. Mirrors the `/v1`-suffixed `VLLM_ENDPOINT` / `LEMONADE_ENDPOINT`.
+/// Found`. Matches the `/v1` convention of `VLLM_ENDPOINT` / `LEMONADE_ENDPOINT`
+/// (those use `localhost`; `127.0.0.1` is the unambiguous IPv4 loopback and
+/// matches the live endpoint asserted in `agent.rs`).
 pub const DEFAULT_CHAT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
 
 /// Fallback model name when none is configured. Many local endpoints ignore
@@ -266,6 +268,16 @@ mod tests {
     fn probed_default_used_when_nothing_configured_but_reachable() {
         let r = resolve_llm_config(None, None, None, None, None, None, None, true).unwrap();
         assert_eq!(r.base_url, DEFAULT_CHAT_BASE_URL);
+        // Regression guard for the 404 bug: Rig appends `chat/completions` to
+        // `base_url`, so the probed default must resolve to a `/v1` base or every
+        // completion POSTs to `/chat/completions` and the server returns 404.
+        // Asserting the *resolved* value (not the constant) fails on a revert of
+        // the suffix rather than being tautological.
+        assert!(
+            r.base_url.ends_with("/v1"),
+            "probed default base_url must end in /v1, got {}",
+            r.base_url
+        );
         assert_eq!(r.model, DEFAULT_CHAT_MODEL);
         assert_eq!(r.api_key, None);
     }

--- a/crates/rocm-dash-tui/src/llm.rs
+++ b/crates/rocm-dash-tui/src/llm.rs
@@ -13,7 +13,12 @@ use std::time::Duration;
 
 /// Probed-default endpoint: the local OpenAI-compatible serving endpoint the
 /// dashboard already watches. Used only when no URL is configured anywhere.
-pub const DEFAULT_CHAT_BASE_URL: &str = "http://127.0.0.1:8000";
+///
+/// The `/v1` suffix is required: the Rig OpenAI client appends `chat/completions`
+/// directly to `base_url` (`base_url + "/" + path`), so a base without `/v1`
+/// POSTs to `/chat/completions` and a vLLM/Lemonade server answers `404 Not
+/// Found`. Mirrors the `/v1`-suffixed `VLLM_ENDPOINT` / `LEMONADE_ENDPOINT`.
+pub const DEFAULT_CHAT_BASE_URL: &str = "http://127.0.0.1:8000/v1";
 
 /// Fallback model name when none is configured. Many local endpoints ignore
 /// the model field or expose a single model, so a neutral default is safe.

--- a/crates/rocm-dash-tui/src/ui/examine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/examine_manager.rs
@@ -205,14 +205,18 @@ mod tests {
     }
 
     #[test]
-    fn esc_dismisses_console_only_when_terminal() {
+    fn esc_closes_overlay_while_running_dismisses_when_terminal() {
+        // Running: Esc closes the whole overlay (the read-only job keeps running).
         let mut d = Some(ExamineManagerState::default());
         let mut jobs = State::default();
         on_key(&mut d, &mut jobs, key(KeyCode::Enter));
-        // Running: Esc does not dismiss.
-        on_key(&mut d, &mut jobs, key(KeyCode::Esc));
         assert!(d.as_ref().unwrap().active_job.is_some());
-        // Terminal: Esc returns to the intro card.
+        on_key(&mut d, &mut jobs, key(KeyCode::Esc));
+        assert!(d.is_none(), "Esc closes the overlay while the job runs");
+        // Terminal: Esc returns to the intro card (overlay stays open).
+        let mut d = Some(ExamineManagerState::default());
+        let mut jobs = State::default();
+        on_key(&mut d, &mut jobs, key(KeyCode::Enter));
         jobs.apply(StateEvent::JobDone {
             id: "examine".into(),
             code: 0,

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -49,6 +49,14 @@ pub fn on_console_key(job_id: &str, jobs: &mut State, key: KeyEvent) -> ConsoleO
         // `q` always closes the overlay so the user is never trapped mid-job
         // (the job keeps running in the background).
         KeyCode::Char('q') => ConsoleOutcome::Closed,
+        // Esc on a still-running job leaves the overlay (the job keeps running in
+        // the background) — the conventional "get me out" key, so the user is
+        // never trapped during a long step (e.g. a managed serve readiness wait).
+        KeyCode::Esc if jobs.job(job_id).is_some_and(|j| !j.is_terminal()) => {
+            ConsoleOutcome::Closed
+        }
+        // On a finished (or vanished) job, Esc/Enter dismiss the console back to
+        // the screen body.
         KeyCode::Esc | KeyCode::Enter
             if jobs
                 .job(job_id)
@@ -124,9 +132,12 @@ pub fn draw_job_console(
         .collect();
     f.render_widget(Paragraph::new(lines).scroll(scroll), rows[1]);
 
-    // Footer: key hints (cancel only while running).
+    // Footer: key hints. While running, Esc leaves the overlay (the job keeps
+    // running in the background) and Ctrl+C cancels — advertise both so the user
+    // is never left feeling trapped during a long step (e.g. a managed serve's
+    // readiness wait).
     let hints = if matches!(job.status, JobStatus::Running) {
-        "Ctrl+C cancel · wheel / PgUp·PgDn scroll"
+        "Esc close (keeps running) · Ctrl+C cancel · wheel / PgUp·PgDn scroll"
     } else {
         "Enter/Esc close · wheel / PgUp·PgDn scroll"
     };
@@ -172,7 +183,7 @@ mod tests {
             on_console_key("j", &mut s, k(KeyCode::Char('q'))),
             ConsoleOutcome::Closed
         ));
-        // Esc on a RUNNING job is not a dismiss (Unhandled).
+        // Esc on a RUNNING job closes the overlay (job keeps running in the bg).
         let mut s2 = State::default();
         s2.apply(StateEvent::StartJob {
             id: "j".into(),
@@ -181,6 +192,11 @@ mod tests {
         });
         assert!(matches!(
             on_console_key("j", &mut s2, k(KeyCode::Esc)),
+            ConsoleOutcome::Closed
+        ));
+        // Enter on a RUNNING job stays Unhandled (avoids accidental dismissal).
+        assert!(matches!(
+            on_console_key("j", &mut s2, k(KeyCode::Enter)),
             ConsoleOutcome::Unhandled
         ));
         // Esc on a TERMINAL job dismisses.

--- a/crates/rocm-dash-tui/src/ui/serve_wizard.rs
+++ b/crates/rocm-dash-tui/src/ui/serve_wizard.rs
@@ -728,7 +728,20 @@ mod tests {
     }
 
     #[test]
-    fn esc_is_ignored_while_job_is_running_then_dismisses_when_terminal() {
+    fn esc_closes_overlay_while_running_then_dismisses_when_terminal() {
+        // Running: Esc leaves the whole overlay (the launch keeps running in the
+        // background) — the user is never trapped during the readiness wait.
+        let mut wiz = Some(ServeWizardState::default());
+        let mut jobs = State::default();
+        wiz.as_mut().unwrap().model = "m".into();
+        wiz.as_mut().unwrap().field = FIELDS.iter().position(|f| *f == Field::Launch).unwrap();
+        on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Enter));
+        on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Char('y')));
+        assert!(wiz.as_ref().unwrap().active_job.is_some());
+        on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Esc));
+        assert!(wiz.is_none(), "Esc closes the overlay even mid-job");
+
+        // Terminal: Esc dismisses the console back to the form (wizard stays open).
         let mut wiz = Some(ServeWizardState::default());
         let mut jobs = State::default();
         wiz.as_mut().unwrap().model = "m".into();
@@ -736,11 +749,6 @@ mod tests {
         on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Enter));
         on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Char('y')));
         let job_id = wiz.as_ref().unwrap().active_job.clone().unwrap();
-        // Job is Running: Esc must NOT dismiss the console or close the overlay.
-        on_key(&mut wiz, &mut jobs, &[], key(KeyCode::Esc));
-        assert_eq!(wiz.as_ref().unwrap().active_job.as_ref(), Some(&job_id));
-        assert!(wiz.is_some());
-        // Once terminal, Esc dismisses the console back to the form.
         jobs.apply(StateEvent::JobDone {
             id: job_id,
             code: 0,
@@ -749,7 +757,7 @@ mod tests {
         assert!(wiz.as_ref().unwrap().active_job.is_none());
         assert!(
             wiz.is_some(),
-            "dismissing the console keeps the wizard open"
+            "dismissing a finished console keeps the wizard open"
         );
     }
 


### PR DESCRIPTION
## Summary

Two dash chat usability bugs hit when serving a model and then chatting:

1. **Chat completions 404 (`completion error, http error, 404 detail not found`).**
   The Rig OpenAI client builds the request URL as `base_url + "/" + "chat/completions"`,
   so `base_url` must end in `/v1`. Every endpoint carried it (`VLLM_ENDPOINT`,
   `LEMONADE_ENDPOINT`, the managed-service `endpoint_url`) **except** the probed
   default `DEFAULT_CHAT_BASE_URL = "http://127.0.0.1:8000"`. So when the dash
   probed a vLLM already listening on :8000 and fell back to that default, it POSTed
   to `/chat/completions` and the server answered `404 {"detail":"Not Found"}`.
   Fix: add the `/v1` suffix so it matches the other endpoints.

2. **Serve modal felt stuck.** A managed serve blocks for up to 45s in its HTTP
   readiness wait (`wait_for_service_http_ready`). During that window the job console
   is `Running`, where `Esc`/`Enter` were swallowed and only `q` closed — but the
   footer advertised only `Ctrl+C cancel`, so there was no visible exit and it
   looked frozen. Fix: **Esc now closes the overlay while a job is running** (the
   job keeps running in the background, same as `q` already did), and the footer
   says so. Finished-job `Esc`/`Enter` still dismiss the console back to the screen
   body; `Enter` stays inert while running to avoid accidental dismissal.

## Scope of the Esc-while-running change

The change lives in the shared `job_console::on_console_key`, so it applies to
**every** overlay that hosts a job console — 12 callers in total: serve, examine,
engine, runtime, install, update, config, logs, command, automations, services,
and **onboarding**.

Behavior change worth flagging: `Esc` on a *running* onboarding step
(`onboarding.rs:180`, `*ob = None`) now closes the whole onboarding wizard. This
is consistent with what `q` already did there, and it's a deliberate decision —
a running step keeps running in the background. Every caller's `Unhandled` arm was
checked; none branch on `Esc`, so nothing screen-specific is silently intercepted.

## Changes
- `llm.rs`: `DEFAULT_CHAT_BASE_URL` → `http://127.0.0.1:8000/v1` (+ rationale doc),
  plus a revert-proof regression test asserting the resolved `base_url` ends in `/v1`.
- `ui/job_console.rs`: `Esc` on a running job → `Closed`; updated footer hint.
- `ui/serve_wizard.rs`, `ui/examine_manager.rs`: updated tests to the new contract.

## Test plan
- [x] `cargo test -p rocm-dash-tui --lib -- --test-threads=1` → 461 passed
- [x] `cargo clippy -p rocm-dash-tui --all-targets` → clean
- [x] Verified the new 404 guard fails when the `/v1` suffix is reverted
- [ ] Manual: probe a vLLM on :8000, open dash chat, confirm a completion returns (no 404)
- [ ] Manual: serve a managed vLLM recipe, press Esc during readiness wait, confirm modal closes and the server keeps coming up in the background, then chat works

Stacked on #67 (retire-legacy-tui).