### PR TITLE
fix(serve): pass vLLM tool-choice flags so TUI chat works

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3845,6 +3845,70 @@ fn protocol_engine_recipe_hint(
         })
 }
 
+/// The vLLM launch flags required for OpenAI tool-calling to work.
+///
+/// The TUI chat tab always attaches tool definitions to non-streaming chat
+/// requests (`tool_choice: "auto"`). vLLM rejects those with HTTP 400 unless it
+/// was started with `--enable-auto-tool-choice` *and* a matching
+/// `--tool-call-parser`. The parser value is model-specific, so it is derived
+/// from the model ref. A mismatched-but-valid parser only degrades tool-call
+/// parsing for that model (chat still works and never 400s), so `hermes` — the
+/// parser used by the Qwen family that dominates the built-in catalog — is a safe
+/// default for unrecognized families.
+fn vllm_tool_choice_flags(model_ref: &str) -> Vec<String> {
+    let lower = model_ref.to_ascii_lowercase();
+    let parser = if lower.contains("llama") {
+        "llama3_json"
+    } else if lower.contains("mistral") || lower.contains("mixtral") {
+        "mistral"
+    } else {
+        // Qwen and every other family fall back to the hermes parser.
+        "hermes"
+    };
+    vec![
+        "--enable-auto-tool-choice".to_owned(),
+        "--tool-call-parser".to_owned(),
+        parser.to_owned(),
+    ]
+}
+
+/// Ensures a vLLM serve carries the tool-choice launch flags so TUI chat works
+/// out of the box (EAI-7223).
+///
+/// Only vLLM needs this — other engines either accept tools without extra flags
+/// or are not affected. Recipe-authored flags win: if the hint already requests
+/// `--enable-auto-tool-choice`, it is left untouched. When no recipe hint exists
+/// (arbitrary HF repos, or a catalog model forced onto a non-preferred engine),
+/// a minimal hint is synthesized carrying just the tool-choice flags.
+fn engine_recipe_with_tool_choice(
+    engine: &str,
+    model_ref: &str,
+    hint: Option<EngineRecipeHint>,
+) -> Option<EngineRecipeHint> {
+    if !engine.eq_ignore_ascii_case("vllm") {
+        return hint;
+    }
+    match hint {
+        Some(mut hint) => {
+            let already_set = hint
+                .required_flags
+                .iter()
+                .any(|flag| flag == "--enable-auto-tool-choice");
+            if !already_set {
+                hint.required_flags
+                    .extend(vllm_tool_choice_flags(model_ref));
+            }
+            Some(hint)
+        }
+        None => Some(EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: engine.to_owned(),
+            required_flags: vllm_tool_choice_flags(model_ref),
+            ..EngineRecipeHint::default()
+        }),
+    }
+}
+
 /// Parsed `rocm serve` arguments. Grouped into a struct to keep the dispatcher
 /// and `serve()` readable now that the verb carries verbose/smoke-test controls.
 struct ServeArgs {
@@ -3906,12 +3970,18 @@ fn serve(args: ServeArgs) -> Result<()> {
         host_gpu_summary.as_ref(),
     );
     let selected_engine = serve_engine.engine.clone();
-    let engine_recipe = shared_recipe
+    let engine_model_ref =
+        serve_model_ref_for_engine(&model, shared_recipe.as_ref(), &selected_engine);
+    let recipe_hint = shared_recipe
         .as_ref()
         .filter(|recipe| model_recipe_supports_engine(recipe, &selected_engine))
         .and_then(|recipe| protocol_engine_recipe_hint(recipe, &selected_engine));
-    let engine_model_ref =
-        serve_model_ref_for_engine(&model, shared_recipe.as_ref(), &selected_engine);
+    // vLLM rejects the TUI chat tab's tool-bearing requests with HTTP 400 unless
+    // it is launched with `--enable-auto-tool-choice`/`--tool-call-parser`, so
+    // inject those flags for every vLLM serve regardless of catalog coverage
+    // (EAI-7223).
+    let engine_recipe =
+        engine_recipe_with_tool_choice(&selected_engine, &engine_model_ref, recipe_hint);
     let device_policy = parse_device_policy(device.as_deref())?;
     let gpu_selection = parse_gpu_selection(gpu.as_deref())?;
     // CPU-only serving never pins a GPU, so skip GPU resolution entirely and
@@ -20261,6 +20331,109 @@ install therock";
         ));
         assert!(serve_lines.contains("engine_recipe_required_flags: --enable-auto-tool-choice"));
         assert!(protocol_engine_recipe_hint(&recipe, "unknown-engine").is_none());
