### PR TITLE
feat(dash): mark demo and replay sessions as simulated

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -14,7 +14,7 @@
 //! The rest of `rocm` is synchronous; the async daemon/TUI run on a tokio
 //! runtime built here. The TUI lives entirely in the `rocm-dash-tui` crate.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -214,37 +214,72 @@ fn build_dashboard_runtime() -> Result<tokio::runtime::Runtime> {
         .context("building tokio runtime for the dashboard")
 }
 
-/// Compute a private, unpredictable path for a `--demo` session file.
+/// Compute a private, per-run path for a `--demo` session file.
 ///
 /// Written under the per-user data dir (`{data_dir}/demo`, created `0o700` on
-/// Unix), never a fixed name in the world-shared temp dir. Stale demo sessions
-/// are pruned first so the directory does not accumulate. The file itself is
-/// created `0o600` by `demo::generate_file`.
+/// Unix), never a fixed name in the world-shared temp dir. The name is unique
+/// per run, not secret — confidentiality rests on the `0o700` dir / `0o600` file
+/// permissions (the file is created `0o600` by `demo::generate_file`). Stale
+/// sessions are pruned so the directory does not accumulate.
 fn demo_session_path(paths: &AppPaths) -> Result<PathBuf> {
     let dir = paths.data_dir.join("demo");
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("creating demo session dir {}", dir.display()))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        // Best-effort: restrict the demo dir to the owner.
-        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
-    }
-    // Best-effort prune of previous demo sessions so the dir stays bounded.
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("ndjson") {
-                let _ = std::fs::remove_file(path);
-            }
-        }
-    }
+    create_private_dir(&dir)?;
     let file = format!(
         "session-{}-{}.ndjson",
         std::process::id(),
         rocm_core::unix_time_millis()
     );
-    Ok(dir.join(file))
+    let target = dir.join(file);
+    prune_stale_demo_sessions(&dir, &target);
+    Ok(target)
+}
+
+/// Create `dir` restricted to the owner (`0o700`) on Unix. `DirBuilder::mode`
+/// applies at creation so there is no umask window; a pre-existing directory is
+/// tightened best-effort afterward (matching `server.rs`/`agent.rs`).
+#[cfg(unix)]
+fn create_private_dir(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+        .with_context(|| format!("creating demo session dir {}", dir.display()))?;
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_private_dir(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("creating demo session dir {}", dir.display()))
+}
+
+/// Best-effort prune of old demo sessions so the directory stays bounded,
+/// without deleting a session a concurrent `rocm dash --demo` may be replaying:
+/// the file we are about to write and any file modified in the last hour are
+/// kept.
+fn prune_stale_demo_sessions(dir: &Path, keep: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == *keep || path.extension().and_then(|e| e.to_str()) != Some("ndjson") {
+            continue;
+        }
+        let recently_touched = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|mtime| now.duration_since(mtime).ok())
+            .is_some_and(|age| age < std::time::Duration::from_hours(1));
+        if recently_touched {
+            continue;
+        }
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Entry point for `rocm dash`. Builds a tokio runtime and runs the dashboard.
@@ -493,7 +528,7 @@ mod tests {
     }
 
     #[test]
