### PR TITLE
ci: allow manual E2E runs via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,24 @@ on:
   merge_group:
     branches: [main]
     types: [checks_requested]
+  # Manual trigger for on-demand E2E runs on the self-hosted GPU runners, without
+  # waiting on a push/PR or the full gate. Dispatch against any ref
+  # (`gh workflow run ci.yml --ref <branch> -f platform=... -f tier=...`) — GitHub
+  # runs THAT ref's copy of this file, so the E2E jobs it selects live on the ref.
+  # A dispatch skips build-and-test (see its `if:`) for a fast loop. This trigger
+  # must exist on the default branch for the workflow to be dispatchable at all.
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Which GPU runner(s) to target
+        type: choice
+        default: all
+        options: [all, app-dev-gpu, strix-ubuntu, strix-windows]
+      tier:
+        description: Which scenario tier(s) to run
+        type: choice
+        default: both
+        options: [both, expect-pass, known-bugs]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -108,6 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
+    # A manual E2E dispatch skips this heavy job for a fast loop; the E2E jobs
+    # tolerate a skipped build-and-test in their own `if:` guards.
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       platform:
-        description: Which GPU runner(s) to target
+        description: Which runner(s) to target
         type: choice
         default: all
-        options: [all, app-dev-gpu, strix-ubuntu, strix-windows]
+        options: [all, mock, app-dev-gpu, strix-ubuntu, strix-windows]
       tier:
         description: Which scenario tier(s) to run
         type: choice


### PR DESCRIPTION
## Summary
- Add a `workflow_dispatch` trigger to `ci.yml` with `platform` and `tier` inputs so the E2E jobs on the self-hosted GPU runners can be run on demand against any ref, without a push or the full pipeline.
- A manual dispatch skips `build-and-test` for a fast iteration loop. Nothing on the default branch depends on that job, so skipping it is safe.

## Why
A `workflow_dispatch` workflow is only dispatchable if the trigger exists on the default branch. Landing it here makes `ci.yml` dispatchable; the E2E jobs that consume these inputs live on their own branch and are exercised by dispatching against that ref (`gh workflow run ci.yml --ref <branch> -f platform=... -f tier=...`).

## Scope
- Only the trigger mechanism + inputs + the `build-and-test` skip. The default branch currently has no E2E jobs to guard; those are added on a separate branch which mirrors this identical `on:` block.

## Test plan
- [x] YAML valid, `actionlint` clean
- [x] Verified no job on the default branch `needs: build-and-test`
- [ ] After merge: confirm the workflow appears under Actions → Run workflow