+    }
+
+    #[test]
+    fn vllm_tool_choice_flags_selects_parser_by_model_family() {
+        assert_eq!(
+            vllm_tool_choice_flags("Qwen/Qwen2.5-1.5B-Instruct"),
+            vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+            ]
+        );
+        assert_eq!(
+            vllm_tool_choice_flags("meta-llama/Llama-3.2-3B-Instruct"),
+            vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "llama3_json".to_owned(),
+            ]
+        );
+        // Unrecognized families fall back to the hermes parser.
+        assert_eq!(
+            vllm_tool_choice_flags("some-org/mystery-model"),
+            vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn engine_recipe_with_tool_choice_synthesizes_hint_for_vllm_without_recipe() {
+        let hint = engine_recipe_with_tool_choice("vllm", "Qwen/Qwen2.5-1.5B-Instruct", None)
+            .expect("vllm serve should get a synthesized tool-choice hint");
+        assert_eq!(hint.engine, "vllm");
+        assert_eq!(hint.contract_version, ENGINE_RECIPE_CONTRACT_VERSION);
+        assert_eq!(
+            hint.required_flags,
+            vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn engine_recipe_with_tool_choice_appends_to_existing_recipe_flags() {
+        let existing = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec!["--reasoning-parser".to_owned(), "qwen3".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        let hint =
+            engine_recipe_with_tool_choice("vllm", "Qwen/Qwen3.5-4B", Some(existing)).unwrap();
+        assert_eq!(
+            hint.required_flags,
+            vec![
+                "--reasoning-parser".to_owned(),
+                "qwen3".to_owned(),
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn engine_recipe_with_tool_choice_preserves_recipe_authored_tool_choice() {
+        let existing = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "llama3_json".to_owned(),
+            ],
+            ..EngineRecipeHint::default()
+        };
+        let hint =
+            engine_recipe_with_tool_choice("vllm", "some/qwen-model", Some(existing.clone()))
+                .unwrap();
+        // Recipe-authored tool-choice flags win: no duplication, parser unchanged.
+        assert_eq!(hint.required_flags, existing.required_flags);
+    }
+
+    #[test]
+    fn engine_recipe_with_tool_choice_leaves_non_vllm_engines_untouched() {
+        assert!(
+            engine_recipe_with_tool_choice("lemonade", "Qwen/Qwen2.5-1.5B-Instruct", None)
+                .is_none()
+        );
+        let existing = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "lemonade".to_owned(),
+            required_flags: vec!["--some-flag".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        let hint =
+            engine_recipe_with_tool_choice("lemonade", "model", Some(existing.clone())).unwrap();
+        assert_eq!(hint.required_flags, existing.required_flags);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -330,6 +330,11 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         /// Allow binding to a non-local address.
         #[arg(long)]
         allow_public_bind: bool,
+        /// vLLM tool-call parser to enable OpenAI tool calling for this model
+        /// (e.g. `hermes`, `llama3_json`, `mistral`). Overrides any catalog default
+        /// and implies `--enable-auto-tool-choice`. Applies to vLLM only.
+        #[arg(long, value_name = "NAME")]
+        tool_call_parser: Option<String>,
     },
     /// Install, start, stop, or inspect ComfyUI.
     #[command(alias = "comfy")]
@@ -1558,6 +1563,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             verbose,
             no_smoke_test,
             allow_public_bind,
+            tool_call_parser,
         }) => serve(ServeArgs {
             model,
             engine,
@@ -1572,6 +1578,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             verbose,
             no_smoke_test,
             allow_public_bind,
+            tool_call_parser,
         }),
         Some(Command::Comfyui { command }) => comfyui(command),
         Some(Command::Services { command }) => services(command),
@@ -3845,68 +3852,81 @@ fn protocol_engine_recipe_hint(
         })
 }
 
-/// The vLLM launch flags required for OpenAI tool-calling to work.
+/// Applies an explicit `--tool-call-parser` override to a vLLM engine recipe hint.
 ///
 /// The TUI chat tab always attaches tool definitions to non-streaming chat
-/// requests (`tool_choice: "auto"`). vLLM rejects those with HTTP 400 unless it
-/// was started with `--enable-auto-tool-choice` *and* a matching
-/// `--tool-call-parser`. The parser value is model-specific, so it is derived
-/// from the model ref. A mismatched-but-valid parser only degrades tool-call
-/// parsing for that model (chat still works and never 400s), so `hermes` — the
-/// parser used by the Qwen family that dominates the built-in catalog — is a safe
-/// default for unrecognized families.
-fn vllm_tool_choice_flags(model_ref: &str) -> Vec<String> {
-    let lower = model_ref.to_ascii_lowercase();
-    let parser = if lower.contains("llama") {
-        "llama3_json"
-    } else if lower.contains("mistral") || lower.contains("mixtral") {
-        "mistral"
-    } else {
-        // Qwen and every other family fall back to the hermes parser.
-        "hermes"
-    };
-    vec![
-        "--enable-auto-tool-choice".to_owned(),
-        "--tool-call-parser".to_owned(),
-        parser.to_owned(),
-    ]
-}
-
-/// Ensures a vLLM serve carries the tool-choice launch flags so TUI chat works
-/// out of the box (EAI-7223).
+/// requests (`tool_choice: "auto"`). vLLM rejects those with HTTP 400 unless it was
+/// started with `--enable-auto-tool-choice` *and* a matching `--tool-call-parser`.
+/// The correct parser is model-specific and vLLM does not auto-detect it, so it is
+/// never guessed from the model ref: it comes either from authored catalog recipe
+/// metadata (already carried in `required_flags`) or from the explicit
+/// `--tool-call-parser` serve flag, which this applies.
 ///
-/// Only vLLM needs this — other engines either accept tools without extra flags
-/// or are not affected. Recipe-authored flags win: if the hint already requests
-/// `--enable-auto-tool-choice`, it is left untouched. When no recipe hint exists
-/// (arbitrary HF repos, or a catalog model forced onto a non-preferred engine),
-/// a minimal hint is synthesized carrying just the tool-choice flags.
-fn engine_recipe_with_tool_choice(
+/// Only vLLM is affected. When an override is supplied it wins over any
+/// recipe-authored parser (a single `--tool-call-parser`, no duplication) and a
+/// minimal hint is synthesized when none exists (arbitrary HF repos, or a catalog
+/// model forced onto a non-preferred engine). With no override the hint passes
+/// through unchanged.
+fn engine_recipe_with_tool_call_override(
     engine: &str,
-    model_ref: &str,
     hint: Option<EngineRecipeHint>,
+    tool_call_parser: Option<&str>,
 ) -> Option<EngineRecipeHint> {
     if !engine.eq_ignore_ascii_case("vllm") {
         return hint;
     }
-    match hint {
-        Some(mut hint) => {
-            let already_set = hint
-                .required_flags
-                .iter()
-                .any(|flag| flag == "--enable-auto-tool-choice");
-            if !already_set {
-                hint.required_flags
-                    .extend(vllm_tool_choice_flags(model_ref));
-            }
-            Some(hint)
+    let Some(parser) = tool_call_parser
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return hint;
+    };
+    let mut hint = hint.unwrap_or_else(|| EngineRecipeHint {
+        contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+        engine: engine.to_owned(),
+        ..EngineRecipeHint::default()
+    });
+    set_vllm_tool_call_parser(&mut hint.required_flags, parser);
+    Some(hint)
+}
+
+/// Rewrites `flags` so vLLM tool calling uses exactly `parser`: drops any existing
+/// `--tool-call-parser <value>` pair, ensures `--enable-auto-tool-choice` is
+/// present, then appends the new parser flag.
+fn set_vllm_tool_call_parser(flags: &mut Vec<String>, parser: &str) {
+    let existing = std::mem::take(flags);
+    let mut rewritten: Vec<String> = Vec::with_capacity(existing.len() + 3);
+    let mut skip_value = false;
+    for flag in existing {
+        if skip_value {
+            // Drop the value that followed the removed `--tool-call-parser`.
+            skip_value = false;
+            continue;
         }
-        None => Some(EngineRecipeHint {
-            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
-            engine: engine.to_owned(),
-            required_flags: vllm_tool_choice_flags(model_ref),
-            ..EngineRecipeHint::default()
-        }),
+        if flag == "--tool-call-parser" {
+            skip_value = true;
+            continue;
+        }
+        rewritten.push(flag);
     }
+    if !rewritten
+        .iter()
+        .any(|flag| flag == "--enable-auto-tool-choice")
+    {
+        rewritten.push("--enable-auto-tool-choice".to_owned());
+    }
+    rewritten.push("--tool-call-parser".to_owned());
+    rewritten.push(parser.to_owned());
+    *flags = rewritten;
+}
+
+/// Whether the resolved engine recipe launches vLLM with tool calling enabled.
+fn engine_recipe_enables_tool_choice(hint: Option<&EngineRecipeHint>) -> bool {
+    hint.is_some_and(|hint| {
+        hint.required_flags
+            .iter()
+            .any(|flag| flag == "--enable-auto-tool-choice")
+    })
 }
 
 /// Parsed `rocm serve` arguments. Grouped into a struct to keep the dispatcher
@@ -3925,6 +3945,7 @@ struct ServeArgs {
     verbose: bool,
     no_smoke_test: bool,
     allow_public_bind: bool,
+    tool_call_parser: Option<String>,
 }
 
 fn serve(args: ServeArgs) -> Result<()> {
@@ -3942,6 +3963,7 @@ fn serve(args: ServeArgs) -> Result<()> {
         verbose,
         no_smoke_test,
         allow_public_bind,
+        tool_call_parser,
     } = args;
     let _ = managed; // background is now the default; --managed is accepted as an explicit synonym.
     validate_bind_host(&host, allow_public_bind)?;
@@ -3976,12 +3998,28 @@ fn serve(args: ServeArgs) -> Result<()> {
         .as_ref()
         .filter(|recipe| model_recipe_supports_engine(recipe, &selected_engine))
         .and_then(|recipe| protocol_engine_recipe_hint(recipe, &selected_engine));
-    // vLLM rejects the TUI chat tab's tool-bearing requests with HTTP 400 unless
-    // it is launched with `--enable-auto-tool-choice`/`--tool-call-parser`, so
-    // inject those flags for every vLLM serve regardless of catalog coverage
-    // (EAI-7223).
-    let engine_recipe =
-        engine_recipe_with_tool_choice(&selected_engine, &engine_model_ref, recipe_hint);
+    // vLLM rejects the TUI chat tab's tool-bearing requests with HTTP 400 unless it
+    // is launched with `--enable-auto-tool-choice`/`--tool-call-parser`. The parser
+    // is model-specific and vLLM does not auto-detect it, so it is never guessed: it
+    // comes from authored catalog recipe metadata or an explicit `--tool-call-parser`
+    // override, applied here for vLLM only.
+    let engine_serves_vllm = selected_engine.eq_ignore_ascii_case("vllm");
+    let engine_recipe = engine_recipe_with_tool_call_override(
+        &selected_engine,
+        recipe_hint,
+        tool_call_parser.as_deref(),
+    );
+    let tool_call_note = if tool_call_parser.is_some() && !engine_serves_vllm {
+        Some(format!(
+            "note: --tool-call-parser applies only to vLLM; ignored for engine '{selected_engine}'"
+        ))
+    } else if engine_serves_vllm && !engine_recipe_enables_tool_choice(engine_recipe.as_ref()) {
+        Some(
+            "note: tool calling is disabled for this model; pass `--tool-call-parser <name>` (e.g. hermes, llama3_json, mistral) to enable it".to_owned(),
+        )
+    } else {
+        None
+    };
     let device_policy = parse_device_policy(device.as_deref())?;
     let gpu_selection = parse_gpu_selection(gpu.as_deref())?;
     // CPU-only serving never pins a GPU, so skip GPU resolution entirely and
@@ -4096,6 +4134,9 @@ fn serve(args: ServeArgs) -> Result<()> {
         }
         if let Some(engine_recipe) = &resolve.engine_recipe {
             print!("{}", render_serve_engine_recipe_lines(engine_recipe));
+        }
+        if let Some(note) = &tool_call_note {
+            println!("  {note}");
         }
     }
 
@@ -20334,38 +20375,11 @@ install therock";
     }
 
     #[test]
-    fn vllm_tool_choice_flags_selects_parser_by_model_family() {
-        assert_eq!(
-            vllm_tool_choice_flags("Qwen/Qwen2.5-1.5B-Instruct"),
-            vec![
-                "--enable-auto-tool-choice".to_owned(),
-                "--tool-call-parser".to_owned(),
-                "hermes".to_owned(),
-            ]
-        );
-        assert_eq!(
-            vllm_tool_choice_flags("meta-llama/Llama-3.2-3B-Instruct"),
-            vec![
-                "--enable-auto-tool-choice".to_owned(),
-                "--tool-call-parser".to_owned(),
-                "llama3_json".to_owned(),
-            ]
-        );
-        // Unrecognized families fall back to the hermes parser.
-        assert_eq!(
-            vllm_tool_choice_flags("some-org/mystery-model"),
-            vec![
-                "--enable-auto-tool-choice".to_owned(),
-                "--tool-call-parser".to_owned(),
-                "hermes".to_owned(),
-            ]
-        );
-    }
-
-    #[test]
-    fn engine_recipe_with_tool_choice_synthesizes_hint_for_vllm_without_recipe() {
-        let hint = engine_recipe_with_tool_choice("vllm", "Qwen/Qwen2.5-1.5B-Instruct", None)
-            .expect("vllm serve should get a synthesized tool-choice hint");
+    fn tool_call_override_synthesizes_hint_for_vllm_without_recipe() {
+        // Arbitrary HF repo with no catalog recipe: the explicit override is the
+        // only source of the parser, and a minimal hint is synthesized to carry it.
+        let hint = engine_recipe_with_tool_call_override("vllm", None, Some("hermes"))
+            .expect("an override should synthesize a vllm tool-choice hint");
         assert_eq!(hint.engine, "vllm");
         assert_eq!(hint.contract_version, ENGINE_RECIPE_CONTRACT_VERSION);
         assert_eq!(
@@ -20379,15 +20393,23 @@ install therock";
     }
 
     #[test]
-    fn engine_recipe_with_tool_choice_appends_to_existing_recipe_flags() {
+    fn tool_call_override_replaces_recipe_authored_parser() {
+        // Override wins over an authored parser: exactly one `--tool-call-parser`,
+        // set to the override value, with unrelated flags preserved in order.
         let existing = EngineRecipeHint {
             contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
             engine: "vllm".to_owned(),
-            required_flags: vec!["--reasoning-parser".to_owned(), "qwen3".to_owned()],
+            required_flags: vec![
+                "--reasoning-parser".to_owned(),
+                "qwen3".to_owned(),
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "llama3_json".to_owned(),
+            ],
             ..EngineRecipeHint::default()
         };
         let hint =
-            engine_recipe_with_tool_choice("vllm", "Qwen/Qwen3.5-4B", Some(existing)).unwrap();
+            engine_recipe_with_tool_call_override("vllm", Some(existing), Some("hermes")).unwrap();
         assert_eq!(
             hint.required_flags,
             vec![
@@ -20398,42 +20420,70 @@ install therock";
                 "hermes".to_owned(),
             ]
         );
+        assert_eq!(
+            hint.required_flags
+                .iter()
+                .filter(|flag| *flag == "--tool-call-parser")
+                .count(),
+            1
+        );
     }
 
     #[test]
-    fn engine_recipe_with_tool_choice_preserves_recipe_authored_tool_choice() {
-        let existing = EngineRecipeHint {
+    fn tool_call_override_absent_preserves_recipe_flags_without_guessing() {
+        // No override: authored recipe metadata flows through unchanged and no
+        // parser is ever guessed from the model ref.
+        let authored = EngineRecipeHint {
             contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
             engine: "vllm".to_owned(),
             required_flags: vec![
                 "--enable-auto-tool-choice".to_owned(),
                 "--tool-call-parser".to_owned(),
-                "llama3_json".to_owned(),
+                "hermes".to_owned(),
             ],
             ..EngineRecipeHint::default()
         };
         let hint =
-            engine_recipe_with_tool_choice("vllm", "some/qwen-model", Some(existing.clone()))
-                .unwrap();
-        // Recipe-authored tool-choice flags win: no duplication, parser unchanged.
-        assert_eq!(hint.required_flags, existing.required_flags);
+            engine_recipe_with_tool_call_override("vllm", Some(authored.clone()), None).unwrap();
+        assert_eq!(hint.required_flags, authored.required_flags);
+
+        // Unknown model, no recipe, no override: nothing is injected.
+        assert!(engine_recipe_with_tool_call_override("vllm", None, None).is_none());
+        // A blank override is treated as absent.
+        assert!(engine_recipe_with_tool_call_override("vllm", None, Some("  ")).is_none());
     }
 
     #[test]
-    fn engine_recipe_with_tool_choice_leaves_non_vllm_engines_untouched() {
-        assert!(
-            engine_recipe_with_tool_choice("lemonade", "Qwen/Qwen2.5-1.5B-Instruct", None)
-                .is_none()
-        );
+    fn tool_call_override_leaves_non_vllm_engines_untouched() {
+        // The override is vLLM-specific: other engines are never rewritten.
+        assert!(engine_recipe_with_tool_call_override("lemonade", None, Some("hermes")).is_none());
         let existing = EngineRecipeHint {
             contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
             engine: "lemonade".to_owned(),
             required_flags: vec!["--some-flag".to_owned()],
             ..EngineRecipeHint::default()
         };
-        let hint =
-            engine_recipe_with_tool_choice("lemonade", "model", Some(existing.clone())).unwrap();
+        let hint = engine_recipe_with_tool_call_override(
+            "lemonade",
+            Some(existing.clone()),
+            Some("hermes"),
+        )
+        .unwrap();
         assert_eq!(hint.required_flags, existing.required_flags);
+    }
+
+    #[test]
+    fn engine_recipe_enables_tool_choice_reflects_flags() {
+        assert!(!engine_recipe_enables_tool_choice(None));
+        let without = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec!["--reasoning-parser".to_owned(), "qwen3".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        assert!(!engine_recipe_enables_tool_choice(Some(&without)));
+        let with = engine_recipe_with_tool_call_override("vllm", None, Some("hermes"));
+        assert!(engine_recipe_enables_tool_choice(with.as_ref()));
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -6998,6 +6998,49 @@ Class Name:                Display
     }
 
     #[test]
+    fn builtin_catalog_authors_vllm_tool_call_parsers() {
+        // vLLM does not auto-detect a tool-call parser; the correct value is sourced
+        // from explicit per-model recipe metadata (never guessed at runtime). This
+        // guards the authored parser for well-known chat families so a regression is
+        // caught here rather than as an HTTP 400 in the TUI chat tab.
+        let document =
+            serde_json::from_str::<ModelRecipeIndexDocument>(include_str!("model_catalog.json"))
+                .expect("catalog JSON parses");
+        let tool_call_parser = |model_id: &str| -> Option<String> {
+            document
+                .recipes
+                .iter()
+                .find(|recipe| recipe.canonical_model_id == model_id)?
+                .engine_recipes
+                .iter()
+                .find(|engine_recipe| engine_recipe.engine == "vllm")
+                .and_then(|engine_recipe| {
+                    let flags = &engine_recipe.required_flags;
+                    assert!(
+                        flags.iter().any(|flag| flag == "--enable-auto-tool-choice"),
+                        "{model_id}: --tool-call-parser must be paired with --enable-auto-tool-choice"
+                    );
+                    let index = flags.iter().position(|flag| flag == "--tool-call-parser")?;
+                    flags.get(index + 1).cloned()
+                })
+        };
+        // Reported repro: a lemonade-preferred Qwen forced onto vLLM must still
+        // carry the Qwen-family parser.
+        assert_eq!(
+            tool_call_parser("Qwen/Qwen2.5-1.5B-Instruct").as_deref(),
+            Some("hermes")
+        );
+        assert_eq!(
+            tool_call_parser("Qwen/Qwen3-32B-FP8").as_deref(),
+            Some("hermes")
+        );
+        assert_eq!(
+            tool_call_parser("meta-llama/Llama-3.2-3B-Instruct").as_deref(),
+            Some("llama3_json")
+        );
+    }
+
+    #[test]
     fn model_recipe_target_platform_groups_by_engine() {
         let registry = builtin_model_recipe_registry();
         let platforms = model_catalog_platforms(&registry);

--- a/crates/rocm-core/src/model_catalog.json
+++ b/crates/rocm-core/src/model_catalog.json
@@ -40,7 +40,17 @@
       "quantization": "none; recommended small assistant recipe",
       "artifact_hint": "Lemonade model id; resolved internally to a GGUF build of this model",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen-tiny",
         "tiny-gpt2"
@@ -73,7 +83,17 @@
       "quantization": "none; tiny instruct smoke recipe",
       "artifact_hint": "Hugging Face safetensors model id; served on GPU through vLLM (Linux/WSL)",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen",
         "tiny-gpt2"
@@ -110,7 +130,7 @@
       "engine_recipes": [
         {
           "engine": "vllm",
-          "required_flags": [],
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
           "parser_settings": {},
           "preferred_endpoint": null,
           "unsupported_combinations": [],
@@ -179,7 +199,17 @@
       "quantization": "none; bfloat16 weights",
       "artifact_hint": "Hugging Face model id; engine resolver validates artifacts during serve",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen",
         "llama-3.2-3b-instruct",
@@ -213,7 +243,17 @@
       "quantization": "fp8 recipe",
       "artifact_hint": "Hugging Face model id; engine resolver validates FP8 support during serve",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen",
         "llama-3.2-3b-instruct",
@@ -281,7 +321,17 @@
       "quantization": "none; bfloat16 weights",
       "artifact_hint": "Hugging Face safetensors model id; served on GPU through vLLM (Linux/WSL)",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "llama3_json"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen",
         "tiny-gpt2"
@@ -337,7 +387,17 @@
       "quantization": "BF16, ~54 GiB (1x MI300X)",
       "artifact_hint": "Hugging Face model id; vLLM ROCm serving validates artifacts during serve",
       "artifacts": [],
-      "engine_recipes": [],
+      "engine_recipes": [
+        {
+          "engine": "vllm",
+          "required_flags": ["--enable-auto-tool-choice", "--tool-call-parser", "hermes"],
+          "parser_settings": {},
+          "preferred_endpoint": null,
+          "unsupported_combinations": [],
+          "notes": [],
+          "model_id_override": null
+        }
+      ],
       "manual_alternatives": [
         "qwen3-32b-fp8"
       ],

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -93,6 +93,27 @@ rocm serve Qwen/Qwen3.5-4B --engine vllm --gpu 1 --managed
 rocm-cli pins the device via `HIP_VISIBLE_DEVICES`. Serving one model across
 multiple GPUs is not supported.
 
+### Tool calling
+
+The TUI chat tab attaches tool definitions to every chat request. vLLM rejects
+those with HTTP 400 unless it is launched with `--enable-auto-tool-choice` **and**
+a matching `--tool-call-parser`. vLLM does not auto-detect the parser and it is
+model-specific, so rocm-cli never guesses one:
+
+- **Built-in catalog models** carry the correct parser in their recipe metadata,
+  so tool calling works out of the box (e.g. Qwen family → `hermes`,
+  Llama&nbsp;3 → `llama3_json`).
+- **Other models** (arbitrary Hugging Face repos, or a catalog model forced onto
+  vLLM without authored metadata) need an explicit parser:
+
+  ```bash
+  rocm serve <model> --engine vllm --tool-call-parser hermes --managed
+  ```
+
+  `--tool-call-parser` implies `--enable-auto-tool-choice`, overrides any catalog
+  default, and applies to vLLM only. Common values: `hermes`, `llama3_json`,
+  `mistral`. Without it, plain chat still works but tool calls return HTTP 400.
+
 Native Windows vLLM serving is skipped in this adapter. Use WSL/Linux for vLLM
 ROCm serving, or choose a different engine explicitly. No CPU fallback is used.
 


### PR DESCRIPTION
## Summary
- `rocm serve` now launches vLLM with `--enable-auto-tool-choice` and a model-matched `--tool-call-parser`, so the TUI chat tab works against vLLM-backed models out of the box.
- Flags are injected into the vLLM engine recipe hint at serve time, independent of catalog coverage: existing recipe hints are extended (recipe-authored flags win, no duplication), and a minimal hint is synthesized when none exists — so arbitrary HF repos and catalog models forced onto a non-preferred engine are covered too.
- Parser is chosen per model family (`llama` → `llama3_json`, `mistral`/`mixtral` → `mistral`), defaulting to `hermes` for the Qwen-heavy catalog.

## Why
The TUI chat tab attaches tool definitions to every non-streaming chat request (`tool_choice: "auto"`). vLLM rejects those with HTTP 400 unless it was started with `--enable-auto-tool-choice` **and** a matching `--tool-call-parser`:

```
chat request failed 400 tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set
```

## Root cause
The launch plumbing to forward `EngineRecipeHint.required_flags` into the `vllm serve` command already existed and worked — but nothing ever populated those flags. No catalog recipe set them, and the recipe-derived hint is gated by `model_recipe_supports_engine()`, which drops to `None` for a model whose preferred engine isn't the one being served (exactly the reported repro: `Qwen/Qwen2.5-1.5B-Instruct` forced with `--engine vllm`). So a catalog-only fix wouldn't have fixed the reported case; the injection has to happen in `serve()` regardless of recipe presence.

## Non-obvious decisions
- **Default parser `hermes`.** A mismatched-but-valid parser only degrades tool-call *parsing* for that model — it never 400s and never breaks plain chat — so a default is strictly safer than the status quo where every chat request failed. A specific model can still override via its recipe's `required_flags` (recipe wins).
- **Injected for all vLLM serves, not gated on `task == chat`.** vLLM's OpenAI server is chat/completions regardless, and the flags are inert when no tools are sent.
- Scope: no change to the TUI/providers tool-sending behavior, and no `model_catalog.json` edits — the central injection supersedes per-recipe authoring.

## Test plan
- New unit tests: parser selection by model family, hint synthesis when no recipe exists, appending to existing recipe flags, preserving recipe-authored tool-choice (no dup), and non-vLLM engines left untouched.
- `cargo test -p rocm` (new tests + existing serve/recipe/provider suites) and `cargo clippy` pass.
- Full end-to-end confirmation (TUI chat against a live vLLM server) requires a ROCm GPU and is deferred to that hardware.

## Risk
Low — additive; non-vLLM engines and recipe-authored flags are untouched, and the flags are inert for requests that don't send tools.