### PR TITLE
fix(dash): harden telemetry socket directory handling (follow-up to #64)

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3832,18 +3832,44 @@ pub struct RocmCliConfig {
 
 fn default_dashboard_socket() -> String {
     // Choose a socket location whose *parent* directory is always user-owned so
-    // that run_unix can tighten it to 0o700 without EPERM. Precedence:
-    //
-    // 1. $XDG_RUNTIME_DIR  — already mode 0700 on systemd systems, ideal.
-    // 2. $HOME/.rocm/data/telemetry — standard per-user data dir.
-    // 3. temp_dir()/rocm-<user> — user-named subdir so the parent is
-    //    something we create and own, not /tmp itself.
+    // that run_unix can tighten it to 0o700 without EPERM. See
+    // `dashboard_socket_path` for the precedence. This resolver is mirrored in
+    // `rocm-dash-core` so the canonical `rocm` config and a standalone
+    // `rocm-dash` config resolve to the same place; keep the two in sync.
+    let path = dashboard_socket_path(
+        std::env::var_os("XDG_RUNTIME_DIR"),
+        std::env::var_os("HOME"),
+        // An empty `USER` must fall through to `LOGNAME`, not short-circuit it.
+        std::env::var("USER")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .or_else(|| std::env::var("LOGNAME").ok().filter(|v| !v.is_empty())),
+        std::env::temp_dir(),
+    );
+    format!("unix:{}", path.display())
+}
+
+/// Pure core of [`default_dashboard_socket`]: resolve the socket path from
+/// explicit env inputs so the precedence is testable without mutating
+/// process-global env vars (unsafe and racy under parallel tests in edition
+/// 2024). Precedence:
+///
+/// 1. `$XDG_RUNTIME_DIR` — already mode `0700` on systemd systems, ideal.
+/// 2. `$HOME/.rocm/data/telemetry` — standard per-user data dir.
+/// 3. `temp_dir()/rocm-<user>` — user-named subdir so the parent is something we
+///    create and own, not `/tmp` itself.
+fn dashboard_socket_path(
+    xdg_runtime_dir: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+    user: Option<String>,
+    temp_dir: std::path::PathBuf,
+) -> std::path::PathBuf {
     use std::path::PathBuf;
-    let path = std::env::var_os("XDG_RUNTIME_DIR")
+    xdg_runtime_dir
         .filter(|v| !v.is_empty())
         .map(|d| PathBuf::from(d).join("rocmdashd.sock"))
         .or_else(|| {
-            std::env::var_os("HOME").filter(|v| !v.is_empty()).map(|h| {
+            home.filter(|v| !v.is_empty()).map(|h| {
                 PathBuf::from(h)
                     .join(".rocm")
                     .join("data")
@@ -3852,13 +3878,10 @@ fn default_dashboard_socket() -> String {
             })
         })
         .unwrap_or_else(|| {
-            let raw = std::env::var("USER")
-                .or_else(|_| std::env::var("LOGNAME"))
-                .unwrap_or_else(|_| "user".to_owned());
-            // Sanitize: keep only alphanumeric, hyphen, and underscore so
-            // that path separators or '..' in a user-controlled env var
-            // cannot escape the intended subdirectory.
-            let user: String = raw
+            let raw = user.unwrap_or_else(|| "user".to_owned());
+            // Sanitize: keep only alphanumeric, hyphen, and underscore so a path
+            // separator or `..` in the env var cannot escape the subdirectory.
+            let sanitized: String = raw
                 .chars()
                 .map(|c| {
                     if c.is_alphanumeric() || c == '-' || c == '_' {
@@ -3868,16 +3891,15 @@ fn default_dashboard_socket() -> String {
                     }
                 })
                 .collect();
-            let user = if user.is_empty() {
+            let sanitized = if sanitized.is_empty() {
                 "user".to_owned()
             } else {
-                user
+                sanitized
             };
-            std::env::temp_dir()
-                .join(format!("rocm-{user}"))
+            temp_dir
+                .join(format!("rocm-{sanitized}"))
                 .join("rocmdashd.sock")
-        });
-    format!("unix:{}", path.display())
+        })
 }
 
 fn default_dashboard_listen() -> String {
@@ -5997,6 +6019,61 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::Path;
+    use std::path::PathBuf;
+
+    // The socket-path precedence is mirrored in `rocm-dash-core`; these tests
+    // mirror the ones there so a divergence in either crate is caught.
+
+    #[test]
+    fn dashboard_socket_path_prefers_xdg_runtime_dir() {
+        // Tier 1: $XDG_RUNTIME_DIR is already mode 0700 on systemd systems, so it
+        // must win over $HOME and the temp dir.
+        let path = dashboard_socket_path(
+            Some("/run/user/1000".into()),
+            Some("/home/alice".into()),
+            Some("alice".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(path, PathBuf::from("/run/user/1000/rocmdashd.sock"));
+    }
+
+    #[test]
+    fn dashboard_socket_path_falls_back_to_home_then_temp() {
+        // Tier 2: no XDG → per-user data dir under $HOME.
+        let path = dashboard_socket_path(
+            None,
+            Some("/home/alice".into()),
+            Some("alice".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/home/alice/.rocm/data/telemetry/rocmdashd.sock")
+        );
+
+        // Tier 3: no XDG and no HOME → user-named subdir of the temp dir, never
+        // the bare temp dir itself.
+        let path =
+            dashboard_socket_path(None, None, Some("alice".to_owned()), PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-alice/rocmdashd.sock"));
+    }
+
+    #[test]
+    fn dashboard_socket_path_sanitizes_user_and_skips_empty_env() {
+        // An empty XDG/HOME value is treated as unset (falls through), and a user
+        // name with path separators cannot escape the intended subdirectory.
+        let path = dashboard_socket_path(
+            Some("".into()),
+            Some("".into()),
+            Some("../../etc".to_owned()),
+            PathBuf::from("/tmp"),
+        );
+        assert_eq!(path, PathBuf::from("/tmp/rocm-______etc/rocmdashd.sock"));
+
+        // No user name at all still yields a valid per-user subdir.
+        let path = dashboard_socket_path(None, None, None, PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
+    }
 
     #[test]
     fn openai_models_endpoint_has_model_checks_loaded_model_ids() -> Result<()> {

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -6073,6 +6073,10 @@ mod tests {
         // No user name at all still yields a valid per-user subdir.
         let path = dashboard_socket_path(None, None, None, PathBuf::from("/tmp"));
         assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
+
+        // A bare empty user name (as opposed to unset) also falls back to "user".
+        let path = dashboard_socket_path(None, None, Some(String::new()), PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
     }
 
     #[test]
@@ -7916,6 +7920,8 @@ Class Name:                Display
         assert_eq!(cfg.daemon.instance_tick_secs, 2.0);
         assert_eq!(cfg.tui.theme, "default-dark");
         assert_eq!(cfg.tui.chat_url, None);
+        // daemon and tui defaults must agree so a default client finds the daemon.
+        assert_eq!(cfg.daemon.listen, cfg.tui.connect);
 
         let json = serde_json::to_string(&cfg).unwrap();
         let back: DashboardConfig = serde_json::from_str(&json).unwrap();

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -118,9 +118,11 @@ fn default_socket() -> String {
     let path = socket_path(
         std::env::var_os("XDG_RUNTIME_DIR"),
         std::env::var_os("HOME"),
+        // An empty `USER` must fall through to `LOGNAME`, not short-circuit it.
         std::env::var("USER")
-            .or_else(|_| std::env::var("LOGNAME"))
-            .ok(),
+            .ok()
+            .filter(|v| !v.is_empty())
+            .or_else(|| std::env::var("LOGNAME").ok().filter(|v| !v.is_empty())),
         std::env::temp_dir(),
     );
     format!("unix:{}", path.display())

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -130,7 +130,12 @@ fn default_socket() -> String {
 
 /// Pure core of [`default_socket`]: resolve the socket path from explicit env
 /// inputs so the precedence is testable without mutating process-global env vars
-/// (unsafe and racy under parallel tests in edition 2024).
+/// (unsafe and racy under parallel tests in edition 2024). Precedence:
+///
+/// 1. `$XDG_RUNTIME_DIR` — already mode `0700` on systemd systems, ideal.
+/// 2. `$HOME/.rocm/data/telemetry` — standard per-user data dir.
+/// 3. `temp_dir()/rocm-<user>` — user-named subdir so the parent is something
+///    the daemon creates and owns, not `/tmp` itself.
 fn socket_path(
     xdg_runtime_dir: Option<std::ffi::OsString>,
     home: Option<std::ffi::OsString>,
@@ -473,6 +478,10 @@ theme = "default-dark"
 
         // No user name at all still yields a valid per-user subdir.
         let path = socket_path(None, None, None, PathBuf::from("/tmp"));
+        assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
+
+        // A bare empty user name (as opposed to unset) also falls back to "user".
+        let path = socket_path(None, None, Some(String::new()), PathBuf::from("/tmp"));
         assert_eq!(path, PathBuf::from("/tmp/rocm-user/rocmdashd.sock"));
     }
 }

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -54,22 +54,36 @@ pub async fn run(listen: &str, opts: RunnerOptions) -> anyhow::Result<()> {
     }
 }
 
+/// A directory we could not tighten to `0o700` is safe to keep using only if no
+/// unprivileged user can tamper with entries inside it. The one such case is a
+/// **root-owned, sticky** directory — the `/tmp` signature (mode `1777`): the
+/// sticky bit means only the owner of an entry (us) may remove or rename it, so
+/// our `0o600` socket cannot be replaced. Any other owner means a local,
+/// unprivileged user controls the path (a squatting attack), which is not safe.
+#[cfg(unix)]
+const fn is_safe_shared_dir(uid: u32, mode: u32) -> bool {
+    uid == 0 && (mode & 0o1000 != 0)
+}
+
 /// Ensure the socket's parent directory exists and is private (mode `0o700`).
 ///
 /// Directory permissions are *defense-in-depth*: the socket itself is bound with
-/// mode `0o600` (see `run_unix`), so only the owning user can ever connect. We
-/// therefore **enforce** `0o700` only on a directory we just created — a
-/// directory we own must be securable, and failing to do so is a real error.
+/// mode `0o600` (see `run_unix`), so only the owning user can ever connect.
+/// `set_permissions` fails with `EPERM` only when we do not own the directory,
+/// which is exactly what we key the policy on:
 ///
-/// For a directory that already existed and is owned by another user (the classic
-/// case is a socket parented directly at `/tmp`, which is root-owned with mode
-/// `1777`), `chmod` returns `EPERM`. Aborting there crashed the embedded
-/// telemetry daemon for any user whose configured socket lived under `/tmp`.
-/// Since the `0o600` socket already restricts access, we log a warning and carry
-/// on instead of failing.
+/// * **We own it** (chmod succeeds) — it is now `0o700`; continue.
+/// * **A root-owned sticky directory** such as `/tmp` (chmod fails) — the sticky
+///   bit stops other users removing our socket, so warn and continue. Aborting
+///   here is what previously crashed the embedded telemetry daemon for any user
+///   whose configured socket lived directly under `/tmp`.
+/// * **Any other owner** (chmod fails) — another unprivileged user owns this
+///   path and could unlink or replace the socket, so refuse rather than bind a
+///   telemetry endpoint inside an attacker-controlled directory.
 #[cfg(unix)]
 fn prepare_socket_dir(parent: &std::path::Path) -> anyhow::Result<()> {
     use std::os::unix::fs::DirBuilderExt;
+    use std::os::unix::fs::MetadataExt;
     use std::os::unix::fs::PermissionsExt;
 
     // Skip an empty parent (relative socket target such as `unix:foo.sock`).
@@ -78,10 +92,9 @@ fn prepare_socket_dir(parent: &std::path::Path) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Whether we are about to create the directory ourselves. `DirBuilder::mode`
-    // only applies to directories it creates; a pre-existing directory keeps its
-    // current permissions, which is why we tighten explicitly below.
-    let created = !parent.exists();
+    // `DirBuilder::mode` only applies to directories it creates; a pre-existing
+    // directory keeps its current permissions, which is why we tighten
+    // explicitly below.
     std::fs::DirBuilder::new()
         .recursive(true)
         .mode(0o700)
@@ -89,26 +102,34 @@ fn prepare_socket_dir(parent: &std::path::Path) -> anyhow::Result<()> {
         .with_context(|| format!("creating socket directory {}", parent.display()))?;
 
     if let Err(e) = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)) {
-        if created {
-            // We created it, so we own it: inability to secure it is a real error.
+        // chmod only fails because we do not own the directory. Decide from the
+        // directory's *actual* owner and mode — not from whether we think we
+        // just created it, which is racy — whether it is nonetheless safe.
+        let meta = std::fs::metadata(parent).with_context(|| {
+            format!(
+                "inspecting socket directory {} after it could not be secured",
+                parent.display()
+            )
+        })?;
+        if is_safe_shared_dir(meta.uid(), meta.mode()) {
+            warn!(
+                dir = %parent.display(),
+                error = %e,
+                "could not restrict socket directory to mode 0700; continuing because \
+                 it is a root-owned sticky directory (e.g. /tmp) and the socket is \
+                 created with mode 0600"
+            );
+        } else {
             return Err(e).with_context(|| {
                 format!(
-                    "restricting socket directory {} to mode 0700 — \
-                     check that the directory is owned by the current user \
-                     (EPERM means it is owned by another user or root)",
+                    "restricting socket directory {} to mode 0700 — it is owned by \
+                     another user, so a local user could replace the telemetry \
+                     socket. Point the socket at a directory you own, for example \
+                     under $XDG_RUNTIME_DIR or $HOME",
                     parent.display()
                 )
             });
         }
-        // Pre-existing directory we do not own (e.g. /tmp, mode 1777): the
-        // 0o600 socket still keeps the endpoint private, so warn and continue.
-        warn!(
-            dir = %parent.display(),
-            error = %e,
-            "could not restrict socket directory to mode 0700; continuing because \
-             the socket is created with mode 0600 (expected for shared directories \
-             such as /tmp)"
-        );
     }
     Ok(())
 }
@@ -295,7 +316,29 @@ mod tests {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::Path;
 
-    use super::prepare_socket_dir;
+    use super::{is_safe_shared_dir, prepare_socket_dir};
+
+    /// The safe-to-continue predicate is the security-critical decision for a
+    /// directory we cannot tighten, and the squatting case (a non-root user
+    /// owning the parent) cannot be reproduced in a unit test without a second
+    /// uid — so pin every owner/mode combination here.
+    #[test]
+    fn only_root_owned_sticky_dir_is_safe_shared() {
+        assert!(is_safe_shared_dir(0, 0o1777), "/tmp signature is safe");
+        assert!(is_safe_shared_dir(0, 0o1700), "root-owned + sticky is safe");
+        assert!(
+            !is_safe_shared_dir(0, 0o0777),
+            "root-owned without the sticky bit is not safe: others can unlink our socket"
+        );
+        assert!(
+            !is_safe_shared_dir(1000, 0o1777),
+            "a non-root user owning the parent is a squatting risk, even with sticky set"
+        );
+        assert!(
+            !is_safe_shared_dir(1000, 0o0700),
+            "another unprivileged owner is never safe"
+        );
+    }
 
     /// A freshly created nested parent must end up at mode 0700.
     #[test]
@@ -325,17 +368,27 @@ mod tests {
         prepare_socket_dir(Path::new("")).expect("empty parent must be skipped");
     }
 
-    /// Regression: a socket parented at a pre-existing directory owned by another
-    /// user (e.g. `/tmp`, root-owned mode 1777) must NOT abort the daemon — the
-    /// chmod EPERM is downgraded to a warning because the 0600 socket already
-    /// protects the endpoint. Before the fix this returned an error and crashed
-    /// the embedded telemetry daemon.
+    /// Regression: a socket parented at a root-owned sticky directory (`/tmp`,
+    /// mode 1777) must NOT abort the daemon — the chmod EPERM is downgraded to a
+    /// warning because the sticky bit + 0600 socket protect the endpoint. Before
+    /// the fix this returned an error and crashed the embedded telemetry daemon.
+    ///
+    /// This exercises the real fix on Linux CI (where `temp_dir()` is `/tmp`,
+    /// root-owned, and the test runs unprivileged). It is skipped when we own the
+    /// temp dir or it is not a root-owned sticky dir (e.g. a custom `TMPDIR`, some
+    /// containers, or macOS) — there chmod would either succeed and mutate a
+    /// shared directory, or the safe-shared predicate would legitimately refuse,
+    /// neither of which is this regression. `is_safe_shared_dir` is unit-tested
+    /// separately for the refuse path.
     #[test]
-    fn preexisting_unowned_parent_does_not_abort() {
+    fn preexisting_root_sticky_parent_does_not_abort() {
         let tmpdir = std::env::temp_dir();
         let Ok(meta) = std::fs::metadata(&tmpdir) else {
             return; // no temp dir to probe; nothing to assert
         };
+        if !is_safe_shared_dir(meta.uid(), meta.mode()) {
+            return; // not the /tmp signature; not this regression
+        }
         // Determine our effective uid by stat-ing a file we create ourselves.
         let probe = tmpdir.join(format!("rocmdashd-uidprobe-{}", std::process::id()));
         if std::fs::write(&probe, b"x").is_err() {
@@ -343,12 +396,11 @@ mod tests {
         }
         let my_uid = std::fs::metadata(&probe).map(|m| m.uid()).ok();
         let _ = std::fs::remove_file(&probe);
-        // Only meaningful when the temp dir is owned by someone else (so chmod is
-        // guaranteed to EPERM). If we own it or are root, chmod would *succeed*
-        // and mutate a shared directory — skip to avoid side effects.
+        // Only meaningful when we do not own the dir, so chmod is guaranteed to
+        // EPERM and the warn-and-continue path is actually taken.
         if my_uid != Some(meta.uid()) {
             prepare_socket_dir(&tmpdir)
-                .expect("must not abort when it cannot chmod a pre-existing unowned parent");
+                .expect("must not abort on a root-owned sticky parent it cannot chmod (e.g. /tmp)");
         }
     }
 }

--- a/crates/rocm-dash-daemon/src/server.rs
+++ b/crates/rocm-dash-daemon/src/server.rs
@@ -384,15 +384,18 @@ mod tests {
     fn preexisting_root_sticky_parent_does_not_abort() {
         let tmpdir = std::env::temp_dir();
         let Ok(meta) = std::fs::metadata(&tmpdir) else {
-            return; // no temp dir to probe; nothing to assert
+            eprintln!("skip: no temp dir to probe; nothing to assert");
+            return;
         };
         if !is_safe_shared_dir(meta.uid(), meta.mode()) {
-            return; // not the /tmp signature; not this regression
+            eprintln!("skip: temp dir is not the root-owned-sticky /tmp signature");
+            return;
         }
         // Determine our effective uid by stat-ing a file we create ourselves.
         let probe = tmpdir.join(format!("rocmdashd-uidprobe-{}", std::process::id()));
         if std::fs::write(&probe, b"x").is_err() {
-            return; // cannot write a probe; skip rather than guess our uid
+            eprintln!("skip: cannot write a probe file; cannot determine our uid");
+            return;
         }
         let my_uid = std::fs::metadata(&probe).map(|m| m.uid()).ok();
         let _ = std::fs::remove_file(&probe);


### PR DESCRIPTION
Follow-up hardening to #64, which kept the telemetry daemon alive when its socket lives under `/tmp`.

## 1 — Refuse a socket directory owned by another user

#64 downgraded a `chmod` failure to a warning for *any* directory the daemon didn't own, and decided that from a racy `!parent.exists()` snapshot. On a shared host, a local user could pre-create the predictable per-user subdirectory (`/tmp/rocm-<user>`) and own it, so the daemon would then remove and bind its socket **inside an attacker-controlled directory** — the owner could unlink or replace the socket (DoS, or substitute an endpoint against clients).

The decision now keys off the directory's *actual* owner: continue only for a root-owned **sticky** directory (the `/tmp` signature, mode `1777`, where the sticky bit stops other users removing our entry); for any other owner, fail with an actionable error instead of binding a telemetry endpoint there. The ownership predicate is a pure function, unit-tested across every owner/mode combination (the squatting case can't be reproduced in a test without a second uid). Keying off the real owner also removes the earlier race between the existence check and directory creation.

## 2 — Consult `LOGNAME` when `USER` is empty

An empty `USER` (`Ok("")`) short-circuited the `LOGNAME` fallback, collapsing the tier-3 subdirectory to the literal `rocm-user`. Empty values are now treated as unset, in both `rocm-core` and `rocm-dash-core`, which carry the same resolver.

## 3 — Test the resolver precedence in `rocm-core`

`rocm-core` resolved the socket path straight from process env vars, so its precedence was untested (unlike `rocm-dash-core`'s injectable helper). Extracted the same pure `dashboard_socket_path` helper and mirrored the four precedence/sanitization tests, so the two copies of this logic can't silently diverge.

## Tests

- New: `is_safe_shared_dir` predicate (root+sticky safe; root-without-sticky, non-root+sticky, and other-owner all refused).
- Updated the `/tmp` regression test to assert the root-owned-sticky continue path, with a documented skip when the temp dir isn't that signature.
- Mirrored `dashboard_socket_path` precedence tests into `rocm-core`.

All of `cargo test`, `clippy -D warnings`, and `fmt --check` pass locally for the three touched crates.