### PR TITLE
fix(dash): give instances a real Ready status instead of a Running catch-all

### DIFF
--- a/crates/rocm-dash-collectors/src/docker.rs
+++ b/crates/rocm-dash-collectors/src/docker.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use bollard::Docker;
 use bollard::container::{InspectContainerOptions, ListContainersOptions};
 use bollard::secret::ContainerInspectResponse;
+use rocm_dash_core::metrics::InstanceStatus;
 use rocm_dash_core::traits::{CollectorError, DiscoveredService, Result, ServiceDiscovery};
 use tokio::time::timeout;
 use tracing::{debug, warn};
@@ -306,6 +307,10 @@ fn parse_container(inspect: &ContainerInspectResponse) -> Result<DiscoveredServi
         env_vars: env,
         pid,
         log_file: None,
+        // Docker gives us no readiness signal of its own; stay `Starting`
+        // until the vLLM Prometheus scrape succeeds at least once (see
+        // `runner::instance_from_discovered` callers).
+        status: InstanceStatus::Starting,
     })
 }
 

--- a/crates/rocm-dash-collectors/src/lemonade.rs
+++ b/crates/rocm-dash-collectors/src/lemonade.rs
@@ -117,6 +117,11 @@ pub fn lemonade_container_id(host: &str, port: u16) -> String {
 
 /// PURE: build a `DiscoveredService` for a Lemonade endpoint. Lemonade is a
 /// single local server (no tensor-parallel sharding metadata), so TP = 1.
+///
+/// Every call site only constructs this after `/api/v1/health` has already
+/// answered (see `LemonadeCollector::discover`), so a successfully-built
+/// service is by definition reachable and serving — mark it `Ready` rather
+/// than the generic `Running`.
 pub fn lemonade_service(host: &str, port: u16, model_name: &str) -> DiscoveredService {
     DiscoveredService {
         container_id: lemonade_container_id(host, port),
@@ -128,6 +133,7 @@ pub fn lemonade_service(host: &str, port: u16, model_name: &str) -> DiscoveredSe
         },
         port: Some(port),
         tensor_parallel_size: 1,
+        status: rocm_dash_core::metrics::InstanceStatus::Ready,
         ..Default::default()
     }
 }
@@ -139,9 +145,7 @@ pub fn lemonade_service(host: &str, port: u16, model_name: &str) -> DiscoveredSe
 pub fn lemonade_instance(host: &str, port: u16, model_name: &str, stats_body: &str) -> Instance {
     let svc = lemonade_service(host, port, model_name);
     let sample = parse_stats(stats_body);
-    let mut inst = merge_instance(&svc, &sample, 0, 0);
-    inst.status = rocm_dash_core::metrics::InstanceStatus::Running;
-    inst
+    merge_instance(&svc, &sample, 0, 0)
 }
 
 /// Async scrape of a local Lemonade endpoint. Network/parse failure degrades to
