### PR TITLE
fix(install): actionable error when GPU family has no wheels

### DIFF
--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -5,12 +5,13 @@
 use anyhow::{Context, Result, bail};
 use rocm_core::{
     AppPaths, ManagedToolConfig, RocmCliConfig, detect_host_gpu_diagnostics,
-    detect_host_therock_family, detect_managed_therock_family, ensure_uv_binary, managed_tools_dir,
-    normalize_runtime_path_for_host, normalize_runtime_path_for_storage,
-    normalize_runtime_path_text_for_host, normalize_runtime_path_text_for_storage,
-    normalize_therock_family, runtime_is_windows, runtime_os_name, runtime_path_for_windows_child,
-    runtime_path_list_split, runtime_python_executable_in_env, unix_time_millis, uv_command_env,
-    uv_pip_install_base, uv_venv_args, verify_rsa_pkcs1_sha256_signature,
+    detect_host_therock_family, detect_managed_therock_family, ensure_uv_binary,
+    known_therock_families, managed_tools_dir, normalize_runtime_path_for_host,
+    normalize_runtime_path_for_storage, normalize_runtime_path_text_for_host,
+    normalize_runtime_path_text_for_storage, normalize_therock_family, runtime_is_windows,
+    runtime_os_name, runtime_path_for_windows_child, runtime_path_list_split,
+    runtime_python_executable_in_env, unix_time_millis, uv_command_env, uv_pip_install_base,
+    uv_venv_args, verify_rsa_pkcs1_sha256_signature,
 };
 #[cfg(test)]
 use rocm_core::{generate_rsa_signing_keypair, sign_rsa_pkcs1_sha256_signature};
@@ -1131,9 +1132,15 @@ fn resolve_pip_runtime_with_timeout(
         }
     }
     bail!(
-        "failed to resolve TheRock {} wheel runtime from candidate indexes:\n  - {}",
+        "failed to resolve TheRock {} wheel runtime from candidate indexes:\n  - {}\n\n{}",
         channel.as_str(),
-        errors.join("\n  - ")
+        errors.join("\n  - "),
+        family_resolution_hint(
+            &family_resolution.source,
+            &family_resolution.family,
+            channel,
+            "wheel",
+        )
     )
 }
 
@@ -1249,9 +1256,17 @@ fn resolve_tarball_artifact_with_timeout(
             .unwrap_or(Ordering::Equal)
             .then_with(|| compare_version_strings(&left.1, &right.1))
     });
-    let (file, version) = candidates
-        .pop()
-        .context("no matching TheRock tarball artifact was found for the resolved GPU family")?;
+    let (file, version) = candidates.pop().with_context(|| {
+        format!(
+            "no matching TheRock tarball artifact was found for the resolved GPU family\n\n{}",
+            family_resolution_hint(
+                &family_resolution.source,
+                &family_resolution.family,
+                channel,
+                "tarball",
+            )
+        )
+    })?;
     Ok(TarballArtifact {
         family: family_resolution.family,
         family_source: family_resolution.source,
@@ -1299,7 +1314,10 @@ fn resolve_family(paths: &AppPaths, family_override: Option<&str>) -> Result<Fam
     }
 
     bail!(
-        "unable to resolve a supported TheRock GPU family for this host\n\n{}",
+        "unable to resolve a supported TheRock GPU family for this host.\n\
+         Re-run with an explicit package family: `rocm install sdk --family <FAMILY>`.\n\
+         Recognized families: {}.\n\n{}",
+        known_therock_families().join(", "),
         detect_host_gpu_diagnostics()
     )
 }
@@ -3170,6 +3188,71 @@ fn therock_index_urls(channel: TheRockChannel, family: &str) -> Vec<String> {
     }
 }
 
