### PR TITLE
fix(chat): revalidate a stale persisted chat_url and fall back to a live endpoint

### DIFF
--- a/crates/rocm-dash-tui/src/app/chat.rs
+++ b/crates/rocm-dash-tui/src/app/chat.rs
@@ -292,41 +292,55 @@ pub(super) const fn startup_chat_outcome(
     }
 }
 
-/// Decide whether a persisted `chat_url` should be replaced by a freshly
-/// detected live endpoint (EAI-7360).
+/// Whether startup should offer to replace a stale persisted `chat_url`.
 ///
-/// Pure — takes the already-computed reachability/detection results rather
-/// than doing I/O itself, so it is unit-testable without a tool executor or a
-/// live socket. The caller only feeds this a `live` detection result when
-/// `chat_url` came from persisted config and neither the managed-services
-/// registry nor a direct TCP probe already confirmed it reachable, so this
-/// never revalidates an explicit env override, and `resolve_llm_config`'s own
-/// CLI>config>env>probe precedence (tested directly in `llm.rs`) is
-/// completely untouched — this only ever supplies a *replacement* config
-/// before that call runs.
-///
-/// Returns `Some(live)` only when the configured endpoint is unreachable and
-/// a *genuinely different*, live endpoint was found; `None` otherwise (nothing
-/// to replace, or detection re-found the same URL modulo a trailing `/`/`/v1`).
-pub(super) fn stale_chat_url_replacement(
-    configured_base_url: &str,
+/// The replacement is keyless, so only an unreachable configured URL with no
+/// credentials is eligible. Keeping this decision pure makes the full startup
+/// guard independently testable before the caller performs another probe.
+pub(super) fn should_revalidate_stale_chat_url(
+    startup_outcome: StartupChatOutcome,
     configured_probe_ok: bool,
-    live: Option<crate::llm::LlmConfig>,
-) -> Option<crate::llm::LlmConfig> {
-    if configured_probe_ok {
-        return None;
-    }
-    let configured = normalize_base_url(configured_base_url);
-    live.filter(|l| normalize_base_url(&l.base_url) != configured)
+    chat_url: Option<&str>,
+    chat_api_key: Option<&str>,
+    chat_auth_header: Option<&str>,
+) -> bool {
+    startup_outcome == StartupChatOutcome::Configured
+        && !configured_probe_ok
+        && chat_url.is_some()
+        && chat_api_key.is_none()
+        && chat_auth_header.is_none()
 }
 
-/// Normalize an OpenAI-style base URL for change-detection comparison: drop a
-/// trailing `/` and a trailing `/v1` so a formatting-only difference (e.g.
-/// `http://h:8000` vs `http://h:8000/v1/`) is not mistaken for a server change
-/// and does not emit a spurious "server changed" notice.
-fn normalize_base_url(base_url: &str) -> String {
+/// Return a newly detected endpoint only when it differs from the stale one.
+///
+/// The caller invokes this after `resolve_llm_config` and routes the result
+/// through [`AppState::set_detect_result`], preserving the existing
+/// accept/save/dismiss flow instead of silently replacing the active config.
+pub(super) fn stale_chat_url_replacement(
+    configured_base_url: &str,
+    live: Option<crate::llm::LlmConfig>,
+) -> Option<crate::llm::LlmConfig> {
+    let configured = normalize_base_url(configured_base_url);
+    live.filter(|candidate| normalize_base_url(&candidate.base_url) != configured)
+}
+
+/// Normalize a local OpenAI-style base URL for change detection.
+///
+/// Trailing `/` and `/v1` are formatting-only. `localhost` and `127.0.0.1`
+/// identify the same loopback server; canonicalizing that spelling avoids a
+/// false server-change offer. The common path remains borrowed.
+fn normalize_base_url(base_url: &str) -> std::borrow::Cow<'_, str> {
     let trimmed = base_url.trim().trim_end_matches('/');
-    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+    let normalized = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
+    for prefix in ["http://localhost", "https://localhost"] {
+        if let Some(rest) = normalized.strip_prefix(prefix)
+            && (rest.is_empty() || rest.starts_with(':') || rest.starts_with('/'))
+        {
+            let scheme = &prefix[..prefix.len() - "localhost".len()];
+            return format!("{scheme}127.0.0.1{rest}").into();
+        }
+    }
+    normalized.into()
 }
 
 /// Persist an accepted local endpoint to the user's `config.toml`: load the
@@ -698,58 +712,83 @@ mod tests {
     }
 
     #[test]
-    fn stale_chat_url_replacement_none_when_configured_endpoint_reachable() {
-        // Reachable configured endpoint must never be swapped out, regardless
-        // of what a stray `live` detection result would have found.
-        assert_eq!(
-            stale_chat_url_replacement(
-                "http://127.0.0.1:9/v1",
-                true,
-                Some(live("http://127.0.0.1:11435/v1"))
+    fn stale_revalidation_requires_unreachable_uncredentialed_persisted_url() {
+        assert!(should_revalidate_stale_chat_url(
+            StartupChatOutcome::Configured,
+            false,
+            Some("http://127.0.0.1:9/v1"),
+            None,
+            None,
+        ));
+
+        for (outcome, probe_ok, url, key, header) in [
+            (
+                StartupChatOutcome::Local,
+                false,
+                Some("http://x"),
+                None,
+                None,
             ),
-            None
-        );
+            (
+                StartupChatOutcome::Configured,
+                true,
+                Some("http://x"),
+                None,
+                None,
+            ),
+            (StartupChatOutcome::Configured, false, None, None, None),
+            (
+                StartupChatOutcome::Configured,
+                false,
+                Some("http://x"),
+                Some("k"),
+                None,
+            ),
+            (
+                StartupChatOutcome::Configured,
+                false,
+                Some("http://x"),
+                None,
+                Some("Authorization"),
+            ),
+        ] {
+            assert!(!should_revalidate_stale_chat_url(
+                outcome, probe_ok, url, key, header
+            ));
+        }
     }
 
     #[test]
     fn stale_chat_url_replacement_none_when_nothing_live_found() {
         assert_eq!(
-            stale_chat_url_replacement("http://127.0.0.1:9/v1", false, None),
+            stale_chat_url_replacement("http://127.0.0.1:9/v1", None),
             None
         );
     }
 
     #[test]
     fn stale_chat_url_replacement_none_when_live_matches_configured() {
-        // Detection simply re-confirming the same (currently-unreachable-by-
-        // TCP-probe-timing) URL is not a "server changed" situation.
         let url = "http://127.0.0.1:11435/v1";
-        assert_eq!(
-            stale_chat_url_replacement(url, false, Some(live(url))),
-            None
-        );
+        assert_eq!(stale_chat_url_replacement(url, Some(live(url))), None);
     }
 
     #[test]
-    fn stale_chat_url_replacement_swaps_to_a_different_live_endpoint() {
+    fn stale_chat_url_replacement_offers_a_different_live_endpoint() {
         let found = live("http://127.0.0.1:13305/v1");
-        let replacement =
-            stale_chat_url_replacement("http://127.0.0.1:9/v1", false, Some(found.clone()))
-                .expect("a different live endpoint replaces the stale one");
+        let replacement = stale_chat_url_replacement("http://127.0.0.1:9/v1", Some(found.clone()))
+            .expect("a different live endpoint is offered");
         assert_eq!(replacement.base_url, found.base_url);
     }
 
     #[test]
-    fn stale_chat_url_replacement_ignores_trailing_slash_and_v1_formatting() {
-        // A formatting-only difference (trailing `/`, presence/absence of the
-        // `/v1` suffix) is the SAME endpoint — no spurious "server changed".
+    fn stale_chat_url_replacement_normalizes_equivalent_urls() {
         for (configured, found) in [
             ("http://127.0.0.1:8000/v1", "http://127.0.0.1:8000/v1/"),
             ("http://127.0.0.1:8000/v1", "http://127.0.0.1:8000"),
-            ("http://127.0.0.1:8000", "http://127.0.0.1:8000/v1"),
+            ("http://localhost:8000/v1", "http://127.0.0.1:8000/v1"),
         ] {
             assert_eq!(
-                stale_chat_url_replacement(configured, false, Some(live(found))),
+                stale_chat_url_replacement(configured, Some(live(found))),
                 None,
                 "{configured} vs {found} must be treated as the same endpoint"
             );
@@ -757,10 +796,9 @@ mod tests {
     }
 
     #[test]
-    fn normalize_base_url_strips_trailing_slash_and_v1() {
-        assert_eq!(normalize_base_url("http://h:8000/v1/"), "http://h:8000");
-        assert_eq!(normalize_base_url("http://h:8000/v1"), "http://h:8000");
-        assert_eq!(normalize_base_url("http://h:8000/"), "http://h:8000");
-        assert_eq!(normalize_base_url("http://h:8000"), "http://h:8000");
+    fn normalize_base_url_strips_suffixes_without_allocating() {
+        let normalized = normalize_base_url("http://h:8000/v1/");
+        assert_eq!(normalized, "http://h:8000");
+        assert!(matches!(normalized, std::borrow::Cow::Borrowed(_)));
     }
 }

--- a/crates/rocm-dash-tui/src/app/chat.rs
+++ b/crates/rocm-dash-tui/src/app/chat.rs
@@ -292,6 +292,43 @@ pub(super) const fn startup_chat_outcome(
     }
 }
 
+/// Decide whether a persisted `chat_url` should be replaced by a freshly
+/// detected live endpoint (EAI-7360).
+///
+/// Pure — takes the already-computed reachability/detection results rather
+/// than doing I/O itself, so it is unit-testable without a tool executor or a
+/// live socket. The caller only feeds this a `live` detection result when
+/// `chat_url` came from persisted config and neither the managed-services
+/// registry nor a direct TCP probe already confirmed it reachable, so this
+/// never revalidates an explicit env override, and `resolve_llm_config`'s own
+/// CLI>config>env>probe precedence (tested directly in `llm.rs`) is
+/// completely untouched — this only ever supplies a *replacement* config
+/// before that call runs.
+///
+/// Returns `Some(live)` only when the configured endpoint is unreachable and
+/// a *genuinely different*, live endpoint was found; `None` otherwise (nothing
+/// to replace, or detection re-found the same URL modulo a trailing `/`/`/v1`).
+pub(super) fn stale_chat_url_replacement(
+    configured_base_url: &str,
+    configured_probe_ok: bool,
+    live: Option<crate::llm::LlmConfig>,
+) -> Option<crate::llm::LlmConfig> {
+    if configured_probe_ok {
+        return None;
+    }
+    let configured = normalize_base_url(configured_base_url);
+    live.filter(|l| normalize_base_url(&l.base_url) != configured)
+}
+
+/// Normalize an OpenAI-style base URL for change-detection comparison: drop a
+/// trailing `/` and a trailing `/v1` so a formatting-only difference (e.g.
+/// `http://h:8000` vs `http://h:8000/v1/`) is not mistaken for a server change
+/// and does not emit a spurious "server changed" notice.
+fn normalize_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+}
+
 /// Persist an accepted local endpoint to the user's `config.toml`: load the
 /// existing config (or defaults), set `tui.chat_url`/`tui.chat_model`, and write
 /// it back. Best-effort — returns a human error string on failure.
@@ -654,5 +691,76 @@ mod tests {
             startup_chat_outcome(false, false),
             StartupChatOutcome::Configured
         );
+    }
+
+    fn live(base_url: &str) -> crate::llm::LlmConfig {
+        crate::llm::detected_llm_config(base_url, "m")
+    }
+
+    #[test]
+    fn stale_chat_url_replacement_none_when_configured_endpoint_reachable() {
+        // Reachable configured endpoint must never be swapped out, regardless
+        // of what a stray `live` detection result would have found.
+        assert_eq!(
+            stale_chat_url_replacement(
+                "http://127.0.0.1:9/v1",
+                true,
+                Some(live("http://127.0.0.1:11435/v1"))
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn stale_chat_url_replacement_none_when_nothing_live_found() {
+        assert_eq!(
+            stale_chat_url_replacement("http://127.0.0.1:9/v1", false, None),
+            None
+        );
+    }
+
+    #[test]
+    fn stale_chat_url_replacement_none_when_live_matches_configured() {
+        // Detection simply re-confirming the same (currently-unreachable-by-
+        // TCP-probe-timing) URL is not a "server changed" situation.
+        let url = "http://127.0.0.1:11435/v1";
+        assert_eq!(
+            stale_chat_url_replacement(url, false, Some(live(url))),
+            None
+        );
+    }
+
+    #[test]
+    fn stale_chat_url_replacement_swaps_to_a_different_live_endpoint() {
+        let found = live("http://127.0.0.1:13305/v1");
+        let replacement =
+            stale_chat_url_replacement("http://127.0.0.1:9/v1", false, Some(found.clone()))
+                .expect("a different live endpoint replaces the stale one");
+        assert_eq!(replacement.base_url, found.base_url);
+    }
+
+    #[test]
+    fn stale_chat_url_replacement_ignores_trailing_slash_and_v1_formatting() {
+        // A formatting-only difference (trailing `/`, presence/absence of the
+        // `/v1` suffix) is the SAME endpoint — no spurious "server changed".
+        for (configured, found) in [
+            ("http://127.0.0.1:8000/v1", "http://127.0.0.1:8000/v1/"),
+            ("http://127.0.0.1:8000/v1", "http://127.0.0.1:8000"),
+            ("http://127.0.0.1:8000", "http://127.0.0.1:8000/v1"),
+        ] {
+            assert_eq!(
+                stale_chat_url_replacement(configured, false, Some(live(found))),
+                None,
+                "{configured} vs {found} must be treated as the same endpoint"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_base_url_strips_trailing_slash_and_v1() {
+        assert_eq!(normalize_base_url("http://h:8000/v1/"), "http://h:8000");
+        assert_eq!(normalize_base_url("http://h:8000/v1"), "http://h:8000");
+        assert_eq!(normalize_base_url("http://h:8000/"), "http://h:8000");
+        assert_eq!(normalize_base_url("http://h:8000"), "http://h:8000");
     }
 }

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -40,8 +40,8 @@ mod summary;
 
 use chat::{
     StartupChatOutcome, build_chat_agent, build_local_agent, detect_local_chat,
-    discover_configured_chat_model, persist_chat_endpoint, stale_chat_url_replacement,
-    startup_chat_outcome,
+    discover_configured_chat_model, persist_chat_endpoint, should_revalidate_stale_chat_url,
+    stale_chat_url_replacement, startup_chat_outcome,
 };
 use summary::{parse_plan_result, summarize_json_value, summarize_slash_tool};
 
@@ -84,7 +84,8 @@ pub struct ResolvedArgs {
     /// There is no `--chat-url` CLI flag today, so this tier is exactly the
     /// persisted config — which is what startup revalidates when it goes stale.
     pub chat_url: Option<String>,
-    /// Chat model, CLI-flag value already merged over config.
+    /// Chat model sourced from persisted config (`tui.chat_model`). There is
+    /// no `--chat-model` CLI flag today.
     pub chat_model: Option<String>,
     /// Custom auth header NAME (CLI-flag value merged over config), e.g.
     /// `Ocp-Apim-Subscription-Key` for Azure APIM gateways.
@@ -1788,44 +1789,29 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             ),
             other => other,
         };
-        // EAI-7360: a persisted `tui.chat_url` can go stale — the server it
-        // pointed at may have been stopped or replaced since the dash last wrote
-        // it. This is the `Configured`-but-unreachable case: the reachable
-        // `Configured` case already ran `discover_configured_chat_model` above,
-        // and a `Local` outcome auto-detected its own live endpoint. Only this
-        // persisted-config tier is revalidated — `chat_env_url` is a separate
-        // tier, and `resolve_llm_config`'s CLI>config>env>probe precedence (the
-        // literal contract unit-tested in `llm.rs`) is untouched: this only
-        // substitutes a *replacement* `LlmConfig` after that call, never changes
-        // how the call itself resolves.
-        //
-        // Require NO configured api_key/auth_header: the replacement is a
-        // keyless `detected_llm_config`, and since `ResolvedArgs` can't
-        // distinguish an explicit `--chat-url` from persisted config, a remote
-        // gateway URL + `OPENAI_API_KEY` that merely TCP-times-out must never
-        // silently swap to a local keyless engine and drop the credential.
-        // Confining the swap to a no-auth `chat_url` keeps it on the true
-        // EAI-7360 target: a dead *persisted* local endpoint.
-        let stale_replacement = if startup_outcome == StartupChatOutcome::Configured
-            && !probe_ok
-            && args.chat_url.is_some()
-            && args.chat_api_key.is_none()
-            && args.chat_auth_header.is_none()
-        {
+        // EAI-7360: a persisted `tui.chat_url` can go stale. Only re-probe an
+        // unreachable configured URL without credentials; a keyless local
+        // offer must never replace a credentialed gateway. `chat_env_url` is a
+        // separate tier, and the resolver's CLI>config>env>probe precedence is
+        // unchanged.
+        let stale_offer = if should_revalidate_stale_chat_url(
+            startup_outcome,
+            probe_ok,
+            args.chat_url.as_deref(),
+            args.chat_api_key.as_deref(),
+            args.chat_auth_header.as_deref(),
+        ) {
             let live = detect_local_chat(state.tool_executor.clone()).await;
-            stale_chat_url_replacement(&probe_target, probe_ok, live)
+            stale_chat_url_replacement(&probe_target, live)
         } else {
             None
         };
-        if let Some(live) = &stale_replacement {
-            state.chat.push(ChatTurn::system(format!(
-                "Configured chat server at {probe_target} is unreachable; switched to the live \
-                 local engine at {} (model: {}). Run `/detect save` to persist it.",
-                live.base_url, live.model
-            )));
-        }
-        let llm = stale_replacement.or(llm);
         state.set_chat_config(llm, args.chat_auto_consent);
+        if let Some(live) = stale_offer {
+            // Reuse the existing offer reducer so accept, save, and dismiss all
+            // work exactly as they do after an explicit `/detect` probe.
+            state.set_detect_result(Some(live));
+        }
         // No reachable local endpoint AND no key/url configured → the no-key
         // ChatGPT OAuth default (device-code login surfaced in the chat tab).
         // This restores the no-key login the vendored Codex path provided; it
@@ -4818,6 +4804,30 @@ mod tests {
             "accept raises the rebuild edge carrying the previous provider"
         );
         assert_eq!(s.active_provider, ChatProvider::Local);
+    }
+
+    #[test]
+    fn stale_startup_endpoint_uses_actionable_detect_offer() {
+        let mut s = AppState::new("t".into(), "default-dark".into());
+        let stale = crate::llm::detected_llm_config("http://127.0.0.1:9/v1", "old");
+        let live = crate::llm::detected_llm_config("http://localhost:13305/v1", "new");
+
+        // Match event_loop ordering: retain the configured endpoint, then offer
+        // the newly detected one through the established reducer.
+        s.set_chat_config(Some(stale.clone()), true);
+        s.set_detect_result(Some(live.clone()));
+
+        assert_eq!(s.chat_llm.as_ref(), Some(&stale));
+        assert_eq!(s.chat_detect_offer.as_ref(), Some(&live));
+        assert!(
+            s.chat
+                .iter()
+                .any(|turn| turn.content.contains("/detect save"))
+        );
+
+        apply_action(&mut s, KeyAction::ChatDetectSave);
+        assert_eq!(s.chat_llm.as_ref(), Some(&live));
+        assert!(s.chat_persist_dispatch);
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -40,7 +40,8 @@ mod summary;
 
 use chat::{
     StartupChatOutcome, build_chat_agent, build_local_agent, detect_local_chat,
-    discover_configured_chat_model, persist_chat_endpoint, startup_chat_outcome,
+    discover_configured_chat_model, persist_chat_endpoint, stale_chat_url_replacement,
+    startup_chat_outcome,
 };
 use summary::{parse_plan_result, summarize_json_value, summarize_slash_tool};
 
@@ -79,7 +80,9 @@ pub struct ResolvedArgs {
     /// exit back to the launcher when the overlay is closed at its root. `None`
     /// (the default) is the normal full dashboard — every path stays unchanged.
     pub focus: Option<Focus>,
-    /// Chat endpoint base URL, CLI-flag value already merged over config.
+    /// Chat endpoint base URL, sourced from persisted config (`tui.chat_url`).
+    /// There is no `--chat-url` CLI flag today, so this tier is exactly the
+    /// persisted config — which is what startup revalidates when it goes stale.
     pub chat_url: Option<String>,
     /// Chat model, CLI-flag value already merged over config.
     pub chat_model: Option<String>,
@@ -1748,11 +1751,16 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
         let probe_ok = match startup_outcome {
             StartupChatOutcome::Local => true,
             StartupChatOutcome::OAuth => false,
-            StartupChatOutcome::Configured => tokio::task::spawn_blocking(move || {
-                crate::llm::probe_endpoint(&probe_target, crate::llm::PROBE_TIMEOUT)
-            })
-            .await
-            .unwrap_or(false),
+            StartupChatOutcome::Configured => {
+                // Clone so `probe_target` stays available for the EAI-7360
+                // stale-URL recovery and its notice below.
+                let target = probe_target.clone();
+                tokio::task::spawn_blocking(move || {
+                    crate::llm::probe_endpoint(&target, crate::llm::PROBE_TIMEOUT)
+                })
+                .await
+                .unwrap_or(false)
+            }
         };
         let llm = detected.or_else(|| {
             crate::llm::resolve_llm_config(
@@ -1780,6 +1788,43 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             ),
             other => other,
         };
+        // EAI-7360: a persisted `tui.chat_url` can go stale — the server it
+        // pointed at may have been stopped or replaced since the dash last wrote
+        // it. This is the `Configured`-but-unreachable case: the reachable
+        // `Configured` case already ran `discover_configured_chat_model` above,
+        // and a `Local` outcome auto-detected its own live endpoint. Only this
+        // persisted-config tier is revalidated — `chat_env_url` is a separate
+        // tier, and `resolve_llm_config`'s CLI>config>env>probe precedence (the
+        // literal contract unit-tested in `llm.rs`) is untouched: this only
+        // substitutes a *replacement* `LlmConfig` after that call, never changes
+        // how the call itself resolves.
+        //
+        // Require NO configured api_key/auth_header: the replacement is a
+        // keyless `detected_llm_config`, and since `ResolvedArgs` can't
+        // distinguish an explicit `--chat-url` from persisted config, a remote
+        // gateway URL + `OPENAI_API_KEY` that merely TCP-times-out must never
+        // silently swap to a local keyless engine and drop the credential.
+        // Confining the swap to a no-auth `chat_url` keeps it on the true
+        // EAI-7360 target: a dead *persisted* local endpoint.
+        let stale_replacement = if startup_outcome == StartupChatOutcome::Configured
+            && !probe_ok
+            && args.chat_url.is_some()
+            && args.chat_api_key.is_none()
+            && args.chat_auth_header.is_none()
+        {
+            let live = detect_local_chat(state.tool_executor.clone()).await;
+            stale_chat_url_replacement(&probe_target, probe_ok, live)
+        } else {
+            None
+        };
+        if let Some(live) = &stale_replacement {
+            state.chat.push(ChatTurn::system(format!(
+                "Configured chat server at {probe_target} is unreachable; switched to the live \
+                 local engine at {} (model: {}). Run `/detect save` to persist it.",
+                live.base_url, live.model
+            )));
+        }
+        let llm = stale_replacement.or(llm);
         state.set_chat_config(llm, args.chat_auto_consent);
         // No reachable local endpoint AND no key/url configured → the no-key
         // ChatGPT OAuth default (device-code login surfaced in the chat tab).

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -75,3 +75,12 @@ Feature: Chat and endpoint detection
     And the model is registered with the CLI
     When the user sends a one-shot chat prompt through the CLI
     Then the CLI prints the assistant's reply
+
+  @id:chat-stale-endpoint-offers-live-engine @requires-os:linux
+  Scenario: 8 - A stale saved endpoint offers the live local engine
+    Given a running managed model is available locally
+    And chat has a stale saved endpoint
+    When the user opens interactive chat
+    Then the local endpoint is shown for confirmation
+    When the user quits interactive chat
+    Then interactive chat exits successfully

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -77,6 +77,28 @@ async fn running_managed_model(world: &mut E2eWorld) {
     setup_managed_model(world, ServiceRecordOptions::default(), false).await;
 }
 
+#[given("chat has a stale saved endpoint")]
+async fn stale_saved_chat_endpoint(world: &mut E2eWorld) {
+    let root = world
+        .isolated_root
+        .as_ref()
+        .expect("scenario has no isolated root");
+    let path = root.path().join("config").join("config.json");
+    let config = serde_json::json!({
+        "dashboard": {
+            "tui": {
+                "chat_url": "http://127.0.0.1:9/v1",
+                "chat_model": "stale-model"
+            }
+        }
+    });
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(&config).expect("serialize config"),
+    )
+    .expect("write stale chat config");
+}
+
 // ── When ───────────────────────────────────────────────────────────
 
 #[when("the user opens the dashboard with demo data")]


### PR DESCRIPTION
## Summary

- Revalidates a persisted `tui.chat_url` at startup when it is unreachable and no API key or auth header is configured.
- Offers a freshly detected local engine through the existing detect-offer flow instead of silently switching, so accept, save, and dismiss all work.
- Treats `localhost` and `127.0.0.1` (plus trailing `/` and `/v1`) as the same local endpoint.

## Root cause

`tui.chat_url` survives across launches. If its server stops or moves, `resolve_llm_config` still returns the persisted URL; `probe_ok` only controls the default fallback. Startup then builds against a dead endpoint.

## Fix

- Encapsulates the complete stale-endpoint eligibility guard in `should_revalidate_stale_chat_url`.
- Detects a replacement only for an unreachable persisted URL with no configured credentials.
- Routes a different live endpoint through `AppState::set_detect_result`, preserving the existing `/detect accept|save|dismiss` reducer and persistence behavior.
- Keeps the stale configured endpoint active until the user accepts or saves the detected offer.
- Preserves an explicitly configured model on the existing endpoint; accepting a different server intentionally adopts that server's detected model.
- Corrects the `ResolvedArgs::chat_url` and `chat_model` source documentation.

## Safety and precedence

The offer requires `chat_api_key.is_none() && chat_auth_header.is_none()`, so an unreachable credentialed gateway is never replaced by a keyless local engine. `resolve_llm_config` precedence is unchanged.

## Rebase note

This branch is based on current `main`; the earlier manual overlap with PR #97 has been removed by the rebase.

Relates to EAI-7360.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets` — 1745 passed, 6 ignored
- `python3 scripts/smoke_local.py`
- `cargo xtask e2e -- -n "A stale saved endpoint offers the live local engine"` — 1 scenario, 6 steps passed

The change adds `@id:chat-stale-endpoint-offers-live-engine` for the user-visible startup behavior.