### PR TITLE
fix(serve): verify process identity and bound stop termination (EAI-7410)

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4478,6 +4478,9 @@ fn spawn_managed_engine_child(
     };
     record.supervisor_pid = child_pid;
     record.engine_pid = Some(child_pid);
+    // Capture the identity token while the child is alive, so a later stop
+    // verifies this exact process rather than a recycled PID.
+    record.supervisor_start_ticks = rocm_core::process_start_ticks(child_pid);
     record.status = "running".to_owned();
     record.write()?;
 
@@ -12436,6 +12439,66 @@ fn run_internal_sandbox_tool(
     }))
 }
 
+/// How long a managed stop waits for each recorded process to actually exit
+/// after `SIGTERM` before escalating to `SIGKILL` and then reporting a timeout.
+const MANAGED_STOP_GRACE: Duration = Duration::from_secs(10);
+
+/// Terminate the processes recorded for a managed service, verifying each PID's
+/// identity first so a recycled PID never causes an unrelated process tree to be
+/// killed.
+///
+/// The supervisor (launcher) and the engine server are distinct processes, so
+/// each PID is paired with **its own** start-time token (`supervisor_start_ticks`
+/// vs `engine_start_ticks`). When they resolve to the same PID (e.g. before the
+/// engine state has been refreshed) the entry is de-duplicated, preferring a
+/// known token. Returns the PIDs actually signalled and whether every recorded
+/// process is confirmed no longer running.
+fn terminate_recorded_service_pids(record: &ManagedServiceRecord) -> (Vec<u32>, bool) {
+    // Build the (pid, own-token) work list, de-duplicating on PID and preferring
+    // an entry that carries a verifiable start-time.
+    let mut entries: Vec<(u32, Option<u64>)> = Vec::new();
+    for (pid, ticks) in [
+        (Some(record.supervisor_pid), record.supervisor_start_ticks),
+        (record.engine_pid, record.engine_start_ticks),
+    ] {
+        let Some(pid) = pid.filter(|pid| *pid != 0 && *pid != std::process::id()) else {
+            continue;
+        };
+        if let Some(existing) = entries.iter_mut().find(|(seen, _)| *seen == pid) {
+            if existing.1.is_none() {
+                existing.1 = ticks;
+            }
+        } else {
+            entries.push((pid, ticks));
+        }
+    }
+
+    let mut signaled_pids = Vec::new();
+    let mut all_stopped = true;
+    for (pid, ticks) in entries {
+        let identity = rocm_core::ProcessIdentity::new(pid, ticks);
+        let outcome = rocm_core::terminate_verified(
+            &identity,
+            rocm_core::KillScope::Tree,
+            MANAGED_STOP_GRACE,
+            true,
+        );
+        if !outcome.stopped() {
+            all_stopped = false;
+        }
+        // Only report PIDs we actually signalled (a live, verified match).
+        if matches!(
+            outcome,
+            rocm_core::TerminationOutcome::Graceful
+                | rocm_core::TerminationOutcome::Forced
+                | rocm_core::TerminationOutcome::TimedOut
+        ) {
+            signaled_pids.push(pid);
+        }
+    }
+    (signaled_pids, all_stopped)
+}
+
 fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<serde_json::Value> {
     let mut record = load_managed_service(paths, service_id)?;
     let engine_stop = if record.engine == "lemonade" {
@@ -12454,17 +12517,15 @@ fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<s
             },
         )
     };
