### PR TITLE
test(e2e): drive the dash TUI black-box over a pseudo-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,12 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +623,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -758,20 +764,6 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
@@ -801,7 +793,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -1011,7 +1003,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.14.0",
+ "itertools",
  "junit-report",
  "linked-hash-map",
  "mime",
@@ -1033,7 +1025,7 @@ checksum = "ed2fc8a8bbb73af3230db699e8690c5c786655f75eb89e5f18d76055fa1a9a4d"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -1236,6 +1228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,12 +1252,14 @@ dependencies = [
  "axum",
  "cucumber",
  "e2e-report",
+ "portable-pty",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "toml",
+ "vt100",
 ]
 
 [[package]]
@@ -1463,12 +1463,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1726,24 +1720,13 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1754,7 +1737,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2175,15 +2158,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2390,15 +2364,6 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -2418,7 +2383,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2535,13 +2500,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2856,12 +2833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "peg"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3048,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -3187,7 +3179,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -3277,27 +3269,6 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.13.0",
- "cassowary",
- "compact_str 0.8.2",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate 1.1.0",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
@@ -3319,19 +3290,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
- "compact_str 0.9.1",
+ "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools 0.14.0",
+ "itertools",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-truncate 2.0.1",
- "unicode-width 0.2.0",
+ "unicode-truncate",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3387,14 +3358,14 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools 0.14.0",
+ "itertools",
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum 0.28.0",
+ "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3600,7 +3571,6 @@ dependencies = [
  "crossterm 0.29.0",
  "flate2",
  "keyring-core",
- "ratatui 0.29.0",
  "rocm-core",
  "rocm-dash-daemon",
  "rocm-dash-tui",
