### PR TITLE
fix: mark non-Linux stub functions as const fn

### DIFF
--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -2026,7 +2026,7 @@ mod tests {
         if runtime_is_windows() {
             assert!(path_entries.contains(&sdk_lib));
             assert!(path_entries.contains(&runtime_lib));
-        } else {
+        } else if runtime_is_linux() {
             let ld_library_path =
                 command_env_value(&command, "LD_LIBRARY_PATH").context("LD_LIBRARY_PATH")?;
             let library_entries = split_runtime_paths(&ld_library_path);

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -3544,6 +3544,12 @@ mod tests {
     #[test]
     #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn python_launcher_prefers_path_python_before_saved_managed_python() -> Result<()> {
+        if current_platform_wheel_tags().is_err() {
+            // No wheel platform tag for this host (e.g. macOS): every python fails
+            // the wheel-compatibility check, so resolution always falls through to
+            // the managed/uv path regardless of PATH. Nothing to assert here.
+            return Ok(());
+        }
         let _guard = PYTHON_RESOLVER_TEST_ENV_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-prefers-path");
         let bin_dir = root.join("bin");
@@ -3654,6 +3660,12 @@ mod tests {
     #[test]
     #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn python_launcher_prefers_path_python_over_managed_when_venv_capable() -> Result<()> {
+        if current_platform_wheel_tags().is_err() {
+            // No wheel platform tag for this host (e.g. macOS): every python fails
+            // the wheel-compatibility check, so resolution always falls through to
+            // the managed/uv path regardless of PATH. Nothing to assert here.
+            return Ok(());
+        }
         let _guard = PYTHON_RESOLVER_TEST_ENV_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-path-over-managed");
         let bin_dir = root.join("bin");

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3124,7 +3124,7 @@ fn detect_linux_primary_gpu_name() -> Option<String> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn detect_linux_primary_gpu_name() -> Option<String> {
+const fn detect_linux_primary_gpu_name() -> Option<String> {
     None
 }
 
@@ -3451,7 +3451,7 @@ fn detect_linux_sysfs_gfx_target() -> Option<String> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn detect_linux_sysfs_gfx_target() -> Option<String> {
+const fn detect_linux_sysfs_gfx_target() -> Option<String> {
     None
 }
 

--- a/crates/rocm-core/src/openmpi.rs
+++ b/crates/rocm-core/src/openmpi.rs
@@ -181,7 +181,7 @@ pub fn running_as_root() -> bool {
 
 /// Whether the current process is running as root. Always false off Linux.
 #[cfg(not(target_os = "linux"))]
-pub fn running_as_root() -> bool {
+pub const fn running_as_root() -> bool {
     false
 }
 
@@ -198,7 +198,7 @@ pub fn can_autoinstall() -> bool {
 
 /// Privileged auto-install is never attempted off Linux.
 #[cfg(not(target_os = "linux"))]
-pub fn can_autoinstall() -> bool {
+pub const fn can_autoinstall() -> bool {
     false
 }
 
@@ -411,7 +411,7 @@ pub fn ensure_mpi_cxx_compat(compat_dir: &Path) -> Option<PathBuf> {
 
 /// Non-Linux hosts never need the OpenMPI C++ bindings shim.
 #[cfg(not(target_os = "linux"))]
-pub fn ensure_mpi_cxx_compat(_compat_dir: &std::path::Path) -> Option<PathBuf> {
+pub const fn ensure_mpi_cxx_compat(_compat_dir: &std::path::Path) -> Option<PathBuf> {
     None
 }
 
@@ -444,7 +444,7 @@ pub fn ensure_compat_symlink(compat_dir: &Path, link_name: &str, target: &Path) 
 
 /// Non-Linux hosts do not create runtime library shims.
 #[cfg(not(target_os = "linux"))]
-pub fn ensure_compat_symlink(
+pub const fn ensure_compat_symlink(
     _compat_dir: &std::path::Path,
     _link_name: &str,
     _target: &std::path::Path,
@@ -473,7 +473,7 @@ pub fn ldconfig_has_soname(soname: &str) -> bool {
 
 /// Always `false` off Linux, where the loader-path shim is not exercised.
 #[cfg(not(target_os = "linux"))]
-pub fn ldconfig_has_soname(_soname: &str) -> bool {
+pub const fn ldconfig_has_soname(_soname: &str) -> bool {
     false
 }
 
@@ -496,7 +496,7 @@ pub fn libatomic_present() -> bool {
 
 /// Non-Linux hosts do not exercise the libatomic dependency path.
 #[cfg(not(target_os = "linux"))]
-pub fn libatomic_present() -> bool {
+pub const fn libatomic_present() -> bool {
     true
 }
 
@@ -528,7 +528,7 @@ pub fn libnuma_present() -> bool {
 
 /// Non-Linux hosts do not exercise the libnuma dependency path.
 #[cfg(not(target_os = "linux"))]
-pub fn libnuma_present() -> bool {
+pub const fn libnuma_present() -> bool {
     true
 }
 

--- a/crates/rocm-dash-collectors/src/cgroup.rs
+++ b/crates/rocm-dash-collectors/src/cgroup.rs
@@ -53,7 +53,7 @@ pub fn container_id_for_pid(pid: u32) -> Option<String> {
 /// Non-linux stub: there is no `/proc/<pid>/cgroup`, so attribution is never
 /// available off linux. Always `None`.
 #[cfg(not(target_os = "linux"))]
-pub fn container_id_for_pid(_pid: u32) -> Option<String> {
+pub const fn container_id_for_pid(_pid: u32) -> Option<String> {
     None
 }
 


### PR DESCRIPTION
## Summary
- `cargo clippy --workspace --all-targets -- -D warnings` flagged `missing_const_for_fn` on several non-Linux stub functions that trivially return a constant value and have no reason not to be `const fn`.
- Marks `container_id_for_pid` (cgroup non-Linux stub) and several `rocm-core` non-Linux stub functions as `const fn`.
- Fixes two environment-dependent test assumptions (`python_launcher_prefers_path_python_*`, `runtime_environment_preloads_managed_rocm_paths`) that incorrectly assumed properties true only on Linux/Windows.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace --all-targets` passes