-    let mut signaled_pids = Vec::new();
-    for pid in [record.engine_pid, Some(record.supervisor_pid)]
-        .into_iter()
-        .flatten()
-        .filter(|pid| *pid != 0 && *pid != std::process::id())
-    {
-        if signal_process_tree(pid).is_ok() {
-            signaled_pids.push(pid);
-        }
+    let (signaled_pids, all_stopped) = terminate_recorded_service_pids(&record);
+    // Only claim "stopped" when every recorded process is confirmed gone. When a
+    // stop cannot confirm termination (rare: SIGKILL-resistant or unverifiable
+    // PID), leave the prior status so the standard liveness refresh reconciles it
+    // to "stopped" once the process actually dies — rather than asserting a stop
+    // that did not happen.
+    if all_stopped {
+        record.status = "stopped".to_owned();
     }
-    record.status = "stopped".to_owned();
     record.write()?;
     let engine_stop = match engine_stop {
         Ok(response) => serde_json::json!({
@@ -12582,6 +12643,8 @@ fn restart_internal_managed_service(
     record.status = "running".to_owned();
     record.supervisor_pid = child_pid;
     record.engine_pid = Some(child_pid);
+    // Refresh the identity token in lockstep with the restarted child's PID.
+    record.supervisor_start_ticks = rocm_core::process_start_ticks(child_pid);
     record.restart_count = record.restart_count.saturating_add(1);
     record.last_restart_unix_ms = Some(rocm_core::unix_time_millis());
     record.status = if wait_for_service_http_ready(
@@ -12597,12 +12660,6 @@ fn restart_internal_managed_service(
     };
     record.write()?;
     Ok(record)
-}
-
-fn signal_process_tree(pid: u32) -> Result<()> {
-    rocm_core::terminate_process_tree(pid)?;
-    thread::sleep(Duration::from_millis(300));
-    Ok(())
 }
 
 fn validate_service_id(service_id: &str) -> Result<()> {
@@ -23075,6 +23132,123 @@ ID_LIKE="suse opensuse"
             imported_from: None,
             installed_at_unix_ms: 1,
         }
+    }
+
+    #[cfg(unix)]
+    fn managed_record_for_pid(
+        paths: &AppPaths,
+        pid: u32,
+        start_ticks: Option<u64>,
+    ) -> ManagedServiceRecord {
+        let mut record = ManagedServiceRecord::new(
+            paths,
+            "svc-managed-stop",
+            "vllm",
+            "m",
+            "m",
+            "127.0.0.1",
+            9,
+            "managed",
+            pid,
+            None,
+            None,
+            None,
+        );
+        record.engine_pid = Some(pid);
+        record.supervisor_pid = pid;
+        record.supervisor_start_ticks = start_ticks;
+        record
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_stop_refuses_recycled_pid() {
+        // A live process whose recorded identity does not match: this is exactly
+        // what a recycled PID looks like. The stop must NOT signal it.
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id();
+        let (root, paths) = test_paths("managed-stop-recycled");
+        let real = rocm_core::process_start_ticks(pid).expect("start-ticks");
+        let record = managed_record_for_pid(&paths, pid, Some(real.wrapping_add(1)));
+
+        let (signaled, all_stopped) = terminate_recorded_service_pids(&record);
+
+        assert!(signaled.is_empty(), "must not signal a mismatched identity");
+        // A recycled PID means the recorded service process itself is gone.
+        assert!(all_stopped);
+        assert!(
+            rocm_core::process_is_running(pid),
+            "the unrelated live process must survive"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_stop_verifies_distinct_supervisor_and_engine_pids() {
+        // The launcher and the engine server are different processes; each PID
+        // must be verified with its OWN start-time token and terminated.
+        let sup = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn supervisor");
+        let eng = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn engine");
+        let (sup_pid, eng_pid) = (sup.id(), eng.id());
+        let (root, paths) = test_paths("managed-stop-distinct");
+        let mut record =
+            managed_record_for_pid(&paths, sup_pid, rocm_core::process_start_ticks(sup_pid));
+        record.engine_pid = Some(eng_pid);
+        record.engine_start_ticks = rocm_core::process_start_ticks(eng_pid);
+
+        let (mut signaled, all_stopped) = terminate_recorded_service_pids(&record);
+        signaled.sort_unstable();
+        let mut expected = vec![sup_pid, eng_pid];
+        expected.sort_unstable();
+
+        assert_eq!(signaled, expected);
+        assert!(all_stopped);
+        let (mut sup, mut eng) = (sup, eng);
+        let _ = sup.wait();
+        let _ = eng.wait();
+        assert!(!rocm_core::process_is_running(sup_pid));
+        assert!(!rocm_core::process_is_running(eng_pid));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_stop_terminates_verified_pid() {
+        // Correct identity: the recorded process is really ours, so it is stopped.
+        let child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn child");
+        let pid = child.id();
+        let (root, paths) = test_paths("managed-stop-verified");
+        let real = rocm_core::process_start_ticks(pid).expect("start-ticks");
+        let record = managed_record_for_pid(&paths, pid, Some(real));
+
+        let (signaled, all_stopped) = terminate_recorded_service_pids(&record);
+
+        assert_eq!(signaled, vec![pid]);
+        assert!(all_stopped);
+        // Reap our own child (a detached managed process would be reaped by init)
+        // so the liveness check does not observe a not-yet-reaped zombie.
+        let mut child = child;
+        let _ = child.wait();
+        assert!(
+            !rocm_core::process_is_running(pid),
+            "the verified process must be terminated"
+        );
+        let _ = fs::remove_dir_all(root);
     }
 
     fn test_paths(name: &str) -> (PathBuf, AppPaths) {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -12477,6 +12477,9 @@ fn terminate_recorded_service_pids(record: &ManagedServiceRecord) -> (Vec<u32>, 
     let mut all_stopped = true;
     for (pid, ticks) in entries {
         let identity = rocm_core::ProcessIdentity::new(pid, ticks);
+        // The managed stop contract is definitive: after the adapter gets its
+        // graceful opportunity, this cleanup pass forces any verified survivor
+        // so the command does not report success while a GPU worker remains.
         let outcome = rocm_core::terminate_verified(
             &identity,
             rocm_core::KillScope::Tree,
@@ -12486,7 +12489,9 @@ fn terminate_recorded_service_pids(record: &ManagedServiceRecord) -> (Vec<u32>, 
         if !outcome.stopped() {
             all_stopped = false;
         }
-        // Only report PIDs we actually signalled (a live, verified match).
+        // Report every PID that received a signal. TimedOut belongs here because
+        // signalling was attempted even though the process was not confirmed
+        // stopped; `all_stopped` separately carries the truthful completion state.
         if matches!(
             outcome,
             rocm_core::TerminationOutcome::Graceful

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod diagnose;
 pub mod examine;
 pub mod fix;
 pub mod openmpi;
+pub mod proc_lifecycle;
 pub mod runtime;
 pub mod uv;
 pub use diagnose::{
@@ -38,6 +39,10 @@ pub use diagnose::{
 };
 pub use examine::{Examination, FrameworkProbe, WSL_ROUTE_OUT_NOTE};
 pub use fix::{FixOptions, apply as apply_fix, list_recipes as list_fix_recipes};
+pub use proc_lifecycle::{
+    IdentityState, KillScope, ProcessIdentity, TerminationOutcome, identity_state,
+    process_start_ticks, terminate_verified,
+};
 use runtime::env_path_override;
 #[cfg(test)]
 use runtime::home_rocm_dir;
@@ -485,6 +490,45 @@ pub fn terminate_process_tree(pid: u32) -> Result<()> {
         return Err(error).with_context(|| format!("failed to terminate process {target}"));
     }
     Ok(())
+}
+
+/// Send `signal` to `pid`, optionally extending to its transitive children.
+///
+/// Delivery to a process that has already exited (`ESRCH`) counts as success:
+/// the goal — that process no longer running — is already met. Returns `false`
+/// only when a signal could not be delivered for another reason (for example
+/// `EPERM`). Used by the verified-termination logic in [`proc_lifecycle`].
+#[cfg(not(windows))]
+#[allow(unsafe_code)] // libc FFI
+pub(crate) fn signal_process_scope(pid: u32, signal: i32, include_tree: bool) -> bool {
+    let targets = if include_tree {
+        collect_process_tree(pid)
+    } else {
+        vec![pid]
+    };
+    let mut delivered = true;
+    for target in targets {
+        let status = unsafe { libc::kill(target.cast_signed(), signal) };
+        if status != 0 && std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH) {
+            delivered = false;
+        }
+    }
+    delivered
+}
+
+/// Snapshot `root` plus its transitive descendants as a flat PID list.
+///
+/// Used by [`proc_lifecycle`] to bind a tree termination to the exact processes
+/// present when the stop began. On platforms without `/proc` only `root` is
+/// returned.
+#[cfg(not(windows))]
+pub(crate) fn process_tree_pids(root: u32) -> Vec<u32> {
+    collect_process_tree(root)
+}
+
+#[cfg(windows)]
+pub(crate) fn process_tree_pids(root: u32) -> Vec<u32> {
+    vec![root]
 }
 
 /// Collect `root` plus all of its transitive descendants by reading `/proc`.
@@ -5485,6 +5529,18 @@ pub struct ManagedServiceRecord {
     pub status: String,
     pub supervisor_pid: u32,
     pub engine_pid: Option<u32>,
+    /// Kernel start-time of the supervisor (launcher) process, captured at
+    /// spawn. Paired with `supervisor_pid` it forms an identity that survives
+    /// PID recycling, so a later stop never signals a reused PID. `None` for
+    /// records written before this field existed.
+    #[serde(default)]
+    pub supervisor_start_ticks: Option<u64>,
+    /// Kernel start-time of the engine server process, adopted from the engine
+    /// state file whenever `engine_pid` is refreshed from it. The launcher and
+    /// the engine server are distinct processes, so each PID carries its own
+    /// identity token. `None` until the engine state records one.
+    #[serde(default)]
+    pub engine_start_ticks: Option<u64>,
     #[serde(default)]
     pub runtime_id: Option<String>,
     #[serde(default)]
@@ -5544,6 +5600,8 @@ impl ManagedServiceRecord {
             status: "starting".to_owned(),
             supervisor_pid,
             engine_pid: None,
+            supervisor_start_ticks: None,
+            engine_start_ticks: None,
             runtime_id,
             env_id,
             device_policy,
@@ -5611,13 +5669,25 @@ impl ManagedServiceRecord {
         {
             self.env_id = Some(env_id.to_owned());
         }
-        if let Some(pid) = state
+        // Adopt the engine server PID together with ITS OWN start-time token so
+        // a later stop verifies the server process, not the launcher. The ticks
+        // key must match the PID key: `server_pid`↔`server_start_ticks`,
+        // `pid`↔`start_ticks`.
+        let engine_pid = state
             .get("server_pid")
-            .or_else(|| state.get("pid"))
             .and_then(serde_json::Value::as_u64)
-            .and_then(|value| u32::try_from(value).ok())
+            .map(|pid| (pid, "server_start_ticks"))
+            .or_else(|| {
+                state
+                    .get("pid")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|pid| (pid, "start_ticks"))
+            });
+        if let Some((pid, ticks_key)) = engine_pid
+            && let Ok(pid) = u32::try_from(pid)
         {
             self.engine_pid = Some(pid);
+            self.engine_start_ticks = state.get(ticks_key).and_then(serde_json::Value::as_u64);
         }
         Ok(self.status != previous)
     }

--- a/crates/rocm-core/src/proc_lifecycle.rs
+++ b/crates/rocm-core/src/proc_lifecycle.rs
@@ -1,0 +1,567 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Verified, bounded process termination.
+//!
+//! Stopping a managed service by a *persisted* PID is unsafe on its own: PIDs
+//! are recycled, so a stale PID may have been reassigned to an unrelated process
+//! by the time a stop is requested. This module pairs each PID with the kernel's
+//! start-time for that PID — an identity that survives recycling — and refuses to
+//! signal a PID whose identity no longer matches. It also reports termination
+//! truthfully: a stop is only "graceful" once the recorded process is observed to
+//! have actually exited within a bounded grace period, escalating to `SIGKILL`
+//! only when the caller opts into a forced stop.
+
+use std::time::{Duration, Instant};
+
+/// How often the bounded waits poll for the target's exit.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Breadth of a termination request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KillScope {
+    /// Signal only the recorded PID.
+    Single,
+    /// Signal the recorded PID plus every transitive child. Engines such as
+    /// vLLM spawn workers that hold the GPU allocation, so the whole tree must
+    /// be signalled to avoid leaking device memory.
+    Tree,
+}
+
+/// A spawned process identified in a way that is robust to PID recycling.
+///
+/// `start_ticks` is the kernel start-time of the process (clock ticks since
+/// boot). It is `None` on platforms without `/proc`, where identity cannot be
+/// verified and callers fall back to best-effort behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub start_ticks: Option<u64>,
+}
+
+impl ProcessIdentity {
+    /// Capture the identity of `pid` as it exists right now (e.g. just after
+    /// spawning it, while it is guaranteed to be alive).
+    #[must_use]
+    pub fn capture(pid: u32) -> Self {
+        Self {
+            pid,
+            start_ticks: process_start_ticks(pid),
+        }
+    }
+
+    /// Reconstruct an identity from persisted values.
+    #[must_use]
+    pub const fn new(pid: u32, start_ticks: Option<u64>) -> Self {
+        Self { pid, start_ticks }
+    }
+}
+
+/// Whether a PID still refers to the recorded process instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityState {
+    /// The PID is live and, where verifiable, its start-time matches. Also the
+    /// best-effort verdict when no identity was recorded (legacy state files).
+    Matches,
+    /// The PID is live but is provably a *different* process: both start-times
+    /// were readable and differ, so the recorded process has exited and its PID
+    /// was recycled.
+    Recycled,
+    /// The PID is live and an identity was recorded, but the current start-time
+    /// cannot be read, so it can be neither confirmed nor refuted. The process
+    /// must not be signalled, and it must not be reported as stopped.
+    Indeterminate,
+    /// The PID is not live (or is a not-yet-reaped zombie).
+    Gone,
+}
+
+/// Classify the current state of `id`'s PID relative to its recorded identity.
+///
+/// Deliberately conservative about killing the wrong process: a recorded
+/// identity that cannot be confirmed (start-time unreadable) is
+/// [`IdentityState::Indeterminate`], never a risky match. When no identity was
+/// recorded (legacy state files), it degrades to best-effort
+/// [`IdentityState::Matches`].
+#[must_use]
+pub fn identity_state(id: &ProcessIdentity) -> IdentityState {
+    if !crate::process_is_running(id.pid) || process_has_exited(id.pid) {
+        return IdentityState::Gone;
+    }
+    match (id.start_ticks, process_start_ticks(id.pid)) {
+        (Some(expected), Some(actual)) => {
+            if expected == actual {
+                IdentityState::Matches
+            } else {
+                IdentityState::Recycled
+            }
+        }
+        // Identity recorded but unconfirmable right now: neither signal nor
+        // claim a stop.
+        (Some(_), None) => IdentityState::Indeterminate,
+        // No recorded identity (legacy state): best-effort proceed.
+        (None, _) => IdentityState::Matches,
+    }
+}
+
+/// Whether `state` means the recorded process is definitively no longer running.
+///
+/// [`IdentityState::Indeterminate`] is intentionally excluded: a process we can
+/// neither confirm nor refute is treated as possibly-alive, so a bounded wait
+/// keeps waiting rather than declaring a premature exit.
+const fn is_exited(state: IdentityState) -> bool {
+    matches!(state, IdentityState::Gone | IdentityState::Recycled)
+}
+
+/// The truthful result of a verified termination attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationOutcome {
+    /// The recorded process was already gone; nothing was signalled.
+    AlreadyGone,
+    /// The PID now belongs to a different process (recycled), so the recorded
+    /// process has already exited; nothing was signalled.
+    IdentityMismatch,
+    /// The recorded PID is live but its identity could not be confirmed, so it
+    /// was deliberately left untouched and its state is unknown.
+    Unverified,
+    /// Every signalled process exited after `SIGTERM`, within the grace period.
+    Graceful,
+    /// Termination required escalating to `SIGKILL`.
+    Forced,
+    /// At least one signalled process was still alive after the bounded deadline.
+    TimedOut,
+}
+
+impl TerminationOutcome {
+    /// Is the recorded service confirmed to be no longer running as a result?
+    ///
+    /// `false` for [`TimedOut`](Self::TimedOut) (still alive) and
+    /// [`Unverified`](Self::Unverified) (could not be confirmed either way).
+    #[must_use]
+    pub const fn stopped(self) -> bool {
+        !matches!(self, Self::TimedOut | Self::Unverified)
+    }
+
+    /// Did the process stop without needing a forced kill (or was it already
+    /// gone / recycled)? Only `true` when no `SIGKILL` was required.
+    #[must_use]
+    pub const fn graceful(self) -> bool {
+        matches!(
+            self,
+            Self::Graceful | Self::AlreadyGone | Self::IdentityMismatch
+        )
+    }
+
+    /// A stable, log-friendly label for the outcome.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AlreadyGone => "already_gone",
+            Self::IdentityMismatch => "identity_mismatch",
+            Self::Unverified => "unverified",
+            Self::Graceful => "graceful",
+            Self::Forced => "forced",
+            Self::TimedOut => "timed_out",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Signal {
+    /// Request a graceful shutdown (`SIGTERM` on Unix).
+    Term,
+    /// Force termination (`SIGKILL` on Unix, `TerminateProcess` on Windows).
+    Kill,
+}
+
+/// Terminate the process recorded in `id`, verifying identity first and
+/// reporting the outcome truthfully.
+///
+/// The process is only signalled when its PID still matches `id`. Under
+/// [`KillScope::Tree`] the descendant set is snapshotted (each child bound to
+/// its own identity) so termination is confirmed for the *whole* tree — not just
+/// the root — which matters when the root is a thin launcher and a child holds
+/// the real resource (e.g. a GPU worker). A graceful `SIGTERM` is sent first and
+/// every signalled process is polled for actual exit up to `grace`. When any do
+/// not exit in time, a forced stop (`force == true`) escalates to `SIGKILL` and
+/// waits again; a non-forced stop reports [`TerminationOutcome::TimedOut`]
+/// rather than pretending success.
+#[must_use]
+pub fn terminate_verified(
+    id: &ProcessIdentity,
+    scope: KillScope,
+    grace: Duration,
+    force: bool,
+) -> TerminationOutcome {
+    match identity_state(id) {
+        IdentityState::Gone => return TerminationOutcome::AlreadyGone,
+        IdentityState::Recycled => return TerminationOutcome::IdentityMismatch,
+        IdentityState::Indeterminate => return TerminationOutcome::Unverified,
+        IdentityState::Matches => {}
+    }
+
+    let tree = matches!(scope, KillScope::Tree);
+
+    // Snapshot the exact processes to account for while the root is still alive.
+    // For a tree this binds each descendant PID to its own start-time, so a PID
+    // recycled during the wait is never mistaken for a survivor.
+    let members: Vec<ProcessIdentity> = if tree {
+        crate::process_tree_pids(id.pid)
+            .into_iter()
+            .map(ProcessIdentity::capture)
+            .collect()
+    } else {
+        vec![*id]
+    };
+
+    // Graceful request first: signal the whole scope, then wait for all to exit.
+    send_signal(id.pid, Signal::Term, tree);
+    if wait_for_all_exit(&members, grace) {
+        return TerminationOutcome::Graceful;
+    }
+
+    if !force {
+        return TerminationOutcome::TimedOut;
+    }
+
+    // Bounded escalation to a forced kill.
+    //
+    // While the root is still ours, SIGKILL the live tree from it (re-enumerated,
+    // root verified) — the safest way to reach current children. Then catch any
+    // reparented survivor, but only one we can still *positively* re-verify: a
+    // member with no recorded start-time cannot be distinguished from a process
+    // that recycled its PID during the wait, so its PID is never targeted
+    // directly (it is left to time out rather than risk signalling a stranger).
+    if matches!(identity_state(id), IdentityState::Matches) {
+        send_signal(id.pid, Signal::Kill, tree);
+    }
+    for member in &members {
+        if member.pid == id.pid || member.start_ticks.is_none() {
+            continue;
+        }
+        if matches!(identity_state(member), IdentityState::Matches) {
+            send_signal(member.pid, Signal::Kill, false);
+        }
+    }
+    if wait_for_all_exit(&members, grace) {
+        TerminationOutcome::Forced
+    } else {
+        TerminationOutcome::TimedOut
+    }
+}
+
+/// Poll until every process in `members` has exited, or `grace` elapses.
+///
+/// A member is exited once its PID is gone or now belongs to a different process
+/// ([`is_exited`]); a member that is merely [`IdentityState::Indeterminate`]
+/// keeps the wait going rather than being counted as exited.
+fn wait_for_all_exit(members: &[ProcessIdentity], grace: Duration) -> bool {
+    let deadline = Instant::now() + grace;
+    loop {
+        if members
+            .iter()
+            .all(|member| is_exited(identity_state(member)))
+        {
+            return true;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        std::thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+    }
+}
+
+#[cfg(not(windows))]
+fn send_signal(pid: u32, signal: Signal, tree: bool) -> bool {
+    let raw = match signal {
+        Signal::Term => libc::SIGTERM,
+        Signal::Kill => libc::SIGKILL,
+    };
+    crate::signal_process_scope(pid, raw, tree)
+}
+
+#[cfg(windows)]
+fn send_signal(pid: u32, signal: Signal, _tree: bool) -> bool {
+    // Windows has no graceful process signal. A `Term` request is therefore a
+    // no-op — the bounded wait will time out and, only under a forced stop, the
+    // `Kill` step force-terminates. This keeps the reported outcome truthful:
+    // non-forced Windows stops surface `TimedOut` rather than a false graceful.
+    match signal {
+        Signal::Term => true,
+        Signal::Kill => crate::terminate_process(pid).is_ok(),
+    }
+}
+
+/// Read the kernel start-time (field 22 of `/proc/<pid>/stat`) for `pid`.
+///
+/// Returns `None` when the value cannot be read, including on non-Linux
+/// platforms, where identity verification degrades to best-effort.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn process_start_ticks(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_start_ticks(&stat)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn process_start_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Whether `pid` has already exited but not yet been reaped (a zombie).
+///
+/// A zombie still has a `/proc` entry and answers `kill(pid, 0)`, yet it is a
+/// terminated process — treating it as still running would make a completed stop
+/// look like a timeout. Detached engine processes are reparented to init and
+/// reaped promptly, so this mainly guards the reaped-by-us and slow-init cases.
+#[cfg(target_os = "linux")]
+fn process_has_exited(pid: u32) -> bool {
+    match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => parse_state_char(&stat) == Some('Z'),
+        // No stat file: the process is gone; `process_is_running` handles the
+        // authoritative check, so report "not a zombie" here.
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_has_exited(_pid: u32) -> bool {
+    false
+}
+
+/// Parse the process state character (field 3) from `/proc/<pid>/stat`.
+#[cfg(target_os = "linux")]
+fn parse_state_char(stat: &str) -> Option<char> {
+    let after_comm = stat.get(stat.rfind(')')? + 1..)?;
+    after_comm.split_whitespace().next()?.chars().next()
+}
+
+/// Parse the `starttime` field (field 22) from the contents of
+/// `/proc/<pid>/stat`.
+///
+/// The `comm` field (field 2) can contain spaces and parentheses, so parsing
+/// begins after the final `)`. From there, field 3 (`state`) is index 0, making
+/// `starttime` index 19.
+#[cfg(any(target_os = "linux", test))]
+fn parse_start_ticks(stat: &str) -> Option<u64> {
+    let after_comm = stat.get(stat.rfind(')')? + 1..)?;
+    after_comm.split_whitespace().nth(19)?.parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Child, Command, Stdio};
+
+    /// Spawn a child that prints a line to stdout once it is ready, and block
+    /// until that line arrives. This replaces sleep-based readiness guesses with
+    /// a deterministic signal (e.g. that a shell has installed its SIGTERM trap),
+    /// and returns any text on that first line (used to pass out a child PID).
+    #[cfg(unix)]
+    fn spawn_ready(script: &str) -> (Child, String) {
+        use std::io::{BufRead, BufReader};
+        let mut child = Command::new("sh")
+            .args(["-c", script])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn ready child");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut line = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut line)
+            .expect("read readiness line");
+        (child, line.trim().to_owned())
+    }
+
+    #[test]
+    fn parse_start_ticks_reads_field_22() {
+        // Fields 3..=22 after "(comm)"; field 22 (starttime) is the value 9988.
+        let stat = "1234 (server) S 1 1234 1234 0 -1 4194304 100 0 0 0 5 6 0 0 20 0 1 0 9988 \
+                    123456789 42 18446744073709551615 1 1 0 0 0 0 0 0 0";
+        assert_eq!(parse_start_ticks(stat), Some(9988));
+    }
+
+    #[test]
+    fn parse_start_ticks_handles_comm_with_spaces_and_parens() {
+        // A comm containing spaces and a ')' must not fool the parser.
+        let stat = "42 (weird ) name) S 1 42 42 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 7777 0 0";
+        assert_eq!(parse_start_ticks(stat), Some(7777));
+    }
+
+    #[test]
+    fn parse_start_ticks_rejects_malformed() {
+        assert_eq!(parse_start_ticks("no parens here"), None);
+        assert_eq!(parse_start_ticks("123 (short) S 1 2 3"), None);
+    }
+
+    #[test]
+    fn outcome_truth_table() {
+        // stopped(): everything except a still-running timeout.
+        assert!(TerminationOutcome::Graceful.stopped());
+        assert!(TerminationOutcome::Forced.stopped());
+        assert!(TerminationOutcome::AlreadyGone.stopped());
+        assert!(TerminationOutcome::IdentityMismatch.stopped());
+        assert!(!TerminationOutcome::TimedOut.stopped());
+
+        // Unverified: neither stopped nor graceful — we could not act.
+        assert!(!TerminationOutcome::Unverified.stopped());
+        assert!(!TerminationOutcome::Unverified.graceful());
+
+        // graceful(): true only when no SIGKILL was needed.
+        assert!(TerminationOutcome::Graceful.graceful());
+        assert!(TerminationOutcome::AlreadyGone.graceful());
+        assert!(TerminationOutcome::IdentityMismatch.graceful());
+        assert!(!TerminationOutcome::Forced.graceful());
+        assert!(!TerminationOutcome::TimedOut.graceful());
+    }
+
+    #[cfg(unix)]
+    fn spawn(args: &[&str]) -> Child {
+        Command::new(args[0])
+            .args(&args[1..])
+            .spawn()
+            .expect("spawn test child")
+    }
+
+    #[cfg(unix)]
+    fn reap(mut child: Child) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn identity_matches_our_own_process() {
+        let pid = std::process::id();
+        let id = ProcessIdentity::capture(pid);
+        assert!(id.start_ticks.is_some(), "should read our own start-time");
+        assert_eq!(identity_state(&id), IdentityState::Matches);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn identity_mismatch_when_start_ticks_differ() {
+        // Same live PID (ours), but a different recorded start-time: a recycled
+        // PID looks exactly like this, and must be treated as a different process.
+        let pid = std::process::id();
+        let real = process_start_ticks(pid).expect("own start-time");
+        let stale = ProcessIdentity::new(pid, Some(real.wrapping_add(1)));
+        assert_eq!(identity_state(&stale), IdentityState::Recycled);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_gone_after_exit() {
+        let child = spawn(&["sh", "-c", "exit 0"]);
+        let id = ProcessIdentity::capture(child.id());
+        reap(child);
+        assert_eq!(identity_state(&id), IdentityState::Gone);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refuses_to_signal_on_identity_mismatch() {
+        // Our own PID with a wrong start-time. A forced stop must NOT kill us:
+        // if it signalled, this test process would die instead of asserting.
+        let pid = std::process::id();
+        let real = process_start_ticks(pid).expect("own start-time");
+        let stale = ProcessIdentity::new(pid, Some(real.wrapping_add(1)));
+        let outcome =
+            terminate_verified(&stale, KillScope::Single, Duration::from_millis(50), true);
+        assert_eq!(outcome, TerminationOutcome::IdentityMismatch);
+        // Still alive to make the assertion at all — nothing was signalled.
+        assert!(crate::process_is_running(pid));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn already_gone_when_process_exited() {
+        let child = spawn(&["sh", "-c", "exit 0"]);
+        let id = ProcessIdentity::capture(child.id());
+        reap(child);
+        let outcome = terminate_verified(&id, KillScope::Single, Duration::from_millis(50), false);
+        assert_eq!(outcome, TerminationOutcome::AlreadyGone);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn graceful_stop_of_signal_respecting_child() {
+        // A plain `sleep` exits on SIGTERM.
+        let child = spawn(&["sleep", "30"]);
+        let id = ProcessIdentity::capture(child.id());
+        let outcome = terminate_verified(&id, KillScope::Single, Duration::from_secs(5), false);
+        assert_eq!(outcome, TerminationOutcome::Graceful);
+        assert_eq!(identity_state(&id), IdentityState::Gone);
+        reap(child);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn timed_out_then_forced_for_sigterm_ignoring_child() {
+        // Trap and ignore SIGTERM, then print `ready` so we only signal after the
+        // trap is installed — no sleep-based race with the default disposition.
+        let (child, _) = spawn_ready("trap '' TERM; echo ready; while true; do sleep 1; done");
+        let id = ProcessIdentity::capture(child.id());
+
+        // Non-forced stop must truthfully report it did not stop.
+        let soft = terminate_verified(&id, KillScope::Single, Duration::from_millis(300), false);
+        assert_eq!(soft, TerminationOutcome::TimedOut);
+        assert!(!soft.stopped());
+        assert_eq!(identity_state(&id), IdentityState::Matches);
+
+        // Forced stop escalates to SIGKILL and actually terminates it.
+        let hard = terminate_verified(&id, KillScope::Single, Duration::from_secs(5), true);
+        assert_eq!(hard, TerminationOutcome::Forced);
+        assert!(hard.stopped());
+        assert!(!hard.graceful());
+        assert_eq!(identity_state(&id), IdentityState::Gone);
+        reap(child);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tree_stop_waits_for_descendants() {
+        // A parent shell with a background child. The child (a grandchild of this
+        // test) must be terminated too — a graceful Tree stop that only confirmed
+        // the root would leave it alive.
+        let (child, gpid_line) = spawn_ready("sleep 300 & echo $!; wait");
+        let grandchild: u32 = gpid_line.parse().expect("grandchild pid");
+        assert!(
+            crate::process_is_running(grandchild),
+            "grandchild should be running before stop"
+        );
+        let id = ProcessIdentity::capture(child.id());
+
+        let outcome = terminate_verified(&id, KillScope::Tree, Duration::from_secs(5), false);
+        assert_eq!(outcome, TerminationOutcome::Graceful);
+        assert_eq!(identity_state(&id), IdentityState::Gone);
+        assert!(
+            !crate::process_is_running(grandchild),
+            "Tree stop must terminate the descendant, not just the root"
+        );
+        reap(child);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tree_forced_kill_reaches_sigterm_ignoring_descendant() {
+        // Root shell backgrounds an inner shell that ignores SIGTERM, prints its
+        // own PID, then becomes `sleep` (SIG_IGN survives exec). A forced Tree
+        // stop must SIGKILL that reparented descendant after the root exits.
+        let (child, gpid_line) =
+            spawn_ready(r#"sh -c "trap '' TERM; echo \$\$; exec sleep 300" & wait"#);
+        let grandchild: u32 = gpid_line.parse().expect("grandchild pid");
+        assert!(crate::process_is_running(grandchild));
+        let id = ProcessIdentity::capture(child.id());
+
+        let outcome = terminate_verified(&id, KillScope::Tree, Duration::from_millis(300), true);
+        assert_eq!(outcome, TerminationOutcome::Forced);
+        assert!(
+            !crate::process_is_running(grandchild),
+            "forced Tree stop must SIGKILL the SIGTERM-ignoring descendant"
+        );
+        reap(child);
+    }
+}

--- a/crates/rocm-core/src/proc_lifecycle.rs
+++ b/crates/rocm-core/src/proc_lifecycle.rs
@@ -169,6 +169,7 @@ impl TerminationOutcome {
 #[derive(Clone, Copy)]
 enum Signal {
     /// Request a graceful shutdown (`SIGTERM` on Unix).
+    #[cfg(not(windows))]
     Term,
     /// Force termination (`SIGKILL` on Unix, `TerminateProcess` on Windows).
     Kill,
@@ -214,12 +215,22 @@ pub fn terminate_verified(
         vec![*id]
     };
 
-    // Graceful request first: signal the whole scope, then wait for all to exit.
-    send_signal(id.pid, Signal::Term, tree);
-    if wait_for_all_exit(&members, grace) {
-        return TerminationOutcome::Graceful;
-    }
+    // Unix can request a graceful shutdown before escalating. Windows has no
+    // equivalent signal: do not burn the grace period on a no-op. A non-forced
+    // Windows stop reports TimedOut immediately; a forced stop proceeds directly
+    // to the verified kill path below.
+    #[cfg(not(windows))]
+    {
+        send_signal(id.pid, Signal::Term, tree);
+        if wait_for_all_exit(&members, grace) {
+            return TerminationOutcome::Graceful;
+        }
 
+        if !force {
+            return TerminationOutcome::TimedOut;
+        }
+    }
+    #[cfg(windows)]
     if !force {
         return TerminationOutcome::TimedOut;
     }
@@ -283,14 +294,8 @@ fn send_signal(pid: u32, signal: Signal, tree: bool) -> bool {
 
 #[cfg(windows)]
 fn send_signal(pid: u32, signal: Signal, _tree: bool) -> bool {
-    // Windows has no graceful process signal. A `Term` request is therefore a
-    // no-op — the bounded wait will time out and, only under a forced stop, the
-    // `Kill` step force-terminates. This keeps the reported outcome truthful:
-    // non-forced Windows stops surface `TimedOut` rather than a false graceful.
-    match signal {
-        Signal::Term => true,
-        Signal::Kill => crate::terminate_process(pid).is_ok(),
-    }
+    debug_assert!(matches!(signal, Signal::Kill));
+    crate::terminate_process(pid).is_ok()
 }
 
 /// Read the kernel start-time (field 22 of `/proc/<pid>/stat`) for `pid`.
@@ -353,6 +358,7 @@ fn parse_start_ticks(stat: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::process::{Child, Command, Stdio};
 
     /// Spawn a child that prints a line to stdout once it is ready, and block

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -42,6 +42,9 @@ const ROCM_BACKEND_NAME: &str = "rocm";
 /// we pick the highest-priority backend it considers supported on this host.
 const LLAMACPP_BACKEND_PRIORITY: [&str; 3] = ["rocm", "vulkan", "cpu"];
 const DEFAULT_LOG_TAIL_LINES: usize = 200;
+/// How long a stop waits for the server to actually exit after each signal
+/// before reporting a timeout (or, under `force`, escalating to `SIGKILL`).
+const STOP_GRACE: Duration = Duration::from_secs(10);
 const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 /// Maximum bytes to read from the end of a log file when extracting tail lines.
 /// Prevents reading entire gigabyte-sized logs on startup timeout.
@@ -504,6 +507,9 @@ fn launch_service(mut request: LaunchRequest) -> Result<LaunchResponse> {
         &json!({
             "pid": wrapper_pid,
             "wrapper_pid": wrapper_pid,
+            // Refresh the identity token in lockstep with the PID so a stop that
+            // lands before the wrapper rewrites its own state still verifies it.
+            "start_ticks": rocm_core::process_start_ticks(wrapper_pid),
         }),
     )?;
     Ok(LaunchResponse {
@@ -639,6 +645,8 @@ fn serve_http(request: ServeHttpRequest) -> Result<()> {
         &json!({
             "status": "ready",
             "server_pid": child.id(),
+            // Identity token for the server PID, captured while the child is alive.
+            "server_start_ticks": rocm_core::process_start_ticks(child.id()),
             "backend_state": "ready",
             "backend_requested": backend,
             "load_response": {
@@ -916,17 +924,27 @@ fn stop_service(request: StopRequest) -> Result<StopResponse> {
     require_nonempty(&request.service_id, "service_id")?;
     let files = service_files(&request.service_id)?;
     let state = read_service_state(&files.state_path).ok();
-    let stopped = match state.as_ref().and_then(pid_to_terminate_from_state) {
-        Some(pid) => terminate_pid(pid, request.force),
-        None => false,
+    // Verify the recorded PID still belongs to our server before signalling it,
+    // then wait for it to actually exit so the reported result is truthful.
+    let outcome = state
+        .as_ref()
+        .and_then(identity_from_state)
+        .map(|identity| {
+            rocm_core::terminate_verified(
+                &identity,
+                rocm_core::KillScope::Single,
+                STOP_GRACE,
+                request.force,
+            )
+        });
+    let (stopped, graceful) = match outcome {
+        Some(outcome) => (outcome.stopped(), outcome.graceful()),
+        None => (false, false),
     };
     if stopped {
         mark_json_status(&files.state_path, "stopped")?;
     }
-    Ok(StopResponse {
-        stopped,
-        graceful: stopped && !request.force,
-    })
+    Ok(StopResponse { stopped, graceful })
 }
 
 fn prepare_embeddable(
@@ -1776,6 +1794,8 @@ fn serve_direct_llama_server(
         &json!({
             "status": "ready",
             "server_pid": child.id(),
+            // Identity token for the server PID, captured while the child is alive.
+            "server_start_ticks": rocm_core::process_start_ticks(child.id()),
             "backend_state": "ready",
             "backend_requested": backend,
             "backend_mode": "lemonade-packaged-llama-server",
@@ -2324,7 +2344,12 @@ fn write_running_state(
             "runtime_executable": runtime.manifest.lemond,
             "log_path": request.log_path.as_ref().map(|path| path.display().to_string()),
             "engine_recipe": request.engine_recipe,
-            "started_at_unix_ms": current_unix_millis()
+            "started_at_unix_ms": current_unix_millis(),
+            // Kernel start-times captured while each PID is alive. Paired with the
+            // PIDs, they identify these exact processes across PID recycling so a
+            // later stop never signals a reused PID.
+            "start_ticks": rocm_core::process_start_ticks(pid),
+            "server_start_ticks": server_pid.and_then(rocm_core::process_start_ticks)
         }),
     )
 }
@@ -2408,8 +2433,18 @@ fn value_u32(value: &Value, key: &str) -> Option<u32> {
         .and_then(|value| u32::try_from(value).ok())
 }
 
-fn pid_to_terminate_from_state(state: &Value) -> Option<u32> {
-    value_u32(state, "server_pid").or_else(|| value_u32(state, "pid"))
+/// Reconstruct the identity (PID + kernel start-time) of the process a stop
+/// should terminate. The server PID is preferred, falling back to the launcher
+/// PID, each paired with its recorded start-time. `start_ticks` is absent in
+/// pre-existing state files, in which case verification degrades to best-effort.
+fn identity_from_state(state: &Value) -> Option<rocm_core::ProcessIdentity> {
+    if let Some(server_pid) = value_u32(state, "server_pid") {
+        let start_ticks = state.get("server_start_ticks").and_then(Value::as_u64);
+        return Some(rocm_core::ProcessIdentity::new(server_pid, start_ticks));
+    }
+    let pid = value_u32(state, "pid")?;
+    let start_ticks = state.get("start_ticks").and_then(Value::as_u64);
+    Some(rocm_core::ProcessIdentity::new(pid, start_ticks))
 }
 
 fn tail_lines(path: &Path, limit: usize) -> Result<Vec<String>> {
@@ -2633,6 +2668,41 @@ fn print_json<T: Serialize>(value: &T) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn identity_from_state_prefers_server_pid_and_its_start_ticks() {
+        let state = json!({
+            "pid": 100,
+            "start_ticks": 111_u64,
+            "server_pid": 200,
+            "server_start_ticks": 222_u64,
+        });
+        let identity = identity_from_state(&state).expect("identity");
+        assert_eq!(identity.pid, 200);
+        assert_eq!(identity.start_ticks, Some(222));
+    }
+
+    #[test]
+    fn identity_from_state_falls_back_to_launcher_pid() {
+        let state = json!({ "pid": 100, "start_ticks": 111_u64 });
+        let identity = identity_from_state(&state).expect("identity");
+        assert_eq!(identity.pid, 100);
+        assert_eq!(identity.start_ticks, Some(111));
+    }
+
+    #[test]
+    fn identity_from_legacy_state_has_no_start_ticks() {
+        // Pre-existing state files carry only PIDs; verification must degrade.
+        let state = json!({ "server_pid": 200 });
+        let identity = identity_from_state(&state).expect("identity");
+        assert_eq!(identity.pid, 200);
+        assert_eq!(identity.start_ticks, None);
+    }
+
+    #[test]
+    fn identity_from_state_without_any_pid_is_none() {
+        assert!(identity_from_state(&json!({ "status": "running" })).is_none());
+    }
 
     #[test]
     fn qwen_alias_resolves_to_validated_assistant_gguf_model() {

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -45,6 +45,8 @@ const DEFAULT_LOG_TAIL_LINES: usize = 200;
 /// How long a stop waits for the server to actually exit after each signal
 /// before reporting a timeout (or, under `force`, escalating to `SIGKILL`).
 const STOP_GRACE: Duration = Duration::from_secs(10);
+/// Lemonade state identifies the actual llama-server process directly.
+const STOP_SCOPE: rocm_core::KillScope = rocm_core::KillScope::Single;
 const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 /// Maximum bytes to read from the end of a log file when extracting tail lines.
 /// Prevents reading entire gigabyte-sized logs on startup timeout.
@@ -930,12 +932,7 @@ fn stop_service(request: StopRequest) -> Result<StopResponse> {
         .as_ref()
         .and_then(identity_from_state)
         .map(|identity| {
-            rocm_core::terminate_verified(
-                &identity,
-                rocm_core::KillScope::Single,
-                STOP_GRACE,
-                request.force,
-            )
+            rocm_core::terminate_verified(&identity, STOP_SCOPE, STOP_GRACE, request.force)
         });
     let (stopped, graceful) = match outcome {
         Some(outcome) => (outcome.stopped(), outcome.graceful()),
@@ -2668,6 +2665,11 @@ fn print_json<T: Serialize>(value: &T) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stop_scope_targets_only_the_recorded_lemonade_server() {
+        assert_eq!(STOP_SCOPE, rocm_core::KillScope::Single);
+    }
 
     #[test]
     fn identity_from_state_prefers_server_pid_and_its_start_ticks() {

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -34,6 +34,9 @@ const HEALTHCHECK_TIMEOUT_MS: u64 = 700;
 const DEFAULT_GPU_MEMORY_UTILIZATION: &str = "0.80";
 const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 const MAX_TAIL_READ: u64 = 4 * 1024 * 1024;
+/// How long a stop waits for the server to actually exit after each signal
+/// before reporting a timeout (or, under `force`, escalating to `SIGKILL`).
+const STOP_GRACE: Duration = Duration::from_secs(10);
 /// Default ROCm wheel index for `uv pip install vllm`.
 ///
 /// This pins both the vLLM release and the ROCm ABI tag, so it can drift from
@@ -798,17 +801,29 @@ fn stop_service(request: StopRequest) -> Result<StopResponse> {
     require_nonempty(&request.service_id, "service_id")?;
     let files = service_files(&request.service_id)?;
     let state = read_service_state(&files.state_path).ok();
-    let stopped = match state.as_ref().and_then(pid_from_state) {
-        Some(pid) => terminate_pid(pid, request.force),
-        None => false,
+    let outcome = state
+        .as_ref()
+        .and_then(identity_from_state)
+        // vLLM spawns an `EngineCore` worker that pins the GPU allocation, so
+        // the whole process tree must be signalled — but only after the recorded
+        // PID is confirmed to still be our server, never a recycled stranger.
+        .map(|identity| {
+            rocm_core::terminate_verified(
+                &identity,
+                rocm_core::KillScope::Tree,
+                STOP_GRACE,
+                request.force,
+            )
+        });
+    let (stopped, graceful) = match outcome {
+        Some(outcome) => (outcome.stopped(), outcome.graceful()),
+        // No PID recorded: nothing we can confirm stopping.
+        None => (false, false),
     };
     if stopped {
         write_terminal_state(&files.state_path, "stopped")?;
     }
-    Ok(StopResponse {
-        stopped,
-        graceful: stopped && !request.force,
-    })
+    Ok(StopResponse { stopped, graceful })
 }
 
 fn resolve_vllm_runtime(runtime_id: Option<&str>) -> Result<VllmRuntime> {
@@ -1440,7 +1455,11 @@ fn write_running_state(request: &ServeHttpRequest, runtime: &VllmRuntime, pid: u
             "engine_recipe": request.engine_recipe,
             "engine_recipe_required_flags": engine_recipe_launch_args(request.engine_recipe.as_ref()),
             "therock_runtime_env": therock_runtime_env_state(runtime),
-            "started_at_unix_ms": current_unix_millis()
+            "started_at_unix_ms": current_unix_millis(),
+            // Kernel start-time of the launcher PID, captured while it is alive.
+            // Paired with `pid`, it identifies this exact process across PID
+            // recycling so a later stop never signals a reused PID.
+            "start_ticks": rocm_core::process_start_ticks(pid)
         }),
     )
 }
@@ -1522,8 +1541,13 @@ fn pid_from_state(state: &Value) -> Option<u32> {
         .and_then(|pid| pid.try_into().ok())
 }
 
-fn terminate_pid(pid: u32, _force: bool) -> bool {
-    rocm_core::terminate_process_tree(pid).is_ok()
+/// Reconstruct the recorded process identity (PID + kernel start-time) from a
+/// service state file. `start_ticks` is absent in state files written before
+/// this field existed, in which case verification degrades to best-effort.
+fn identity_from_state(state: &Value) -> Option<rocm_core::ProcessIdentity> {
+    let pid = pid_from_state(state)?;
+    let start_ticks = state.get("start_ticks").and_then(Value::as_u64);
+    Some(rocm_core::ProcessIdentity::new(pid, start_ticks))
 }
 
 fn value_string(value: &Value, key: &str) -> Option<String> {
@@ -2224,6 +2248,31 @@ mod tests {
                 .and_then(Value::as_array)
                 .is_some_and(|paths| !paths.is_empty())
         );
+        // The identity token must be recorded so a later stop can verify it.
+        assert!(state.get("start_ticks").is_some());
         Ok(())
+    }
+
+    #[test]
+    fn identity_from_state_carries_pid_and_start_ticks() {
+        let state = json!({ "pid": 4321, "start_ticks": 987_654_u64 });
+        let identity = identity_from_state(&state).expect("identity");
+        assert_eq!(identity.pid, 4321);
+        assert_eq!(identity.start_ticks, Some(987_654));
+    }
+
+    #[test]
+    fn identity_from_legacy_state_has_no_start_ticks() {
+        // State files written before this change carry only `pid`; verification
+        // must degrade gracefully rather than fail to parse.
+        let state = json!({ "pid": 4321 });
+        let identity = identity_from_state(&state).expect("identity");
+        assert_eq!(identity.pid, 4321);
+        assert_eq!(identity.start_ticks, None);
+    }
+
+    #[test]
+    fn identity_from_state_without_pid_is_none() {
+        assert!(identity_from_state(&json!({ "status": "running" })).is_none());
     }
 }

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -37,6 +37,8 @@ const MAX_TAIL_READ: u64 = 4 * 1024 * 1024;
 /// How long a stop waits for the server to actually exit after each signal
 /// before reporting a timeout (or, under `force`, escalating to `SIGKILL`).
 const STOP_GRACE: Duration = Duration::from_secs(10);
+/// vLLM launches worker descendants that retain GPU allocations.
+const STOP_SCOPE: rocm_core::KillScope = rocm_core::KillScope::Tree;
 /// Default ROCm wheel index for `uv pip install vllm`.
 ///
 /// This pins both the vLLM release and the ROCm ABI tag, so it can drift from
@@ -808,12 +810,7 @@ fn stop_service(request: StopRequest) -> Result<StopResponse> {
         // the whole process tree must be signalled — but only after the recorded
         // PID is confirmed to still be our server, never a recycled stranger.
         .map(|identity| {
-            rocm_core::terminate_verified(
-                &identity,
-                rocm_core::KillScope::Tree,
-                STOP_GRACE,
-                request.force,
-            )
+            rocm_core::terminate_verified(&identity, STOP_SCOPE, STOP_GRACE, request.force)
         });
     let (stopped, graceful) = match outcome {
         Some(outcome) => (outcome.stopped(), outcome.graceful()),
@@ -2251,6 +2248,11 @@ mod tests {
         // The identity token must be recorded so a later stop can verify it.
         assert!(state.get("start_ticks").is_some());
         Ok(())
+    }
+
+    #[test]
+    fn stop_scope_includes_vllm_workers() {
+        assert_eq!(STOP_SCOPE, rocm_core::KillScope::Tree);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes **EAI-7410**: the serve **stop** path signalled a PID read from a state file with no identity check and reported success without confirming the process actually exited.

Two defects, shared by both engine adapters and the CLI managed-service layer:

1. **PID reuse → wrong-process kill.** `stop` read a persisted PID and `SIGTERM`ed it (vLLM signalled the whole `/proc` descendant tree). Linux recycles PIDs, so a stale PID could belong to an unrelated process by stop time — killing an innocent process (and its subtree).
2. **Untruthful, unbounded termination.** Success was reported when `SIGTERM` was merely *delivered* (`ESRCH`/already-gone counted as success). No bounded wait, no confirmed exit, no `SIGKILL` escalation — so `stopped`/`graceful` were claimed even while the process was still alive or already gone.

## What changed

**New `rocm-core::proc_lifecycle`:**
- `ProcessIdentity` = `(pid, kernel start-time)` from `/proc/<pid>/stat` (field 22). A recycled PID has a different start-time, so the pair is a recycle-proof identity.
- `identity_state` → `Matches` / `Recycled` / `Indeterminate` / `Gone` (zombie-aware; refuses when a recorded identity can't be confirmed).
- `terminate_verified(id, scope, grace, force)` → verify identity, `SIGTERM`, poll for **actual exit** up to a bounded `grace`, escalate to `SIGKILL` only under `force`, and return a **truthful** `TerminationOutcome`. **Tree** scope snapshots every descendant and waits for **all** to exit, so a lingering GPU worker is never reported as a graceful stop; forced escalation only targets survivors it can positively re-verify.

**Wiring:**
- vLLM & lemonade persist `start_ticks`/`server_start_ticks` in engine state and verify identity in `stop_service` (vLLM `Tree`, lemonade `Single`); lemonade also refreshes the token at every state PID-swap.
- CLI `stop_internal_managed_service` verifies `ManagedServiceRecord` identities before signalling; the supervisor (launcher) and engine server carry their own tokens (`supervisor_start_ticks` / `engine_start_ticks`, the latter adopted in `refresh_from_engine_state`). A stop claims `"stopped"` only when every recorded process is confirmed gone; otherwise the prior status stands and the existing liveness refresh reconciles it.
- Removed the now-unused unverified `signal_process_tree`.

Behavior degrades gracefully: legacy state files without a token, and non-Linux platforms, fall back to documented best-effort (unchanged from prior behavior).

## Testing

- `cargo test --workspace` → **1459 passed, 0 failed** (`--test-threads=1`).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- New focused lifecycle tests: identity match/recycle/gone/indeterminate, refuse-to-signal on mismatch, graceful/timed-out/forced, **tree waits for descendants**, **forced tree kill of a SIGTERM-ignoring reparented descendant**, engine `identity_from_state` (incl. legacy/no-token), and managed-layer stop (refuse recycled PID, verified kill, distinct supervisor/engine PIDs).
- Reviewed across three rounds (reliability + security + OSS + dual fresh adversarial); all confirmed findings resolved.

## Follow-ups (out of scope — separate subsystems, same pattern)

- `apps/rocm/src/comfyui.rs` and the `rocmd` supervised-record stop path still use the store-then-kill pattern; recommend routing them through `terminate_verified` in a follow-up.
