### PR TITLE
feat(serve): deployment summary by default instead of a log stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,22 @@ rocm serve <model> [--engine lemonade|pytorch|llama.cpp|atom|vllm|sglang]
                    [--gpu auto|<index>]
                    [--runtime-id KEY | --env-id ID]
                    [--host HOST] [--port PORT]
-                   [--foreground | --managed]
+                   [--verbose] [--foreground | --managed]
+                   [--no-smoke-test]
                    [--allow-public-bind]
 ```
 
-`--managed` runs the server in the background under rocm-cli's supervision.
-`--foreground` attaches it to the current terminal.
+By default the server runs in the background under rocm-cli's supervision and
+prints a deployment summary — a progress indicator while it starts, then a table
+with the status, the full inference endpoint, the API-qualified model name, and a
+quick smoke test (time to first token and approximate tokens/sec). Control
+returns to your shell with the server still running; manage it later with `rocm
+services` (below).
+
+`--verbose` (or `--foreground`) instead attaches the server to the current
+terminal and streams every engine log line — use it to debug a startup problem.
+`--managed` is the explicit form of the default background behavior.
+`--no-smoke-test` skips the post-startup inference probe.
 
 `--gpu` selects which AMD GPU the server runs on. `auto` (the default) probes
 per-GPU VRAM with `amd-smi` and picks the lowest-numbered GPU that is idle and

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -9,6 +9,7 @@ mod dash;
 mod dash_seam;
 mod provider_keys;
 mod providers;
+mod serve_summary;
 mod therock;
 mod uninstall;
 
@@ -271,12 +272,13 @@ rocm model --verbose"
     /// Start a local OpenAI-compatible model server.
     ///
     /// Picks an engine and ROCm runtime automatically unless overridden. By default the
-    /// server runs as a managed background service; use --foreground to keep it attached
-    /// to this terminal. Inspect or stop servers later with `rocm services`.
+    /// server runs as a managed background service and prints a deployment summary
+    /// (status, endpoint, model, and smoke-test metrics); use --verbose to stream engine
+    /// logs in this terminal instead. Inspect or stop servers later with `rocm services`.
     #[command(after_help = "EXAMPLES:\n  \
 rocm serve qwen2.5-7b-instruct\n  \
 rocm serve ./models/model.gguf --engine llama.cpp --port 8080\n  \
-rocm serve qwen2.5-7b-instruct --foreground --device gpu_required")]
+rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
     Serve {
         /// Model name, alias, or local model file path.
         model: String,
@@ -308,6 +310,12 @@ rocm serve qwen2.5-7b-instruct --foreground --device gpu_required")]
         /// Keep the server managed by ROCm CLI.
         #[arg(long)]
         managed: bool,
+        /// Stream every engine log line in this terminal instead of a deployment summary.
+        #[arg(long, conflicts_with = "managed")]
+        verbose: bool,
+        /// Skip the post-startup inference smoke test (time-to-first-token, tokens/sec).
+        #[arg(long)]
+        no_smoke_test: bool,
         /// Allow binding to a non-local address.
         #[arg(long)]
         allow_public_bind: bool,
@@ -1477,8 +1485,10 @@ fn dispatch(cli: Cli) -> Result<()> {
             port,
             foreground,
             managed,
+            verbose,
+            no_smoke_test,
             allow_public_bind,
-        }) => serve(
+        }) => serve(ServeArgs {
             model,
             engine,
             device,
@@ -1489,8 +1499,10 @@ fn dispatch(cli: Cli) -> Result<()> {
             port,
             foreground,
             managed,
+            verbose,
+            no_smoke_test,
             allow_public_bind,
-        ),
+        }),
         Some(Command::Comfyui { command }) => comfyui(command),
         Some(Command::Services { command }) => services(command),
         Some(Command::Automations { command }) => automations(command),
@@ -3721,8 +3733,9 @@ fn protocol_engine_recipe_hint(
         })
 }
 
-#[allow(clippy::too_many_arguments)]
-fn serve(
+/// Parsed `rocm serve` arguments. Grouped into a struct to keep the dispatcher
+/// and `serve()` readable now that the verb carries verbose/smoke-test controls.
+struct ServeArgs {
     model: String,
     engine: Option<String>,
     device: Option<String>,
@@ -3733,8 +3746,28 @@ fn serve(
     port: u16,
     foreground: bool,
     managed: bool,
+    verbose: bool,
+    no_smoke_test: bool,
     allow_public_bind: bool,
-) -> Result<()> {
+}
+
+fn serve(args: ServeArgs) -> Result<()> {
+    let ServeArgs {
+        model,
+        engine,
+        device,
+        gpu,
+        runtime_id,
+        env_id,
+        host,
+        port,
+        foreground,
+        managed,
+        verbose,
+        no_smoke_test,
+        allow_public_bind,
+    } = args;
+    let _ = managed; // background is now the default; --managed is accepted as an explicit synonym.
     validate_bind_host(&host, allow_public_bind)?;
     let paths = AppPaths::discover()?;
     let mut config = RocmCliConfig::load(&paths)?;
@@ -3819,63 +3852,74 @@ fn serve(
     )?;
     let service_id = generate_service_id(&selected_engine, &resolve.canonical_model_id);
 
-    println!("serve plan");
-    println!("  requested model: {model}");
-    println!("  resolved model: {}", resolve.canonical_model_id);
-    println!("  engine: {selected_engine}");
-    println!("{}", serve_engine_selection_line(&serve_engine));
-    println!("  host: {host}");
-    println!("  port: {port}");
-    if let Some(runtime_id) = resolved_selection.runtime_id.as_deref() {
-        println!("  runtime_id: {runtime_id}");
-    }
-    if let Some(env_id) = resolved_selection.env_id.as_deref() {
-        println!("  env_id: {env_id}");
-    }
-    if let Some(source) = resolved_selection.source.as_deref() {
-        println!("  selection_source: {source}");
-    }
-    println!(
-        "  device_policy: {}",
-        device_policy_name(&resolve.device_policy)
-    );
-    if cpu_only {
-        if matches!(gpu_selection, GpuSelection::Index(_)) {
-            println!(
-                "  warning: --gpu was ignored because --device cpu_only runs the model on CPU"
-            );
+    // Attached foreground streaming is the debugging path, selected by `--verbose`
+    // or `--foreground`. Everything else backgrounds the server and, when writing
+    // to an interactive terminal, shows a progress spinner + deployment summary
+    // instead of a raw log stream. Piped/captured output (CI, the chat assistant)
+    // keeps the plain line-by-line form.
+    let use_foreground = foreground || verbose;
+    let background = !use_foreground;
+    let summary_mode = background && std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+    if !summary_mode {
+        println!("serve plan");
+        println!("  requested model: {model}");
+        println!("  resolved model: {}", resolve.canonical_model_id);
+        println!("  engine: {selected_engine}");
+        println!("{}", serve_engine_selection_line(&serve_engine));
+        println!("  host: {host}");
+        println!("  port: {port}");
+        if let Some(runtime_id) = resolved_selection.runtime_id.as_deref() {
+            println!("  runtime_id: {runtime_id}");
         }
-    } else {
-        match &gpu_selection {
-            GpuSelection::Auto => {
-                let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
-                    .unwrap_or_else(|| "none".to_owned());
-                println!("  gpu: auto (selected {csv})");
+        if let Some(env_id) = resolved_selection.env_id.as_deref() {
+            println!("  env_id: {env_id}");
+        }
+        if let Some(source) = resolved_selection.source.as_deref() {
+            println!("  selection_source: {source}");
+        }
+        println!(
+            "  device_policy: {}",
+            device_policy_name(&resolve.device_policy)
+        );
+        if cpu_only {
+            if matches!(gpu_selection, GpuSelection::Index(_)) {
+                println!(
+                    "  warning: --gpu was ignored because --device cpu_only runs the model on CPU"
+                );
             }
-            GpuSelection::Index(_) => {
-                let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
-                    .unwrap_or_else(|| "none".to_owned());
-                println!("  gpu: {csv}");
+        } else {
+            match &gpu_selection {
+                GpuSelection::Auto => {
+                    let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                        .unwrap_or_else(|| "none".to_owned());
+                    println!("  gpu: auto (selected {csv})");
+                }
+                GpuSelection::Index(_) => {
+                    let csv = rocm_engine_protocol::gpu_indices_to_csv(&gpu_indices)
+                        .unwrap_or_else(|| "none".to_owned());
+                    println!("  gpu: {csv}");
+                }
+            }
+            if rocr_visible_devices_set {
+                println!(
+                    "  warning: ROCR_VISIBLE_DEVICES is set; --gpu selects by the amd-smi ordinal but \
+                     is applied via HIP_VISIBLE_DEVICES, so the chosen device may differ. Verify the \
+                     selected GPU or unset ROCR_VISIBLE_DEVICES."
+                );
+            }
+            if let Some(warning) = gpu_low_memory_warning(&gpu_indices, gpu_vram.as_deref()) {
+                println!("  {warning}");
             }
         }
-        if rocr_visible_devices_set {
-            println!(
-                "  warning: ROCR_VISIBLE_DEVICES is set; --gpu selects by the amd-smi ordinal but \
-                 is applied via HIP_VISIBLE_DEVICES, so the chosen device may differ. Verify the \
-                 selected GPU or unset ROCR_VISIBLE_DEVICES."
-            );
+        if let Some(engine_recipe) = &resolve.engine_recipe {
+            print!("{}", render_serve_engine_recipe_lines(engine_recipe));
         }
-        if let Some(warning) = gpu_low_memory_warning(&gpu_indices, gpu_vram.as_deref()) {
-            println!("  {warning}");
-        }
-    }
-    if let Some(engine_recipe) = &resolve.engine_recipe {
-        print!("{}", render_serve_engine_recipe_lines(engine_recipe));
     }
 
     let mut managed_runtime_id = resolved_selection.runtime_id.clone();
     let mut managed_env_id = resolved_selection.env_id.clone();
-    if managed && selected_engine == "pytorch" {
+    if background && selected_engine == "pytorch" {
         let engine_env = resolve_engine_env(
             &paths,
             &config,
@@ -3883,13 +3927,18 @@ fn serve(
             resolved_selection.runtime_id.as_deref(),
             resolved_selection.env_id.as_deref(),
         )?;
-        println!("  engine_env_id: {}", engine_env.env_id);
+        if !summary_mode {
+            println!("  engine_env_id: {}", engine_env.env_id);
+        }
         managed_runtime_id = Some(engine_env.runtime_id);
         managed_env_id = engine_env.managed_env_id;
     }
 
-    if managed {
-        start_managed_service(
+    if background {
+        let mut spinner =
+            serve_summary::Spinner::new(format!("Starting {model} on {selected_engine}…"));
+        spinner.tick();
+        let report = start_managed_service(
             &selected_engine,
             &service_id,
             &model,
@@ -3901,15 +3950,47 @@ fn serve(
             managed_runtime_id.as_deref(),
             managed_env_id.as_deref(),
             resolve.engine_recipe.as_ref(),
+            &mut |_elapsed| spinner.tick(),
         )?;
-        ensure_background_helper_running()?;
+        ensure_background_helper_running_quiet(summary_mode)?;
+
+        if summary_mode {
+            // Best-effort inference smoke test, on by default (opt out with
+            // `--no-smoke-test`). Only meaningful for a freshly-ready server we
+            // just launched; skipped when metrics could not be shown anyway.
+            let metrics = if !no_smoke_test && !report.already_running && report.status == "ready" {
+                spinner.set_label("Running smoke test…");
+                serve_summary::run_smoke_test(&paths, &resolve.canonical_model_id)
+            } else {
+                serve_summary::SmokeMetrics::default()
+            };
+            spinner.clear();
+
+            let notes = collect_serve_notes(
+                cpu_only,
+                &gpu_selection,
+                rocr_visible_devices_set,
+                &gpu_indices,
+                gpu_vram.as_deref(),
+            );
+            let summary = serve_summary::DeploymentSummary {
+                engine: selected_engine.clone(),
+                api_model: resolve.canonical_model_id,
+                chat_endpoint: format!("{}/chat/completions", report.endpoint_url),
+                service_id: report.service_id.clone(),
+                status: report.status.clone(),
+                already_running: report.already_running,
+                metrics,
+                notes,
+            };
+            print!("{}", serve_summary::render_summary(&summary));
+        } else {
+            spinner.clear();
+            print_managed_launch_plain(&report);
+        }
         return Ok(());
     }
 
-    if !foreground {
-        println!("  mode: foreground (default)");
-        println!("  note: use --managed to hand supervision to rocmd.");
-    }
     run_foreground_service(
         &selected_engine,
         &service_id,
@@ -3922,6 +4003,38 @@ fn serve(
         resolved_selection.env_id.as_deref(),
         resolve.engine_recipe.as_ref(),
     )
+}
+
+/// GPU/device warnings folded into the interactive deployment summary. Mirrors the
+/// inline warnings printed in the plain serve plan, in the same order.
+fn collect_serve_notes(
+    cpu_only: bool,
+    gpu_selection: &GpuSelection,
+    rocr_visible_devices_set: bool,
+    gpu_indices: &[u32],
+    gpu_vram: Option<&[GpuVramUsage]>,
+) -> Vec<String> {
+    let mut notes = Vec::new();
+    if cpu_only {
+        if matches!(gpu_selection, GpuSelection::Index(_)) {
+            notes.push(
+                "--gpu was ignored because --device cpu_only runs the model on CPU".to_owned(),
+            );
+        }
+    } else {
+        if rocr_visible_devices_set {
+            notes.push(
+                "ROCR_VISIBLE_DEVICES is set; --gpu selects by the amd-smi ordinal but is applied \
+                 via HIP_VISIBLE_DEVICES, so the chosen device may differ. Verify the selected GPU \
+                 or unset ROCR_VISIBLE_DEVICES."
+                    .to_owned(),
+            );
+        }
+        if let Some(warning) = gpu_low_memory_warning(gpu_indices, gpu_vram) {
+            notes.push(warning);
+        }
+    }
+    notes
 }
 
 fn validate_bind_host(host: &str, allow_public_bind: bool) -> Result<()> {
@@ -3990,6 +4103,22 @@ fn managed_service_process_command(program: &Path, args: &[String]) -> ProcessCo
     command
 }
 
+/// Engine-neutral result of a managed launch. Returned rather than printed so the
+/// caller can render it either as the rich deployment summary (interactive TTY) or
+/// as the plain line-by-line form (piped output, chat assistant), from one code path.
+struct ManagedLaunchReport {
+    service_id: String,
+    /// `http://host:port/v1`.
+    endpoint_url: String,
+    /// `"ready"`, `"starting"`, or the existing service's status.
+    status: String,
+    /// True when an equivalent service was already live and nothing was spawned.
+    already_running: bool,
+    child_pid: Option<u32>,
+    log_path: Option<PathBuf>,
+    manifest_path: Option<PathBuf>,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn start_managed_service(
     engine: &str,
@@ -4003,7 +4132,8 @@ fn start_managed_service(
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe: Option<&EngineRecipeHint>,
-) -> Result<()> {
+    on_wait_tick: &mut dyn FnMut(Duration),
+) -> Result<ManagedLaunchReport> {
     let paths = AppPaths::discover()?;
     paths.ensure()?;
     fs::create_dir_all(paths.services_dir())?;
@@ -4017,11 +4147,6 @@ fn start_managed_service(
     if let Some(existing) =
         existing_live_managed_service(&paths, engine, &resolve.canonical_model_id)
     {
-        println!("managed service already running");
-        println!("  service_id: {}", existing.service_id);
-        println!("  endpoint: {}", existing.endpoint_url);
-        println!("  status: {}", existing.status);
-        println!("  note: existing service detected; no second process spawned");
         record_cli_audit_event(
             &paths,
             "service",
@@ -4033,7 +4158,15 @@ fn start_managed_service(
             ),
             Some(&existing.service_id),
         );
-        return Ok(());
+        return Ok(ManagedLaunchReport {
+            service_id: existing.service_id,
+            endpoint_url: existing.endpoint_url,
+            status: existing.status,
+            already_running: true,
+            child_pid: None,
+            log_path: None,
+            manifest_path: None,
+        });
     }
 
     let mut record = ManagedServiceRecord::new(
@@ -4121,26 +4254,17 @@ fn start_managed_service(
     #[cfg(windows)]
     thread::sleep(Duration::from_millis(200));
 
-    let readiness = wait_for_service_http_ready(
+    let readiness = wait_for_service_http_ready_with_progress(
         engine,
         host,
         port,
         &resolve.canonical_model_id,
         Duration::from_secs(45),
+        on_wait_tick,
     );
     record.status = if readiness { "ready" } else { "starting" }.to_owned();
     record.write()?;
     let endpoint_url = format!("{}/v1", format_http_base_url(host, port));
-    println!("managed service launched");
-    println!("  service_id: {service_id}");
-    println!("  process_pid: {child_pid}");
-    println!("  endpoint: {endpoint_url}");
-    println!("  log_path: {}", record.log_path.display());
-    println!("  manifest_path: {}", record.manifest_path.display());
-    println!(
-        "  readiness: {}",
-        if readiness { "ready" } else { "starting" }
-    );
     record_cli_audit_event(
         &paths,
         "service",
@@ -4155,7 +4279,43 @@ fn start_managed_service(
         ),
         Some(service_id),
     );
-    Ok(())
+    Ok(ManagedLaunchReport {
+        service_id: service_id.to_owned(),
+        endpoint_url,
+        status: if readiness { "ready" } else { "starting" }.to_owned(),
+        already_running: false,
+        child_pid: Some(child_pid),
+        log_path: Some(record.log_path),
+        manifest_path: Some(record.manifest_path),
+    })
+}
+
+/// Reproduce the original plain, line-by-line managed-launch output. Used for
+/// non-interactive output (piped, CI, the chat assistant's `serve --managed`),
+/// where the animated summary is inappropriate. The interactive path renders the
+/// summary table via [`serve_summary`] instead.
+fn print_managed_launch_plain(report: &ManagedLaunchReport) {
+    if report.already_running {
+        println!("managed service already running");
+        println!("  service_id: {}", report.service_id);
+        println!("  endpoint: {}", report.endpoint_url);
+        println!("  status: {}", report.status);
+        println!("  note: existing service detected; no second process spawned");
+        return;
+    }
+    println!("managed service launched");
+    println!("  service_id: {}", report.service_id);
+    if let Some(child_pid) = report.child_pid {
+        println!("  process_pid: {child_pid}");
+    }
+    println!("  endpoint: {}", report.endpoint_url);
+    if let Some(log_path) = report.log_path.as_deref() {
+        println!("  log_path: {}", log_path.display());
+    }
+    if let Some(manifest_path) = report.manifest_path.as_deref() {
+        println!("  manifest_path: {}", manifest_path.display());
+    }
+    println!("  readiness: {}", report.status);
 }
 
 /// The "should we spawn?" decision for [`ensure_background_helper_running`],
@@ -4175,6 +4335,13 @@ pub(crate) fn background_helper_already_running(paths: &AppPaths) -> Result<bool
 /// itself (`command.spawn()` / `spawn_detached_no_inherit`) is logged rather than
 /// propagated; setup errors (path discovery, stdio attach) still return `Err`.
 pub(crate) fn ensure_background_helper_running() -> Result<()> {
+    ensure_background_helper_running_quiet(false)
+}
+
+/// As [`ensure_background_helper_running`], but suppresses the stdout status line
+/// when `quiet` is set. The interactive `rocm serve` summary path uses `quiet` so
+/// the daemon-spawn note does not appear above the deployment summary table.
+pub(crate) fn ensure_background_helper_running_quiet(quiet: bool) -> Result<()> {
     let paths = AppPaths::discover()?;
     if background_helper_already_running(&paths)? {
         return Ok(());
@@ -4199,8 +4366,12 @@ pub(crate) fn ensure_background_helper_running() -> Result<()> {
         command.spawn().map(|_| ())
     };
     match spawn_result {
-        Ok(()) => println!("  helper: started background automation daemon"),
-        Err(error) => println!("  helper: could not start background automation daemon: {error}"),
+        Ok(()) if !quiet => println!("  helper: started background automation daemon"),
+        Ok(()) => {}
+        Err(error) if !quiet => {
+            println!("  helper: could not start background automation daemon: {error}");
+        }
+        Err(_) => {}
     }
     Ok(())
 }
@@ -15053,6 +15224,28 @@ fn wait_for_service_http_ready(
     canonical_model_id: &str,
     timeout: Duration,
 ) -> bool {
+    wait_for_service_http_ready_with_progress(
+        engine,
+        host,
+        port,
+        canonical_model_id,
+        timeout,
+        &mut |_elapsed| {},
+    )
+}
+
+/// Poll the engine's health endpoints until the server answers ready or `timeout`
+/// elapses, invoking `on_tick(elapsed)` once per polling iteration so a caller can
+/// animate a spinner. Engine-neutral: `service_http_readiness_paths` already maps
+/// each engine to the right health path and normalizes the response to ready/not.
+fn wait_for_service_http_ready_with_progress(
+    engine: &str,
+    host: &str,
+    port: u16,
+    canonical_model_id: &str,
+    timeout: Duration,
+    on_tick: &mut dyn FnMut(Duration),
+) -> bool {
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
         for path in service_http_readiness_paths(engine) {
@@ -15069,6 +15262,7 @@ fn wait_for_service_http_ready(
                 return true;
             }
         }
+        on_tick(start.elapsed());
         thread::sleep(Duration::from_millis(250));
     }
     false
@@ -15358,6 +15552,58 @@ mod tests {
             listed, expected,
             "serve --device help possible-values must stay in sync with DevicePolicy names"
         );
+    }
+
+    fn parse_serve(args: &[&str]) -> Result<Cli, clap::Error> {
+        let mut argv = vec!["rocm", "serve", "qwen"];
+        argv.extend_from_slice(args);
+        Cli::try_parse_from(argv)
+    }
+
+    #[test]
+    fn serve_parses_verbose_and_no_smoke_test_flags() {
+        let cli = parse_serve(&["--verbose", "--no-smoke-test"]).expect("flags parse");
+        match cli.command {
+            Some(Command::Serve {
+                verbose,
+                no_smoke_test,
+                foreground,
+                managed,
+                ..
+            }) => {
+                assert!(verbose, "--verbose should set verbose");
+                assert!(no_smoke_test, "--no-smoke-test should set no_smoke_test");
+                assert!(!foreground);
+                assert!(!managed);
+            }
+            other => panic!("expected Serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serve_verbose_conflicts_with_managed() {
+        // `--verbose` streams logs in the foreground; a backgrounded managed
+        // server has no foreground stream to attach to, so the two are mutually
+        // exclusive (point users at `rocm logs` for a managed server instead).
+        let error = parse_serve(&["--verbose", "--managed"]).expect_err("conflict rejected");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn serve_defaults_have_all_flags_off() {
+        let cli = parse_serve(&[]).expect("bare serve parses");
+        match cli.command {
+            Some(Command::Serve {
+                verbose,
+                no_smoke_test,
+                foreground,
+                managed,
+                ..
+            }) => {
+                assert!(!verbose && !no_smoke_test && !foreground && !managed);
+            }
+            other => panic!("expected Serve, got {other:?}"),
+        }
     }
 
     #[test]

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -1,0 +1,378 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Engine-agnostic deployment summary for `rocm serve`.
+//!
+//! By default `rocm serve <model>` no longer streams raw engine logs. Instead it
+//! shows an animated status indicator while the server starts, runs a small
+//! inference smoke test, and then prints a compact summary table: deployment
+//! status, the full inference endpoint (with port), the API-qualified model name,
+//! and the measured time-to-first-token / throughput.
+//!
+//! Everything here operates at the CLI/HTTP layer *above* the per-engine
+//! adapters, so the summary shape is identical for every serving engine
+//! (lemonade, vLLM, SGLang, PyTorch, llama.cpp, atom). Only two things vary by
+//! engine, and both are already normalized elsewhere: the health path used for
+//! readiness, and whether the server reports token usage (which only affects
+//! whether throughput is exact, approximated, or `n/a`).
+
+use std::fmt::Write as _;
+use std::io::{IsTerminal, Write};
+use std::time::{Duration, Instant};
+
+use crossterm::QueueableCommand;
+use crossterm::cursor::MoveToColumn;
+use crossterm::terminal::{Clear, ClearType};
+use rocm_core::AppPaths;
+
+use crate::providers::{self, ChatMessage, ChatRequest, ProviderStreamEvent};
+
+/// Tiny prompt used for the startup smoke test. Kept short so the probe adds only
+/// a second or two to an otherwise-ready deployment.
+const SMOKE_PROMPT: &str = "Reply with a short one-sentence greeting.";
+/// Cap the smoke-test generation so a slow or verbose model cannot stall startup.
+const SMOKE_MAX_TOKENS: u32 = 32;
+/// Braille spinner frames (matching the dashboard's visual language).
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Best-effort metrics measured against a freshly-started server. Every field is
+/// optional: any probe failure leaves it `None` and the summary renders `n/a`.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct SmokeMetrics {
+    /// Time from request send to the first streamed content token.
+    pub ttft: Option<Duration>,
+    /// Generation throughput in tokens/sec (inter-token rate after the first token).
+    pub gen_tps: Option<f64>,
+}
+
+/// Everything the summary table renders. Built by `serve()` from the
+/// engine-neutral launch result, so the shape is identical for every engine.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DeploymentSummary {
+    pub engine: String,
+    /// Canonical / API-qualified model id clients pass as `"model"`.
+    pub api_model: String,
+    /// Full chat-completions endpoint, e.g. `http://127.0.0.1:1337/v1/chat/completions`.
+    pub chat_endpoint: String,
+    pub service_id: String,
+    /// `"ready"`, `"starting"`, or an existing service's status.
+    pub status: String,
+    /// True when an equivalent server was already running and nothing was spawned.
+    pub already_running: bool,
+    pub metrics: SmokeMetrics,
+    /// GPU/device warnings folded in from the serve plan.
+    pub notes: Vec<String>,
+}
+
+/// Render `Some(ttft)` as a human duration, or `n/a` when the probe did not
+/// produce a first token.
+pub(crate) fn format_ttft(ttft: Option<Duration>) -> String {
+    match ttft {
+        Some(duration) => {
+            let millis = duration.as_secs_f64() * 1000.0;
+            if millis < 1000.0 {
+                format!("{} ms", millis.round() as u64)
+            } else {
+                format!("{:.2} s", duration.as_secs_f64())
+            }
+        }
+        None => "n/a".to_owned(),
+    }
+}
+
+/// Render `Some(tps)` as `NN.N tok/s`, or `n/a` when throughput was not measured.
+pub(crate) fn format_tps(tps: Option<f64>) -> String {
+    match tps {
+        Some(value) if value.is_finite() && value > 0.0 => format!("{value:.1} tok/s"),
+        _ => "n/a".to_owned(),
+    }
+}
+
+/// Render the deployment summary table as plain text (returned rather than
+/// printed so it is unit-testable and identical across engines).
+pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
+    let heading = if summary.already_running {
+        "Deployment summary (already running)"
+    } else {
+        "Deployment summary"
+    };
+
+    // (label, value) rows, in the order the ticket calls out.
+    let rows: Vec<(&str, String)> = vec![
+        ("status", summary.status.clone()),
+        ("engine", summary.engine.clone()),
+        ("model", summary.api_model.clone()),
+        ("endpoint", summary.chat_endpoint.clone()),
+        ("time to first token", format_ttft(summary.metrics.ttft)),
+        ("throughput", format_tps(summary.metrics.gen_tps)),
+        ("service", summary.service_id.clone()),
+        ("stop", format!("rocm services stop {}", summary.service_id)),
+        (
+            "logs",
+            format!("rocm logs --service {}", summary.service_id),
+        ),
+    ];
+
+    let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
+
+    let mut out = String::new();
+    out.push_str(heading);
+    out.push('\n');
+    for (label, value) in rows {
+        let _ = writeln!(out, "  {label:<label_width$}  {value}");
+    }
+    for note in &summary.notes {
+        let _ = writeln!(out, "  note: {note}");
+    }
+    out
+}
+
+/// Run a single small chat completion against the just-started local server and
+/// measure time-to-first-token and generation throughput. Best-effort: any error
+/// (server not OpenAI-compatible, refused, timed out) yields empty metrics rather
+/// than failing the launch.
+pub(crate) fn run_smoke_test(paths: &AppPaths, api_model: &str) -> SmokeMetrics {
+    let request = ChatRequest {
+        model: Some(api_model.to_owned()),
+        messages: vec![ChatMessage {
+            role: "user".to_owned(),
+            content: SMOKE_PROMPT.to_owned(),
+        }],
+        max_tokens: Some(SMOKE_MAX_TOKENS),
+        rocm_tools: false,
+    };
+
+    let start = Instant::now();
+    let mut first_token: Option<Instant> = None;
+    let mut last_token: Option<Instant> = None;
+    let mut token_chunks: u64 = 0;
+
+    let result = providers::provider_stream_chat_with_callback(
+        paths,
+        "local",
+        &request,
+        &mut |event: ProviderStreamEvent| {
+            if !event.content.is_empty() {
+                let now = Instant::now();
+                first_token.get_or_insert(now);
+                last_token = Some(now);
+                token_chunks += 1;
+            }
+            Ok(())
+        },
+    );
+
+    if result.is_err() {
+        return SmokeMetrics::default();
+    }
+
+    compute_metrics(start, first_token, last_token, token_chunks)
+}
+
+/// Pure metric math, split out so it can be unit-tested without a live server.
+/// Throughput is the inter-token rate: tokens generated after the first, divided
+/// by the elapsed time between the first and last token.
+fn compute_metrics(
+    start: Instant,
+    first_token: Option<Instant>,
+    last_token: Option<Instant>,
+    token_chunks: u64,
+) -> SmokeMetrics {
+    let ttft = first_token.map(|first| first.saturating_duration_since(start));
+    let gen_tps = match (first_token, last_token) {
+        (Some(first), Some(last)) if token_chunks > 1 => {
+            let window = last.saturating_duration_since(first).as_secs_f64();
+            if window > 0.0 {
+                Some((token_chunks as f64 - 1.0) / window)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    SmokeMetrics { ttft, gen_tps }
+}
+
+/// A carriage-return status indicator written to stderr. Disabled (a no-op) when
+/// stderr is not a TTY, so piped/redirected output never receives control
+/// characters. Keeps stdout clean for the summary table.
+pub(crate) struct Spinner {
+    enabled: bool,
+    idx: usize,
+    label: String,
+    active: bool,
+}
+
+impl Spinner {
+    pub(crate) fn new(label: impl Into<String>) -> Self {
+        Self {
+            enabled: std::io::stderr().is_terminal(),
+            idx: 0,
+            label: label.into(),
+            active: false,
+        }
+    }
+
+    /// Change the message shown next to the spinner (e.g. "Running smoke test…").
+    pub(crate) fn set_label(&mut self, label: impl Into<String>) {
+        self.label = label.into();
+        self.render_current();
+    }
+
+    /// Advance to the next animation frame and repaint.
+    pub(crate) fn tick(&mut self) {
+        self.idx = self.idx.wrapping_add(1);
+        self.render_current();
+    }
+
+    fn render_current(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        let frame = SPINNER_FRAMES[self.idx % SPINNER_FRAMES.len()];
+        let mut err = std::io::stderr();
+        let _ = err.queue(MoveToColumn(0));
+        let _ = err.queue(Clear(ClearType::CurrentLine));
+        let _ = write!(err, "{frame} {}", self.label);
+        let _ = err.flush();
+        self.active = true;
+    }
+
+    /// Erase the spinner line so the summary table starts on a clean line.
+    pub(crate) fn clear(&mut self) {
+        if self.enabled && self.active {
+            let mut err = std::io::stderr();
+            let _ = err.queue(MoveToColumn(0));
+            let _ = err.queue(Clear(ClearType::CurrentLine));
+            let _ = err.flush();
+            self.active = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_summary() -> DeploymentSummary {
+        DeploymentSummary {
+            engine: "vllm".to_owned(),
+            api_model: "Qwen/Qwen2.5-7B-Instruct".to_owned(),
+            chat_endpoint: "http://127.0.0.1:1337/v1/chat/completions".to_owned(),
+            service_id: "vllm-qwen-1720000000".to_owned(),
+            status: "ready".to_owned(),
+            already_running: false,
+            metrics: SmokeMetrics {
+                ttft: Some(Duration::from_millis(180)),
+                gen_tps: Some(42.15),
+            },
+            notes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn format_ttft_uses_ms_under_a_second_and_seconds_above() {
+        assert_eq!(format_ttft(Some(Duration::from_millis(180))), "180 ms");
+        assert_eq!(format_ttft(Some(Duration::from_millis(1500))), "1.50 s");
+        assert_eq!(format_ttft(None), "n/a");
+    }
+
+    #[test]
+    fn format_tps_renders_rate_or_na() {
+        assert_eq!(format_tps(Some(42.15)), "42.1 tok/s");
+        assert_eq!(format_tps(None), "n/a");
+        assert_eq!(format_tps(Some(0.0)), "n/a");
+        assert_eq!(format_tps(Some(f64::INFINITY)), "n/a");
+    }
+
+    #[test]
+    fn summary_shows_endpoint_model_and_metrics() {
+        let rendered = render_summary(&base_summary());
+        assert!(rendered.contains("Deployment summary"));
+        assert!(rendered.contains("http://127.0.0.1:1337/v1/chat/completions"));
+        assert!(rendered.contains("Qwen/Qwen2.5-7B-Instruct"));
+        assert!(rendered.contains("180 ms"));
+        assert!(rendered.contains("42.1 tok/s"));
+        assert!(rendered.contains("rocm services stop vllm-qwen-1720000000"));
+    }
+
+    #[test]
+    fn summary_structure_is_identical_across_engines() {
+        // The same fields render in the same order regardless of engine; only the
+        // engine/model/endpoint values differ. Compare the row *labels*.
+        fn labels(text: &str) -> Vec<String> {
+            text.lines()
+                .filter(|line| line.starts_with("  ") && !line.starts_with("  note:"))
+                .map(|line| {
+                    line.trim_start()
+                        .split("  ")
+                        .next()
+                        .unwrap_or("")
+                        .to_owned()
+                })
+                .collect()
+        }
+
+        let mut vllm = base_summary();
+        vllm.engine = "vllm".to_owned();
+        let mut lemonade = base_summary();
+        lemonade.engine = "lemonade".to_owned();
+        lemonade.api_model = "Qwen3-0.6B-GGUF".to_owned();
+        lemonade.chat_endpoint = "http://127.0.0.1:8000/v1/chat/completions".to_owned();
+        lemonade.metrics = SmokeMetrics::default(); // engine reported no usage
+
+        assert_eq!(
+            labels(&render_summary(&vllm)),
+            labels(&render_summary(&lemonade))
+        );
+        // Even when metrics are missing, the rows still exist and read n/a.
+        let rendered = render_summary(&lemonade);
+        assert!(rendered.contains("time to first token"));
+        assert!(rendered.contains("n/a"));
+    }
+
+    #[test]
+    fn already_running_is_flagged_in_the_heading() {
+        let mut summary = base_summary();
+        summary.already_running = true;
+        assert!(render_summary(&summary).contains("already running"));
+    }
+
+    #[test]
+    fn notes_are_rendered_when_present() {
+        let mut summary = base_summary();
+        summary.notes = vec!["selected GPU 0 has low free VRAM".to_owned()];
+        assert!(render_summary(&summary).contains("note: selected GPU 0 has low free VRAM"));
+    }
+
+    #[test]
+    fn compute_metrics_derives_ttft_and_throughput() {
+        let start = Instant::now();
+        let first = start + Duration::from_millis(200);
+        let last = first + Duration::from_millis(500);
+        let metrics = compute_metrics(start, Some(first), Some(last), 11);
+        assert_eq!(metrics.ttft, Some(Duration::from_millis(200)));
+        // 10 tokens after the first over 0.5s => 20 tok/s.
+        let tps = metrics.gen_tps.expect("throughput present");
+        assert!((tps - 20.0).abs() < 0.001, "unexpected tps {tps}");
+    }
+
+    #[test]
+    fn compute_metrics_without_tokens_is_empty() {
+        let start = Instant::now();
+        assert_eq!(
+            compute_metrics(start, None, None, 0),
+            SmokeMetrics::default()
+        );
+    }
+
+    #[test]
+    fn compute_metrics_single_token_has_ttft_but_no_throughput() {
+        let start = Instant::now();
+        let first = start + Duration::from_millis(120);
+        let metrics = compute_metrics(start, Some(first), Some(first), 1);
+        assert_eq!(metrics.ttft, Some(Duration::from_millis(120)));
+        assert_eq!(metrics.gen_tps, None);
+    }
+}

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -92,20 +92,29 @@ pub(crate) fn format_tps(tps: Option<f64>) -> String {
 /// Render the deployment summary table as plain text (returned rather than
 /// printed so it is unit-testable and identical across engines).
 pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
+    // The server answered its health check within the startup window. A launch
+    // that timed out lands here with `status == "starting"`; the heading and a
+    // note must make that visibly different from a healthy deployment so the
+    // summary is never mistaken for success.
+    let ready = summary.status == "ready";
     let heading = if summary.already_running {
         "Deployment summary (already running)"
-    } else {
+    } else if ready {
         "Deployment summary"
+    } else {
+        "Deployment summary (not ready yet)"
     };
 
-    // (label, value) rows, in the order the ticket calls out.
+    // (label, value) rows, in the order the ticket calls out. Throughput is
+    // labelled "approx" because it is derived from streamed SSE chunk counts
+    // (~1 token per chunk), not the engine's own token accounting.
     let rows: Vec<(&str, String)> = vec![
         ("status", summary.status.clone()),
         ("engine", summary.engine.clone()),
         ("model", summary.api_model.clone()),
         ("endpoint", summary.chat_endpoint.clone()),
         ("time to first token", format_ttft(summary.metrics.ttft)),
-        ("throughput", format_tps(summary.metrics.gen_tps)),
+        ("throughput (approx)", format_tps(summary.metrics.gen_tps)),
         ("service", summary.service_id.clone()),
         ("stop", format!("rocm services stop {}", summary.service_id)),
         (
@@ -121,6 +130,14 @@ pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
     out.push('\n');
     for (label, value) in rows {
         let _ = writeln!(out, "  {label:<label_width$}  {value}");
+    }
+    if !ready && !summary.already_running {
+        let _ = writeln!(
+            out,
+            "  note: the server did not report ready before the startup timeout; \
+             it may still be loading — check `rocm logs --service {}` or `rocm services list`",
+            summary.service_id
+        );
     }
     for note in &summary.notes {
         let _ = writeln!(out, "  note: {note}");
@@ -337,6 +354,24 @@ mod tests {
         let mut summary = base_summary();
         summary.already_running = true;
         assert!(render_summary(&summary).contains("already running"));
+    }
+
+    #[test]
+    fn readiness_timeout_does_not_read_as_success() {
+        // A launch that never became ready lands here with status "starting". The
+        // heading must flag it and a note must point the user at the logs, so the
+        // summary is not mistaken for a healthy deployment.
+        let mut summary = base_summary();
+        summary.status = "starting".to_owned();
+        let rendered = render_summary(&summary);
+        assert!(rendered.contains("not ready yet"), "heading: {rendered}");
+        assert!(rendered.contains("did not report ready"));
+        assert!(rendered.contains("rocm logs --service"));
+    }
+
+    #[test]
+    fn throughput_row_is_labelled_approximate() {
+        assert!(render_summary(&base_summary()).contains("throughput (approx)"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`rocm serve <model>` streamed raw engine logs and blocked the terminal. It now defaults to backgrounding the server and printing a progressive **deployment summary**:

- An animated spinner while the server starts up.
- A summary table once ready: deployment status, full inference endpoint with port (e.g. `http://127.0.0.1:1337/v1/chat/completions`), the API-qualified model name, and a best-effort inference smoke test (time-to-first-token, tokens/sec).
- Control returns to the shell with the server running in the background; stop via `rocm services stop`, logs via `rocm logs`.

## Flags

- `--verbose` (or `--foreground`) — attach to this terminal and stream every engine log line, as before. For debugging/diagnostics.
- `--no-smoke-test` — skip the post-startup inference probe (metrics show `n/a`).
- `--managed` — now an explicit synonym for the default (background) behavior.

`--verbose` conflicts with `--managed` (no foreground stream to attach to a backgrounded server — use `rocm logs`).

## Works the same across every engine

All new logic lives at the CLI/HTTP layer above the engine adapters, so the summary shape is identical for lemonade, vLLM, SGLang, PyTorch, llama.cpp, and atom. Readiness already normalizes per-engine health paths; the smoke test uses the OpenAI-compatible `/v1/chat/completions` every serving engine exposes. TTFT is measured exactly; throughput is approximated from the token stream and degrades to `n/a` where unavailable.

## Notes

- Rich output is gated on an interactive TTY. Piped / CI / chat-assistant output keeps the plain line-by-line form unchanged.
- `start_managed_service` now returns a report rather than printing, so the rich and plain renderings share one launch path.
- Default lifecycle changes from foreground to background (the old attached behavior is preserved under `--verbose`/`--foreground`).

## Testing

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-targets` green (12 new tests: summary rendering, cross-engine row parity, metric math, `n/a` fallback, flag parsing/conflicts)
- [ ] Live GPU check (deferred, needs AMD hardware): `rocm serve qwen-smoke` and a vLLM model to confirm spinner → table → real TTFT/tok-s, plus `--verbose` streaming