@@ -298,10 +302,7 @@ mod tests {
         assert_eq!(inst.container_id, "lemonade-127.0.0.1-13305");
         assert_eq!(inst.port, Some(13305));
         assert_eq!(inst.gen_tps, Some(33.33));
-        assert_eq!(
-            inst.status,
-            rocm_dash_core::metrics::InstanceStatus::Running
-        );
+        assert_eq!(inst.status, rocm_dash_core::metrics::InstanceStatus::Ready);
         // Lemonade exposes no KV/req metrics → those stay None on the Instance.
         assert_eq!(inst.kv_cache_usage_pct, None);
         assert_eq!(inst.running_reqs, None);

--- a/crates/rocm-dash-core/src/metrics.rs
+++ b/crates/rocm-dash-core/src/metrics.rs
@@ -65,12 +65,26 @@ pub struct GpuSystemInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum InstanceStatus {
+    /// The endpoint has passed its model-ready probe (HTTP `/v1/models` or
+    /// equivalent) and is serving inference requests.
+    Ready,
     Running,
     Starting,
     Stopped,
     Error,
     #[default]
     Unknown,
+}
+
+impl InstanceStatus {
+    /// True for a status that means "actively serving" from the user's point
+    /// of view. `Ready` is the precise state; `Running` is kept as a synonym
+    /// for sources that have not yet been wired to the real readiness probe
+    /// (e.g. Docker-discovered containers before their first successful scrape).
+    #[must_use]
+    pub const fn is_serving(self) -> bool {
+        matches!(self, Self::Ready | Self::Running)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -148,5 +162,25 @@ mod tests {
         let back: Instance = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.ttft_ms, Some(180.5));
         assert_eq!(back.tpot_ms, Some(22.0));
+    }
+
+    #[test]
+    fn instance_status_ready_round_trips_as_lowercase_json() {
+        // The new `Ready` variant must serialize/deserialize the same way the
+        // pre-existing variants do (bare lowercase string, no wrapper object).
+        let json = serde_json::to_string(&InstanceStatus::Ready).expect("serialize");
+        assert_eq!(json, "\"ready\"");
+        let back: InstanceStatus = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, InstanceStatus::Ready);
+    }
+
+    #[test]
+    fn instance_status_is_serving_covers_ready_and_running_only() {
+        assert!(InstanceStatus::Ready.is_serving());
+        assert!(InstanceStatus::Running.is_serving());
+        assert!(!InstanceStatus::Starting.is_serving());
+        assert!(!InstanceStatus::Stopped.is_serving());
+        assert!(!InstanceStatus::Error.is_serving());
+        assert!(!InstanceStatus::Unknown.is_serving());
     }
 }

