### PR TITLE
ci: harden GitHub Actions (SHA-pin + Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to SHAs but current: Dependabot reads the version
+  # from the trailing `# vX.Y.Z` comment on each `uses:` and opens PRs that bump
+  # the SHA when a new release lands, so pinning for supply-chain safety does not
+  # mean going stale.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       lint: ${{ steps.filter.outputs.lint || steps.all.outputs.forced }}
       tpn: ${{ steps.filter.outputs.tpn || steps.all.outputs.forced }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Filter changed paths (pull requests only)
         id: filter
@@ -109,13 +109,13 @@ jobs:
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install native build deps
         if: needs.changes.outputs.heavy == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
 
       # Build the runtime binaries the smoke + acceptance steps below need (every
@@ -171,7 +171,7 @@ jobs:
     # cheap checks are green.
     needs: [changes, clippy, prek]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # `cargo xtask affected` diffs origin/<base>...HEAD, so it needs the
           # base history and the real PR head (not the synthetic merge ref).
@@ -228,9 +228,9 @@ jobs:
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
         with:
           cache-on-failure: true
@@ -292,10 +292,10 @@ jobs:
     # PRs that match no `changes` category. Like license-headers and
     # commit-signatures, it is not gated.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # cargo-fmt hook needs rustfmt (no build).
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: rustfmt
           cache: false
@@ -315,9 +315,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.rust == 'true'
 
       - name: Clippy
@@ -333,9 +333,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.tpn == 'true'
 
       # Pin the cargo-about version so the check compares against the exact same
@@ -347,7 +347,7 @@ jobs:
       - name: Cache cargo-about
         if: needs.changes.outputs.tpn == 'true'
         id: cache-cargo-about
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cargo/bin/cargo-about
           key: ${{ runner.os }}-cargo-about-0.9.1
@@ -365,13 +365,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install native build deps
         if: needs.changes.outputs.rust == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: dtolnay/rust-toolchain@1.96.0
+      - uses: dtolnay/rust-toolchain@c0e9df88980754dd93e5833b8dcb1b304c1fe173 # 1.96.0
         if: needs.changes.outputs.rust == 'true'
         with:
           components: llvm-tools-preview
@@ -384,7 +384,7 @@ jobs:
 
       - name: Cache cargo registry and build
         if: needs.changes.outputs.rust == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -418,9 +418,9 @@ jobs:
     runs-on: windows-latest
     needs: changes
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.lint == 'true'
 
       - name: Install PSScriptAnalyzer (PowerShell 7)
@@ -460,11 +460,11 @@ jobs:
       HAWKEYE_SHA256: d6eb0505a45a15244f4f789158aafe5e3f1a7dc86c9dc1d7651f3cb1e1b321e0
       HAWKEYE_INSTALL_DIR: ${{ github.workspace }}/.hawkeye-bin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Cache hawkeye binary
         id: cache-hawkeye
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ env.HAWKEYE_INSTALL_DIR }}
           key: ${{ runner.os }}-hawkeye-${{ env.HAWKEYE_VERSION }}-${{ env.HAWKEYE_SHA256 }}
@@ -495,7 +495,7 @@ jobs:
     # entry would stall forever.
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           # PR: check out the PR head, not the synthetic refs/pull/N/merge commit
@@ -507,7 +507,7 @@ jobs:
           # and are GitHub "Verified" (web-flow signed).
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Verify commits are signed and signed-off
         # `--require-verified` shells out to the `gh` CLI; pass the job token so

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       short_sha: ${{ steps.meta.outputs.short_sha }}
       staging_tag: ${{ steps.staging.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check for changes since last nightly
         id: check
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Cargo home and build artifacts
         if: steps.check.outputs.skip != 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -178,9 +178,9 @@ jobs:
     needs: nightly
     if: needs.nightly.outputs.skip != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Build release binaries
         shell: pwsh
@@ -235,7 +235,7 @@ jobs:
       - windows-nightly
     if: needs.nightly.outputs.skip != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Publish staged nightly
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.value }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Determine version
         id: version
@@ -47,7 +47,7 @@ jobs:
           echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Cargo home and build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/bin
@@ -162,9 +162,9 @@ jobs:
     runs-on: windows-latest
     needs: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Build release binaries
         shell: pwsh


### PR DESCRIPTION
## Summary
- SHA-pin all remaining tag-referenced actions across `ci.yml`, `nightly.yml`, `release.yml` (each with a `# vX.Y.Z` comment).
- Add `.github/dependabot.yml` (github-actions, weekly) so the pins stay current.

## Why
Mutable action tags (`@v6`, `@v1`) can be hijacked — a force-moved tag would run attacker code on our runners, including the self-hosted GPU boxes. Immutable commit SHAs close that supply-chain vector; Dependabot keeps them from going stale.

## Actions pinned
| Action | SHA | Version |
|---|---|---|
| actions/checkout | df4cb1c069e1874edd31b4311f1884172cec0e10 | v6.0.3 |
| actions/cache | caa296126883cff596d87d8935842f9db880ef25 | v5.1.0 |
| actions-rust-lang/setup-rust-toolchain | 166cdcfd11aee3cb47222f9ddb555ce30ddb9659 | v1.17.0 |
| dtolnay/rust-toolchain | c0e9df88980754dd93e5833b8dcb1b304c1fe173 | 1.96.0 |

(`dorny/paths-filter`, `taiki-e/install-action`, `j178/prek-action` were already SHA-pinned.)

## Related hardening already applied to repo settings (not in this diff)
- Default `GITHUB_TOKEN` permissions: **write → read**
- GitHub Actions can create/approve PRs: **true → false**
- Fork-PR workflow approval: confirmed **required for all external contributors**

## Follow-up (deliberately NOT in this PR)
- Enable repo setting `sha_pinning_required` **only after** this merges and other open branches are rebased onto the pinned `main` — otherwise GitHub rejects runs on any ref whose workflows still reference tags.
- Optional: narrow `allowed_actions` from `all` to `selected`.

## Test plan
- [x] `actionlint` clean (aside from pre-existing self-hosted runner labels + one pre-existing shellcheck style nit)
- [x] No remaining tag-based `uses:` refs in any workflow or composite action
- [x] CI green on this PR