### PR TITLE
fix(daemon): decouple vLLM Prometheus scraping from enable_docker

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -462,7 +462,9 @@ mod tests {
     /// Prometheus scraper must NOT be gated on `enable_docker` — otherwise it
     /// is permanently dead in the common no-Docker / managed-vLLM case even
     /// though `vllm_prom.rs` has zero Docker dependency (plain HTTP GET).
-    /// `disable_vllm_metrics` is the only knob that should turn it off.
+    /// The scrape stays on by default; `disable_vllm_metrics` is the internal
+    /// gate that would turn it off, but it is not currently wired to any CLI
+    /// flag or config field, so today it is always `false`.
     #[test]
     fn runner_options_keeps_vllm_metrics_enabled_without_docker() {
         let p = paths();

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -457,6 +457,23 @@ mod tests {
         assert!(!opts.enable_docker);
     }
 
+    /// EAI-7359 regression: the embedded daemon (`maybe_spawn_embedded_daemon`)
+    /// always calls `runner_options(.., enable_docker=false)`, so the vLLM
+    /// Prometheus scraper must NOT be gated on `enable_docker` — otherwise it
+    /// is permanently dead in the common no-Docker / managed-vLLM case even
+    /// though `vllm_prom.rs` has zero Docker dependency (plain HTTP GET).
+    /// `disable_vllm_metrics` is the only knob that should turn it off.
+    #[test]
+    fn runner_options_keeps_vllm_metrics_enabled_without_docker() {
+        let p = paths();
+        let opts = runner_options(&cfg(), &p, false);
+        assert!(!opts.enable_docker);
+        assert!(
+            !opts.disable_vllm_metrics,
+            "vLLM metrics must stay on by default even when Docker discovery is off"
+        );
+    }
+
     #[test]
     fn bootstrap_routes_to_focused_setup() {
         // `rocm bootstrap setup` must route to the same focused Setup host as the

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -42,8 +42,11 @@ pub struct RunnerOptions {
     pub gpu_tick: Duration,
     pub discovery_tick: Duration,
     pub instance_tick: Duration,
-    /// Disable the per-instance Prometheus scrape (otherwise runs whenever
-    /// docker discovery is enabled).
+    /// Disable the per-instance vLLM Prometheus scrape. Independent of
+    /// `enable_docker`: the scraper is a plain HTTP GET against a vLLM
+    /// instance's `/metrics` endpoint and runs for BOTH Docker-discovered and
+    /// managed (native, `services_dir`-discovered) instances. `false` (the
+    /// default) means the scrape runs.
     pub disable_vllm_metrics: bool,
     /// Hostname to scrape; `127.0.0.1` for the typical co-located daemon.
     pub vllm_metrics_host: String,
@@ -96,6 +99,17 @@ pub struct Runner {
     pub state: State,
 }
 
+/// Whether `run_loop` should construct the [`VllmPrometheusCollector`].
+///
+/// EAI-7359: the scraper is a plain HTTP GET against a vLLM instance's
+/// `/metrics` endpoint — it has no Docker dependency. Managed (native)
+/// instances are already discovered via `services_dir` independently of
+/// Docker, so this is gated on `disable_vllm_metrics` ALONE; `enable_docker`
+/// must never factor in here (it continues to gate only `DockerDiscovery`).
+const fn vllm_metrics_enabled(opts: &RunnerOptions) -> bool {
+    !opts.disable_vllm_metrics
+}
+
 /// Loop forever: tick host + gpu metrics + bench rows, apply through reducer, broadcast.
 ///
 /// `tick_override` lets tests run faster than `opts.gpu_tick`; production passes
@@ -119,7 +133,7 @@ pub async fn run_loop(
     let instance_ticks = ticks_per(opts.instance_tick, tick);
     let sysinfo_refresh_ticks = ticks_per(Duration::from_secs(SYSINFO_REFRESH_SECS), tick);
 
-    let vllm = if opts.enable_docker && !opts.disable_vllm_metrics {
+    let vllm = if vllm_metrics_enabled(&opts) {
         Some(Arc::new(VllmPrometheusCollector::new(
             opts.vllm_metrics_host.clone(),
             Duration::from_millis(1500),
@@ -836,6 +850,42 @@ mod tests {
         enrich_instance_vram(&mut instances, &gpus, &per);
         assert_eq!(instances[0].vram_used_mb, 0);
         assert_eq!(instances[0].vram_total_mb, 0);
+    }
+
+    /// EAI-7359 regression: vLLM Prometheus scraping must be constructed
+    /// regardless of `enable_docker` — only `disable_vllm_metrics` may turn
+    /// it off. Before the fix this was `enable_docker && !disable_vllm_metrics`,
+    /// which permanently killed the scraper for the embedded daemon (always
+    /// launched with `enable_docker = false`).
+    #[test]
+    fn vllm_metrics_enabled_is_independent_of_docker() {
+        let mut opts = RunnerOptions {
+            enable_docker: false,
+            disable_vllm_metrics: false,
+            ..RunnerOptions::default()
+        };
+        assert!(
+            vllm_metrics_enabled(&opts),
+            "no-Docker case must still scrape"
+        );
+
+        opts.enable_docker = true;
+        assert!(
+            vllm_metrics_enabled(&opts),
+            "Docker enabled must still scrape"
+        );
+
+        opts.disable_vllm_metrics = true;
+        assert!(
+            !vllm_metrics_enabled(&opts),
+            "explicit disable must always win"
+        );
+
+        opts.enable_docker = false;
+        assert!(
+            !vllm_metrics_enabled(&opts),
+            "explicit disable must always win regardless of docker"
+        );
     }
 
     #[test]

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -42,11 +42,13 @@ pub struct RunnerOptions {
     pub gpu_tick: Duration,
     pub discovery_tick: Duration,
     pub instance_tick: Duration,
-    /// Disable the per-instance vLLM Prometheus scrape. Independent of
-    /// `enable_docker`: the scraper is a plain HTTP GET against a vLLM
-    /// instance's `/metrics` endpoint and runs for BOTH Docker-discovered and
-    /// managed (native, `services_dir`-discovered) instances. `false` (the
-    /// default) means the scrape runs.
+    /// Internal gate for the per-instance vLLM Prometheus scrape. Currently
+    /// always `false` (the scrape runs) — it is NOT yet wired to a CLI flag or
+    /// config field, so callers cannot turn it off today; it exists as the
+    /// single seam a future opt-out would flip. Independent of `enable_docker`:
+    /// the scraper is a plain HTTP GET against a vLLM instance's `/metrics`
+    /// endpoint and runs for BOTH Docker-discovered and managed (native,
+    /// `services_dir`-discovered) instances.
     pub disable_vllm_metrics: bool,
     /// Hostname to scrape; `127.0.0.1` for the typical co-located daemon.
     pub vllm_metrics_host: String,
@@ -853,10 +855,15 @@ mod tests {
     }
 
     /// EAI-7359 regression: vLLM Prometheus scraping must be constructed
-    /// regardless of `enable_docker` — only `disable_vllm_metrics` may turn
-    /// it off. Before the fix this was `enable_docker && !disable_vllm_metrics`,
-    /// which permanently killed the scraper for the embedded daemon (always
-    /// launched with `enable_docker = false`).
+    /// regardless of `enable_docker`. Before the fix this was
+    /// `enable_docker && !disable_vllm_metrics`, which permanently killed the
+    /// scraper for the embedded daemon (always launched with
+    /// `enable_docker = false`).
+    ///
+    /// The `disable_vllm_metrics = true` cases below exercise the internal
+    /// gate directly; it is not currently user-reachable (no CLI flag / config
+    /// field sets it), so this asserts the gate's logic, not a shipped
+    /// off-switch.
     #[test]
     fn vllm_metrics_enabled_is_independent_of_docker() {
         let mut opts = RunnerOptions {
@@ -875,16 +882,18 @@ mod tests {
             "Docker enabled must still scrape"
         );
 
+        // Internal gate (not user-reachable today): flipping it off must win
+        // over any Docker state.
         opts.disable_vllm_metrics = true;
         assert!(
             !vllm_metrics_enabled(&opts),
-            "explicit disable must always win"
+            "internal disable gate must always win"
         );
 
         opts.enable_docker = false;
         assert!(
             !vllm_metrics_enabled(&opts),
-            "explicit disable must always win regardless of docker"
+            "internal disable gate must always win regardless of docker"
         );
     }
 


### PR DESCRIPTION
## Summary

- `VllmPrometheusCollector` (the vLLM `/metrics` HTTP scraper) was only constructed when `opts.enable_docker && !opts.disable_vllm_metrics`, even though the scraper has zero Docker dependency — it's a plain HTTP GET against a vLLM instance's `/metrics` endpoint.
- `apps/rocm/src/dash.rs::maybe_spawn_embedded_daemon` always calls `runner_options(config, paths, false)`, hardcoding `enable_docker = false`. Combined with the gate above, this made the vLLM Prometheus scraper **permanently dead** for the embedded daemon — the common no-Docker / managed-vLLM path.
- Fix: gate `vllm` construction in `run_loop` on `!opts.disable_vllm_metrics` alone. `enable_docker` continues to gate only `DockerDiscovery`, which is the only genuinely Docker-dependent piece.

## Root cause

Managed (native) vLLM instances are already discovered independently of Docker via `services_dir`, so the scraper never needed `enable_docker` as a precondition. The original gate conflated "Docker discovery is enabled" with "scrape metrics from any known vLLM instance," silently disabling metrics for every embedded-daemon deployment.

Relates to EAI-7359

## Test Plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p rocm-dash-daemon runner::` — 11 passed, including new `vllm_metrics_enabled_is_independent_of_docker` regression test
- [x] `cargo test -p rocm dash:: -- --test-threads=1` — 8 passed, including new `runner_options_keeps_vllm_metrics_enabled_without_docker` regression test