--- a/crates/rocm-dash-core/src/traits.rs
+++ b/crates/rocm-dash-core/src/traits.rs
@@ -69,6 +69,11 @@ pub struct DiscoveredService {
     pub env_vars: std::collections::BTreeMap<String, String>,
     pub pid: u32,
     pub log_file: Option<String>,
+    /// The instance's real status, when the discovery source knows it (e.g. a
+    /// rocm-cli managed-service record's `status` field). Sources with no
+    /// authoritative status (Docker containers) leave this at the default and
+    /// the caller decides how to treat it.
+    pub status: crate::metrics::InstanceStatus,
 }
 
 pub trait ServiceDiscovery: Send + Sync {
@@ -119,6 +124,11 @@ pub trait BenchTailer: Send + Sync {
 }
 
 /// Merge per-instance metadata + live sample into a finished `Instance`.
+///
+/// `status` comes from `svc.status` — the discovery source's own knowledge of
+/// the instance's real state (e.g. a managed-service record's `status`
+/// field). Sources with no authoritative status leave `svc.status` at its
+/// default and the caller is responsible for setting it before/after this call.
 pub fn merge_instance(
     svc: &DiscoveredService,
     sample: &InstanceSample,
@@ -128,7 +138,7 @@ pub fn merge_instance(
     Instance {
         container_id: svc.container_id.clone(),
         container_name: svc.container_name.clone(),
-        status: crate::metrics::InstanceStatus::Running,
+        status: svc.status,
         model_name: svc.model_name.clone(),
         gpu_ids: svc.gpu_ids.clone(),
         partition_info: None,

--- a/crates/rocm-dash-daemon/src/registry.rs
+++ b/crates/rocm-dash-daemon/src/registry.rs
@@ -36,7 +36,7 @@ use std::path::Path;
 
 use crate::runner::instance_from_discovered;
 use rocm_dash_collectors::engine_registry::EngineKind;
-use rocm_dash_core::metrics::Instance;
+use rocm_dash_core::metrics::{Instance, InstanceStatus};
 use rocm_dash_core::traits::DiscoveredService;
 use serde::Deserialize;
 
@@ -67,13 +67,28 @@ pub struct ServiceRecord {
 
 /// Service statuses worth scraping.
 ///
-/// Matches the live set the rocm-cli supervisor overlays onto a record (`ready`/`running`/`starting`);
-/// a `failed`/`stopped` record is skipped so we never poll a dead port.
+/// Matches the live set the rocm-cli supervisor overlays onto a record
+/// (`ready`/`running`/`starting`/`recovering` — see e.g. `apps/rocm/src/main.rs`'s
+/// own "is this service live" checks); a `failed`/`stopped` record is skipped
+/// so we never poll a dead port.
 pub fn is_scrapeable_status(status: &str) -> bool {
     matches!(
         status.trim().to_ascii_lowercase().as_str(),
-        "ready" | "running" | "starting"
+        "ready" | "running" | "starting" | "recovering"
     )
+}
+
+/// Map a rocm-cli managed-service record's `status` string onto the
+/// dashboard's `InstanceStatus`. Only called after `is_scrapeable_status` has
+/// already filtered out `failed`/`stopped`/unrecognized strings, so the `_`
+/// fallback arm is unreachable in practice but kept total for safety.
+fn instance_status_for_record_status(status: &str) -> InstanceStatus {
+    match status.trim().to_ascii_lowercase().as_str() {
+        "ready" => InstanceStatus::Ready,
+        "running" => InstanceStatus::Running,
+        "starting" | "recovering" => InstanceStatus::Starting,
+        _ => InstanceStatus::Unknown,
+    }
 }
 
 /// Load every managed-service record under `services_dir`, newest first.
@@ -129,6 +144,7 @@ pub fn discovered_from_record(record: &ServiceRecord) -> Option<DiscoveredServic
         container_name: record.service_id.clone(),
         model_name,
         port: Some(record.port),
+        status: instance_status_for_record_status(&record.status),
         ..Default::default()
     })
 }
@@ -294,6 +310,26 @@ mod tests {
                 discovered_from_record(&rec).is_some(),
                 "status {live:?} must be scraped"
             );
+        }
+    }
+
+    #[test]
+    fn discovered_from_record_maps_status_string_to_instance_status() {
+        // The registry seam must surface the record's real lifecycle state,
+        // not silently downgrade everything to `Running`/`Unknown`.
+        let cases = [
+            ("ready", InstanceStatus::Ready),
+            ("running", InstanceStatus::Running),
+            ("RUNNING", InstanceStatus::Running),
+            ("starting", InstanceStatus::Starting),
+            ("recovering", InstanceStatus::Starting),
+        ];
+        for (status, expected) in cases {
+            let rec: ServiceRecord =
+                serde_json::from_str(&record_json("svc", "vllm", 8000, status, 1)).unwrap();
+            let svc = discovered_from_record(&rec)
+                .unwrap_or_else(|| panic!("status {status:?} must be scrapeable"));
+            assert_eq!(svc.status, expected, "status {status:?}");
         }
     }
 

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -426,6 +426,15 @@ pub async fn run_loop(
                             inst.gen_tps = gen_tps;
                             inst.ttft_ms = ttft_ms;
                             inst.tpot_ms = tpot_ms;
+                            // Docker-discovered instances have no
+                            // `ManagedServiceRecord` to promote their status, so
+                            // they start life as `Starting`. A successful vLLM
+                            // Prometheus scrape is the first hard evidence the
+                            // instance is actually serving requests, so promote
+                            // it to `Ready` here.
+                            if inst.status == InstanceStatus::Starting {
+                                inst.status = InstanceStatus::Ready;
+                            }
                             runner.state.apply(StateEvent::InstanceUpserted(inst));
                         }
                     }
@@ -474,6 +483,12 @@ pub async fn run_loop(
                         inst.kv_cache_usage_pct = sample.kv_cache_usage_pct;
                         inst.running_reqs = sample.running_reqs;
                         inst.waiting_reqs = sample.waiting_reqs;
+                        // See the vLLM scrape-success handler above: a
+                        // successful stats fetch is proof the Lemonade
+                        // instance is serving, so promote it out of Starting.
+                        if inst.status == InstanceStatus::Starting {
+                            inst.status = InstanceStatus::Ready;
+                        }
                         runner.state.apply(StateEvent::InstanceUpserted(inst));
                     }
                 }