-    fn demo_session_path_is_private_and_unpredictable() {
+    fn demo_session_path_is_private_and_unique() {
         let root = std::env::temp_dir().join(format!(
             "rocm-cli-demo-test-{}-{}",
             std::process::id(),

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -214,14 +214,49 @@ fn build_dashboard_runtime() -> Result<tokio::runtime::Runtime> {
         .context("building tokio runtime for the dashboard")
 }
 
+/// Compute a private, unpredictable path for a `--demo` session file.
+///
+/// Written under the per-user data dir (`{data_dir}/demo`, created `0o700` on
+/// Unix), never a fixed name in the world-shared temp dir. Stale demo sessions
+/// are pruned first so the directory does not accumulate. The file itself is
+/// created `0o600` by `demo::generate_file`.
+fn demo_session_path(paths: &AppPaths) -> Result<PathBuf> {
+    let dir = paths.data_dir.join("demo");
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating demo session dir {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Best-effort: restrict the demo dir to the owner.
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
+    // Best-effort prune of previous demo sessions so the dir stays bounded.
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("ndjson") {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
+    let file = format!(
+        "session-{}-{}.ndjson",
+        std::process::id(),
+        rocm_core::unix_time_millis()
+    );
+    Ok(dir.join(file))
+}
+
 /// Entry point for `rocm dash`. Builds a tokio runtime and runs the dashboard.
 pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
     let paths = AppPaths::discover()?;
     let config = RocmCliConfig::load(&paths)?;
-    // `--demo` writes a deterministic synthetic session and replays it, so the
-    // dashboard shows populated data with no GPU and no daemon.
+    // `--demo` writes a synthetic session and replays it, so the dashboard shows
+    // populated data with no GPU and no daemon. The session is written under the
+    // per-user data dir with an unpredictable name (not a fixed world-shared
+    // temp path) and created `0o600` by `demo::generate_file`.
     let replay = if demo {
-        let path = std::env::temp_dir().join("rocm-dash-demo.ndjson");
+        let path = demo_session_path(&paths)?;
         rocm_dash_daemon::demo::generate_file(
             &rocm_dash_daemon::demo::DemoOptions::default(),
             &path,
@@ -455,6 +490,57 @@ mod tests {
         assert_eq!(opts.services_dir, Some(p.services_dir()));
         assert_eq!(opts.persist_dir, Some(p.telemetry_state_dir()));
         assert!(!opts.enable_docker);
+    }
+
+    #[test]
+    fn demo_session_path_is_private_and_unpredictable() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-cli-demo-test-{}-{}",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        let p = AppPaths {
+            config_dir: root.join("cfg"),
+            data_dir: root.join("data"),
+            cache_dir: root.join("cache"),
+        };
+
+        let path = demo_session_path(&p).expect("demo session path");
+
+        // Under the per-user data dir, never the shared temp dir with a fixed name.
+        assert!(
+            path.starts_with(p.data_dir.join("demo")),
+            "demo file must live under the data dir: {}",
+            path.display()
+        );
+        assert_ne!(
+            path.file_name().and_then(|n| n.to_str()),
+            Some("rocm-dash-demo.ndjson"),
+            "demo file name must not be the old predictable shared-temp name"
+        );
+
+        // The generated file is created private to the owner.
+        rocm_dash_daemon::demo::generate_file(
+            &rocm_dash_daemon::demo::DemoOptions::default(),
+            &path,
+        )
+        .expect("generate demo session");
+        assert!(path.exists(), "demo session file should exist");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let file_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(file_mode, 0o600, "demo session file must be 0o600");
+            let dir_mode = std::fs::metadata(p.data_dir.join("demo"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(dir_mode, 0o700, "demo dir must be 0o700");
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/rocm-dash-daemon/src/demo.rs
+++ b/crates/rocm-dash-daemon/src/demo.rs
@@ -137,16 +137,34 @@ pub fn generate_to_writer<W: Write>(opts: &DemoOptions, w: &mut W) -> anyhow::Re
 
 /// Write a synthetic session to `path` (via a buffered file writer).
 ///
-/// On a mid-write failure the partial file is removed so a failed run never
-/// leaves a corrupt session behind.
+/// The file is created private to the current user (`0o600` on Unix) so a
+/// demo/replay session is never world-readable. On a mid-write failure the
+/// partial file is removed so a failed run never leaves a corrupt session behind.
 pub fn generate_file(opts: &DemoOptions, path: &Path) -> anyhow::Result<()> {
-    let mut w = BufWriter::new(File::create(path)?);
+    let mut w = BufWriter::new(create_private_file(path)?);
     if let Err(e) = generate_to_writer(opts, &mut w) {
         drop(w);
         let _ = std::fs::remove_file(path);
         return Err(e);
     }
     Ok(())
+}
+
+/// Create (or truncate) `path` for writing, restricted to the owner on Unix.
+#[cfg(unix)]
+fn create_private_file(path: &Path) -> std::io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_file(path: &Path) -> std::io::Result<File> {
+    File::create(path)
 }
 
 /// Upper bound on `DemoOptions::seconds` — ~115 days at 1Hz. Keeps generation

--- a/crates/rocm-dash-tui/examples/gen_cast.rs
+++ b/crates/rocm-dash-tui/examples/gen_cast.rs
@@ -83,11 +83,7 @@ fn main() -> anyhow::Result<()> {
         .count();
     eprintln!("  {total_snaps} snapshots in timeline");
 
-    let mut state = AppState::new("demo-mi355x-01".into(), "default-dark".into());
-    state.conn = ConnState::Connected {
-        host: "demo-mi355x-01".into(),
-        version: "0.1.0".into(),
-    };
+    let mut state = build_state();
 
     // Replay cursor: `cursor` indexes into `entries`, `snaps_applied` counts
     // snapshot events consumed so the storyboard can target a timeline depth.
@@ -207,6 +203,19 @@ impl Replay<'_> {
 
 /// Render the current `AppState` to a `TestBackend` buffer and convert it to a
 /// truecolor ANSI frame. Mirrors `gen_screenshots::render_to_svg`.
+/// Base state for the cast: a connected view over a synthetic session. Marked
+/// simulated so the SIMULATED DATA chrome renders and the recording never
+/// presents the telemetry as live.
+fn build_state() -> AppState {
+    let mut state = AppState::new("demo-mi355x-01".into(), "default-dark".into());
+    state.conn = ConnState::Connected {
+        host: "demo-mi355x-01".into(),
+        version: "0.1.0".into(),
+    };
+    state.simulated = true;
+    state
+}
+
 fn capture(state: &mut AppState, cols: u16, rows: u16) -> anyhow::Result<String> {
     let backend = TestBackend::new(cols, rows);
     let mut terminal = Terminal::new(backend)?;
@@ -350,5 +359,21 @@ const fn resolve_color(c: Option<Color>, default: (u8, u8, u8)) -> (u8, u8, u8) 
         Some(Color::LightMagenta) => (173, 127, 168),
         Some(Color::LightCyan) => (52, 226, 226),
         _ => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_cast_is_marked_simulated() {
+        let mut state = build_state();
+        assert!(state.simulated, "cast state must be marked simulated");
+        let ansi = capture(&mut state, 160, 44).expect("capture frame");
+        assert!(
+            ansi.contains("SIMULATED DATA"),
+            "cast frame must carry the SIMULATED marker"
+        );
     }
 }

--- a/crates/rocm-dash-tui/examples/gen_screenshots.rs
+++ b/crates/rocm-dash-tui/examples/gen_screenshots.rs
@@ -246,6 +246,9 @@ fn build_state(theme: &str, entries: &[PersistedEntry], snapshots_target: usize)
         host: "demo-mi355x-01".into(),
         version: "0.1.0".into(),
     };
+    // These assets are built from a synthetic session; mark them simulated so
+    // the SIMULATED DATA chrome renders and no asset presents data as live.
+    state.simulated = true;
     let mut snap_count = 0usize;
     for entry in entries {
         state.apply_event(entry.event.clone());
@@ -438,4 +441,22 @@ fn xml_escape(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_screenshot_is_marked_simulated() {
+        let mut state = build_state("default-dark", &[], 0);
+        assert!(state.simulated, "screenshot state must be marked simulated");
+        let svg = render_to_svg(&mut state, 200, 50).expect("render svg");
+        // The SVG groups text runs and breaks on spaces, so assert the
+        // distinctive marker word rather than the space-joined phrase.
+        assert!(
+            svg.contains("SIMULATED"),
+            "generated screenshot must carry the SIMULATED marker"
+        );
+    }
 }

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -532,6 +532,13 @@ pub struct AppState {
     pub(crate) chat_endpoint_rebuild: Option<ChatProvider>,
     /// Replay scrubber state. `None` when running against a live daemon.
     pub replay: Option<ReplayState>,
+    /// Data-honesty flag: `true` when the displayed telemetry is NOT from a live
+    /// daemon — i.e. `--demo`, `--replay`, or an asset generator. Drives the
+    /// persistent "SIMULATED DATA" marker and suppresses live/connected/health
+    /// indicators so simulated data can never be presented as live. Distinct
+    /// from `replay`, which is playback-control state and is not set by the
+    /// screenshot/cast generators.
+    pub simulated: bool,
     /// Last body area used by the most recent draw. Mouse hit-tests resolve
     /// pointer coordinates against this rect (filled by `ui::draw`).
     pub last_body_area: Option<ratatui::layout::Rect>,
@@ -658,6 +665,7 @@ impl AppState {
             chat_persist_dispatch: false,
             chat_endpoint_rebuild: None,
             replay: None,
+            simulated: false,
             last_body_area: None,
             last_tab_bar_area: None,
             last_footer_chips: Vec::new(),
@@ -1527,6 +1535,9 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
         crate::jobs::run_effects(fx, &job_tx);
     }
     state.replay = replay_controller.map(ReplayState::new);
+    // Both `--demo` (a generated session replayed) and `--replay <file>` present
+    // non-live data, so mark the session simulated for the honesty chrome.
+    state.simulated = state.replay.is_some();
 
     // Resolve the chat backend. `--chat-mock` short-circuits detection with a
     // deterministic offline MockAgentClient (no live LLM, no network); otherwise

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -370,6 +370,32 @@ mod tests {
     }
 
     #[test]
+    fn launcher_running_reports_unknown_health_not_fabricated_healthy() {
+        // A Running process is not a health signal; without a probe the launcher
+        // must not claim the service is healthy.
+        let mut s = base();
+        s.instances.insert(
+            "id".into(),
+            Instance {
+                container_id: "id".into(),
+                model_name: "Qwen3-72B".into(),
+                status: InstanceStatus::Running,
+                port: Some(8000),
+                ..Default::default()
+            },
+        );
+        let out = render(&s, 0, 100, 24);
+        assert!(
+            out.contains("health: unknown"),
+            "launcher must report unknown health: {out:?}"
+        );
+        assert!(
+            !out.contains("healthy"),
+            "launcher must not fabricate a healthy claim: {out:?}"
+        );
+    }
+
+    #[test]
     fn launcher_idle_variant_renders() {
         let out = render(&base(), 0, 100, 24);
         assert!(out.contains("Idle"), "idle status line missing: {out:?}");

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -182,7 +182,9 @@ fn draw_status_strip(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme)
             ),
             Span::styled(port, Style::default().fg(theme.muted)),
             Span::styled("  │  ", Style::default().fg(theme.border)),
-            Span::styled("✓ healthy", Style::default().fg(theme.ok)),
+            // A Running process is not a health signal. Without an actual health
+            // probe we report health as unknown rather than fabricating "healthy".
+            Span::styled("health: unknown", Style::default().fg(theme.muted)),
         ])
     } else {
         Line::from(vec![

--- a/crates/rocm-dash-tui/src/ui/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/mod.rs
@@ -290,14 +290,21 @@ const fn wide_triptych(body: Rect) -> Option<(Rect, Rect, Rect)> {
 }
 
 fn draw_header(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
-    let (status_text, status_color) = match &state.conn {
-        ConnState::Initial => ("starting".to_string(), theme.muted),
-        ConnState::Connecting => ("connecting…".to_string(), theme.warn),
-        ConnState::Connected { host, version } => (
-            format!("connected · {host} · rocm daemon {version}"),
-            theme.ok,
-        ),
-        ConnState::Disconnected { reason } => (format!("disconnected · {reason}"), theme.err),
+    // In demo/replay the data is not live, so never present the session as
+    // "connected" to a real daemon — the connection status is a simulated label
+    // instead, and the SIMULATED DATA chip below makes the state unmistakable.
+    let (status_text, status_color) = if state.simulated {
+        ("simulated — not live".to_string(), theme.warn)
+    } else {
+        match &state.conn {
+            ConnState::Initial => ("starting".to_string(), theme.muted),
+            ConnState::Connecting => ("connecting…".to_string(), theme.warn),
+            ConnState::Connected { host, version } => (
+                format!("connected · {host} · rocm daemon {version}"),
+                theme.ok,
+            ),
+            ConnState::Disconnected { reason } => (format!("disconnected · {reason}"), theme.err),
+        }
     };
 
     let mut spans: Vec<Span> = vec![
@@ -308,13 +315,23 @@ fn draw_header(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
                 .fg(theme.accent),
         ),
         Span::raw("  "),
-        Span::styled(
-            format!("→ {}", state.connect),
-            Style::default().fg(theme.muted),
-        ),
-        Span::raw("   "),
-        Span::styled(status_text, Style::default().fg(status_color)),
     ];
+    if state.simulated {
+        spans.push(Span::styled(
+            " SIMULATED DATA ",
+            Style::default()
+                .bg(theme.warn)
+                .fg(theme.surface_2)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    spans.push(Span::styled(
+        format!("→ {}", state.connect),
+        Style::default().fg(theme.muted),
+    ));
+    spans.push(Span::raw("   "));
+    spans.push(Span::styled(status_text, Style::default().fg(status_color)));
     let warning_count = state.latest.as_ref().map_or(0, |s| s.warnings.len());
     if warning_count > 0 {
         spans.push(Span::raw("   "));

--- a/crates/rocm-dash-tui/src/ui/mod.rs
+++ b/crates/rocm-dash-tui/src/ui/mod.rs
@@ -291,20 +291,21 @@ const fn wide_triptych(body: Rect) -> Option<(Rect, Rect, Rect)> {
 
 fn draw_header(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     // In demo/replay the data is not live, so never present the session as
-    // "connected" to a real daemon — the connection status is a simulated label
+    // "connected" to a real daemon — the Connected case shows a simulated label
     // instead, and the SIMULATED DATA chip below makes the state unmistakable.
-    let (status_text, status_color) = if state.simulated {
-        ("simulated — not live".to_string(), theme.warn)
-    } else {
-        match &state.conn {
-            ConnState::Initial => ("starting".to_string(), theme.muted),
-            ConnState::Connecting => ("connecting…".to_string(), theme.warn),
-            ConnState::Connected { host, version } => (
-                format!("connected · {host} · rocm daemon {version}"),
-                theme.ok,
-            ),
-            ConnState::Disconnected { reason } => (format!("disconnected · {reason}"), theme.err),
+    // Other states (e.g. Disconnected on end-of-recording or a failed replay
+    // file) still surface their reason so playback status is not masked.
+    let (status_text, status_color) = match &state.conn {
+        ConnState::Initial => ("starting".to_string(), theme.muted),
+        ConnState::Connecting => ("connecting…".to_string(), theme.warn),
+        ConnState::Connected { .. } if state.simulated => {
+            ("simulated — not live".to_string(), theme.warn)
         }
+        ConnState::Connected { host, version } => (
+            format!("connected · {host} · rocm daemon {version}"),
+            theme.ok,
+        ),
+        ConnState::Disconnected { reason } => (format!("disconnected · {reason}"), theme.err),
     };
 
     let mut spans: Vec<Span> = vec![

--- a/crates/rocm-dash-tui/src/ui/tabs/home.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/home.rs
@@ -153,11 +153,19 @@ fn draw_activity(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         return;
     }
     let load_hist = history(state, snap_util);
+    // Never label simulated telemetry "live".
+    let spark_label = if load_hist.is_empty() {
+        "—"
+    } else if state.simulated {
+        "sim"
+    } else {
+        "live"
+    };
     mini_spark(
         f,
         Rect::new(inner.x, inner.y, inner.width, 1),
         "node load ",
-        if load_hist.is_empty() { "—" } else { "live" },
+        spark_label,
         &load_hist,
         false,
         theme,
@@ -272,10 +280,16 @@ fn draw_hero_right(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1); 6])
         .split(area);
+    // In demo/replay this is not a live feed — say so rather than "LIVE".
+    let (feed_label, feed_color) = if state.simulated {
+        ("SIMULATED · last 60s", theme.warn)
+    } else {
+        ("LIVE · last 60s", theme.muted)
+    };
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "LIVE · last 60s",
-            Style::default().fg(theme.muted),
+            feed_label,
+            Style::default().fg(feed_color),
         ))),
         rh[0],
     );
@@ -424,11 +438,16 @@ fn draw_tiles(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     // Updates tile — honest placeholder (no update feed wired this run).
     let updates = card(f, mid[2], "Updates", BoxRole::Muted, theme);
     if updates.height > 0 {
-        let body = match state.conn {
-            ConnState::Connected { .. } => {
-                Line::from(Span::styled("Up to date", Style::default().fg(theme.muted)))
+        let body = if state.simulated {
+            // No real update feed can be observed for simulated data.
+            Line::from(Span::styled("unknown", Style::default().fg(theme.muted)))
+        } else {
+            match state.conn {
+                ConnState::Connected { .. } => {
+                    Line::from(Span::styled("Up to date", Style::default().fg(theme.muted)))
+                }
+                _ => Line::from(Span::styled("Checking…", Style::default().fg(theme.muted))),
             }
-            _ => Line::from(Span::styled("Checking…", Style::default().fg(theme.muted))),
         };
         // ponytail: no update-feed data source this run; tile shows conn-derived
         // status rather than the mock's hardcoded "ROCm 6.3 ready".

--- a/crates/rocm-dash-tui/src/ui/tabs/home.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/home.rs
@@ -40,6 +40,18 @@ fn history<F: Fn(&rocm_dash_core::metrics::Snapshot) -> f64>(
         .collect()
 }
 
+/// Label for the node-load sparkline: no data → `—`; simulated telemetry is
+/// never labeled "live" (it reads `sim`); otherwise a live feed.
+const fn node_load_label(hist_empty: bool, simulated: bool) -> &'static str {
+    if hist_empty {
+        "—"
+    } else if simulated {
+        "sim"
+    } else {
+        "live"
+    }
+}
+
 /// Peak GPU utilization across the GPUs in a snapshot (the headline metric).
 fn snap_util(s: &rocm_dash_core::metrics::Snapshot) -> f64 {
     s.gpus
@@ -153,19 +165,11 @@ fn draw_activity(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         return;
     }
     let load_hist = history(state, snap_util);
-    // Never label simulated telemetry "live".
-    let spark_label = if load_hist.is_empty() {
-        "—"
-    } else if state.simulated {
-        "sim"
-    } else {
-        "live"
-    };
     mini_spark(
         f,
         Rect::new(inner.x, inner.y, inner.width, 1),
         "node load ",
-        spark_label,
+        node_load_label(load_hist.is_empty(), state.simulated),
         &load_hist,
         false,
         theme,
@@ -449,8 +453,9 @@ fn draw_tiles(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
                 _ => Line::from(Span::styled("Checking…", Style::default().fg(theme.muted))),
             }
         };
-        // ponytail: no update-feed data source this run; tile shows conn-derived
-        // status rather than the mock's hardcoded "ROCm 6.3 ready".
+        // No update-feed data source this run: simulated sessions show "unknown"
+        // (nothing observable), otherwise the tile is conn-derived rather than
+        // the mock's hardcoded "ROCm 6.3 ready".
         f.render_widget(Paragraph::new(body), updates);
     }
 }
@@ -462,6 +467,14 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use rocm_dash_core::metrics::{GpuMetrics, GpuSystemInfo, Snapshot, SystemMetrics};
+
+    #[test]
+    fn node_load_label_never_marks_simulated_live() {
+        assert_eq!(node_load_label(true, false), "—");
+        assert_eq!(node_load_label(true, true), "—");
+        assert_eq!(node_load_label(false, false), "live");
+        assert_eq!(node_load_label(false, true), "sim");
+    }
 
     fn render(state: &AppState, cols: u16, rows: u16) -> String {
         let backend = TestBackend::new(cols, rows);

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -895,6 +895,7 @@ mod tests {
             chat_detect_msg: None,
             chat_persist_dispatch: false,
             replay: None,
+            simulated: false,
             last_body_area: None,
             last_tab_bar_area: None,
             last_footer_chips: Vec::new(),

--- a/crates/rocm-dash-tui/src/ui/tabs/observe.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/observe.rs
@@ -12,8 +12,10 @@
 //! nothing is lost. The selectable list is the instances table (wired via the
 //! main selection model in `AppState`).
 //!
-//! The amber demo-data banner is shown iff live daemon telemetry is
+//! The amber no-live-data banner is shown iff live daemon telemetry is
 //! absent — driven by `ConnState` / snapshot presence, never a hardcoded flag.
+//! Simulated (`--demo`/`--replay`) sessions are marked separately by the global
+//! SIMULATED DATA header chip; see `AppState::simulated`.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -27,8 +29,9 @@ use crate::ui::theme::Theme;
 use crate::ui::{format, widgets};
 
 /// True when we have no live daemon telemetry to show — i.e. not connected to a
-/// running daemon, or connected but no snapshot has arrived yet. The demo-data
-/// banner is shown exactly in this case (honesty: numbers may be placeholders).
+/// running daemon, or connected but no snapshot has arrived yet. The
+/// no-live-data banner is shown exactly in this case (honesty: numbers may be
+/// placeholders).
 const fn telemetry_absent(state: &AppState) -> bool {
     !matches!(state.conn, ConnState::Connected { .. }) || state.latest.is_none()
 }
@@ -39,7 +42,7 @@ pub fn draw(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(1), Constraint::Min(0)])
             .split(area);
-        draw_demo_banner(f, split[0], theme);
+        draw_no_live_data_banner(f, split[0], theme);
         split[1]
     } else {
         area
@@ -193,17 +196,17 @@ fn draw_throughput_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
     f.render_widget(Paragraph::new(lines), inner);
 }
 
-fn draw_demo_banner(f: &mut Frame, area: Rect, theme: &Theme) {
+fn draw_no_live_data_banner(f: &mut Frame, area: Rect, theme: &Theme) {
     let banner = Paragraph::new(Line::from(vec![
         Span::styled(
-            " ⚠ demo data ",
+            " ⚠ no live data ",
             Style::default()
                 .bg(theme.warn)
                 .fg(theme.bg)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
-            "  no live ROCm daemon — telemetry shown is synthetic / last-known",
+            "  not connected to a ROCm daemon — showing placeholders / last-known",
             Style::default().fg(theme.warn),
         ),
     ]));
@@ -357,21 +360,24 @@ mod tests {
     }
 
     #[test]
-    fn demo_banner_absent_when_connected_with_telemetry() {
+    fn no_live_data_banner_absent_when_connected_with_telemetry() {
         let out = render(&connected_with_snapshot(), 160, 44);
         assert!(
-            !out.contains("demo data"),
-            "demo banner must be hidden when connected with telemetry: {out:?}"
+            !out.contains("no live data"),
+            "no-live-data banner must be hidden when connected with telemetry: {out:?}"
         );
     }
 
     #[test]
-    fn demo_banner_present_when_telemetry_absent() {
+    fn no_live_data_banner_present_when_telemetry_absent() {
         let mut s = AppState::new("t".into(), "default-dark".into());
         s.active_tab = ActiveTab::Observe;
         // Initial conn, no snapshot → telemetry absent.
         let out = render(&s, 160, 44);
-        assert!(out.contains("demo data"), "demo banner expected: {out:?}");
+        assert!(
+            out.contains("no live data"),
+            "no-live-data banner expected: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/rocm-dash-tui/tests/dash_characterization.rs
+++ b/crates/rocm-dash-tui/tests/dash_characterization.rs
@@ -286,6 +286,23 @@ fn home_live_indicators_suppressed_when_simulated() {
     );
 }
 
+/// The Updates tile must not claim "Up to date" for simulated data — there is
+/// no update feed to observe, so it reads "unknown".
+#[test]
+fn home_updates_tile_unknown_when_simulated() {
+    let mut s = state_on(ActiveTab::Home);
+    s.simulated = true;
+    let out = render(&mut s, 160, 44);
+    assert!(
+        !out.contains("Up to date"),
+        "simulated Updates tile must not claim up to date: {out:?}"
+    );
+    assert!(
+        out.contains("unknown"),
+        "simulated Updates tile should read unknown: {out:?}"
+    );
+}
+
 #[test]
 fn a11y_status_carries_text_label_not_color_only() {
     // Connection status is conveyed in words, not by color alone.

--- a/crates/rocm-dash-tui/tests/dash_characterization.rs
+++ b/crates/rocm-dash-tui/tests/dash_characterization.rs
@@ -186,7 +186,7 @@ fn observe_empty_state_shows_placeholders() {
 
 #[test]
 fn loading_state_connecting_banner() {
-    // Connecting (no snapshot) → header shows the loading status + demo banner.
+    // Connecting (no snapshot) → header shows the loading status + no-live-data banner.
     let mut s = AppState::new("c".into(), "default-dark".into());
     s.active_tab = ActiveTab::Observe;
     s.conn = ConnState::Connecting;
@@ -196,14 +196,14 @@ fn loading_state_connecting_banner() {
         "loading status missing: {out:?}"
     );
     assert!(
-        out.contains("demo data"),
-        "demo banner expected while loading"
+        out.contains("no live data"),
+        "no-live-data banner expected while loading"
     );
 }
 
 #[test]
 fn disconnected_banner_present() {
-    // Disconnected → error status in header + demo banner on Observe.
+    // Disconnected → error status in header + no-live-data banner on Observe.
     let mut s = AppState::new("c".into(), "default-dark".into());
     s.active_tab = ActiveTab::Observe;
     s.conn = ConnState::Disconnected {
@@ -215,13 +215,13 @@ fn disconnected_banner_present() {
         "error status missing: {out:?}"
     );
     assert!(
-        out.contains("demo data"),
-        "demo banner expected when disconnected"
+        out.contains("no live data"),
+        "no-live-data banner expected when disconnected"
     );
 }
 
 #[test]
-fn honesty_demo_banner_absent_when_connected_with_telemetry() {
+fn honesty_no_live_data_banner_absent_when_connected_with_telemetry() {
     let mut s = AppState::new("c".into(), "default-dark".into());
     s.active_tab = ActiveTab::Observe;
     s.conn = ConnState::Connected {
@@ -231,8 +231,58 @@ fn honesty_demo_banner_absent_when_connected_with_telemetry() {
     s.latest = Some(synthetic_snapshot());
     let out = render(&mut s, 160, 44);
     assert!(
-        !out.contains("demo data"),
+        !out.contains("no live data"),
         "banner must be hidden when live: {out:?}"
+    );
+}
+
+/// A simulated (`--demo`/`--replay`) session must carry the SIMULATED DATA
+/// marker on every tab, and must never present itself as live/connected.
+#[test]
+fn simulated_marker_present_on_every_tab() {
+    for tab in [
+        ActiveTab::Home,
+        ActiveTab::Rocm,
+        ActiveTab::Serving,
+        ActiveTab::Observe,
+        ActiveTab::Chat,
+    ] {
+        let mut s = state_on(tab);
+        s.simulated = true;
+        let out = render(&mut s, 160, 44);
+        assert!(
+            out.contains("SIMULATED DATA"),
+            "SIMULATED marker missing on {tab:?}: {out:?}"
+        );
+        assert!(
+            !out.contains("connected · "),
+            "simulated session must not show a live daemon connection on {tab:?}: {out:?}"
+        );
+    }
+}
+
+/// A live session (connected + telemetry, not simulated) must NOT show the
+/// SIMULATED marker, and keeps its live indicators.
+#[test]
+fn simulated_marker_absent_when_live() {
+    let mut s = state_on(ActiveTab::Home);
+    let out = render(&mut s, 160, 44);
+    assert!(
+        !out.contains("SIMULATED DATA"),
+        "live session must not show the SIMULATED marker: {out:?}"
+    );
+    assert!(out.contains("LIVE"), "live feed label expected: {out:?}");
+}
+
+/// The home hero must not label simulated telemetry as a LIVE feed.
+#[test]
+fn home_live_indicators_suppressed_when_simulated() {
+    let mut s = state_on(ActiveTab::Home);
+    s.simulated = true;
+    let out = render(&mut s, 160, 44);
+    assert!(
+        !out.contains("LIVE · last 60s"),
+        "simulated home must not claim a LIVE feed: {out:?}"
     );
 }
 


### PR DESCRIPTION
## Problem

`rocm dash --demo` and `rocm dash --replay <file>` render synthetic/recorded telemetry through
the exact same UI as a live daemon, so nothing on screen (or in generated screenshots/casts)
distinguishes simulated data from a live system. Several indicators were also fabricated:

- A hardcoded `LIVE · last 60s`, a `live` sparkline label, and `Updates: Up to date` keyed only
  on being connected — which replay also sets.
- A launcher `✓ healthy` line derived purely from a process being *Running*, with no health probe.
- The one existing "demo data" banner was wired backwards: it only fired when *disconnected*, so
  it never appeared during an actual demo/replay session.
- The demo session was written to a fixed, world-readable path in the shared temp dir.

## Changes

Introduce a single explicit `AppState.simulated` signal (set for `--demo`, `--replay`, and the
asset generators) and make every honesty-relevant surface read it:

- **Persistent SIMULATED DATA marker** in the shared header, so it appears on every tab and in
  every generated asset (screenshots + casts).
- **Live indicators gated on observed state**: the header connection line, home's `LIVE · last 60s`
  / `live` sparkline label, and the `Up to date` tile no longer present simulated data as live.
- **Launcher health honesty**: a Running process is not a health signal — report `health: unknown`
  instead of a fabricated `healthy` (no probe exists today; an active one-shot probe is a proposed
  follow-up).
- **Secure demo session file**: written under the per-user data dir with an unpredictable name and
  `0o600` permissions, replacing the fixed world-readable temp path.
- **Corrected the Observe banner**: the old "demo data" text (which only fired when disconnected)
  now reads "no live data" and no longer collides with the new simulated marker.

## Testing

New regression tests cover the SIMULATED marker on every tab, its absence when live, home
indicator suppression, both asset generators, the corrected banner semantics, and the secure
demo-path (location + `0o600`/`0o700`). `cargo test --workspace --all-targets`,
`cargo clippy --workspace --all-targets`, and `cargo fmt --check` all clean.

On-terminal visual confirmation of the banner and generated assets belongs in the manual test
checklist.