+/// Recovery guidance appended to family/index resolution failures so a clean
+/// first run can recover without the user having to guess a `--family`.
+///
+/// `source` is the [`FamilyResolution::source`] that produced `family`:
+/// auto-detected (`host`, `managed-runtime`) versus user-supplied (`manifest`
+/// from `--family`, `env` from `ROCM_CLI_THEROCK_FAMILY`). The wording differs
+/// so an auto-detected miss points the user at `--family`, while a user-supplied
+/// miss confirms the family they already named. Both point at the other channel
+/// and, where valid for the platform, the other install format.
+fn family_resolution_hint(
+    source: &str,
+    family: &str,
+    channel: TheRockChannel,
+    format: &str,
+) -> String {
+    let families = known_therock_families().join(", ");
+    let auto_detected = matches!(source, "host" | "managed-runtime");
+    let mut hint = String::new();
+
+    if auto_detected {
+        let _ = write!(
+            hint,
+            "no installable TheRock {} runtime was found for the auto-detected GPU family `{family}`.\n\
+             Re-run with an explicit package family: `rocm install sdk --family <FAMILY>`.\n\
+             Recognized families: {families}.",
+            channel.as_str()
+        );
+    } else {
+        let _ = write!(
+            hint,
+            "no installable TheRock {} runtime was found for the requested package family `{family}`.\n\
+             Recognized families: {families}.",
+            channel.as_str()
+        );
+    }
+
+    let other_channel = match channel {
+        TheRockChannel::Release => "nightly",
+        TheRockChannel::Nightly => "release",
+    };
+    let alternate_format = match format {
+        "wheel" if !runtime_is_windows() => Some("tarball"),
+        "tarball" => Some("wheel"),
+        _ => None,
+    };
+    match alternate_format {
+        Some(alternate_format) => {
+            let _ = write!(
+                hint,
+                "\nIf your GPU is newer than the {} packages, try `--channel {other_channel}` or `--format {alternate_format}`.",
+                channel.as_str()
+            );
+        }
+        None => {
+            let _ = write!(
+                hint,
+                "\nIf your GPU is newer than the {} packages, try `--channel {other_channel}`.",
+                channel.as_str()
+            );
+        }
+    }
+
+    hint
+}
+
 const fn platform_tarball_token() -> &'static str {
     if runtime_is_windows() {
         "windows"
@@ -4056,6 +4139,37 @@ echo Python 3.12.10
         assert_eq!(resolution.source, "managed-runtime");
         let _ = fs::remove_dir_all(root);
         Ok(())
+    }
+
+    #[test]
+    fn family_resolution_hint_for_auto_detected_points_at_family_flag() {
+        let hint = family_resolution_hint("host", "gfx950-dcgpu", TheRockChannel::Release, "wheel");
+
+        assert!(hint.contains("auto-detected GPU family `gfx950-dcgpu`"));
+        assert!(hint.contains("--family <FAMILY>"));
+        // Lists recognized families the user can pass instead.
+        assert!(hint.contains("gfx110X-all"));
+        // Points at the other channel as an escape hatch.
+        assert!(hint.contains("--channel nightly"));
+    }
+
+    #[test]
+    fn family_resolution_hint_for_user_supplied_frames_around_requested_family() {
+        let hint =
+            family_resolution_hint("manifest", "gfx110X-all", TheRockChannel::Release, "wheel");
+
+        assert!(hint.contains("requested package family `gfx110X-all`"));
+        // A family the user named themselves is not described as auto-detected.
+        assert!(!hint.contains("auto-detected"));
+        assert!(!hint.contains("--family <FAMILY>"));
+        assert!(hint.contains("--channel nightly"));
+    }
+
+    #[test]
+    fn family_resolution_hint_suggests_release_channel_from_nightly() {
+        let hint = family_resolution_hint("host", "gfx950-dcgpu", TheRockChannel::Nightly, "wheel");
+
+        assert!(hint.contains("--channel release"));
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -2801,6 +2801,38 @@ pub fn normalize_therock_family(value: &str) -> Option<String> {
     }
 }
 
+/// The TheRock package families the CLI recognizes.
+///
+/// This is the full set of values [`normalize_therock_family`] can produce. Used
+/// to tell the user which `--family` values are valid when GPU auto-detection
+/// cannot resolve an installable runtime. Whether a given family currently has
+/// published wheels depends on the channel and release; recognition here does
+/// not guarantee availability.
+///
+/// Kept in sync with [`normalize_therock_family`] by
+/// `known_therock_families_all_round_trip` — every entry must normalize back to
+/// itself.
+pub const fn known_therock_families() -> &'static [&'static str] {
+    &[
+        "gfx90X-dgpu",
+        "gfx90X-dcgpu",
+        "gfx900",
+        "gfx906",
+        "gfx908",
+        "gfx90a",
+        "gfx94X-dcgpu",
+        "gfx950-dcgpu",
+        "gfx101X-dgpu",
+        "gfx103X-dgpu",
+        "gfx110X-all",
+        "gfx1150",
+        "gfx1151",
+        "gfx1152",
+        "gfx1153",
+        "gfx120X-all",
+    ]
+}
+
 fn capture_optional_command(program: &str, args: &[&str]) -> Option<String> {
     capture_optional_command_with_timeout(program, args, OPTIONAL_COMMAND_TIMEOUT)
 }
@@ -6125,6 +6157,22 @@ mod tests {
             normalize_therock_family("gfx94X-dcgpu"),
             Some("gfx94X-dcgpu".to_owned())
         );
+    }
+
+    #[test]
+    fn known_therock_families_all_round_trip() {
+        for family in known_therock_families() {
+            assert_eq!(
+                normalize_therock_family(family).as_deref(),
+                Some(*family),
+                "known family `{family}` must normalize back to itself"
+            );
+        }
+    }
+
+    #[test]
+    fn known_therock_families_is_not_empty() {
+        assert!(!known_therock_families().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On a clean first run, `rocm install sdk` auto-detects the GPU, normalizes it to a TheRock
package family, and resolves a wheel/tarball index for that family. When the detected family
has **no published index** on the selected channel, the fetch returns HTTP 404 and the command
died with an opaque error:

```
failed to resolve TheRock release wheel runtime from candidate indexes:
  - https://repo.amd.com/rocm/whl/<family>: HTTP 404 while fetching ...
  - https://repo.amd.com/rocm/whl-multi-arch/<family>: HTTP 404 while fetching ...
```

Nothing told the user that `--family` was the escape hatch or which values are valid, so the
only recovery was to guess a working family.

## Fix

Turn the opaque failures into actionable guidance:

- Added `known_therock_families()` in `rocm-core` — the canonical set of families the CLI
  recognizes (the full output set of `normalize_therock_family`), guarded by a round-trip test
  so it can't drift from the normalizer.
- Added `family_resolution_hint()` — a pure, tested message builder that names the resolved
  family, lists the valid `--family` values, and suggests the alternate channel/format. Wording
  differs for auto-detected vs. user-supplied families.
- Wired the hint into the wheel-index failure (the reported 404 path), the tarball
  "no matching artifact" failure, and the "no supported family" bail.

### Deliberately not done

No auto-fallback to a nearby family: installing wheels built for a different architecture can
silently produce a broken runtime, which is worse than a clear stop on a first-run path.

## Testing

- New unit tests for the family list round-trip and the message builder (auto-detected vs.
  user-supplied, channel suggestions).
- `cargo test -p rocm-core -p rocm`, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

The end-to-end 404 path depends on live index endpoints and real hardware, so it is covered here
by the message-builder unit tests and left to the manual setup checklist for on-hardware
confirmation.