@@ -593,11 +608,14 @@ pub async fn run_loop(
 }
 
 /// Build an `Instance` from a `DiscoveredService` with no live KV/req sample yet.
-/// vLLM Prometheus scraping will fill these fields in a later collector.
+///
+/// Status is taken from `svc.status` — the caller sets it from whatever real
+/// signal its discovery source has (a managed-service record's status, a
+/// Lemonade health probe, or `Starting` for a Docker container with no status
+/// source until its first successful vLLM Prometheus scrape). vLLM Prometheus
+/// scraping fills the KV/req sample fields in a later collector tick.
 pub(crate) fn instance_from_discovered(svc: &DiscoveredService) -> Instance {
-    let mut inst = merge_instance(svc, &InstanceSample::default(), 0, 0);
-    inst.status = InstanceStatus::Running;
-    inst
+    merge_instance(svc, &InstanceSample::default(), 0, 0)
 }
 
 /// Set `vram_used_mb`/`vram_total_mb` on each instance from the per-process

--- a/crates/rocm-dash-tui/src/ui/dock.rs
+++ b/crates/rocm-dash-tui/src/ui/dock.rs
@@ -16,6 +16,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+#[cfg(test)]
 use rocm_dash_core::metrics::InstanceStatus;
 use rocm_dash_core::state::JobStatus;
 
@@ -202,7 +203,7 @@ pub fn context_rail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) 
     let running: Vec<_> = state
         .instances
         .values()
