### PR TITLE
fix(lemonade): stop silently substituting valid Hugging Face model ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,13 @@ creates a separate managed runtime alongside it.
 Then serve a model:
 
 ```
-rocm serve Qwen/Qwen2.5-1.5B-Instruct
+rocm serve qwen
 ```
+
+`qwen` is a built-in alias for a small assistant model that serves out of the
+box. You can also serve any compatible Hugging Face model directly — see
+[Model serving](#model-serving) for the GGUF-vs-safetensors rule, since which
+form works depends on the engine your GPU selects.
 
 Use `rocm model` to see available model recipes and their GPU memory
 requirements.
@@ -300,9 +305,14 @@ server keeps running (manage it afterward with `rocm services`). Press **Ctrl-C*
 to stop the server instead. `--managed` is the explicit form of the default
 background behavior. `--no-smoke-test` skips the post-startup inference probe.
 
-Use full HuggingFace model IDs (e.g., `Qwen/Qwen2.5-1.5B-Instruct`) for
-reliable cross-engine compatibility. Short aliases from `rocm model` may not
-resolve with all engines.
+Which model form to pass depends on the engine your GPU selects. The Lemonade
+engine (Ryzen AI / Radeon) serves llama.cpp **GGUF** models — pass a GGUF repo
+with an explicit quantization variant, e.g.
+`rocm serve unsloth/Qwen3-0.6B-GGUF:Q4_0`. The vLLM engine (Instinct) serves
+**safetensors** repos, e.g. `rocm serve Qwen/Qwen2.5-1.5B-Instruct`. A
+safetensors-only id has no GGUF build, so serving it through Lemonade fails with
+a clear message rather than silently substituting a different model. Short
+aliases from `rocm model` may not resolve with all engines.
 
 Some models (e.g., Llama) are gated and require HuggingFace authentication.
 Log in with `huggingface-cli login` or set `HF_TOKEN` in your environment

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -3887,6 +3887,7 @@ fn serve(args: ServeArgs) -> Result<()> {
             );
             let summary = serve_summary::DeploymentSummary {
                 engine: selected_engine.clone(),
+                requested_model: model,
                 api_model: resolve.canonical_model_id,
                 chat_endpoint: format!("{}/chat/completions", report.endpoint_url),
                 service_id: report.service_id.clone(),

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -51,7 +51,10 @@ pub(crate) struct SmokeMetrics {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DeploymentSummary {
     pub engine: String,
-    /// Canonical / API-qualified model id clients pass as `"model"`.
+    /// The model reference the user requested on the command line.
+    pub requested_model: String,
+    /// Canonical / API-qualified model id clients pass as `"model"`. May differ
+    /// from `requested_model` when a recipe alias resolves to a canonical id.
     pub api_model: String,
     /// Full chat-completions endpoint, e.g. `http://127.0.0.1:1337/v1/chat/completions`.
     pub chat_endpoint: String,
@@ -108,20 +111,37 @@ pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
     // (label, value) rows, in the order the ticket calls out. Throughput is
     // labelled "approx" because it is derived from streamed SSE chunk counts
     // (~1 token per chunk), not the engine's own token accounting.
-    let rows: Vec<(&str, String)> = vec![
-        ("status", summary.status.clone()),
-        ("engine", summary.engine.clone()),
-        ("model", summary.api_model.clone()),
-        ("endpoint", summary.chat_endpoint.clone()),
-        ("time to first token", format_ttft(summary.metrics.ttft)),
-        ("throughput (approx)", format_tps(summary.metrics.gen_tps)),
-        ("service", summary.service_id.clone()),
-        ("stop", format!("rocm services stop {}", summary.service_id)),
-        (
-            "logs",
-            format!("rocm logs --service {}", summary.service_id),
-        ),
-    ];
+    // When the requested reference resolved to a different canonical id, show
+    // both so a silent substitution can never masquerade as the requested model;
+    // when they match, a single `model` row keeps the common case uncluttered.
+    let model_rows: Vec<(&str, String)> = if summary.requested_model == summary.api_model {
+        vec![("model", summary.api_model.clone())]
+    } else {
+        vec![
+            ("requested model", summary.requested_model.clone()),
+            ("resolved model", summary.api_model.clone()),
+        ]
+    };
+
+    let rows: Vec<(&str, String)> = [
+        vec![
+            ("status", summary.status.clone()),
+            ("engine", summary.engine.clone()),
+        ],
+        model_rows,
+        vec![
+            ("endpoint", summary.chat_endpoint.clone()),
+            ("time to first token", format_ttft(summary.metrics.ttft)),
+            ("throughput (approx)", format_tps(summary.metrics.gen_tps)),
+            ("service", summary.service_id.clone()),
+            ("stop", format!("rocm services stop {}", summary.service_id)),
+            (
+                "logs",
+                format!("rocm logs --service {}", summary.service_id),
+            ),
+        ],
+    ]
+    .concat();
 
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
 
@@ -275,6 +295,7 @@ mod tests {
     fn base_summary() -> DeploymentSummary {
         DeploymentSummary {
             engine: "vllm".to_owned(),
+            requested_model: "Qwen/Qwen2.5-7B-Instruct".to_owned(),
             api_model: "Qwen/Qwen2.5-7B-Instruct".to_owned(),
             chat_endpoint: "http://127.0.0.1:1337/v1/chat/completions".to_owned(),
             service_id: "vllm-qwen-1720000000".to_owned(),
@@ -335,6 +356,7 @@ mod tests {
         vllm.engine = "vllm".to_owned();
         let mut lemonade = base_summary();
         lemonade.engine = "lemonade".to_owned();
+        lemonade.requested_model = "Qwen3-0.6B-GGUF".to_owned();
         lemonade.api_model = "Qwen3-0.6B-GGUF".to_owned();
         lemonade.chat_endpoint = "http://127.0.0.1:8000/v1/chat/completions".to_owned();
         lemonade.metrics = SmokeMetrics::default(); // engine reported no usage
@@ -347,6 +369,41 @@ mod tests {
         let rendered = render_summary(&lemonade);
         assert!(rendered.contains("time to first token"));
         assert!(rendered.contains("n/a"));
+    }
+
+    #[test]
+    fn matching_request_and_resolved_show_a_single_model_row() {
+        let rendered = render_summary(&base_summary());
+        assert!(rendered.contains("  model  "));
+        assert!(!rendered.contains("requested model"));
+        assert!(!rendered.contains("resolved model"));
+    }
+
+    #[test]
+    fn divergent_request_and_resolved_are_both_reported() {
+        // A recipe alias that resolves to a different canonical id must surface
+        // both identities so a substitution is never silent (EAI-7370).
+        let mut summary = base_summary();
+        summary.requested_model = "qwen".to_owned();
+        summary.api_model = "Qwen3-4B-Instruct-2507-GGUF".to_owned();
+        let rendered = render_summary(&summary);
+        let row = |label: &str, value: &str| {
+            rendered.lines().any(|line| {
+                line.trim_start().starts_with(label) && line.trim_end().ends_with(value)
+            })
+        };
+        assert!(row("requested model", "qwen"), "{rendered}");
+        assert!(
+            row("resolved model", "Qwen3-4B-Instruct-2507-GGUF"),
+            "{rendered}"
+        );
+        // The bare `model` row is not used when the two differ.
+        assert!(
+            !rendered
+                .lines()
+                .any(|line| line.trim_start().starts_with("model ")),
+            "{rendered}"
+        );
     }
 
     #[test]

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2665,6 +2665,12 @@ fn parse_engine_recipe_json(value: Option<String>) -> Result<Option<EngineRecipe
 fn resolve_lemonade_model_ref(model_ref: &str) -> String {
     let trimmed = model_ref.trim();
     let lower = trimmed.to_ascii_lowercase();
+    // Only exact, recognized shorthand aliases map to the bundled assistant GGUF.
+    // A syntactically valid `owner/repo` Hugging Face checkpoint must never be
+    // silently rewritten here — e.g. `Qwen/Qwen2.5-1.5B-Instruct` is a real
+    // checkpoint id, not a shorthand, and is passed through unchanged so the
+    // serve path can honour (or explicitly reject) it rather than substituting
+    // an unrelated model behind the user's back.
     if trimmed.is_empty()
         || matches!(
             lower.as_str(),
@@ -2678,8 +2684,6 @@ fn resolve_lemonade_model_ref(model_ref: &str) -> String {
                 | "qwen3-4b-instruct"
                 | "qwen3-4b-instruct-2507-gguf"
         )
-        || lower.contains("qwen2.5-1.5b")
-        || lower.contains("qwen3.5-0.8b")
     {
         DEFAULT_MODEL.to_owned()
     } else if matches!(
@@ -2731,10 +2735,6 @@ mod tests {
     #[test]
     fn qwen_alias_resolves_to_validated_assistant_gguf_model() {
         assert_eq!(resolve_lemonade_model_ref("qwen"), DEFAULT_MODEL);
-        assert_eq!(
-            resolve_lemonade_model_ref("Qwen/Qwen2.5-1.5B-Instruct"),
-            DEFAULT_MODEL
-        );
         assert_eq!(resolve_lemonade_model_ref("qwen-smoke"), "Qwen3-0.6B-GGUF");
     }
 
@@ -2743,6 +2743,14 @@ mod tests {
         assert_eq!(
             resolve_lemonade_model_ref("LiquidAI/LFM2.5-230M-GGUF:Q4_0"),
             "LiquidAI/LFM2.5-230M-GGUF:Q4_0"
+        );
+        // Regression (EAI-7370): a fully-qualified checkpoint id that merely
+        // contains a known-alias substring must not be swapped for the bundled
+        // default. `Qwen/Qwen2.5-1.5B-Instruct` was silently served as
+        // `Qwen3-4B-Instruct-2507-GGUF`; it must now pass through verbatim.
+        assert_eq!(
+            resolve_lemonade_model_ref("Qwen/Qwen2.5-1.5B-Instruct"),
+            "Qwen/Qwen2.5-1.5B-Instruct"
         );
     }
 


### PR DESCRIPTION
## Summary

`rocm serve Qwen/Qwen2.5-1.5B-Instruct` printed a deployment summary for `Qwen3-4B-Instruct-2507-GGUF`, while `rocm services` afterwards showed the requested `Qwen/Qwen2.5-1.5B-Instruct` — the two commands appeared to disagree about which model was running. In fact the requested model was silently swapped for an unrelated one, and the served `/v1/models` id (and the `model` field in chat completions) reflected the substitute, not the request.

## Root cause

`resolve_lemonade_model_ref` aliased any reference whose lowercased form merely **contained** the substring `qwen2.5-1.5b` (or `qwen3.5-0.8b`) to the bundled default model. The fully-qualified Hugging Face checkpoint id `Qwen/Qwen2.5-1.5B-Instruct` contains that substring, so it was rewritten to `Qwen3-4B-Instruct-2507-GGUF` with no notice on stdout, stderr, or in the logs. `rocm serve`'s summary shows the resolved id; `rocm services` reads back the stored raw request — hence the mismatch.

## Fix

- **Stop the silent substitution.** Drop the substring checks; only exact, recognized shorthand aliases (`qwen`, `qwen3-4b-instruct`, …) still resolve to the bundled GGUF. A syntactically valid `owner/repo` checkpoint now passes through unchanged, so the serve path either honours it or rejects it explicitly. `Qwen/Qwen2.5-1.5B-Instruct` is safetensors-only, so on Lemonade it now hits the existing "needs an explicit `owner/repo:variant`" message instead of serving a different model behind the user's back.
- **Report both identities.** When the requested reference resolves to a different canonical id, the deployment summary now shows `requested model` and `resolved model` rows (mirroring the plain-text serve output); a single `model` row is kept when they match, so the common case stays uncluttered.
- **README.** The quick-start used the exact substituted command, and the guidance claimed full HF ids are reliable cross-engine. Both are corrected: the quick-start uses the `qwen` alias (works on both engines), and the guidance now states the real split — Lemonade serves GGUF via `owner/repo:variant`, vLLM serves safetensors repos.

## Out of scope (follow-up)

The built-in catalog still lists this safetensors model as a llama.cpp/GGUF recipe with no real GGUF artifact — the removed substring hack was masking that. Making it genuinely Lemonade-servable (mapping it to a real GGUF build) is left as a separate change rather than silently substituting one here.

## Test plan

- New regression test: `resolve_lemonade_model_ref("Qwen/Qwen2.5-1.5B-Instruct")` returns it verbatim (this assertion fails before the change — the previous test codified the buggy substitution).
- New summary tests: matching request/resolved shows a single `model` row; divergent shows both `requested model` / `resolved model`.
- `cargo test -p rocm-engine-lemonade` (27 passed) and `cargo test -p rocm --bin rocm` (339 passed).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Risk

Low. The resolver change only narrows an over-broad alias match; built-in aliases and the default-model path are unchanged. The summary change is additive and only alters output when requested/resolved differ.

Relates to EAI-7370.