@@ -3705,7 +3675,7 @@ dependencies = [
  "crossterm 0.28.1",
  "futures",
  "http",
- "ratatui 0.30.2",
+ "ratatui",
  "reqwest 0.13.4",
  "rig-core",
  "rocm-dash-core",
@@ -4231,6 +4201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,6 +4241,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4411,33 +4408,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.118",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4659,7 +4634,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -4691,7 +4666,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5189,37 +5164,20 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-truncate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5306,6 +5264,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -5885,6 +5864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ directories = "6.0"
 keyring-core = "1.0.0"
 libc = "0.2"
 rand = "0.8"
-ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 rpassword = "7.5"
 rsa = "0.9"
 semver = "1.0"

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,6 +48,7 @@ repository.
 | anyhow | 1.0.102 | MIT OR Apache-2.0 |
 | apple-native-keyring-store | 1.0.0 | MIT OR Apache-2.0 |
 | approx | 0.5.1 | Apache-2.0 |
+| arrayvec | 0.7.8 | MIT OR Apache-2.0 |
 | as-any | 0.3.2 | MIT OR Apache-2.0 |
 | assert-json-diff | 2.0.2 | MIT |
 | async-broadcast | 0.7.2 | MIT OR Apache-2.0 |
@@ -89,11 +90,11 @@ repository.
 | bytemuck | 1.25.0 | Zlib OR Apache-2.0 OR MIT |
 | byteorder | 1.5.0 | Unlicense OR MIT |
 | bytes | 1.12.0 | MIT |
-| cassowary | 0.3.0 | MIT / Apache-2.0 |
 | castaway | 0.2.4 | MIT |
 | cbc | 0.1.2 | MIT OR Apache-2.0 |
 | cc | 1.2.65 | MIT OR Apache-2.0 |
 | cfg-if | 1.0.4 | MIT OR Apache-2.0 |
+| cfg_aliases | 0.1.1 | MIT |
 | cfg_aliases | 0.2.1 | MIT |
 | chrono | 0.4.45 | MIT OR Apache-2.0 |
 | cipher | 0.4.4 | MIT OR Apache-2.0 |
@@ -107,7 +108,6 @@ repository.
 | color-spantrace | 0.3.0 | MIT OR Apache-2.0 |
 | colorchoice | 1.0.5 | MIT OR Apache-2.0 |
 | combine | 4.6.7 | MIT |
-| compact_str | 0.8.2 | MIT |
 | compact_str | 0.9.1 | MIT |
 | concurrent-queue | 2.5.0 | Apache-2.0 OR MIT |
 | console | 0.16.4 | MIT |
@@ -151,6 +151,7 @@ repository.
 | dirs-sys | 0.5.0 | MIT OR Apache-2.0 |
 | displaydoc | 0.2.6 | MIT OR Apache-2.0 |
 | document-features | 0.2.12 | MIT OR Apache-2.0 |
+| downcast-rs | 1.2.1 | MIT/Apache-2.0 |
 | dunce | 1.0.5 | CC0-1.0 OR MIT-0 OR Apache-2.0 |
 | dyn-clone | 1.0.20 | MIT OR Apache-2.0 |
 | either | 1.16.0 | MIT OR Apache-2.0 |
@@ -176,7 +177,6 @@ repository.
 | fixedbitset | 0.4.2 | MIT/Apache-2.0 |
 | flate2 | 1.1.9 | MIT OR Apache-2.0 |
 | fnv | 1.0.7 | Apache-2.0 / MIT |
-| foldhash | 0.1.5 | Zlib |
 | foldhash | 0.2.0 | Zlib |
 | form_urlencoded | 1.2.2 | MIT OR Apache-2.0 |
 | fs_extra | 1.3.0 | MIT |
@@ -202,7 +202,6 @@ repository.
 | globwalk | 0.9.1 | MIT |
 | h2 | 0.4.15 | MIT |
 | hashbrown | 0.12.3 | MIT OR Apache-2.0 |
-| hashbrown | 0.15.5 | MIT OR Apache-2.0 |
 | hashbrown | 0.16.1 | MIT OR Apache-2.0 |
 | hashbrown | 0.17.1 | MIT OR Apache-2.0 |
 | heck | 0.5.0 | MIT OR Apache-2.0 |
@@ -244,7 +243,6 @@ repository.
 | inventory | 0.3.24 | MIT OR Apache-2.0 |
 | ipnet | 2.12.0 | MIT OR Apache-2.0 |
 | is_terminal_polyfill | 1.70.2 | MIT OR Apache-2.0 |
-| itertools | 0.13.0 | MIT OR Apache-2.0 |
 | itertools | 0.14.0 | MIT OR Apache-2.0 |
 | itoa | 1.0.18 | MIT OR Apache-2.0 |
 | jni | 0.22.4 | MIT OR Apache-2.0 |
@@ -269,7 +267,6 @@ repository.
 | litrs | 1.0.0 | MIT OR Apache-2.0 |
 | lock_api | 0.4.14 | MIT OR Apache-2.0 |
 | log | 0.4.33 | MIT OR Apache-2.0 |
-| lru | 0.12.5 | MIT |
 | lru | 0.18.0 | MIT |
 | lru-slab | 0.1.2 | MIT OR Apache-2.0 OR Zlib |
 | mac_address | 1.1.8 | MIT OR Apache-2.0 |
@@ -286,6 +283,7 @@ repository.
 | miniz_oxide | 0.8.9 | MIT OR Zlib OR Apache-2.0 |
 | mio | 1.2.1 | MIT |
 | nanoid | 0.4.0 | MIT |
+| nix | 0.28.0 | MIT |
 | nix | 0.29.0 | MIT |
 | nom | 7.1.3 | MIT |
 | nom | 8.0.0 | MIT |
@@ -320,7 +318,6 @@ repository.
 | parking | 2.2.1 | Apache-2.0 OR MIT |
 | parking_lot | 0.12.5 | MIT OR Apache-2.0 |
 | parking_lot_core | 0.9.12 | MIT OR Apache-2.0 |
-| paste | 1.0.15 | MIT OR Apache-2.0 |
 | peg | 0.6.3 | MIT |
 | peg-macros | 0.6.3 | MIT |
 | peg-runtime | 0.6.3 | MIT |
@@ -343,6 +340,7 @@ repository.
 | pkcs8 | 0.10.2 | Apache-2.0 OR MIT |
 | polling | 3.11.0 | Apache-2.0 OR MIT |
 | portable-atomic | 1.13.1 | Apache-2.0 OR MIT |
+| portable-pty | 0.9.0 | MIT |
 | potential_utf | 0.1.5 | Unicode-3.0 |
 | powerfmt | 0.2.0 | MIT OR Apache-2.0 |
 | ppv-lite86 | 0.2.21 | MIT OR Apache-2.0 |
@@ -362,7 +360,6 @@ repository.
 | rand_chacha | 0.9.0 | MIT OR Apache-2.0 |
 | rand_core | 0.6.4 | MIT OR Apache-2.0 |
 | rand_core | 0.9.5 | MIT OR Apache-2.0 |
-| ratatui | 0.29.0 | MIT |
 | ratatui | 0.30.2 | MIT |
 | ratatui-core | 0.1.2 | MIT |
 | ratatui-crossterm | 0.1.2 | MIT |
@@ -422,9 +419,12 @@ repository.
 | serde_urlencoded | 0.7.1 | MIT/Apache-2.0 |
 | serde_with | 3.21.0 | MIT OR Apache-2.0 |
 | serde_with_macros | 3.21.0 | MIT OR Apache-2.0 |
+| serial2 | 0.2.37 | BSD-2-Clause OR Apache-2.0 |
 | sha1 | 0.10.6 | MIT OR Apache-2.0 |
 | sha2 | 0.10.9 | MIT OR Apache-2.0 |
 | sharded-slab | 0.1.7 | MIT |
+| shared_library | 0.1.9 | Apache-2.0/MIT |
+| shell-words | 1.1.1 | MIT/Apache-2.0 |
 | shlex | 2.0.1 | MIT OR Apache-2.0 |
 | signal-hook | 0.3.18 | Apache-2.0/MIT |
 | signal-hook-mio | 0.2.5 | MIT OR Apache-2.0 |
@@ -444,9 +444,7 @@ repository.
 | stable_deref_trait | 1.2.1 | MIT OR Apache-2.0 |
 | static_assertions | 1.1.0 | MIT OR Apache-2.0 |
 | strsim | 0.11.1 | MIT |
-| strum | 0.26.3 | MIT |
 | strum | 0.28.0 | MIT |
-| strum_macros | 0.26.4 | MIT |
 | strum_macros | 0.28.0 | MIT |
 | subtle | 2.6.1 | BSD-3-Clause |
 | symlink | 0.1.0 | MIT/Apache-2.0 |
@@ -515,10 +513,8 @@ repository.
 | unicode-ident | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 |
 | unicode-linebreak | 0.1.5 | Apache-2.0 |
 | unicode-segmentation | 1.13.3 | MIT OR Apache-2.0 |
-| unicode-truncate | 1.1.0 | MIT OR Apache-2.0 |
 | unicode-truncate | 2.0.1 | MIT OR Apache-2.0 |
-| unicode-width | 0.1.14 | MIT OR Apache-2.0 |
-| unicode-width | 0.2.0 | MIT OR Apache-2.0 |
+| unicode-width | 0.2.2 | MIT OR Apache-2.0 |
 | unicode-xid | 0.2.6 | MIT OR Apache-2.0 |
 | untrusted | 0.9.0 | ISC |
 | ureq | 2.12.1 | MIT OR Apache-2.0 |
@@ -529,6 +525,8 @@ repository.
 | uuid | 1.23.3 | Apache-2.0 OR MIT |
 | valuable | 0.1.1 | MIT |
 | version_check | 0.9.5 | MIT/Apache-2.0 |
+| vt100 | 0.16.2 | MIT |
+| vte | 0.15.0 | Apache-2.0 OR MIT |
 | vtparse | 0.6.2 | MIT |
 | walkdir | 2.5.0 | Unlicense/MIT |
 | want | 0.3.1 | MIT |
@@ -592,6 +590,7 @@ repository.
 | windows_x86_64_msvc | 0.53.1 | MIT OR Apache-2.0 |
 | winnow | 0.7.15 | MIT |
 | winnow | 1.0.3 | MIT |
+| winreg | 0.10.1 | MIT |
 | wiremock | 0.6.5 | MIT/Apache-2.0 |
 | wit-bindgen | 0.57.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT |
 | writeable | 0.6.3 | Unicode-3.0 |

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -3213,209 +3213,209 @@ Apache License 2.0
 ================================================================================
 
 The following component(s) are licensed under Apache License 2.0:
-  - cassowary 0.3.0 <https://github.com/dylanede/cassowary-rs>
+  - shell-words 1.1.1 <https://github.com/tmiasko/shell-words>
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                               Apache License
+                         Version 2.0, January 2004
+                      http://www.apache.org/licenses/
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-   1. Definitions.
+1. Definitions.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
 
-   END OF TERMS AND CONDITIONS
+END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
+APPENDIX: How to apply the Apache License to your work.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+Copyright [yyyy] [name of copyright owner]
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 
 ================================================================================
@@ -5537,6 +5537,7 @@ Apache License 2.0
 
 The following component(s) are licensed under Apache License 2.0:
   - addr2line 0.25.1 <https://github.com/gimli-rs/addr2line>
+  - arrayvec 0.7.8 <https://github.com/bluss/arrayvec>
   - async-channel 2.5.0 <https://github.com/smol-rs/async-channel>
   - async-executor 1.14.0 <https://github.com/smol-rs/async-executor>
   - async-io 2.6.0 <https://github.com/smol-rs/async-io>
@@ -5547,6 +5548,7 @@ The following component(s) are licensed under Apache License 2.0:
   - atomic-waker 1.1.2 <https://github.com/smol-rs/atomic-waker>
   - backtrace 0.3.76 <https://github.com/rust-lang/backtrace-rs>
   - base64 0.22.1 <https://github.com/marshallpierce/rust-base64>
+  - bitflags 1.3.2 <https://github.com/bitflags/bitflags>
   - bitflags 2.13.0 <https://github.com/bitflags/bitflags>
   - blocking 1.6.2 <https://github.com/smol-rs/blocking>
   - bstr 1.12.3 <https://github.com/BurntSushi/bstr>
@@ -5582,7 +5584,6 @@ The following component(s) are licensed under Apache License 2.0:
   - gherkin 0.16.0 <https://github.com/cucumber-rs/gherkin>
   - gimli 0.32.3 <https://github.com/gimli-rs/gimli>
   - glob 0.3.3 <https://github.com/rust-lang/glob>
-  - hashbrown 0.15.5 <https://github.com/rust-lang/hashbrown>
   - hashbrown 0.16.1 <https://github.com/rust-lang/hashbrown>
   - hashbrown 0.17.1 <https://github.com/rust-lang/hashbrown>
   - heck 0.5.0 <https://github.com/withoutboats/heck>
@@ -5592,7 +5593,6 @@ The following component(s) are licensed under Apache License 2.0:
   - idna 1.1.0 <https://github.com/servo/rust-url/>
   - idna_adapter 1.2.2 <https://github.com/hsivonen/idna_adapter>
   - indexmap 2.14.0 <https://github.com/indexmap-rs/indexmap>
-  - itertools 0.13.0 <https://github.com/rust-itertools/itertools>
   - itertools 0.14.0 <https://github.com/rust-itertools/itertools>
   - js-sys 0.3.102 <https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys>
   - lazy_static 1.5.0 <https://github.com/rust-lang-nursery/lazy-static.rs>
@@ -5655,10 +5655,8 @@ The following component(s) are licensed under Apache License 2.0:
   - typed-builder 0.23.2 <https://github.com/idanarye/rust-typed-builder>
   - unicase 2.9.0 <https://github.com/seanmonstar/unicase>
   - unicode-segmentation 1.13.3 <https://github.com/unicode-rs/unicode-segmentation>
-  - unicode-truncate 1.1.0 <https://github.com/Aetf/unicode-truncate>
   - unicode-truncate 2.0.1 <https://github.com/Aetf/unicode-truncate>
-  - unicode-width 0.1.14 <https://github.com/unicode-rs/unicode-width>
-  - unicode-width 0.2.0 <https://github.com/unicode-rs/unicode-width>
+  - unicode-width 0.2.2 <https://github.com/unicode-rs/unicode-width>
   - unicode-xid 0.2.6 <https://github.com/unicode-rs/unicode-xid>
   - url 2.5.8 <https://github.com/servo/rust-url>
   - uuid 1.23.3 <https://github.com/uuid-rs/uuid>
@@ -5879,6 +5877,216 @@ Apache License 2.0
 ================================================================================
 
 The following component(s) are licensed under Apache License 2.0:
+  - shared_library 0.1.9 <https://github.com/tomaka/shared_library/>
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================================================================================
+Apache License 2.0
+================================================================================
+
+The following component(s) are licensed under Apache License 2.0:
+  - downcast-rs 1.2.1 <https://github.com/marcianx/downcast-rs>
   - linked-hash-map 0.5.6 <https://github.com/contain-rs/linked-hash-map>
   - minimal-lexical 0.2.1 <https://github.com/Alexhuszagh/minimal-lexical>
 
@@ -7748,7 +7956,6 @@ The following component(s) are licensed under Apache License 2.0:
   - miniz_oxide 0.8.9 <https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide>
   - num-conv 0.2.2 <https://github.com/jhpratt/num-conv>
   - objc2-core-foundation 0.3.2 <https://github.com/madsmtm/objc2>
-  - paste 1.0.15 <https://github.com/dtolnay/paste>
   - pin-project-internal 1.1.13 <https://github.com/taiki-e/pin-project>
   - pin-project-lite 0.2.17 <https://github.com/taiki-e/pin-project-lite>
   - pin-project 1.1.13 <https://github.com/taiki-e/pin-project>
@@ -7773,6 +7980,7 @@ The following component(s) are licensed under Apache License 2.0:
   - serde_path_to_error 0.1.20 <https://github.com/dtolnay/path-to-error>
   - serde_repr 0.1.20 <https://github.com/dtolnay/serde-repr>
   - serde_urlencoded 0.7.1 <https://github.com/nox/serde_urlencoded>
+  - serial2 0.2.37 <https://github.com/de-vri-es/serial2-rs>
   - simdutf8 0.1.5 <https://github.com/rusticstuff/simdutf8>
   - syn 2.0.118 <https://github.com/dtolnay/syn>
   - sync_wrapper 1.0.2 <https://github.com/Actyx/sync_wrapper>
@@ -7785,6 +7993,7 @@ The following component(s) are licensed under Apache License 2.0:
   - time 0.3.51 <https://github.com/time-rs/time>
   - unicode-ident 1.0.24 <https://github.com/dtolnay/unicode-ident>
   - utf8parse 0.2.2 <https://github.com/alacritty/vte>
+  - vte 0.15.0 <https://github.com/alacritty/vte>
   - wasm-streams 0.5.0 <https://github.com/MattiasBuelens/wasm-streams/>
   - winapi-i686-pc-windows-gnu 0.4.0 <https://github.com/retep998/winapi-rs>
   - winapi-x86_64-pc-windows-gnu 0.4.0 <https://github.com/retep998/winapi-rs>
@@ -8740,6 +8949,34 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
+  - winreg 0.10.1 <https://github.com/gentoo90/winreg-rs>
+
+Copyright (c) 2015 Igor Shaula
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+================================================================================
+MIT License
+================================================================================
+
+The following component(s) are licensed under MIT License:
   - ordered-float 5.3.0 <https://github.com/reem/rust-ordered-float>
 
 Copyright (c) 2015 Jonathan Reem
@@ -9526,7 +9763,6 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
-  - lru 0.12.5 <https://github.com/jeromefroe/lru-rs.git>
   - lru 0.18.0 <https://github.com/jeromefroe/lru-rs.git>
 
 MIT License
@@ -9709,6 +9945,7 @@ MIT License
 
 The following component(s) are licensed under MIT License:
   - filedescriptor 0.8.3 <https://github.com/wezterm/wezterm>
+  - portable-pty 0.9.0 <https://github.com/wezterm/wezterm>
 
 MIT License
 
@@ -9769,9 +10006,7 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
-  - strum 0.26.3 <https://github.com/Peternator7/strum>
   - strum 0.28.0 <https://github.com/Peternator7/strum>
-  - strum_macros 0.26.4 <https://github.com/Peternator7/strum>
   - strum_macros 0.28.0 <https://github.com/Peternator7/strum>
 
 MIT License
@@ -9898,7 +10133,6 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
-  - compact_str 0.8.2 <https://github.com/ParkMyCar/compact_str>
   - compact_str 0.9.1 <https://github.com/ParkMyCar/compact_str>
 
 MIT License
@@ -10330,6 +10564,36 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
+  - nix 0.28.0 <https://github.com/nix-rust/nix>
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Carl Lerche + nix-rust Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+================================================================================
+MIT License
+================================================================================
+
+The following component(s) are licensed under MIT License:
   - strsim 0.11.1 <https://github.com/rapidfuzz/strsim-rs>
 
 The MIT License (MIT)
@@ -10486,19 +10750,18 @@ MIT License
 ================================================================================
 
 The following component(s) are licensed under MIT License:
-  - ratatui 0.29.0 <https://github.com/ratatui/ratatui>
+  - vt100 0.16.2 <https://github.com/doy/vt100-rust>
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2022 Florian Dehau
-Copyright (c) 2023-2024 The Ratatui Developers
+Copyright (c) 2016 Jesse Luehrs
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
@@ -11269,7 +11532,6 @@ zlib License
 ================================================================================
 
 The following component(s) are licensed under zlib License:
-  - foldhash 0.1.5 <https://github.com/orlp/foldhash>
   - foldhash 0.2.0 <https://github.com/orlp/foldhash>
 
 Copyright (c) 2024 Orson Peters

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -17,7 +17,6 @@ clap_complete.workspace = true
 crossterm.workspace = true
 flate2 = "1.1"
 keyring-core.workspace = true
-ratatui.workspace = true
 rocm-core = { path = "../../crates/rocm-core" }
 # rocm-dash unified dashboard launch. The
 # telemetry daemon + ratatui-0.30 TUI are launched from the `dash` verb; tokio

--- a/crates/rocm-dash-tui/Cargo.toml
+++ b/crates/rocm-dash-tui/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/lib.rs"
 
 [dependencies]
 rocm-dash-core = { path = "../rocm-dash-core" }
-# Unified dashboard TUI base: ratatui 0.30 + crossterm 0.28 stay
-# confined to this crate. The frozen rocm-cli tui.rs keeps ratatui 0.29; the two
-# majors coexist in the tree, each confined to its own crate.
-# Exact wrapped-row counts must match Ratatui rendering so chat scroll bounds stay correct.
-# `line_count` is currently gated by Ratatui's unstable rendered-line-info feature.
+# Unified dashboard TUI base: ratatui 0.30 + crossterm 0.28. This is the only
+# ratatui in the workspace — the `rocm` binary no longer carries a (dead) 0.29
+# dependency, so no second major is pulled in. Exact wrapped-row counts must
+# match Ratatui rendering so chat scroll bounds stay correct; `line_count` is
+# gated by Ratatui's unstable rendered-line-info feature.
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 tokio = { version = "1", features = ["full"] }

--- a/tests/e2e-cucumber/Cargo.toml
+++ b/tests/e2e-cucumber/Cargo.toml
@@ -20,12 +20,18 @@ path = "src/bin/rocm-demo-env.rs"
 axum.workspace = true
 cucumber = { version = "0.23", features = ["output-json", "output-junit"] }
 e2e-report = { path = "../../crates/e2e-report" }
+# Drive the interactive dash TUI black-box: spawn the real `rocm` binary under a
+# pseudo-terminal (`portable-pty`, cross-platform openpty/ConPTY) and parse the
+# emitted terminal stream into the current on-screen grid (`vt100`). This is the
+# only way to exercise the crossterm raw-mode event loop a piped `Command` can't.
+portable-pty = "0.9"
 reqwest = { version = "0.13", features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
 tempfile = "3"
 tokio.workspace = true
 toml = "0.8"
+vt100 = "0.16"
 
 [[test]]
 name = "e2e"

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -23,14 +23,6 @@
 #
 # An empty `when = {}` means "always xfail" (platform-independent bug).
 
-# --- EAI-7222: privacy notice is only shown in the interactive dash/TUI, so a
-# black-box CLI test can't verify it. Tracked as xfail (any platform) rather than
-# a silent green no-op — the step panics, which is the expected outcome here. ---
-[["chat-privacy-notice-accurate"]]
-when = {}
-bug = "EAI-7222"
-reason = "Privacy notice is TUI-only; cannot be verified by a black-box CLI test."
-
 # --- EAI-7219: short-name expansion not surfaced in serve output (any engine) ---
 [["serve-short-name-expansion"]]
 when = {}

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -10,8 +10,8 @@ Feature: Chat and endpoint detection
   # Driven through the interactive TUI (a pseudo-terminal): the privacy notice
   # lives on the chat consent gate, which only the real terminal path renders.
   # The model is registered so the CLI discovers it on its OS-assigned port and
-  # offers it — the notice must precede any request. (Was EAI-7222, previously
-  # an untestable-black-box gap.)
+  # offers it — the notice must precede any request. (Previously an
+  # untestable-black-box gap.)
   @id:chat-privacy-notice-accurate @requires-os:linux
   Scenario: 2 - The privacy notice is shown before using a local endpoint
     Given a model is being served locally
@@ -28,6 +28,7 @@ Feature: Chat and endpoint detection
     When the user accepts the local endpoint
     And the user sends a message to the managed model
     Then the managed model's response is displayed
+    And the mock received the typed prompt
     When the user quits interactive chat
     Then interactive chat exits successfully
 

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -20,36 +20,47 @@ Feature: Chat and endpoint detection
     Then the local endpoint is shown for confirmation
     And the privacy notice is shown before any message is sent
 
+  @id:chat-managed-model-interactive @requires-os:linux
+  Scenario: 3 - Interactive chat uses a running managed model
+    Given a running managed model is available locally
+    When the user opens interactive chat
+    Then the local endpoint is shown for confirmation
+    When the user accepts the local endpoint
+    And the user sends a message to the managed model
+    Then the managed model's response is displayed
+    When the user quits interactive chat
+    Then interactive chat exits successfully
+
   @id:chat-endpoint-shown-in-services
-  Scenario: 3 - A served model's endpoint is shown in the services list
+  Scenario: 4 - A served model's endpoint is shown in the services list
     Given a model is being served
     And the model is registered with the CLI
     When the user lists running services
     Then the served model endpoint is listed
 
-  # Exercises the `rocm chat` CLI itself (one-shot `--prompt` via the local
-  # provider), not just the model endpoint over HTTP — so the command surface
-  # reports `rocm chat` as covered. Runs on mock (no GPU): the local provider
-  # resolves the planted managed-service record and talks to the mock server.
-  @id:chat-cli-oneshot-prompt
-  Scenario: 6 - The chat CLI answers a one-shot prompt against a local server
-    Given a model is being served
-    And the model is registered with the CLI
-    When the user sends a one-shot chat prompt through the CLI
-    Then the CLI prints the assistant's reply
-
   @id:chat-tool-definitions-accepted @requires-gpu
-  Scenario: 4 - Chat requests that include tool definitions are accepted
+  Scenario: 5 - Chat requests that include tool definitions are accepted
     Given a managed runtime is active
     And a model is served in the background
     When a chat request with tool definitions is sent
     Then the chat response is successful
 
   @id:chat-end-to-end-local-model @requires-gpu
-  Scenario: 5 - End-to-end chat through a locally served model
+  Scenario: 6 - End-to-end chat through a locally served model
     Given a managed runtime is active
     And a model is served in the background
     And the served model has been detected
     When the user sends a chat message
     Then the chat response is successful
     And the response contains a model-generated reply
+
+  # Exercises the `rocm chat` CLI itself (one-shot `--prompt` via the local
+  # provider), not just the model endpoint over HTTP — so the command surface
+  # reports `rocm chat` as covered. Runs on mock (no GPU): the local provider
+  # resolves the planted managed-service record and talks to the mock server.
+  @id:chat-cli-oneshot-prompt
+  Scenario: 7 - The chat CLI answers a one-shot prompt against a local server
+    Given a model is being served
+    And the model is registered with the CLI
+    When the user sends a one-shot chat prompt through the CLI
+    Then the CLI prints the assistant's reply

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -19,6 +19,8 @@ Feature: Chat and endpoint detection
     When the user opens interactive chat
     Then the local endpoint is shown for confirmation
     And the privacy notice is shown before any message is sent
+    When the user quits interactive chat
+    Then interactive chat exits successfully
 
   @id:chat-managed-model-interactive @requires-os:linux
   Scenario: 3 - Interactive chat uses a running managed model

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -7,11 +7,18 @@ Feature: Chat and endpoint detection
     When the user checks for running services
     Then the served model is listed
 
-  @id:chat-privacy-notice-accurate
-  Scenario: 2 - The privacy notice is accurate for local endpoints
+  # Driven through the interactive TUI (a pseudo-terminal): the privacy notice
+  # lives on the chat consent gate, which only the real terminal path renders.
+  # The model is registered so the CLI discovers it on its OS-assigned port and
+  # offers it — the notice must precede any request. (Was EAI-7222, previously
+  # an untestable-black-box gap.)
+  @id:chat-privacy-notice-accurate @requires-os:linux
+  Scenario: 2 - The privacy notice is shown before using a local endpoint
     Given a model is being served locally
-    When the user is offered the detected endpoint
-    Then the notice does not claim that requests leave the machine
+    And the model is registered with the CLI
+    When the user opens interactive chat
+    Then the local endpoint is shown for confirmation
+    And the privacy notice is shown before any message is sent
 
   @id:chat-endpoint-shown-in-services
   Scenario: 3 - A served model's endpoint is shown in the services list

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -1,0 +1,24 @@
+Feature: Interactive dashboard
+
+  # These scenarios drive the real interactive TUI through a pseudo-terminal —
+  # the crossterm raw-mode event loop that a piped command can't reach. Linux
+  # only for now: portable-pty compiles on Windows via ConPTY, but that path is
+  # not yet promoted to a blocking contract (tracked as a follow-up).
+
+  @id:dash-opens-and-navigates @requires-os:linux
+  Scenario: 1 - A user opens the dashboard and navigates to ROCm setup
+    When the user opens the dashboard with demo data
+    Then the dashboard home view is displayed
+    When the user opens the ROCm view
+    Then ROCm setup actions are displayed
+    When the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:dash-chat-offline-reply @requires-os:linux
+  Scenario: 2 - A user receives a response in interactive chat
+    Given interactive chat uses an offline assistant
+    When the user opens interactive chat
+    And the user sends a message about GPU health
+    Then the assistant's GPU status response is displayed
+    When the user quits the dashboard
+    Then the dashboard exits successfully

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -20,8 +20,8 @@ Feature: Interactive dashboard
     When the user opens interactive chat
     And the user sends a message about GPU health
     Then the assistant's GPU status response is displayed
-    When the user quits the dashboard
-    Then the dashboard exits successfully
+    When the user quits interactive chat
+    Then interactive chat exits successfully
 
   @id:dash-loading-service-status @requires-os:linux
   Scenario: 3 - The dashboard reports a model that is still loading as loading

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -22,3 +22,49 @@ Feature: Interactive dashboard
     Then the assistant's GPU status response is displayed
     When the user quits the dashboard
     Then the dashboard exits successfully
+
+  @id:dash-loading-service-status @requires-os:linux
+  Scenario: 3 - The dashboard reports a model that is still loading as loading
+    Given a managed model is still loading
+    When the user opens the dashboard
+    And the user opens the Observe view
+    Then the managed model is shown as loading rather than ready
+    When the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:dash-managed-service-metrics @requires-os:linux
+  Scenario: 4 - Observe displays metrics from a managed model
+    Given a managed model exposes serving metrics
+    When the user opens the dashboard
+    And the user opens the Observe view
+    Then live serving metrics are displayed for the managed model
+    When the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:dash-help-guidance @requires-os:linux
+  Scenario: 5 - A user can discover dashboard help and next-step guidance
+    When the user opens the dashboard with demo data
+    And the user opens dashboard help
+    Then navigation and next-step guidance are displayed
+    When the user closes dashboard help
+    And the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:dash-command-palette-navigation @requires-os:linux
+  Scenario: 6 - A user navigates to Serving through the command palette
+    When the user opens the dashboard with demo data
+    And the user opens the command palette
+    Then dashboard destinations are displayed
+    When the user chooses Serving
+    Then Serving actions are displayed
+    When the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:dash-managed-service-visible @requires-os:linux
+  Scenario: 7 - A managed model is visible in the dashboard
+    Given a running managed model is available locally
+    When the user opens the dashboard
+    And the user opens the Observe view
+    Then the managed model is displayed
+    When the user quits the dashboard
+    Then the dashboard exits successfully

--- a/tests/e2e-cucumber/src/lib.rs
+++ b/tests/e2e-cucumber/src/lib.rs
@@ -6,6 +6,7 @@ pub mod capability;
 pub mod expectation;
 pub mod mock_server;
 pub mod model_id;
+pub mod panic_capture;
 
 pub fn chat_response_is_successful(response: &serde_json::Value) -> bool {
     response

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -4,6 +4,8 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use axum::Router;
 use axum::extract::State;
@@ -15,6 +17,80 @@ use tokio::net::TcpListener;
 #[derive(Clone)]
 struct ServerState {
     model_name: String,
+    /// `Some` only when this server was started via
+    /// [`MockServer::start_with_metrics`]; drives the `/metrics` route. Kept as
+    /// an `Option` (rather than always registering the route) so a plain
+    /// [`MockServer::start`] — used by every scenario that doesn't care about
+    /// dashboard metrics — gets a 404 for `/metrics`, matching a vLLM instance
+    /// that scenario never asked to simulate.
+    metrics: Option<Arc<MetricsCounter>>,
+}
+
+/// Deterministic, monotonically-advancing state behind the mock `/metrics`
+/// route, so successive scrapes exercise the daemon's rate/average windowing
+/// (`gen_tps_from_delta`, `avg_ms_from_histogram` in
+/// `rocm-dash-daemon::runner`) the same way a real vLLM would:
+///   * `vllm:generation_tokens_total` strictly increases every scrape, so the
+///     counter-delta windowing yields a positive, visible generation rate
+///     from the second scrape onward (never zero/negative/`None`).
+///   * the TTFT/TPOT histograms' `_sum`/`_count` pairs both advance by a fixed
+///     amount per tick, so their ratio — and therefore the windowed average
+///     latency — stays constant scrape over scrape instead of drifting.
+struct MetricsCounter {
+    ticks: AtomicU64,
+}
+
+impl MetricsCounter {
+    const fn new() -> Self {
+        Self {
+            ticks: AtomicU64::new(0),
+        }
+    }
+
+    /// Advance one scrape and render the resulting Prometheus exposition text.
+    fn scrape(&self) -> String {
+        // Start at 1 (not 0) so even the very first scrape already reports
+        // non-zero cumulative counters, giving tests a realistic "already
+        // serving" sample without a "first scrape is empty" special case.
+        let tick = self.ticks.fetch_add(1, Ordering::Relaxed) + 1;
+
+        // 20 generation tokens per scrape keeps gen_tps comfortably positive
+        // even at the daemon's multi-second poll interval.
+        let gen_tokens_total = tick * 20;
+        // One request "completes" per scrape: a fixed 50ms TTFT and a fixed
+        // 20ms/token TPOT over those 20 tokens. Sum and count both grow
+        // linearly in `tick`, so Δsum/Δcount — the windowed average the
+        // daemon reports — is the same constant on every pair of scrapes.
+        let ttft_count = tick;
+        let ttft_sum_s = tick as f64 * 0.050;
+        let tpot_count = tick * 20;
+        let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+
+        format!(
+            "\
+# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} 1
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{{model=\"mock\"}} 0
+# HELP vllm:gpu_cache_usage_perc GPU KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc{{model=\"mock\"}} 0.25
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {gen_tokens_total}
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {ttft_count}
+# HELP vllm:time_per_output_token_seconds Histogram of time per output token.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tpot_count}
+"
+        )
+    }
 }
 
 pub struct MockServer {
@@ -32,16 +108,34 @@ impl std::fmt::Debug for MockServer {
 
 impl MockServer {
     pub async fn start(model_name: &str) -> Self {
+        Self::spawn(model_name, false).await
+    }
+
+    /// Like [`Self::start`], but also opts into a deterministic vLLM-flavoured
+    /// `/metrics` route (see [`MetricsCounter`]) — for scenarios that exercise
+    /// the dashboard's live generation-rate / TTFT / TPOT display against a
+    /// served model. Plain [`Self::start`] registers no `/metrics` route at
+    /// all, so it keeps returning a 404 there, same as before this method
+    /// existed.
+    pub async fn start_with_metrics(model_name: &str) -> Self {
+        Self::spawn(model_name, true).await
+    }
+
+    async fn spawn(model_name: &str, with_metrics: bool) -> Self {
         let state = ServerState {
             model_name: model_name.to_string(),
+            metrics: with_metrics.then(|| Arc::new(MetricsCounter::new())),
         };
 
-        let app = Router::new()
+        let mut app = Router::new()
             .route("/v1/models", get(handle_models))
             .route("/models", get(handle_models))
             .route("/v1/chat/completions", post(handle_chat))
-            .route("/chat/completions", post(handle_chat))
-            .with_state(state);
+            .route("/chat/completions", post(handle_chat));
+        if with_metrics {
+            app = app.route("/metrics", get(handle_metrics));
+        }
+        let app = app.with_state(state);
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -123,6 +217,14 @@ async fn handle_models(State(state): State<ServerState>) -> Json<Value> {
     }))
 }
 
+async fn handle_metrics(State(state): State<ServerState>) -> String {
+    state
+        .metrics
+        .as_ref()
+        .expect("metrics route requires metrics state")
+        .scrape()
+}
+
 async fn handle_chat(Json(body): Json<Value>) -> Json<Value> {
     let model = body
         .get("model")
@@ -139,7 +241,9 @@ async fn handle_chat(Json(body): Json<Value>) -> Json<Value> {
     Json(json!({
         "id": "mock-completion-1",
         "object": "chat.completion",
+        "created": 1_700_000_000_u64,
         "model": model,
+        "system_fingerprint": null,
         "choices": [{
             "index": 0,
             "message": {

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -4,8 +4,9 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::extract::State;
@@ -13,6 +14,10 @@ use axum::response::Json;
 use axum::routing::{get, post};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
+
+/// How often [`MockServer::wait_for_chat_request`] re-checks the captured
+/// request while waiting for the client to POST.
+const CHAT_REQUEST_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Clone)]
 struct ServerState {
@@ -24,6 +29,11 @@ struct ServerState {
     /// dashboard metrics — gets a 404 for `/metrics`, matching a vLLM instance
     /// that scenario never asked to simulate.
     metrics: Option<Arc<MetricsCounter>>,
+    /// The most recently received `/v1/chat/completions` request body, shared
+    /// with the `MockServer` handle so scenarios can assert on exactly what the
+    /// CLI sent — not just on the (fixed) canned reply, which would silently
+    /// mask a corrupted or missing prompt. `None` until a chat request arrives.
+    last_chat_request: Arc<Mutex<Option<Value>>>,
 }
 
 /// Deterministic, monotonically-advancing state behind the mock `/metrics`
@@ -96,6 +106,8 @@ vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tpot_count}
 pub struct MockServer {
     addr: SocketAddr,
     shutdown: tokio::sync::oneshot::Sender<()>,
+    /// Shared with the running server's `ServerState`; see the field doc there.
+    last_chat_request: Arc<Mutex<Option<Value>>>,
 }
 
 impl std::fmt::Debug for MockServer {
@@ -122,9 +134,11 @@ impl MockServer {
     }
 
     async fn spawn(model_name: &str, with_metrics: bool) -> Self {
+        let last_chat_request = Arc::new(Mutex::new(None));
         let state = ServerState {
             model_name: model_name.to_string(),
             metrics: with_metrics.then(|| Arc::new(MetricsCounter::new())),
+            last_chat_request: Arc::clone(&last_chat_request),
         };
 
         let mut app = Router::new()
@@ -151,7 +165,11 @@ impl MockServer {
                 .ok();
         });
 
-        Self { addr, shutdown: tx }
+        Self {
+            addr,
+            shutdown: tx,
+            last_chat_request,
+        }
     }
 
     pub fn base_url(&self) -> String {
@@ -162,12 +180,71 @@ impl MockServer {
         self.addr.port()
     }
 
+    /// The most recently received `/v1/chat/completions` request body, if any
+    /// chat request has landed yet. Recovers a poisoned lock rather than
+    /// propagating the panic: a torn-down request body is still the most
+    /// recent one worth inspecting on assertion failure.
+    pub fn last_chat_request(&self) -> Option<Value> {
+        self.last_chat_request
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Poll for a chat request to arrive, so scenarios that assert on the exact
+    /// request body don't race the TUI's async send. Returns the body once
+    /// present, or `Err` with a diagnostic if none arrives within `timeout`.
+    pub async fn wait_for_chat_request(&self, timeout: Duration) -> Result<Value, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(body) = self.last_chat_request() {
+                return Ok(body);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for a chat request"
+                ));
+            }
+            tokio::time::sleep(CHAT_REQUEST_POLL_INTERVAL).await;
+        }
+    }
+
     pub fn stop(self) {
         self.shutdown.send(()).ok();
     }
 }
 
-/// Write a managed-service record pointing the CLI at a mock server on `port`.
+/// Lifecycle fields of the on-disk managed-service record that vary across
+/// callers.
+///
+/// The default matches a service that passed its readiness probe with no
+/// process attached (the `rocm-demo-env` shape: `status: "ready"`, no
+/// `startup_phase`, `supervisor_pid: 0`, `engine_pid: null`). Cucumber
+/// scenarios that need a mid-startup record, or one the CLI's process-liveness
+/// overlay keeps alive (pointed at this test process), override the relevant
+/// fields via [`write_service_record_with`] instead of duplicating the whole
+/// record shape.
+#[derive(Debug, Clone, Copy)]
+pub struct ServiceRecordOptions {
+    pub status: &'static str,
+    pub startup_phase: Option<&'static str>,
+    pub supervisor_pid: u32,
+    pub engine_pid: Option<u32>,
+}
+
+impl Default for ServiceRecordOptions {
+    fn default() -> Self {
+        Self {
+            status: "ready",
+            startup_phase: None,
+            supervisor_pid: 0,
+            engine_pid: None,
+        }
+    }
+}
+
+/// Write a managed-service record pointing the CLI at a mock server on `port`,
+/// using [`ServiceRecordOptions::default`] (ready, no attached process).
 ///
 /// Drops the JSON into `services_dir` (`<data>/services/`) exactly as `rocm serve
 /// --managed` would. Shared by the cucumber `World` and the standalone
@@ -175,6 +252,20 @@ impl MockServer {
 /// plain JSON matching the CLI's on-disk schema, not a typed import from the
 /// rocm-cli crates.
 pub fn write_service_record(services_dir: &Path, model: &str, port: u16) {
+    write_service_record_with(services_dir, model, port, ServiceRecordOptions::default());
+}
+
+/// Like [`write_service_record`], but with caller-specified lifecycle fields.
+///
+/// See [`ServiceRecordOptions`] -- e.g. a "still loading" status/startup_phase,
+/// or `supervisor_pid`/`engine_pid` pointed at a live process so the CLI's
+/// liveness overlay doesn't mark the planted record dead.
+pub fn write_service_record_with(
+    services_dir: &Path,
+    model: &str,
+    port: u16,
+    options: ServiceRecordOptions,
+) {
     std::fs::create_dir_all(services_dir).expect("failed to create services dir");
 
     // The CLI only extracts host:port from `endpoint_url` and appends
@@ -188,9 +279,10 @@ pub fn write_service_record(services_dir: &Path, model: &str, port: u16) {
         "port": port,
         "endpoint_url": format!("http://127.0.0.1:{port}/v1"),
         "mode": "managed",
-        "status": "ready",
-        "supervisor_pid": 0,
-        "engine_pid": null,
+        "status": options.status,
+        "startup_phase": options.startup_phase,
+        "supervisor_pid": options.supervisor_pid,
+        "engine_pid": options.engine_pid,
         "runtime_id": null,
         "env_id": null,
         "device_policy": null,
@@ -225,12 +317,21 @@ async fn handle_metrics(State(state): State<ServerState>) -> String {
         .scrape()
 }
 
-async fn handle_chat(Json(body): Json<Value>) -> Json<Value> {
+async fn handle_chat(State(state): State<ServerState>, Json(body): Json<Value>) -> Json<Value> {
     let model = body
         .get("model")
         .and_then(Value::as_str)
         .unwrap_or("<missing>")
         .to_string();
+
+    // Record the request body so scenarios can assert on exactly what the CLI
+    // sent (see `MockServer::last_chat_request` / `wait_for_chat_request`) —
+    // the canned reply below never varies with the prompt, so without this a
+    // corrupted or missing request would pass unnoticed.
+    *state
+        .last_chat_request
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(body);
 
     // Tests assert on the request contract, not the reply text, so the default
     // is a fixed stub. Demos (`rocm-demo-env`) set `ROCM_MOCK_CHAT_REPLY` to a

--- a/tests/e2e-cucumber/src/panic_capture.rs
+++ b/tests/e2e-cucumber/src/panic_capture.rs
@@ -1,0 +1,115 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Panic-message extraction and mutex-poison recovery.
+//!
+//! Shared by black-box drivers (currently `tests/e2e/tui_driver.rs`) that run
+//! background OS threads they can't afford to let fail silently. This lives in
+//! the library target (unlike `tui_driver.rs`, which is deliberately part of
+//! the `harness = false` cucumber test binary and has no `#[test]`s of its own)
+//! specifically so its pure logic gets real `#[test]` coverage under `cargo
+//! test -p e2e-cucumber --lib` — the cucumber binary's custom harness never
+//! executes plain `#[test]` functions placed inside it.
+
+/// Best-effort extraction of a human-readable message from a `catch_unwind`
+/// payload (which is typically a `&str` or `String`, but isn't guaranteed to be).
+pub fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "thread panicked with a non-string payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::panic_message;
+    use std::sync::{Arc, Mutex};
+
+    /// A lock poisoned by a panicking holder must still be recoverable rather
+    /// than treated as unusable: this is the same pattern `tui_driver`'s
+    /// `screen_snapshot`/`use_detail_size` rely on to keep reading/writing a
+    /// shared parser after some unrelated panic, instead of falling back to a
+    /// silently blank screen.
+    #[test]
+    fn poisoned_mutex_is_recoverable() {
+        let mutex = Arc::new(Mutex::new(vec![1, 2, 3]));
+        let poisoned = Arc::clone(&mutex);
+        let result = std::panic::catch_unwind(move || {
+            let mut guard = poisoned.lock().unwrap();
+            guard.push(4);
+            panic!("simulated panic while holding the lock");
+        });
+        assert!(result.is_err());
+        assert!(mutex.is_poisoned());
+
+        // The same recovery `tui_driver` uses: `unwrap_or_else` with
+        // `PoisonError::into_inner` instead of propagating or defaulting.
+        let guard = mutex
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // The data written before the panic is still intact and readable.
+        assert_eq!(*guard, vec![1, 2, 3, 4]);
+    }
+
+    /// `panic_message` must handle both common `catch_unwind` payload shapes
+    /// (`&str` from `panic!("literal")`, `String` from `panic!("{}", x)`) plus
+    /// the fallback for anything else, since a poorly-typed panic payload
+    /// shouldn't itself cause a second failure while building a diagnostic.
+    #[test]
+    fn panic_message_handles_str_and_string_and_other_payloads() {
+        let str_payload: Box<dyn std::any::Any + Send> = Box::new("literal panic");
+        assert_eq!(panic_message(&str_payload), "literal panic");
+
+        let string_payload: Box<dyn std::any::Any + Send> =
+            Box::new(format!("formatted {}", "panic"));
+        assert_eq!(panic_message(&string_payload), "formatted panic");
+
+        let other_payload: Box<dyn std::any::Any + Send> = Box::new(42_i32);
+        assert_eq!(
+            panic_message(&other_payload),
+            "thread panicked with a non-string payload"
+        );
+    }
+
+    /// Exercises the same catch/record sequence `tui_driver::spawn_reader` uses
+    /// around `vt100::Parser::process`, without needing a real PTY or parser:
+    /// a panic while holding a lock is caught, the lock is dropped (not held
+    /// across the panic boundary), and the message is captured for a caller to
+    /// report later — rather than the OS thread just dying silently.
+    #[test]
+    fn captured_panic_is_recorded_not_lost() {
+        let state: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        let mut guard = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            guard.extend_from_slice(b"partial frame");
+            panic!("simulated processing panic");
+        }));
+        drop(guard);
+        let payload = result.expect_err("closure above always panics");
+        let message = panic_message(&payload);
+        *captured
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(message);
+
+        let message = captured
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        assert_eq!(message.as_deref(), Some("simulated processing panic"));
+        // The state itself is still usable afterwards (poison was recovered).
+        assert_eq!(
+            *state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            b"partial frame"
+        );
+    }
+}

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -16,10 +16,12 @@ use tempfile::TempDir;
 
 mod e2e {
     pub mod chat_steps;
+    pub mod dash_steps;
     pub mod diagnose_steps;
     pub mod examine_steps;
     pub mod runtime_steps;
     pub mod serving_steps;
+    pub mod tui_driver;
 }
 
 // ── World ──────────────────────────────────────────────────────────
@@ -54,6 +56,15 @@ pub struct E2eWorld {
     /// fail fast instead of burning the full cold-start window. `None` → the
     /// step's default / `E2E_SERVE_TIMEOUT_SECS`.
     pub serve_timeout_override: Option<u64>,
+    /// The interactive dash/chat TUI spawned under a pseudo-terminal for this
+    /// scenario, if any (see `e2e::tui_driver`). Torn down in `Drop` before the
+    /// mock server and isolated directory so the child process never outlives
+    /// the scenario. `None` for the non-interactive (piped `Command`) scenarios.
+    pub tui: Option<e2e::tui_driver::TuiSession>,
+    /// Set by the "interactive chat uses an offline assistant" step so the chat
+    /// launch step knows to pass `--chat-mock` (deterministic offline agent, no
+    /// endpoint detection) instead of driving the real detection/consent path.
+    pub chat_use_mock: bool,
 }
 
 /// Resolve a CI-provided shared-directory env var to a validated, existing path.
@@ -155,17 +166,26 @@ impl Default for E2eWorld {
             isolated_root: Some(root),
             legacy_rocm_path: None,
             serve_timeout_override: None,
+            tui: None,
+            chat_use_mock: false,
         }
     }
 }
 
 impl E2eWorld {
-    pub fn isolate_cmd(&self, cmd: &mut std::process::Command) {
+    /// The isolation/behaviour environment every spawned `rocm` gets, as owned
+    /// `(key, value)` pairs. One source of truth for both the piped
+    /// `std::process::Command` path (`isolate_cmd`) and the pseudo-terminal path
+    /// (`tui_driver`, whose `portable_pty::CommandBuilder` has its own env API and
+    /// can't take a `std::process::Command`) — so the interactive and
+    /// non-interactive spawns can never drift.
+    pub fn isolate_env(&self) -> Vec<(&'static str, std::ffi::OsString)> {
+        let mut env = Vec::new();
         if let Some(root) = &self.isolated_root {
             let root = root.path();
-            cmd.env("ROCM_CLI_CONFIG_DIR", root.join("config"));
-            cmd.env("ROCM_CLI_DATA_DIR", root.join("data"));
-            cmd.env("ROCM_CLI_CACHE_DIR", root.join("cache"));
+            env.push(("ROCM_CLI_CONFIG_DIR", root.join("config").into_os_string()));
+            env.push(("ROCM_CLI_DATA_DIR", root.join("data").into_os_string()));
+            env.push(("ROCM_CLI_CACHE_DIR", root.join("cache").into_os_string()));
         }
         // Share only STATE-FREE, content-addressed caches across scenarios when
         // CI provides a persistent shared dir (see shared_cache_dir): HF model
@@ -174,21 +194,21 @@ impl E2eWorld {
         // runtimes or engine envs — those carry state the suite asserts on (see
         // the note in `default()`).
         if let Some(shared) = shared_cache_dir() {
-            cmd.env("HF_HOME", shared.join("huggingface"));
-            cmd.env("PIP_CACHE_DIR", shared.join("pip"));
+            env.push(("HF_HOME", shared.join("huggingface").into_os_string()));
+            env.push(("PIP_CACHE_DIR", shared.join("pip").into_os_string()));
         }
         // Share uv's content-addressed download/build cache (the wheels `rocm
         // install sdk` fetches) so only the first scenario pays the cold download.
         // Independent of the weights cache above so CI can host it on a larger
         // disk; the runtimes registry the suite asserts on stays isolated.
         if let Some(uv_cache) = shared_uv_cache_dir() {
-            cmd.env("UV_CACHE_DIR", uv_cache);
+            env.push(("UV_CACHE_DIR", uv_cache.into_os_string()));
         }
         // A scenario that planted a fake pre-existing ROCm install points the
         // CLI's legacy-ROCm probe at it via ROCM_PATH, so `rocm examine` detects
         // "unmanaged ROCm" hermetically on any platform (see plant_unmanaged_rocm).
         if let Some(path) = &self.legacy_rocm_path {
-            cmd.env("ROCM_PATH", path);
+            env.push(("ROCM_PATH", path.clone().into_os_string()));
         }
         // When a scenario declares a longer serve-readiness window (via a
         // `@serve-timeout:<secs>` tag → serve_timeout_override), also raise the
@@ -199,7 +219,14 @@ impl E2eWorld {
         // would kill the server first. Keeping the two in lockstep makes the
         // big-model serve actually reach ready (verified on MI300X with Qwen3.6-27B).
         if let Some(secs) = self.serve_timeout_override {
-            cmd.env("ROCM_CLI_VLLM_READY_TIMEOUT_SECS", secs.to_string());
+            env.push(("ROCM_CLI_VLLM_READY_TIMEOUT_SECS", secs.to_string().into()));
+        }
+        env
+    }
+
+    pub fn isolate_cmd(&self, cmd: &mut std::process::Command) {
+        for (key, value) in self.isolate_env() {
+            cmd.env(key, value);
         }
     }
 
@@ -283,6 +310,12 @@ impl E2eWorld {
 
 impl Drop for E2eWorld {
     fn drop(&mut self) {
+        // Kill/reap any interactive TUI child FIRST — before the mock server it
+        // may be talking to stops and before the isolated dir it reads is
+        // removed — so it never outlives the scenario or races teardown.
+        if let Some(tui) = self.tui.take() {
+            drop(tui);
+        }
         if let Some(mock) = self.mock.take() {
             mock.stop();
         }

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -193,11 +193,8 @@ impl Default for E2eWorld {
 
 impl E2eWorld {
     /// The isolation/behaviour environment every spawned `rocm` gets, as owned
-    /// `(key, value)` pairs. One source of truth for both the piped
-    /// `std::process::Command` path (`isolate_cmd`) and the pseudo-terminal path
-    /// (`tui_driver`, whose `portable_pty::CommandBuilder` has its own env API and
-    /// can't take a `std::process::Command`) — so the interactive and
-    /// non-interactive spawns can never drift.
+    /// `(key, value)` pairs. Shared by the piped `std::process::Command` path and
+    /// the pseudo-terminal path; PTY-only isolation is added by [`pty_env`].
     pub fn isolate_env(&self) -> Vec<(&'static str, std::ffi::OsString)> {
         let mut env = Vec::new();
         if let Some(root) = &self.isolated_root {
@@ -205,17 +202,6 @@ impl E2eWorld {
             env.push(("ROCM_CLI_CONFIG_DIR", root.join("config").into_os_string()));
             env.push(("ROCM_CLI_DATA_DIR", root.join("data").into_os_string()));
             env.push(("ROCM_CLI_CACHE_DIR", root.join("cache").into_os_string()));
-            // The dashboard socket default is derived from HOME/XDG rather than
-            // AppPaths, so isolate it too; otherwise a host daemon can answer
-            // the scenario and hide the planted service registry. Create both
-            // directories because some PTY implementations use HOME as the
-            // child's working directory.
-            let home = root.join("home");
-            let runtime = root.join("runtime");
-            std::fs::create_dir_all(&home).expect("failed to create isolated HOME");
-            std::fs::create_dir_all(&runtime).expect("failed to create isolated runtime dir");
-            env.push(("HOME", home.into_os_string()));
-            env.push(("XDG_RUNTIME_DIR", runtime.into_os_string()));
         }
         // Share only STATE-FREE, content-addressed caches across scenarios when
         // CI provides a persistent shared dir (see shared_cache_dir): HF model
@@ -252,6 +238,24 @@ impl E2eWorld {
             env.push(("ROCM_CLI_VLLM_READY_TIMEOUT_SECS", secs.to_string().into()));
         }
         env
+    }
+
+    /// Additional isolation for interactive sessions. The dashboard socket
+    /// default is derived from HOME/XDG rather than the CLI AppPaths, so a PTY
+    /// must not inherit the host daemon's socket location. Piped scenarios keep
+    /// their historical HOME/XDG environment, including GPU/runtime defaults.
+    pub fn pty_env(&self) -> Vec<(&'static str, std::ffi::OsString)> {
+        let Some(root) = &self.isolated_root else {
+            return Vec::new();
+        };
+        let home = root.path().join("home");
+        let runtime = root.path().join("runtime");
+        std::fs::create_dir_all(&home).expect("failed to create isolated HOME");
+        std::fs::create_dir_all(&runtime).expect("failed to create isolated runtime dir");
+        vec![
+            ("HOME", home.into_os_string()),
+            ("XDG_RUNTIME_DIR", runtime.into_os_string()),
+        ]
     }
 
     pub fn isolate_cmd(&self, cmd: &mut std::process::Command) {

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -26,6 +26,25 @@ mod e2e {
 
 // ── World ──────────────────────────────────────────────────────────
 
+/// Managed-service registry fields that vary between black-box scenarios.
+///
+/// The default matches a service that passed its readiness probe. Tests can
+/// override the lifecycle fields without duplicating the on-disk record shape.
+#[derive(Debug, Clone, Copy)]
+pub struct RegisterServiceOptions {
+    pub status: &'static str,
+    pub startup_phase: Option<&'static str>,
+}
+
+impl Default for RegisterServiceOptions {
+    fn default() -> Self {
+        Self {
+            status: "ready",
+            startup_phase: None,
+        }
+    }
+}
+
 #[derive(Debug, cucumber::World)]
 pub struct E2eWorld {
     pub mock: Option<MockServer>,
@@ -186,6 +205,17 @@ impl E2eWorld {
             env.push(("ROCM_CLI_CONFIG_DIR", root.join("config").into_os_string()));
             env.push(("ROCM_CLI_DATA_DIR", root.join("data").into_os_string()));
             env.push(("ROCM_CLI_CACHE_DIR", root.join("cache").into_os_string()));
+            // The dashboard socket default is derived from HOME/XDG rather than
+            // AppPaths, so isolate it too; otherwise a host daemon can answer
+            // the scenario and hide the planted service registry. Create both
+            // directories because some PTY implementations use HOME as the
+            // child's working directory.
+            let home = root.join("home");
+            let runtime = root.join("runtime");
+            std::fs::create_dir_all(&home).expect("failed to create isolated HOME");
+            std::fs::create_dir_all(&runtime).expect("failed to create isolated runtime dir");
+            env.push(("HOME", home.into_os_string()));
+            env.push(("XDG_RUNTIME_DIR", runtime.into_os_string()));
         }
         // Share only STATE-FREE, content-addressed caches across scenarios when
         // CI provides a persistent shared dir (see shared_cache_dir): HF model
@@ -300,11 +330,51 @@ impl E2eWorld {
     /// record is plain JSON matching the CLI's on-disk schema, not a typed import
     /// from the rocm-cli crates.
     pub fn register_mock_service(&self) {
+        self.register_mock_service_with(RegisterServiceOptions::default());
+    }
+
+    pub fn register_mock_service_with(&self, options: RegisterServiceOptions) {
         let root = self.isolated_root.as_ref().expect("no isolated root");
         let mock = self.mock.as_ref().expect("no mock server running");
         let model = self.model_name.as_deref().expect("no model name set");
+        let port = mock.port();
         let services = root.path().join("data").join("services");
-        e2e_cucumber::mock_server::write_service_record(&services, model, mock.port());
+        std::fs::create_dir_all(&services).expect("failed to create services dir");
+
+        // The CLI only extracts host:port from `endpoint_url` and appends
+        // `/v1/models` for its readiness probe, which the mock serves.
+        let record = serde_json::json!({
+            "service_id": "e2e-mock",
+            "engine": "vllm",
+            "model_ref": model,
+            "canonical_model_id": model,
+            "host": "127.0.0.1",
+            "port": port,
+            "endpoint_url": format!("http://127.0.0.1:{port}/v1"),
+            "mode": "managed",
+            "status": options.status,
+            "startup_phase": options.startup_phase,
+            // Keep the planted record live when the CLI overlays process
+            // liveness during startup; this test process owns the mock server.
+            "supervisor_pid": std::process::id(),
+            "engine_pid": std::process::id(),
+            "runtime_id": null,
+            "env_id": null,
+            "device_policy": null,
+            "gpu_indices": [],
+            "engine_recipe_json": null,
+            "restart_count": 0,
+            "last_restart_unix_ms": null,
+            "manifest_path": services.join("e2e-mock.json"),
+            "log_path": services.join("e2e-mock.log"),
+            "engine_state_path": services.join("e2e-mock.state.json"),
+            "created_at_unix_ms": 1_700_000_000_000_u64,
+        });
+        std::fs::write(
+            services.join("e2e-mock.json"),
+            serde_json::to_vec_pretty(&record).expect("failed to serialize record"),
+        )
+        .expect("failed to write service record");
     }
 }
 

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -11,7 +11,7 @@
 use std::path::PathBuf;
 
 use cucumber::{World as _, WriterExt as _};
-use e2e_cucumber::mock_server::MockServer;
+use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions, write_service_record_with};
 use tempfile::TempDir;
 
 mod e2e {
@@ -25,25 +25,6 @@ mod e2e {
 }
 
 // ── World ──────────────────────────────────────────────────────────
-
-/// Managed-service registry fields that vary between black-box scenarios.
-///
-/// The default matches a service that passed its readiness probe. Tests can
-/// override the lifecycle fields without duplicating the on-disk record shape.
-#[derive(Debug, Clone, Copy)]
-pub struct RegisterServiceOptions {
-    pub status: &'static str,
-    pub startup_phase: Option<&'static str>,
-}
-
-impl Default for RegisterServiceOptions {
-    fn default() -> Self {
-        Self {
-            status: "ready",
-            startup_phase: None,
-        }
-    }
-}
 
 #[derive(Debug, cucumber::World)]
 pub struct E2eWorld {
@@ -332,53 +313,30 @@ impl E2eWorld {
     /// `local` chat provider discover the mock — so scenarios exercise the real
     /// binary instead of asserting against the test's own helper. Black-box: the
     /// record is plain JSON matching the CLI's on-disk schema, not a typed import
-    /// from the rocm-cli crates.
+    /// from the rocm-cli crates. The schema itself lives in
+    /// `mock_server::write_service_record_with`; this only supplies the World's
+    /// own lifecycle defaults (a record kept alive by this test process).
     pub fn register_mock_service(&self) {
-        self.register_mock_service_with(RegisterServiceOptions::default());
+        self.register_mock_service_with(ServiceRecordOptions::default());
     }
 
-    pub fn register_mock_service_with(&self, options: RegisterServiceOptions) {
+    pub fn register_mock_service_with(&self, options: ServiceRecordOptions) {
         let root = self.isolated_root.as_ref().expect("no isolated root");
         let mock = self.mock.as_ref().expect("no mock server running");
         let model = self.model_name.as_deref().expect("no model name set");
         let port = mock.port();
         let services = root.path().join("data").join("services");
-        std::fs::create_dir_all(&services).expect("failed to create services dir");
 
-        // The CLI only extracts host:port from `endpoint_url` and appends
-        // `/v1/models` for its readiness probe, which the mock serves.
-        let record = serde_json::json!({
-            "service_id": "e2e-mock",
-            "engine": "vllm",
-            "model_ref": model,
-            "canonical_model_id": model,
-            "host": "127.0.0.1",
-            "port": port,
-            "endpoint_url": format!("http://127.0.0.1:{port}/v1"),
-            "mode": "managed",
-            "status": options.status,
-            "startup_phase": options.startup_phase,
-            // Keep the planted record live when the CLI overlays process
-            // liveness during startup; this test process owns the mock server.
-            "supervisor_pid": std::process::id(),
-            "engine_pid": std::process::id(),
-            "runtime_id": null,
-            "env_id": null,
-            "device_policy": null,
-            "gpu_indices": [],
-            "engine_recipe_json": null,
-            "restart_count": 0,
-            "last_restart_unix_ms": null,
-            "manifest_path": services.join("e2e-mock.json"),
-            "log_path": services.join("e2e-mock.log"),
-            "engine_state_path": services.join("e2e-mock.state.json"),
-            "created_at_unix_ms": 1_700_000_000_000_u64,
-        });
-        std::fs::write(
-            services.join("e2e-mock.json"),
-            serde_json::to_vec_pretty(&record).expect("failed to serialize record"),
-        )
-        .expect("failed to write service record");
+        // Keep the planted record live when the CLI overlays process liveness
+        // during startup; this test process owns the mock server. Overrides
+        // whatever PIDs the caller passed in `options` — the World always wants
+        // a live-looking record, unlike `rocm-demo-env`'s supervisor-less one.
+        let options = ServiceRecordOptions {
+            supervisor_pid: std::process::id(),
+            engine_pid: Some(std::process::id()),
+            ..options
+        };
+        write_service_record_with(&services, model, port, options);
     }
 }
 

--- a/tests/e2e-cucumber/tests/e2e/chat_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/chat_steps.rs
@@ -35,9 +35,6 @@ async fn user_checks_services(world: &mut E2eWorld) {
     world.cli_output = Some(stdout);
 }
 
-#[when("the user is offered the detected endpoint")]
-async fn user_offered_endpoint(_world: &mut E2eWorld) {}
-
 #[when("a chat request with tool definitions is sent")]
 async fn send_chat_with_tools(world: &mut E2eWorld) {
     let endpoint = world.endpoint.as_ref().expect("no endpoint configured");
@@ -140,20 +137,6 @@ async fn assert_model_endpoint_listed(world: &mut E2eWorld) {
     assert!(
         output.contains(&port.to_string()),
         "served model endpoint (port {port}) not found in services list:\n{output}"
-    );
-}
-
-#[then("the notice does not claim that requests leave the machine")]
-async fn assert_privacy_notice_accurate(_world: &mut E2eWorld) {
-    // The privacy notice is only shown in the interactive dash/TUI, which a
-    // black-box CLI test can't drive — so this behaviour genuinely cannot be
-    // verified here (EAI-7222). Rather than pass silently (a green no-op that
-    // tests nothing), fail: the scenario is marked xfail in expectations.toml
-    // with EAI-7222, so this failure is the *expected* outcome and the gap stays
-    // visible until the notice is exposed on a non-TUI surface.
-    panic!(
-        "privacy notice is TUI-only and cannot be verified black-box (EAI-7222); \
-         scenario is tracked as xfail"
     );
 }
 

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -8,10 +8,15 @@
 //! screen, and clean exit — which the piped-`Command` steps structurally cannot.
 
 use cucumber::{given, then, when};
-use e2e_cucumber::mock_server::MockServer;
+use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions};
 
+use crate::E2eWorld;
 use crate::e2e::tui_driver::{DEFAULT_TIMEOUT, TuiSession};
-use crate::{E2eWorld, RegisterServiceOptions};
+
+/// The exact prompt `send_managed_model_message` types, and the string the
+/// corresponding `Then` step (`managed_chat_request_carried_prompt`) asserts
+/// the mock actually received — so the two can never silently drift apart.
+const MANAGED_MODEL_PROMPT: &str = "hello from the terminal";
 
 /// Borrow the scenario's active TUI session, or fail clearly if none was opened.
 const fn session(world: &mut E2eWorld) -> &mut TuiSession {
@@ -33,7 +38,7 @@ async fn chat_offline(world: &mut E2eWorld) {
 
 async fn setup_managed_model(
     world: &mut E2eWorld,
-    options: RegisterServiceOptions,
+    options: ServiceRecordOptions,
     with_metrics: bool,
 ) {
     let model = "TestModel/E2E-1B";
@@ -52,9 +57,10 @@ async fn setup_managed_model(
 async fn managed_model_loading(world: &mut E2eWorld) {
     setup_managed_model(
         world,
-        RegisterServiceOptions {
+        ServiceRecordOptions {
             status: "starting",
             startup_phase: Some("loading"),
+            ..ServiceRecordOptions::default()
         },
         false,
     )
@@ -63,12 +69,12 @@ async fn managed_model_loading(world: &mut E2eWorld) {
 
 #[given("a managed model exposes serving metrics")]
 async fn managed_model_with_metrics(world: &mut E2eWorld) {
-    setup_managed_model(world, RegisterServiceOptions::default(), true).await;
+    setup_managed_model(world, ServiceRecordOptions::default(), true).await;
 }
 
 #[given("a running managed model is available locally")]
 async fn running_managed_model(world: &mut E2eWorld) {
-    setup_managed_model(world, RegisterServiceOptions::default(), false).await;
+    setup_managed_model(world, ServiceRecordOptions::default(), false).await;
 }
 
 // ── When ───────────────────────────────────────────────────────────
@@ -167,9 +173,11 @@ async fn send_managed_model_message(world: &mut E2eWorld) {
     tui.wait_for_screen("No messages yet.", DEFAULT_TIMEOUT)
         .await
         .unwrap_or_else(|e| panic!("chat surface never became ready: {e}"));
-    tui.send("i")
-        .unwrap_or_else(|e| panic!("failed to focus the chat input: {e}"));
-    tui.send("hello from the terminal")
+    // No `i` here: accepting local-endpoint consent (`accept_chat_consent`) already
+    // focused the input, so an extra `i` would be typed as a literal character
+    // instead of a focus gesture (contrast the offline path in
+    // `send_gpu_message`, whose `--chat-mock` consent does not focus the input).
+    tui.send(MANAGED_MODEL_PROMPT)
         .unwrap_or_else(|e| panic!("failed to type the chat message: {e}"));
     tui.send("\r")
         .unwrap_or_else(|e| panic!("failed to submit the chat message: {e}"));
@@ -248,6 +256,39 @@ async fn managed_model_response_displayed(world: &mut E2eWorld) {
         .wait_for_screen("mock response for testing", DEFAULT_TIMEOUT)
         .await
         .unwrap_or_else(|e| panic!("the managed model's response did not appear: {e}"));
+}
+
+#[then("the mock received the typed prompt")]
+async fn managed_chat_request_carried_prompt(world: &mut E2eWorld) {
+    // The canned reply above is fixed regardless of what was sent, so it alone
+    // can't prove the TUI actually submitted `MANAGED_MODEL_PROMPT` (a stray
+    // keystroke corrupting the prompt would still show that reply). Assert on
+    // the request the mock actually received instead. `wait_for_chat_request`
+    // polls rather than reading a single snapshot: the response already
+    // rendering on screen only proves the reply arrived, not that the mock's
+    // handler finished recording the request into shared state first.
+    let body = world
+        .mock
+        .as_ref()
+        .expect("no mock server running")
+        .wait_for_chat_request(DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the mock never received a chat request: {e}"));
+    let messages = body
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("chat request had no messages array:\n{body}"));
+    let last_user_content = messages
+        .iter()
+        .rev()
+        .find(|m| m.get("role").and_then(serde_json::Value::as_str) == Some("user"))
+        .and_then(|m| m.get("content"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("no user message found in chat request:\n{body}"));
+    assert_eq!(
+        last_user_content, MANAGED_MODEL_PROMPT,
+        "mock did not receive the exact typed prompt; full request:\n{body}"
+    );
 }
 
 #[then("the managed model is shown as loading rather than ready")]
@@ -363,7 +404,7 @@ async fn interactive_chat_exited(world: &mut E2eWorld) {
     assert_tui_opened(world);
 }
 
-// ── Then: chat privacy consent gate (real endpoint, EAI-7222) ──────
+// ── Then: chat privacy consent gate (real endpoint) ──
 
 #[then("the local endpoint is shown for confirmation")]
 async fn local_endpoint_shown(world: &mut E2eWorld) {

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -103,6 +103,8 @@ async fn open_dashboard(world: &mut E2eWorld) {
 
 #[when("the user opens the ROCm view")]
 async fn open_rocm_view(world: &mut E2eWorld) {
+    // Dashboard tabs are currently ordered Home, ROCm, Serving, Observe; these
+    // numeric shortcuts intentionally exercise that user-visible ordering.
     session(world)
         .send("2")
         .unwrap_or_else(|e| panic!("failed to switch to the ROCm tab: {e}"));
@@ -141,6 +143,8 @@ async fn open_command_palette(world: &mut E2eWorld) {
 #[when("the user chooses Serving")]
 async fn choose_serving(world: &mut E2eWorld) {
     let tui = session(world);
+    // The palette initially selects Home; Serving is the third destination, so
+    // two downward moves intentionally assert the current destination ordering.
     tui.send("jj")
         .unwrap_or_else(|e| panic!("failed to select Serving: {e}"));
     tui.send("\r")

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -8,9 +8,10 @@
 //! screen, and clean exit — which the piped-`Command` steps structurally cannot.
 
 use cucumber::{given, then, when};
+use e2e_cucumber::mock_server::MockServer;
 
-use crate::E2eWorld;
 use crate::e2e::tui_driver::{DEFAULT_TIMEOUT, TuiSession};
+use crate::{E2eWorld, RegisterServiceOptions};
 
 /// Borrow the scenario's active TUI session, or fail clearly if none was opened.
 const fn session(world: &mut E2eWorld) -> &mut TuiSession {
@@ -28,6 +29,46 @@ async fn chat_offline(world: &mut E2eWorld) {
     // pre-accepted and a fixed reply is returned, so the journey needs no live
     // model or network. The launch step reads this flag.
     world.chat_use_mock = true;
+}
+
+async fn setup_managed_model(
+    world: &mut E2eWorld,
+    options: RegisterServiceOptions,
+    with_metrics: bool,
+) {
+    let model = "TestModel/E2E-1B";
+    let mock = if with_metrics {
+        MockServer::start_with_metrics(model).await
+    } else {
+        MockServer::start(model).await
+    };
+    world.endpoint = Some(mock.base_url());
+    world.model_name = Some(model.to_string());
+    world.mock = Some(mock);
+    world.register_mock_service_with(options);
+}
+
+#[given("a managed model is still loading")]
+async fn managed_model_loading(world: &mut E2eWorld) {
+    setup_managed_model(
+        world,
+        RegisterServiceOptions {
+            status: "starting",
+            startup_phase: Some("loading"),
+        },
+        false,
+    )
+    .await;
+}
+
+#[given("a managed model exposes serving metrics")]
+async fn managed_model_with_metrics(world: &mut E2eWorld) {
+    setup_managed_model(world, RegisterServiceOptions::default(), true).await;
+}
+
+#[given("a running managed model is available locally")]
+async fn running_managed_model(world: &mut E2eWorld) {
+    setup_managed_model(world, RegisterServiceOptions::default(), false).await;
 }
 
 // ── When ───────────────────────────────────────────────────────────
@@ -53,11 +94,81 @@ async fn open_chat(world: &mut E2eWorld) {
     world.tui = Some(session);
 }
 
+#[when("the user opens the dashboard")]
+async fn open_dashboard(world: &mut E2eWorld) {
+    let tui = TuiSession::spawn(world, &["dash"])
+        .unwrap_or_else(|e| panic!("failed to open the dashboard: {e}"));
+    world.tui = Some(tui);
+}
+
 #[when("the user opens the ROCm view")]
 async fn open_rocm_view(world: &mut E2eWorld) {
     session(world)
         .send("2")
         .unwrap_or_else(|e| panic!("failed to switch to the ROCm tab: {e}"));
+}
+
+#[when("the user opens the Observe view")]
+async fn open_observe_view(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.use_detail_size()
+        .unwrap_or_else(|e| panic!("failed to enlarge the dashboard: {e}"));
+    tui.send("4")
+        .unwrap_or_else(|e| panic!("failed to switch to the Observe tab: {e}"));
+}
+
+#[when("the user opens dashboard help")]
+async fn open_dashboard_help(world: &mut E2eWorld) {
+    session(world)
+        .send("?")
+        .unwrap_or_else(|e| panic!("failed to open dashboard help: {e}"));
+}
+
+#[when("the user closes dashboard help")]
+async fn close_dashboard_help(world: &mut E2eWorld) {
+    session(world)
+        .send("?")
+        .unwrap_or_else(|e| panic!("failed to close dashboard help: {e}"));
+}
+
+#[when("the user opens the command palette")]
+async fn open_command_palette(world: &mut E2eWorld) {
+    session(world)
+        .send(":")
+        .unwrap_or_else(|e| panic!("failed to open the command palette: {e}"));
+}
+
+#[when("the user chooses Serving")]
+async fn choose_serving(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.send("jj")
+        .unwrap_or_else(|e| panic!("failed to select Serving: {e}"));
+    tui.send("\r")
+        .unwrap_or_else(|e| panic!("failed to open Serving: {e}"));
+}
+
+#[when("the user accepts the local endpoint")]
+async fn accept_local_endpoint(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.wait_for_screen("Your request only leaves this machine", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("local endpoint consent did not appear: {e}"));
+    tui.send("y")
+        .unwrap_or_else(|e| panic!("failed to accept local endpoint: {e}"));
+}
+
+#[when("the user sends a message to the managed model")]
+async fn send_managed_model_message(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.wait_for_screen("No messages yet.", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("chat surface never became ready: {e}"));
+    tui.send("i")
+        .unwrap_or_else(|e| panic!("failed to focus the chat input: {e}"));
+    tui.send("hello from the terminal")
+        .unwrap_or_else(|e| panic!("failed to type the chat message: {e}"));
+    tui.send("\r")
+        .unwrap_or_else(|e| panic!("failed to submit the chat message: {e}"));
 }
 
 #[when("the user sends a message about GPU health")]
@@ -77,12 +188,21 @@ async fn send_gpu_message(world: &mut E2eWorld) {
         .unwrap_or_else(|e| panic!("failed to submit the chat message: {e}"));
 }
 
-#[when("the user quits the dashboard")]
-async fn quit_dashboard(world: &mut E2eWorld) {
+async fn quit_tui(world: &mut E2eWorld, surface: &str) {
     session(world)
         .quit_and_wait(DEFAULT_TIMEOUT)
         .await
-        .unwrap_or_else(|e| panic!("the dashboard did not exit cleanly: {e}"));
+        .unwrap_or_else(|e| panic!("{surface} did not exit cleanly: {e}"));
+}
+
+#[when("the user quits the dashboard")]
+async fn quit_dashboard(world: &mut E2eWorld) {
+    quit_tui(world, "the dashboard").await;
+}
+
+#[when("the user quits interactive chat")]
+async fn quit_interactive_chat(world: &mut E2eWorld) {
+    quit_tui(world, "interactive chat").await;
 }
 
 // ── Then ───────────────────────────────────────────────────────────
@@ -118,8 +238,108 @@ async fn gpu_response_displayed(world: &mut E2eWorld) {
         .unwrap_or_else(|e| panic!("the assistant's response did not appear: {e}"));
 }
 
-#[then("the dashboard exits successfully")]
-async fn dashboard_exited(world: &mut E2eWorld) {
+#[then("the managed model's response is displayed")]
+async fn managed_model_response_displayed(world: &mut E2eWorld) {
+    session(world)
+        .wait_for_screen("mock response for testing", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the managed model's response did not appear: {e}"));
+}
+
+#[then("the managed model is shown as loading rather than ready")]
+async fn managed_model_shown_loading(world: &mut E2eWorld) {
+    let model = world.model_name.clone().expect("no model name set");
+    let tui = session(world);
+    tui.wait_for_screen(&model, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the managed model did not appear: {e}"));
+    // The compact Observe table intentionally omits lifecycle status; opening
+    // the selected instance exposes the status a user uses to diagnose startup.
+    tui.send("\r")
+        .unwrap_or_else(|e| panic!("failed to open instance details: {e}"));
+    tui.wait_for_screen("LOADING", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the loading state did not appear: {e}"));
+    let screen = tui.screen_text();
+    assert!(screen.contains(&model), "managed model missing:\n{screen}");
+    assert!(
+        !screen
+            .lines()
+            .any(|line| line.contains(&model) && line.contains("READY")),
+        "loading model was presented as ready:\n{screen}"
+    );
+}
+
+#[then("live serving metrics are displayed for the managed model")]
+async fn managed_model_metrics_displayed(world: &mut E2eWorld) {
+    let model = world.model_name.clone().expect("no model name set");
+    let tui = session(world);
+    tui.wait_for_screen(&model, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the managed model did not appear: {e}"));
+    tui.wait_for_screen("50ms", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("TTFT metrics did not appear: {e}"));
+    let screen = tui.screen_text();
+    assert!(screen.contains("20ms"), "TPOT metrics missing:\n{screen}");
+    let row = screen
+        .lines()
+        .find(|line| line.contains(&model))
+        .unwrap_or_default();
+    assert!(
+        row.contains("50ms") && row.contains("20ms") && row.contains("1/0") && row.contains("25%"),
+        "managed serving metrics were incomplete:\n{screen}"
+    );
+}
+
+#[then("navigation and next-step guidance are displayed")]
+async fn navigation_guidance_displayed(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.wait_for_screen("toggle this help", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("dashboard help did not appear: {e}"));
+    let screen = tui.screen_text();
+    assert!(
+        screen.contains("next / previous tab") && screen.contains("Home tab"),
+        "navigation or contextual guidance missing:\n{screen}"
+    );
+}
+
+#[then("dashboard destinations are displayed")]
+async fn dashboard_destinations_displayed(world: &mut E2eWorld) {
+    let tui = session(world);
+    tui.wait_for_screen("Go to", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("command palette did not appear: {e}"));
+    let screen = tui.screen_text();
+    assert!(
+        screen.contains("Home") && screen.contains("Serving") && screen.contains("Observe"),
+        "command-palette destinations missing:\n{screen}"
+    );
+}
+
+#[then("Serving actions are displayed")]
+async fn serving_actions_displayed(world: &mut E2eWorld) {
+    session(world)
+        .wait_for_screen("Serving actions", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("Serving actions did not appear: {e}"));
+}
+
+#[then("the managed model is displayed")]
+async fn managed_model_displayed(world: &mut E2eWorld) {
+    let model = world
+        .model_name
+        .as_deref()
+        .expect("no model name set")
+        .to_string();
+    session(world)
+        .wait_for_screen(&model, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("managed model did not appear: {e}"));
+}
+
+fn assert_tui_opened(world: &E2eWorld) {
     // `quit_and_wait` (in the "quits" step) already reaped the process and
     // asserted a zero exit; reaching here means the whole launch→interact→quit
     // round trip through the real terminal succeeded.
@@ -127,6 +347,16 @@ async fn dashboard_exited(world: &mut E2eWorld) {
         world.tui.is_some(),
         "no TUI session was opened for this scenario"
     );
+}
+
+#[then("the dashboard exits successfully")]
+async fn dashboard_exited(world: &mut E2eWorld) {
+    assert_tui_opened(world);
+}
+
+#[then("interactive chat exits successfully")]
+async fn interactive_chat_exited(world: &mut E2eWorld) {
+    assert_tui_opened(world);
 }
 
 // ── Then: chat privacy consent gate (real endpoint, EAI-7222) ──────

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -1,0 +1,162 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Steps for the interactive dashboard/chat TUI, driven black-box through a
+//! pseudo-terminal (see `tui_driver`). These are the only steps that exercise
+//! the real crossterm event loop end to end — launch, key input, rendered
+//! screen, and clean exit — which the piped-`Command` steps structurally cannot.
+
+use cucumber::{given, then, when};
+
+use crate::E2eWorld;
+use crate::e2e::tui_driver::{DEFAULT_TIMEOUT, TuiSession};
+
+/// Borrow the scenario's active TUI session, or fail clearly if none was opened.
+const fn session(world: &mut E2eWorld) -> &mut TuiSession {
+    world
+        .tui
+        .as_mut()
+        .expect("no interactive TUI session is open for this scenario")
+}
+
+// ── Given ──────────────────────────────────────────────────────────
+
+#[given("interactive chat uses an offline assistant")]
+async fn chat_offline(world: &mut E2eWorld) {
+    // The offline assistant is the CLI's own `--chat-mock` backend: consent is
+    // pre-accepted and a fixed reply is returned, so the journey needs no live
+    // model or network. The launch step reads this flag.
+    world.chat_use_mock = true;
+}
+
+// ── When ───────────────────────────────────────────────────────────
+
+#[when("the user opens the dashboard with demo data")]
+async fn open_dashboard_demo(world: &mut E2eWorld) {
+    // `--demo` replays a deterministic synthetic session, so the dashboard
+    // populates with no GPU and no daemon — a stable, mock-tier target.
+    let session = TuiSession::spawn(world, &["dash", "--demo"])
+        .unwrap_or_else(|e| panic!("failed to open the dashboard: {e}"));
+    world.tui = Some(session);
+}
+
+#[when("the user opens interactive chat")]
+async fn open_chat(world: &mut E2eWorld) {
+    let args: &[&str] = if world.chat_use_mock {
+        &["chat", "--chat-mock"]
+    } else {
+        &["chat"]
+    };
+    let session = TuiSession::spawn(world, args)
+        .unwrap_or_else(|e| panic!("failed to open interactive chat: {e}"));
+    world.tui = Some(session);
+}
+
+#[when("the user opens the ROCm view")]
+async fn open_rocm_view(world: &mut E2eWorld) {
+    session(world)
+        .send("2")
+        .unwrap_or_else(|e| panic!("failed to switch to the ROCm tab: {e}"));
+}
+
+#[when("the user sends a message about GPU health")]
+async fn send_gpu_message(world: &mut E2eWorld) {
+    let tui = session(world);
+    // Wait for the accepted, empty chat surface before typing so the input is
+    // ready to receive focus.
+    tui.wait_for_screen("No messages yet.", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("chat surface never became ready: {e}"));
+    // `i` focuses the input; then the message, then Enter to submit.
+    tui.send("i")
+        .unwrap_or_else(|e| panic!("failed to focus the chat input: {e}"));
+    tui.send("how is gpu-2 doing")
+        .unwrap_or_else(|e| panic!("failed to type the chat message: {e}"));
+    tui.send("\r")
+        .unwrap_or_else(|e| panic!("failed to submit the chat message: {e}"));
+}
+
+#[when("the user quits the dashboard")]
+async fn quit_dashboard(world: &mut E2eWorld) {
+    session(world)
+        .quit_and_wait(DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the dashboard did not exit cleanly: {e}"));
+}
+
+// ── Then ───────────────────────────────────────────────────────────
+
+#[then("the dashboard home view is displayed")]
+async fn home_view_displayed(world: &mut E2eWorld) {
+    let tui = session(world);
+    // The Home tab's summary cards (Running / Health / Updates) are drawn at any
+    // size; the wider "GPU UTILIZATION" hero is not, so assert on the cards.
+    tui.wait_for_screen("Updates", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the home view did not appear: {e}"));
+    let screen = tui.screen_text();
+    assert!(
+        screen.contains("Running") && screen.contains("Health"),
+        "home summary cards missing:\n{screen}"
+    );
+}
+
+#[then("ROCm setup actions are displayed")]
+async fn rocm_actions_displayed(world: &mut E2eWorld) {
+    session(world)
+        .wait_for_screen("Set up / Install ROCm", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the ROCm setup actions did not appear: {e}"));
+}
+
+#[then("the assistant's GPU status response is displayed")]
+async fn gpu_response_displayed(world: &mut E2eWorld) {
+    session(world)
+        .wait_for_screen("GPU-2 is running hot", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the assistant's response did not appear: {e}"));
+}
+
+#[then("the dashboard exits successfully")]
+async fn dashboard_exited(world: &mut E2eWorld) {
+    // `quit_and_wait` (in the "quits" step) already reaped the process and
+    // asserted a zero exit; reaching here means the whole launch→interact→quit
+    // round trip through the real terminal succeeded.
+    assert!(
+        world.tui.is_some(),
+        "no TUI session was opened for this scenario"
+    );
+}
+
+// ── Then: chat privacy consent gate (real endpoint, EAI-7222) ──────
+
+#[then("the local endpoint is shown for confirmation")]
+async fn local_endpoint_shown(world: &mut E2eWorld) {
+    // The consent gate echoes the detected endpoint; its port is the mock's
+    // OS-assigned one, proving the CLI discovered the planted managed service
+    // (not a hard-coded default) before offering it.
+    let port = world
+        .mock
+        .as_ref()
+        .expect("no mock server running")
+        .port()
+        .to_string();
+    session(world)
+        .wait_for_screen(&port, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| panic!("the detected endpoint was not shown: {e}"));
+}
+
+#[then("the privacy notice is shown before any message is sent")]
+async fn privacy_notice_shown(world: &mut E2eWorld) {
+    // The gate is reached before any message can be submitted, so seeing this
+    // line proves the notice precedes the first request.
+    session(world)
+        .wait_for_screen(
+            "Your request only leaves this machine after you accept.",
+            DEFAULT_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("the privacy notice was not shown: {e}"));
+}

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -36,6 +36,10 @@ use crate::E2eWorld;
 /// terminal.
 const ROWS: u16 = 24;
 const COLS: u16 = 80;
+/// Taller geometry for journeys that assert rows below the dashboard's summary
+/// cards (managed instances and live serving metrics).
+const DETAIL_ROWS: u16 = 40;
+const DETAIL_COLS: u16 = 120;
 
 /// How often `wait_for_*` re-checks the screen/process while waiting. This is a
 /// poll cadence, not a fixed readiness sleep: every wait has a deadline and
@@ -57,7 +61,7 @@ pub struct TuiSession {
     reader: Option<JoinHandle<()>>,
     /// Kept alive for the lifetime of the session: the reader/writer are cloned
     /// from it, and dropping it early would close the PTY.
-    _master: Box<dyn MasterPty + Send>,
+    master: Box<dyn MasterPty + Send>,
     /// `true` once the child has been reaped, so `Drop` doesn't kill/wait twice.
     finished: bool,
     /// Guards a single coverage record per session.
@@ -140,7 +144,7 @@ impl TuiSession {
             parser,
             reader_stop,
             reader: Some(reader),
-            _master: pair.master,
+            master: pair.master,
             finished: false,
             recorded: false,
             is_chat: args.first() == Some(&"chat"),
@@ -157,6 +161,27 @@ impl TuiSession {
             .lock()
             .map(|p| p.screen().contents())
             .unwrap_or_default()
+    }
+
+    /// Resize both the real PTY and the emulated screen. The application receives
+    /// the normal terminal resize event; assertions continue to inspect exactly
+    /// what a user would see at the new geometry.
+    pub fn use_detail_size(&mut self) -> Result<(), String> {
+        let size = PtySize {
+            rows: DETAIL_ROWS,
+            cols: DETAIL_COLS,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        self.master
+            .resize(size)
+            .map_err(|e| format!("failed to resize pty: {e}"))?;
+        self.parser
+            .lock()
+            .map_err(|_| "failed to lock vt100 parser".to_string())?
+            .screen_mut()
+            .set_size(DETAIL_ROWS, DETAIL_COLS);
+        Ok(())
     }
 
     /// Write raw bytes to the terminal (keystrokes/text). `Enter` is `"\r"`.

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -45,6 +45,9 @@ const DETAIL_COLS: u16 = 120;
 /// poll cadence, not a fixed readiness sleep: every wait has a deadline and
 /// returns the instant its condition holds.
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// Maximum time to let the PTY reader consume the child's final frame after the
+/// process exits. This is bounded so a misbehaving PTY cannot stall a scenario.
+const DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Default wall-clock budget for a single wait. Generous enough for a cold dash
 /// start plus the embedded-daemon connect, while still turning a genuine hang
@@ -108,7 +111,7 @@ impl TuiSession {
         for (key, value) in std::env::vars_os() {
             cmd.env(key, value);
         }
-        for (key, value) in world.isolate_env() {
+        for (key, value) in world.isolate_env().into_iter().chain(world.pty_env()) {
             cmd.env(key, value);
         }
         // Deterministic terminal type; the PTY ioctl size above is authoritative
@@ -157,10 +160,19 @@ impl TuiSession {
     /// already resolved escape sequences and styling into cells, so this is
     /// exactly what a user sees — color/attribute independent.
     pub fn screen_text(&self) -> String {
+        self.screen_snapshot().0
+    }
+
+    fn screen_snapshot(&self) -> (String, (u16, u16)) {
         self.parser
             .lock()
-            .map(|p| p.screen().contents())
+            .map(|p| (p.screen().contents(), p.screen().size()))
             .unwrap_or_default()
+    }
+
+    fn framed_screen(&self) -> String {
+        let (screen, (rows, cols)) = self.screen_snapshot();
+        format!("--- last screen ({cols}x{rows}) ---\n{screen}\n--- end screen ---")
     }
 
     /// Resize both the real PTY and the emulated screen. The application receives
@@ -201,24 +213,41 @@ impl TuiSession {
             if self.screen_text().contains(marker) {
                 return Ok(());
             }
-            // If the process is gone, give the reader a beat to drain any final
-            // bytes, then check once more before declaring failure.
+            // If the process is gone, let the reader drain the final frame for a
+            // short bounded window. A single poll is not enough when a large frame
+            // is still buffered behind the process exit notification.
             if let Ok(Some(status)) = self.child.try_wait() {
                 self.finished = true;
-                tokio::time::sleep(POLL_INTERVAL).await;
-                let screen = self.screen_text();
-                if screen.contains(marker) {
+                self.record_once(i32::try_from(status.exit_code()).unwrap_or(-1));
+                let drain_deadline = Instant::now() + DRAIN_TIMEOUT;
+                while Instant::now() < drain_deadline {
+                    if self.screen_text().contains(marker) {
+                        return Ok(());
+                    }
+                    if self
+                        .reader
+                        .as_ref()
+                        .is_some_and(std::thread::JoinHandle::is_finished)
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
+                // Final check after the drain window closes: the reader may have
+                // committed the last frame between the loop's screen check and the
+                // `is_finished`/deadline exit, so re-read before declaring failure.
+                if self.screen_text().contains(marker) {
                     return Ok(());
                 }
                 return Err(format!(
                     "process exited ({status:?}) before {marker:?} appeared.\n{}",
-                    framed_screen(&screen)
+                    self.framed_screen()
                 ));
             }
             if Instant::now() >= deadline {
                 return Err(format!(
                     "timed out after {timeout:?} waiting for {marker:?}.\n{}",
-                    framed_screen(&self.screen_text())
+                    self.framed_screen()
                 ));
             }
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -250,7 +279,7 @@ impl TuiSession {
                     } else {
                         Err(format!(
                             "TUI exited unsuccessfully ({status:?}).\n{}",
-                            framed_screen(&self.screen_text())
+                            self.framed_screen()
                         ))
                     };
                 }
@@ -260,7 +289,7 @@ impl TuiSession {
             if Instant::now() >= deadline {
                 return Err(format!(
                     "timed out after {timeout:?} waiting for the TUI to exit.\n{}",
-                    framed_screen(&self.screen_text())
+                    self.framed_screen()
                 ));
             }
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -288,8 +317,14 @@ impl Drop for TuiSession {
         // without an explicit quit (e.g. the consent-gate scenarios).
         if !self.finished {
             let _ = self.child.kill();
-            let _ = self.child.wait();
+            let rc = self
+                .child
+                .wait()
+                .ok()
+                .and_then(|status| i32::try_from(status.exit_code()).ok())
+                .unwrap_or(-1);
             self.finished = true;
+            self.record_once(rc);
         }
         self.reader_stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.reader.take() {
@@ -326,9 +361,4 @@ fn spawn_reader(
             }
         }
     })
-}
-
-/// Wrap a screen dump in delimiters so failure messages are easy to read.
-fn framed_screen(screen: &str) -> String {
-    format!("--- last screen ({COLS}x{ROWS}) ---\n{screen}\n--- end screen ---")
 }

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -140,7 +140,7 @@ impl TuiSession {
         cmd.env("COLUMNS", COLS.to_string());
         cmd.env("LINES", ROWS.to_string());
 
-        let child = pair
+        let mut child = pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| format!("failed to spawn rocm under a pty: {e}"))?;
@@ -148,14 +148,21 @@ impl TuiSession {
         // would prevent the reader from seeing EOF when the child exits.
         drop(pair.slave);
 
+        // `Child` does not kill the process on drop. Reap it if either remaining
+        // fallible setup step fails before `TuiSession` takes ownership.
+        let mut reap_orphan = |error: String| -> String {
+            let _ = child.kill();
+            let _ = child.wait();
+            error
+        };
         let reader = pair
             .master
             .try_clone_reader()
-            .map_err(|e| format!("failed to clone pty reader: {e}"))?;
+            .map_err(|e| reap_orphan(format!("failed to clone pty reader: {e}")))?;
         let writer = pair
             .master
             .take_writer()
-            .map_err(|e| format!("failed to take pty writer: {e}"))?;
+            .map_err(|e| reap_orphan(format!("failed to take pty writer: {e}")))?;
 
         let parser = Arc::new(Mutex::new(vt100::Parser::new(ROWS, COLS, 0)));
         let reader_stop = Arc::new(AtomicBool::new(false));

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -1,0 +1,309 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Black-box driver for the interactive dash/chat TUI.
+//!
+//! The rest of the suite spawns `rocm` with piped stdin/stdout via
+//! `std::process::Command`. That can never exercise the interactive dashboard:
+//! the CLI only enters the crossterm raw-mode event loop when both stdin and
+//! stdout are a real terminal (`rocm_core::interactive_terminal`), and a pipe is
+//! not. So the dash was previously "untestable black-box" (e.g. the chat privacy
+//! notice, EAI-7222) and only had in-process render tests.
+//!
+//! This driver closes that gap the way a user's terminal does: it spawns the
+//! real binary under a pseudo-terminal (`portable-pty`), feeds keystrokes to the
+//! master side, and parses the emitted byte stream into an emulated screen grid
+//! (`vt100`). Assertions read the *current visible screen* — the same thing a
+//! user sees — never the raw output transcript, so stale/erased frames or partial
+//! escape sequences can't cause false matches.
+//!
+//! It stays black-box: it drives the compiled binary and reads its terminal
+//! output, importing nothing from the product crates.
+
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+use crate::E2eWorld;
+
+/// Fixed terminal geometry. Pinning the size keeps layout (and therefore the
+/// text we assert on) deterministic across hosts, independent of the ambient
+/// terminal.
+const ROWS: u16 = 24;
+const COLS: u16 = 80;
+
+/// How often `wait_for_*` re-checks the screen/process while waiting. This is a
+/// poll cadence, not a fixed readiness sleep: every wait has a deadline and
+/// returns the instant its condition holds.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Default wall-clock budget for a single wait. Generous enough for a cold dash
+/// start plus the embedded-daemon connect, while still turning a genuine hang
+/// into a prompt, diagnosable failure rather than a CI-timeout.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A running `rocm` TUI attached to a pseudo-terminal.
+pub struct TuiSession {
+    child: Box<dyn Child + Send + Sync>,
+    writer: Box<dyn Write + Send>,
+    /// The emulated screen, updated continuously by the reader thread.
+    parser: Arc<Mutex<vt100::Parser>>,
+    reader_stop: Arc<AtomicBool>,
+    reader: Option<JoinHandle<()>>,
+    /// Kept alive for the lifetime of the session: the reader/writer are cloned
+    /// from it, and dropping it early would close the PTY.
+    _master: Box<dyn MasterPty + Send>,
+    /// `true` once the child has been reaped, so `Drop` doesn't kill/wait twice.
+    finished: bool,
+    /// Guards a single coverage record per session.
+    recorded: bool,
+    /// Whether this is a chat session (`rocm chat`) — chat quits via the `/quit`
+    /// slash command while the input is focused, whereas the dashboard quits with
+    /// a bare `q` (which chat would otherwise consume as typed input).
+    is_chat: bool,
+    scenario: Option<String>,
+    argv: Vec<String>,
+}
+
+impl std::fmt::Debug for TuiSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TuiSession")
+            .field("argv", &self.argv)
+            .field("finished", &self.finished)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TuiSession {
+    /// Spawn `rocm <args>` under a fresh PTY with the scenario's isolated
+    /// environment. The child renders into the emulated screen immediately; use
+    /// [`wait_for_screen`](Self::wait_for_screen) to synchronise before asserting.
+    pub fn spawn(world: &E2eWorld, args: &[&str]) -> Result<Self, String> {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: ROWS,
+                cols: COLS,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| format!("openpty failed: {e}"))?;
+
+        let mut cmd = CommandBuilder::new(crate::rocm_binary());
+        for arg in args {
+            cmd.arg(arg);
+        }
+        // Inherit the parent environment first, then overlay the isolation and
+        // deterministic-terminal vars — mirroring how the piped `run_rocm` path
+        // (`std::process::Command`, which inherits by default) resolves PATH and
+        // shared libraries, so the two spawn paths behave identically.
+        for (key, value) in std::env::vars_os() {
+            cmd.env(key, value);
+        }
+        for (key, value) in world.isolate_env() {
+            cmd.env(key, value);
+        }
+        // Deterministic terminal type; the PTY ioctl size above is authoritative
+        // for crossterm, with COLUMNS/LINES as a belt-and-braces fallback.
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLUMNS", COLS.to_string());
+        cmd.env("LINES", ROWS.to_string());
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| format!("failed to spawn rocm under a pty: {e}"))?;
+        // Drop the slave in the parent: only the child needs it. Keeping it open
+        // would prevent the reader from seeing EOF when the child exits.
+        drop(pair.slave);
+
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| format!("failed to clone pty reader: {e}"))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| format!("failed to take pty writer: {e}"))?;
+
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(ROWS, COLS, 0)));
+        let reader_stop = Arc::new(AtomicBool::new(false));
+        let reader = spawn_reader(reader, Arc::clone(&parser), Arc::clone(&reader_stop));
+
+        Ok(Self {
+            child,
+            writer,
+            parser,
+            reader_stop,
+            reader: Some(reader),
+            _master: pair.master,
+            finished: false,
+            recorded: false,
+            is_chat: args.first() == Some(&"chat"),
+            scenario: world.current_scenario.clone(),
+            argv: args.iter().map(|s| (*s).to_string()).collect(),
+        })
+    }
+
+    /// The current visible screen as plain text (one row per line). `vt100` has
+    /// already resolved escape sequences and styling into cells, so this is
+    /// exactly what a user sees — color/attribute independent.
+    pub fn screen_text(&self) -> String {
+        self.parser
+            .lock()
+            .map(|p| p.screen().contents())
+            .unwrap_or_default()
+    }
+
+    /// Write raw bytes to the terminal (keystrokes/text). `Enter` is `"\r"`.
+    pub fn send(&mut self, bytes: &str) -> Result<(), String> {
+        self.writer
+            .write_all(bytes.as_bytes())
+            .and_then(|()| self.writer.flush())
+            .map_err(|e| format!("failed to write to pty: {e}"))
+    }
+
+    /// Poll the current screen until it contains `marker`, or fail with a
+    /// deadline that includes the last screen for diagnosis. Also fails fast if
+    /// the child exits before the marker appears.
+    pub async fn wait_for_screen(&mut self, marker: &str, timeout: Duration) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.screen_text().contains(marker) {
+                return Ok(());
+            }
+            // If the process is gone, give the reader a beat to drain any final
+            // bytes, then check once more before declaring failure.
+            if let Ok(Some(status)) = self.child.try_wait() {
+                self.finished = true;
+                tokio::time::sleep(POLL_INTERVAL).await;
+                let screen = self.screen_text();
+                if screen.contains(marker) {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "process exited ({status:?}) before {marker:?} appeared.\n{}",
+                    framed_screen(&screen)
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for {marker:?}.\n{}",
+                    framed_screen(&self.screen_text())
+                ));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    /// Send the quit gesture appropriate to the session and wait for a clean
+    /// exit. The dashboard quits with `q`; chat quits with the `/quit` slash
+    /// command (a bare `q` would be typed into the focused input instead).
+    pub async fn quit_and_wait(&mut self, timeout: Duration) -> Result<(), String> {
+        if self.is_chat {
+            self.send("/quit\r")?;
+        } else {
+            self.send("q")?;
+        }
+        self.wait_for_exit(timeout).await
+    }
+
+    /// Poll until the child exits, asserting a successful (zero) exit code.
+    pub async fn wait_for_exit(&mut self, timeout: Duration) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    self.finished = true;
+                    self.record_once(i32::try_from(status.exit_code()).unwrap_or(-1));
+                    return if status.success() {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "TUI exited unsuccessfully ({status:?}).\n{}",
+                            framed_screen(&self.screen_text())
+                        ))
+                    };
+                }
+                Ok(None) => {}
+                Err(e) => return Err(format!("failed to poll TUI child: {e}")),
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for the TUI to exit.\n{}",
+                    framed_screen(&self.screen_text())
+                ));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    /// Record this invocation once for the command-coverage report (so `rocm
+    /// dash` / `rocm chat` count as covered), tied to the scenario for the
+    /// pass/fail join. Best-effort and idempotent.
+    fn record_once(&mut self, rc: i32) {
+        if self.recorded {
+            return;
+        }
+        self.recorded = true;
+        let argv: Vec<&str> = self.argv.iter().map(String::as_str).collect();
+        crate::record_command(self.scenario.as_deref(), &argv, rc, "");
+    }
+}
+
+impl Drop for TuiSession {
+    fn drop(&mut self) {
+        // Kill and reap the child FIRST so the slave closes and the reader thread
+        // sees EOF; only then join it, so teardown can never hang on a blocked
+        // read. This is the safety net for steps that panicked or returned early
+        // without an explicit quit (e.g. the consent-gate scenarios).
+        if !self.finished {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+            self.finished = true;
+        }
+        self.reader_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.reader.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Continuously drain the PTY into the shared parser until EOF or stop. Runs on a
+/// dedicated OS thread because PTY reads block; the assertion side only ever
+/// inspects the resulting `Screen`, never the reader.
+fn spawn_reader(
+    mut reader: Box<dyn Read + Send>,
+    parser: Arc<Mutex<vt100::Parser>>,
+    stop: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Ok(mut p) = parser.lock() {
+                        p.process(&buf[..n]);
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                // Any other error (e.g. EIO once the slave closes) means the
+                // session is over.
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+/// Wrap a screen dump in delimiters so failure messages are easy to read.
+fn framed_screen(screen: &str) -> String {
+    format!("--- last screen ({COLS}x{ROWS}) ---\n{screen}\n--- end screen ---")
+}

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -9,7 +9,7 @@
 //! the CLI only enters the crossterm raw-mode event loop when both stdin and
 //! stdout are a real terminal (`rocm_core::interactive_terminal`), and a pipe is
 //! not. So the dash was previously "untestable black-box" (e.g. the chat privacy
-//! notice, EAI-7222) and only had in-process render tests.
+//! notice) and only had in-process render tests.
 //!
 //! This driver closes that gap the way a user's terminal does: it spawns the
 //! real binary under a pseudo-terminal (`portable-pty`), feeds keystrokes to the
@@ -28,6 +28,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+use e2e_cucumber::panic_capture::panic_message;
 
 use crate::E2eWorld;
 
@@ -62,6 +64,12 @@ pub struct TuiSession {
     parser: Arc<Mutex<vt100::Parser>>,
     reader_stop: Arc<AtomicBool>,
     reader: Option<JoinHandle<()>>,
+    /// Set by the reader thread if `vt100::Parser::process` ever panics, before
+    /// the thread exits. `wait_for_screen`/`wait_for_exit` check this every poll
+    /// so a reader panic (which would otherwise just stop screen updates and
+    /// poison `parser`) is reported directly instead of surfacing as a 20s
+    /// timeout over an unexplained blank/stale screen.
+    reader_panic: Arc<Mutex<Option<String>>>,
     /// Kept alive for the lifetime of the session: the reader/writer are cloned
     /// from it, and dropping it early would close the PTY.
     master: Box<dyn MasterPty + Send>,
@@ -139,7 +147,13 @@ impl TuiSession {
 
         let parser = Arc::new(Mutex::new(vt100::Parser::new(ROWS, COLS, 0)));
         let reader_stop = Arc::new(AtomicBool::new(false));
-        let reader = spawn_reader(reader, Arc::clone(&parser), Arc::clone(&reader_stop));
+        let reader_panic: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let reader = spawn_reader(
+            reader,
+            Arc::clone(&parser),
+            Arc::clone(&reader_stop),
+            Arc::clone(&reader_panic),
+        );
 
         Ok(Self {
             child,
@@ -147,6 +161,7 @@ impl TuiSession {
             parser,
             reader_stop,
             reader: Some(reader),
+            reader_panic,
             master: pair.master,
             finished: false,
             recorded: false,
@@ -164,15 +179,34 @@ impl TuiSession {
     }
 
     fn screen_snapshot(&self) -> (String, (u16, u16)) {
-        self.parser
+        // Recover a poisoned lock rather than defaulting to a blank screen: the
+        // parser's data is still valid even if some other thread panicked while
+        // holding the lock (the reader thread never panics while holding it —
+        // see `spawn_reader` — but recovering here keeps this robust regardless).
+        // A silent blank default would otherwise masquerade as "nothing rendered
+        // yet" and burn the full poll timeout instead of failing immediately.
+        let p = self
+            .parser
             .lock()
-            .map(|p| (p.screen().contents(), p.screen().size()))
-            .unwrap_or_default()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (p.screen().contents(), p.screen().size())
     }
 
     fn framed_screen(&self) -> String {
         let (screen, (rows, cols)) = self.screen_snapshot();
         format!("--- last screen ({cols}x{rows}) ---\n{screen}\n--- end screen ---")
+    }
+
+    /// Take the reader thread's recorded panic message, if any, clearing it so
+    /// it's only reported once. Checked on every poll in `wait_for_screen`/
+    /// `wait_for_exit` so a reader-thread fault surfaces immediately with a
+    /// direct diagnostic instead of a 20s timeout over a screen that stopped
+    /// updating for an unexplained reason.
+    fn take_reader_panic(&self) -> Option<String> {
+        self.reader_panic
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
     }
 
     /// Resize both the real PTY and the emulated screen. The application receives
@@ -188,9 +222,12 @@ impl TuiSession {
         self.master
             .resize(size)
             .map_err(|e| format!("failed to resize pty: {e}"))?;
+        // As in `screen_snapshot`, recover rather than fail on a poisoned lock —
+        // resizing is still meaningful even if some earlier operation panicked
+        // while holding it.
         self.parser
             .lock()
-            .map_err(|_| "failed to lock vt100 parser".to_string())?
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .screen_mut()
             .set_size(DETAIL_ROWS, DETAIL_COLS);
         Ok(())
@@ -213,6 +250,12 @@ impl TuiSession {
             if self.screen_text().contains(marker) {
                 return Ok(());
             }
+            if let Some(panic_message) = self.take_reader_panic() {
+                return Err(format!(
+                    "pty reader thread panicked while waiting for {marker:?}: {panic_message}\n{}",
+                    self.framed_screen()
+                ));
+            }
             // If the process is gone, let the reader drain the final frame for a
             // short bounded window. A single poll is not enough when a large frame
             // is still buffered behind the process exit notification.
@@ -223,6 +266,12 @@ impl TuiSession {
                 while Instant::now() < drain_deadline {
                     if self.screen_text().contains(marker) {
                         return Ok(());
+                    }
+                    if let Some(panic_message) = self.take_reader_panic() {
+                        return Err(format!(
+                            "pty reader thread panicked while draining the final frame for {marker:?}: {panic_message}\n{}",
+                            self.framed_screen()
+                        ));
                     }
                     if self
                         .reader
@@ -286,6 +335,15 @@ impl TuiSession {
                 Ok(None) => {}
                 Err(e) => return Err(format!("failed to poll TUI child: {e}")),
             }
+            // A reader panic doesn't affect whether the child itself has exited,
+            // but it does mean the screen in any resulting error/diagnostic is
+            // stale, so surface it rather than let this poll silently continue.
+            if let Some(panic_message) = self.take_reader_panic() {
+                return Err(format!(
+                    "pty reader thread panicked while waiting for exit: {panic_message}\n{}",
+                    self.framed_screen()
+                ));
+            }
             if Instant::now() >= deadline {
                 return Err(format!(
                     "timed out after {timeout:?} waiting for the TUI to exit.\n{}",
@@ -328,7 +386,33 @@ impl Drop for TuiSession {
         }
         self.reader_stop.store(true, Ordering::Relaxed);
         if let Some(handle) = self.reader.take() {
-            let _ = handle.join();
+            // `join` returns `Err` only if the reader thread itself panicked
+            // (distinct from `reader_panic`, which we set *before* the thread
+            // exits normally after catching a `p.process` panic — so `join`
+            // failing here would mean some other, uncaught panic in the reader).
+            // Never re-panic here: if a scenario step already panicked and this
+            // `drop` is running during that unwind, turning a teardown detail
+            // into a second panic would abort the process and destroy the
+            // original failure's message. Log to stderr instead, and only ever
+            // panic (to fail an otherwise-green test) when nothing is unwinding.
+            if let Err(payload) = handle.join() {
+                let message = panic_message(&payload);
+                if std::thread::panicking() {
+                    eprintln!(
+                        "pty reader thread also panicked during teardown (suppressed to preserve the original panic): {message}"
+                    );
+                } else {
+                    panic!("pty reader thread panicked: {message}");
+                }
+            } else if let Some(message) = self.take_reader_panic()
+                && !std::thread::panicking()
+            {
+                // The reader caught its own panic and exited cleanly (see
+                // `spawn_reader`), but no `wait_for_screen`/`wait_for_exit` call
+                // ever observed and reported it — surface it now rather than
+                // silently dropping the diagnostic.
+                panic!("pty reader thread panicked: {message}");
+            }
         }
     }
 }
@@ -336,10 +420,16 @@ impl Drop for TuiSession {
 /// Continuously drain the PTY into the shared parser until EOF or stop. Runs on a
 /// dedicated OS thread because PTY reads block; the assertion side only ever
 /// inspects the resulting `Screen`, never the reader.
+///
+/// If `vt100::Parser::process` ever panics, it's caught here (rather than left
+/// to unwind the reader thread silently) and recorded into `reader_panic` before
+/// the thread exits, so `wait_for_screen`/`wait_for_exit` can fail fast with the
+/// actual cause instead of quietly polling a screen that will never update again.
 fn spawn_reader(
     mut reader: Box<dyn Read + Send>,
     parser: Arc<Mutex<vt100::Parser>>,
     stop: Arc<AtomicBool>,
+    reader_panic: Arc<Mutex<Option<String>>>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let mut buf = [0u8; 8192];
@@ -350,8 +440,19 @@ fn spawn_reader(
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    if let Ok(mut p) = parser.lock() {
+                    let mut p = parser
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         p.process(&buf[..n]);
+                    }));
+                    drop(p);
+                    if let Err(payload) = result {
+                        let message = panic_message(&payload);
+                        *reader_panic
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(message);
+                        break;
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -122,6 +122,18 @@ impl TuiSession {
         for (key, value) in world.isolate_env().into_iter().chain(world.pty_env()) {
             cmd.env(key, value);
         }
+        // Provider configuration changes product startup semantics: a host API
+        // key or endpoint suppresses local managed-service detection. These PTY
+        // journeys exercise deterministic local/mock chat, so do not let the
+        // developer's shell or CI credential environment select a cloud backend.
+        for key in [
+            "ROCMDASH_CHAT_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "ANTHROPIC_API_KEY",
+        ] {
+            cmd.env_remove(key);
+        }
         // Deterministic terminal type; the PTY ioctl size above is authoritative
         // for crossterm, with COLUMNS/LINES as a belt-and-braces fallback.
         cmd.env("TERM", "xterm-256color");

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -288,6 +288,16 @@ impl TuiSession {
                 if self.screen_text().contains(marker) {
                     return Ok(());
                 }
+                // A reader panic landing exactly on the drain deadline would
+                // otherwise be masked by the generic "process exited" error below
+                // (and then swallowed entirely if `Drop` runs during another
+                // unwind). Surface it here so the real cause wins.
+                if let Some(panic_message) = self.take_reader_panic() {
+                    return Err(format!(
+                        "pty reader thread panicked while draining the final frame for {marker:?}: {panic_message}\n{}",
+                        self.framed_screen()
+                    ));
+                }
                 return Err(format!(
                     "process exited ({status:?}) before {marker:?} appeared.\n{}",
                     self.framed_screen()
@@ -404,14 +414,21 @@ impl Drop for TuiSession {
                 } else {
                     panic!("pty reader thread panicked: {message}");
                 }
-            } else if let Some(message) = self.take_reader_panic()
-                && !std::thread::panicking()
-            {
+            } else if let Some(message) = self.take_reader_panic() {
                 // The reader caught its own panic and exited cleanly (see
                 // `spawn_reader`), but no `wait_for_screen`/`wait_for_exit` call
                 // ever observed and reported it — surface it now rather than
-                // silently dropping the diagnostic.
-                panic!("pty reader thread panicked: {message}");
+                // silently dropping the diagnostic. As with the `join` branch
+                // above, never turn this into a second panic while another panic
+                // is already unwinding (it would abort the process and destroy
+                // the original failure's message); log to stderr in that case.
+                if std::thread::panicking() {
+                    eprintln!(
+                        "pty reader thread panicked (suppressed to preserve the original panic): {message}"
+                    );
+                } else {
+                    panic!("pty reader thread panicked: {message}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds a pseudo-terminal driver (`portable-pty` + `vt100`) so the Cucumber suite can launch the real dash/chat raw-mode event loop, send keystrokes, resize the terminal, and assert on the current rendered screen rather than an escape-sequence transcript.
- Covers the interactive dashboard end to end: Home-to-ROCm navigation, help and command-palette discovery, managed-model visibility and loading status, live serving metrics, offline chat, and a managed local chat exchange using the registry-provided model and OS-assigned endpoint.
- Turns the local-endpoint privacy gate into passing black-box coverage and removes its former expected-failure entry.
- Removes the unused `ratatui` dependency from the `rocm` binary, eliminating the conflicting older dependency line that blocked the terminal emulator dependency.

## Why

The existing in-process render tests verify component behavior, but a piped `Command` never enters crossterm raw mode and therefore cannot prove that users can complete interactive terminal journeys. This adds the missing acceptance layer while retaining the in-process tests as the fast rendering layer.

## Design notes

- Piped and PTY launches share the same isolated config/data/cache environment; PTY scenarios additionally isolate `HOME` and `XDG_RUNTIME_DIR` so a host daemon cannot mask the scenario's embedded daemon and managed-service registry.
- The managed-service fixture uses plain on-disk JSON and an OS-assigned mock endpoint, keeping the scenarios black-box and free of GPU/network requirements.
- The metrics fixture serves deterministic vLLM-compatible counters and histograms; scenarios assert the rendered latency, queue, and KV-cache values through the real daemon scrape path.
- Waits poll visible screen state against deadlines, with the final screen included on failure. Teardown kills and reaps the child before joining the PTY reader.

## Scope / risk

- **Linux-only** for now (`@requires-os:linux`). The dependency supports ConPTY, but Windows is not a blocking contract until that path has dedicated stability coverage.
- Risk: low. The change is test infrastructure and scenarios plus one unused dependency removal; product behavior is unchanged.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy -p e2e-cucumber --test e2e -- -D warnings`
- `cargo test -p e2e-cucumber --lib` — 23 passed
- Focused expanded PTY journeys — 6 scenarios / 39 steps passed, 0 xfail, 0 XPASS
- `cargo xtask e2e` — 17 passed, 3 existing expected failures, 0 XPASS, 0 unexpected failures
- Push hooks: commit signatures/sign-off, format, clippy, unit tests, license checks all passed