-        .filter(|i| i.status == InstanceStatus::Running)
+        .filter(|i| i.status.is_serving())
         .collect();
     if running.is_empty() {
         lines.push(Line::from(Span::styled(

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -16,6 +16,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+#[cfg(test)]
 use rocm_dash_core::metrics::InstanceStatus;
 
 use crate::app::AppState;
@@ -84,10 +85,7 @@ pub fn choice_for(sel: usize) -> LauncherChoice {
 
 /// True when a model is actively serving (drives the running vs idle variant).
 fn is_running(state: &AppState) -> bool {
-    state
-        .instances
-        .values()
-        .any(|i| i.status == InstanceStatus::Running)
+    state.instances.values().any(|i| i.status.is_serving())
 }
 
 pub fn draw(f: &mut Frame, area: Rect, state: &AppState, sel: usize, theme: &Theme) {
@@ -163,10 +161,7 @@ fn draw_status_strip(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme)
         },
     );
     let serve_line = if running {
-        let inst = state
-            .instances
-            .values()
-            .find(|i| i.status == InstanceStatus::Running);
+        let inst = state.instances.values().find(|i| i.status.is_serving());
         let (name, port) = inst.map_or(("model", String::new()), |i| {
             (
                 i.model_name.as_str(),

--- a/crates/rocm-dash-tui/src/ui/tabs/home.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/home.rs
@@ -19,8 +19,6 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use rocm_dash_core::metrics::InstanceStatus;
-
 use crate::app::{AppState, ConnState};
 use crate::ui::format;
 use crate::ui::gradient::GradientGauge;
@@ -171,7 +169,7 @@ fn draw_activity(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     for inst in state
         .instances
         .values()
-        .filter(|i| i.status == InstanceStatus::Running)
+        .filter(|i| i.status.is_serving())
         .take(feed.height as usize)
     {
         let port = inst.port.map_or_else(String::new, |p| format!(" on :{p}"));
@@ -350,7 +348,7 @@ fn draw_tiles(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let n_running = state
         .instances
         .values()
-        .filter(|i| i.status == InstanceStatus::Running)
+        .filter(|i| i.status.is_serving())
         .count();
     let running = card(
         f,
@@ -363,7 +361,7 @@ fn draw_tiles(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         let line = state
             .instances
             .values()
-            .find(|i| i.status == InstanceStatus::Running)
+            .find(|i| i.status.is_serving())
             .map_or_else(
                 || {
                     Line::from(Span::styled(

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -301,6 +301,7 @@ const fn status_meta(
 ) -> (ratatui::style::Color, &'static str) {
     match status {
         InstanceStatus::Running => (theme.ok, "RUNNING"),
+        InstanceStatus::Ready => (theme.ok, "READY"),
         InstanceStatus::Starting => (theme.warn, "STARTING"),
         InstanceStatus::Stopped => (theme.err, "STOPPED"),
         InstanceStatus::Error => (theme.err, "ERROR"),
@@ -312,7 +313,7 @@ const fn status_meta(
 /// health-driven border color.
 const fn status_role(status: InstanceStatus) -> BoxRole {
     match status {
-        InstanceStatus::Running => BoxRole::Success,
+        InstanceStatus::Running | InstanceStatus::Ready => BoxRole::Success,
         InstanceStatus::Starting => BoxRole::Warning,
         InstanceStatus::Stopped | InstanceStatus::Error => BoxRole::Danger,
         InstanceStatus::Unknown => BoxRole::Muted,


### PR DESCRIPTION
## Summary

`InstanceStatus` had no `Ready` state, so `merge_instance` hardcoded every discovered instance to `Running` regardless of whether it had actually passed a readiness probe. Managed services with a `"ready"` record status, Lemonade endpoints (only ever built after a health probe), and Docker-discovered containers all collapsed into the same `Running` label, hiding real lifecycle differences from the TUI and any future readiness-aware consumer (e.g. chat endpoint selection).

## Root Cause

`rocm_dash_core::traits::merge_instance` unconditionally set `status: InstanceStatus::Running` on every `Instance` it built, and `InstanceStatus` itself had no variant to represent "passed its readiness probe" as distinct from "process is up." Every discovery source (managed-service registry, Lemonade collector, Docker collector) therefore reported the same status label no matter what it actually knew about the endpoint's readiness.

## Changes

- Add `InstanceStatus::Ready` and an `is_serving()` helper (`Ready | Running`) for call sites that only care about "is this actively serving."
- Add a `status` field to `DiscoveredService` so each discovery source reports what it actually knows; `merge_instance` now uses `svc.status` instead of a hardcoded `Running`.
- `rocm-dash-daemon::registry::discovered_from_record` maps a managed-service record's status string (`ready`/`running`/`starting`/`recovering`) to the matching `InstanceStatus`. `"recovering"` was previously dropped from the scrapeable set entirely (a bug relative to `apps/rocm/src/main.rs`'s own "is this service live" checks, which treat `recovering` as live) — it's now scraped and mapped to `Starting`.
- `rocm-dash-collectors::lemonade::lemonade_service` builds as `Ready` since every call site only constructs it after a successful `/api/v1/health` probe.
- `rocm-dash-collectors::docker` has no readiness signal of its own, so Docker-discovered instances start `Starting`; `rocm-dash-daemon::runner::run_loop` promotes them to `Ready` on their first successful vLLM Prometheus scrape or Lemonade stats fetch (documented scope: this is the only readiness signal available for Docker-discovered instances).
- Add `Ready` arms to the exhaustive `status_meta`/`status_role` matches in `crates/rocm-dash-tui/src/ui/tabs/instances.rs`; switch the `== InstanceStatus::Running` equality checks in `home.rs`/`dock.rs`/`launcher.rs` to `.is_serving()`.

## Test Plan

- [x] `cargo build -p rocm-dash-core -p rocm-dash-collectors -p rocm-dash-daemon -p rocm-dash-tui`
- [x] `cargo clippy -p rocm-dash-core -p rocm-dash-collectors -p rocm-dash-daemon -p rocm-dash-tui --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rocm-dash-core -p rocm-dash-collectors -p rocm-dash-daemon` (all green, including 2 new tests: `instance_status_ready_round_trips_as_lowercase_json`, `instance_status_is_serving_covers_ready_and_running_only`, and `discovered_from_record_maps_status_string_to_instance_status`)
- [x] `cargo test -p rocm-dash-tui -- --test-threads=1` (543 + 16 + 5 tests green)

Relates to EAI-7350