### PR TITLE
ci: run on pull requests against any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on PRs against ANY base branch, not just main, so a stacked PR (based on
+  # another in-flight feature branch) still gets CI instead of no checks until it
+  # is retargeted to main. Affected-crate selection already diffs against
+  # `github.base_ref`, so a non-main base works. push/merge_group stay main-only.
   pull_request:
-    branches: [main]
   # The merge queue creates a temporary branch and fires `merge_group`; without
   # this trigger the required checks never start and queued PRs stall forever.
   merge_group:


### PR DESCRIPTION
## Summary

- CI only triggered on PRs targeting `main`, so a **stacked PR** (based on another in-flight feature branch) got **no checks at all** until it was retargeted to `main`. This drops the base-branch filter on the `pull_request` trigger so those PRs run CI too.
- `push` and `merge_group` stay `main`-only.

## Why

We open stacked PRs regularly. Without this, the intermediate PR sits with zero CI signal and reviewers can't tell it's validated. Discussed in #amd-rocm-ai-cli — approach approved by the team.

## Notes

- Affected-crate selection already diffs against `github.base_ref` (not a hardcoded `main`), so a non-`main` base is handled with no other changes.
- This only makes checks *run* on non-`main` PRs; whether they're *required* for merging into a feature branch is a separate branch-protection/settings concern.

## Risk

Low. One trigger-scope change; no job logic touched.