### PR TITLE
fix(serve): persist running->ready promotion in CLI liveness refresh

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1725,6 +1725,7 @@ Apache License 2.0
 
 The following component(s) are licensed under Apache License 2.0:
   - rustls-platform-verifier 0.7.0 <https://github.com/rustls/rustls-platform-verifier>
+  - ureq 2.12.1 <https://github.com/algesten/ureq>
 
                                  Apache License
                            Version 2.0, January 2004
@@ -5641,7 +5642,6 @@ The following component(s) are licensed under Apache License 2.0:
   - unicode-truncate 2.0.1 <https://github.com/Aetf/unicode-truncate>
   - unicode-width 0.1.14 <https://github.com/unicode-rs/unicode-width>
   - unicode-width 0.2.0 <https://github.com/unicode-rs/unicode-width>
-  - ureq 2.12.1 <https://github.com/algesten/ureq>
   - url 2.5.8 <https://github.com/servo/rust-url>
   - uuid 1.23.3 <https://github.com/uuid-rs/uuid>
   - wasi 0.11.1+wasi-snapshot-preview1 <https://github.com/bytecodealliance/wasi>

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1725,7 +1725,6 @@ Apache License 2.0
 
 The following component(s) are licensed under Apache License 2.0:
   - rustls-platform-verifier 0.7.0 <https://github.com/rustls/rustls-platform-verifier>
-  - ureq 2.12.1 <https://github.com/algesten/ureq>
 
                                  Apache License
                            Version 2.0, January 2004
@@ -5642,6 +5641,7 @@ The following component(s) are licensed under Apache License 2.0:
   - unicode-truncate 2.0.1 <https://github.com/Aetf/unicode-truncate>
   - unicode-width 0.1.14 <https://github.com/unicode-rs/unicode-width>
   - unicode-width 0.2.0 <https://github.com/unicode-rs/unicode-width>
+  - ureq 2.12.1 <https://github.com/algesten/ureq>
   - url 2.5.8 <https://github.com/servo/rust-url>
   - uuid 1.23.3 <https://github.com/uuid-rs/uuid>
   - wasi 0.11.1+wasi-snapshot-preview1 <https://github.com/bytecodealliance/wasi>

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -13082,6 +13082,12 @@ fn refresh_managed_service_runtime_liveness(record: &mut ManagedServiceRecord) -
         && managed_service_endpoint_model_ready(record, SERVICE_LIVENESS_CHECK_TIMEOUT)
             .unwrap_or(false);
     if endpoint_ready {
+        // Mirror `providers.rs::ready_local_services()`: a live, probe-passing
+        // service should be persisted as "ready", not left stuck at "running".
+        if record.status == "running" {
+            record.status = "ready".to_owned();
+            return true;
+        }
         return false;
     }
 
@@ -16093,6 +16099,81 @@ mod tests {
         let request = receiver.recv_timeout(Duration::from_secs(1))?;
         assert!(request.starts_with("POST /v1/unload HTTP/1.1"));
         assert!(request.contains("\"model_name\":\"Qwen3-0.6B-GGUF\""));
+        Ok(())
+    }
+
+    #[test]
+    fn load_managed_services_promotes_running_to_ready_once_probe_passes() -> Result<()> {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        // Two probes hit this mock: one from `load_managed_services`, another
+        // from the `load_managed_service` re-read below that verifies the
+        // promotion was actually persisted, not just returned in-memory.
+        let server = thread::spawn(move || -> Result<()> {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut request_bytes = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let read = stream.read(&mut buffer)?;
+                    if read == 0 {
+                        break;
+                    }
+                    request_bytes.extend_from_slice(&buffer[..read]);
+                    if String::from_utf8_lossy(&request_bytes).contains("\r\n\r\n") {
+                        break;
+                    }
+                }
+                let body = r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#;
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )?;
+            }
+            Ok(())
+        });
+
+        let (root, paths) = test_paths("load-managed-services-promote-ready");
+        paths.ensure()?;
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            "svc-qwen-promote",
+            "vllm",
+            "Qwen3-0.6B-GGUF",
+            "Qwen3-0.6B-GGUF",
+            "127.0.0.1",
+            port,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            None,
+        );
+        // A supervisor that has already observed the engine come up reports
+        // "running"; only the HTTP model-ready probe should promote it further.
+        record.status = "running".to_owned();
+        record.write()?;
+
+        let records = load_managed_services(&paths)?;
+        let promoted = records
+            .iter()
+            .find(|found| found.service_id == "svc-qwen-promote")
+            .expect("service should be present");
+        assert_eq!(promoted.status, "ready");
+
+        // The promotion must have been persisted to disk, not just returned
+        // in-memory, since chat's `pick_managed_chat_endpoint` re-reads it.
+        let reloaded = load_managed_service(&paths, "svc-qwen-promote")?;
+        assert_eq!(reloaded.status, "ready");
+
+        server.join().expect("server thread should not panic")?;
+        fs::remove_dir_all(root).ok();
         Ok(())
     }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -16167,6 +16167,17 @@ mod tests {
             .expect("service should be present");
         assert_eq!(promoted.status, "ready");
 
+        // Re-read the manifest file directly (bypassing any code path that
+        // could itself re-run the promotion) to prove the transition was
+        // actually written to disk, not just returned in the in-memory
+        // `Vec<ManagedServiceRecord>` above. `load_managed_service` below
+        // also calls `refresh_managed_service_runtime_liveness` on every
+        // read, so asserting only on its return value would pass even if
+        // `load_managed_services` never persisted anything.
+        let on_disk_bytes = fs::read(&record.manifest_path)?;
+        let on_disk = serde_json::from_slice::<ManagedServiceRecord>(&on_disk_bytes)?;
+        assert_eq!(on_disk.status, "ready");
+
         // The promotion must have been persisted to disk, not just returned
         // in-memory, since chat's `pick_managed_chat_endpoint` re-reads it.
         let reloaded = load_managed_service(&paths, "svc-qwen-promote")?;


### PR DESCRIPTION
## Summary

`refresh_managed_service_runtime_liveness()` in `apps/rocm/src/main.rs` already runs the real HTTP readiness probe (`managed_service_endpoint_model_ready()`), but only used a passing probe to **skip demotion** — it never persisted the `running` -> `ready` transition. This means a service manifest can sit forever at `status: "running"` even after the model has actually finished loading and is serving requests.

## Root cause

The twin code path in `apps/rocm/src/providers.rs::ready_local_services()` already does this correctly: on a passing probe it sets `record.status = "ready"` and writes the manifest back to disk. `refresh_managed_service_runtime_liveness()` (used by `load_managed_services()`, which backs the `services` MCP tool and — via `pick_managed_chat_endpoint()` — chat's endpoint selection, which requires the *exact* string `"ready"`) never got the same fix. As a result chat could never discover a genuinely ready local server if the record had been left at `"running"`.

## Fix

Mirror `ready_local_services()`'s promotion: when the probe passes and `record.status == "running"`, set it to `"ready"` and signal a change so the existing write-back logic in `load_managed_services()` / `load_managed_service()` persists it.

## Test Plan

- [x] Added `load_managed_services_promotes_running_to_ready_once_probe_passes` — spins up a mock `/v1/models` HTTP endpoint, writes a manifest with `status: "running"`, calls `load_managed_services`, and asserts the in-memory and on-disk (`load_managed_service` re-read) status is `"ready"`.
- [x] `cargo build -p rocm`
- [x] `cargo clippy -p rocm --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rocm -- --test-threads=1` (338 passed)

Relates to EAI-7352