### PR TITLE
fix(examine): classify gfx1100/1101/1102 as discrete, not APU (EAI-7412)

### DIFF
--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -874,6 +874,31 @@ fn check_9_igpu_dgpu_collision(e: &Examination, symptom: &str) -> Diagnosis {
     }
 
     let gfx_targets = amd_gfx_targets(e);
+    // Name the discrete GPU explicitly instead of guessing by gfx number: on
+    // RDNA3 the integrated APU (gfx1103 / gfx115x) can outrank its discrete
+    // neighbor (gfx1100/1101/1102), so "the higher-numbered target is the dGPU"
+    // is actively wrong for exactly the APU+dGPU pairing this check fires on.
+    let discrete_targets: Vec<String> = e
+        .gpus
+        .iter()
+        .filter(|g| g.is_amd && g.is_apu == Some(false) && !g.gfx_target.is_empty())
+        .map(|g| g.gfx_target.clone())
+        .collect();
+    let apu_targets: Vec<String> = e
+        .gpus
+        .iter()
+        .filter(|g| g.is_amd && g.is_apu == Some(true) && !g.gfx_target.is_empty())
+        .map(|g| g.gfx_target.clone())
+        .collect();
+    let note = if discrete_targets.is_empty() {
+        format!(
+            "Detected gfx targets: {gfx_targets:?}. Pin HIP_VISIBLE_DEVICES to the discrete GPU so the integrated APU is hidden."
+        )
+    } else {
+        format!(
+            "Detected gfx targets: {gfx_targets:?}. Discrete GPU(s): {discrete_targets:?}; integrated APU(s): {apu_targets:?}. Pin HIP_VISIBLE_DEVICES to the discrete GPU — do not assume the higher-numbered gfx target is the dGPU (on RDNA3 the APU can be higher)."
+        )
+    };
     let fix = if e.os_family == "windows" {
         Fix {
             summary: "Pin the HIP runtime to the discrete GPU with HIP_VISIBLE_DEVICES so the iGPU is hidden.".to_owned(),
@@ -887,7 +912,7 @@ fn check_9_igpu_dgpu_collision(e: &Examination, symptom: &str) -> Diagnosis {
             fix_id: "fix-9-igpu-dgpu".to_owned(),
             auto_applicable: true,
             verify: "powershell -NoProfile -Command \"$env:HIP_VISIBLE_DEVICES=1; python -c \\\"import torch; print(torch.cuda.device_count())\\\"\"".to_owned(),
-            notes: vec![format!("Detected gfx targets: {gfx_targets:?}. The dGPU is usually the higher-numbered family (gfx11xx).")],
+            notes: vec![note],
             ..Fix::default()
         }
     } else {
@@ -903,7 +928,7 @@ fn check_9_igpu_dgpu_collision(e: &Examination, symptom: &str) -> Diagnosis {
             fix_id: "fix-9-igpu-dgpu".to_owned(),
             auto_applicable: false,
             verify: "HIP_VISIBLE_DEVICES=1 python -c \"import torch; print(torch.cuda.device_count())\"".to_owned(),
-            notes: vec![format!("Detected gfx targets: {gfx_targets:?}. The dGPU is usually the higher-numbered family (gfx11xx).")],
+            notes: vec![note],
             ..Fix::default()
         }
     };
@@ -1446,6 +1471,44 @@ mod tests {
         assert_eq!(top.id, "fix-1-arch");
         // 50 (keyword) + 55 (missing arch), clamped to 100.
         assert_eq!(top.score, 100);
+    }
+
+    #[test]
+    fn igpu_dgpu_collision_fires_for_rdna3_apu_plus_discrete() {
+        // End-to-end guard for EAI-7412: a gfx1103 (Phoenix APU) + gfx1100
+        // (Navi 31 dGPU) box must now trigger the iGPU+dGPU collision fix,
+        // which was silently suppressed while gfx1100 was misclassified as an
+        // APU. The note must name the discrete target rather than telling the
+        // user the higher-numbered gfx target is the dGPU (false here).
+        let mut e = linux_base();
+        e.has_apu = true;
+        e.has_discrete_amd = true;
+        e.gpus = vec![
+            Gpu {
+                gfx_target: "gfx1103".to_owned(),
+                is_amd: true,
+                is_apu: Some(true),
+                ..Gpu::default()
+            },
+            Gpu {
+                gfx_target: "gfx1100".to_owned(),
+                is_amd: true,
+                is_apu: Some(false),
+                ..Gpu::default()
+            },
+        ];
+        let report = diagnose(&e, "torch crashes with a segfault");
+        let hit = report
+            .matched
+            .iter()
+            .find(|d| d.id == "fix-9-igpu-dgpu")
+            .expect("iGPU+dGPU collision should be diagnosed");
+        let note = hit.fix.as_ref().unwrap().notes.join(" ");
+        assert!(note.contains("gfx1100"), "note must name the dGPU: {note}");
+        assert!(
+            !note.contains("usually the higher-numbered"),
+            "note must not repeat the old wrong gfx-number heuristic: {note}"
+        );
     }
 
     #[test]

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -545,13 +545,33 @@ fn classify_amd_marketing_name(name: &str) -> (String, bool) {
     (String::new(), APU_KEYWORDS.iter().any(|kw| n.contains(kw)))
 }
 
-/// Whether a gfx target belongs to an APU family the doctor cares about
-/// (gfx115x / gfx110x / gfx103x).
+/// Whether a gfx target belongs to an AMD APU family the doctor cares about.
+///
+/// APUs: gfx1103 (Phoenix / Hawk Point) and the gfx115x parts (Strix Point /
+/// Strix Halo). Their neighbors gfx1100 / gfx1101 / gfx1102 (Navi 31 / 32 / 33)
+/// share the gfx110x prefix but are *discrete* RDNA3 GPUs, so they must not
+/// match — otherwise they inflate `has_apu` and suppress `has_discrete_amd`,
+/// which gates the iGPU+dGPU collision fix. (Target -> product per LLVM
+/// AMDGPUUsage.)
 fn gfx_is_apu_family(gfx: &str) -> bool {
     let g = gfx.to_lowercase();
-    (g.starts_with("gfx110") || g.starts_with("gfx115"))
-        && g.len() >= 7
-        && g.as_bytes()[6].is_ascii_digit()
+    // gfx115x: every Strix part is an APU.
+    if gfx_model_digit(&g, "gfx115").is_some() {
+        return true;
+    }
+    // gfx110x: only gfx1103 and above are APUs; gfx1100/1101/1102 are discrete.
+    if let Some(digit) = gfx_model_digit(&g, "gfx110") {
+        return digit >= 3;
+    }
+    false
+}
+
+/// The model digit that follows `prefix` in a gfx target, e.g. `3` from
+/// `gfx1103` given prefix `gfx110`. Returns `None` when `gfx` does not start
+/// with `prefix` or has no digit there. Any trailing feature suffix (such as
+/// `:sramecc+:xnack-`) is ignored, matching how gcnArchName can be reported.
+fn gfx_model_digit(gfx: &str, prefix: &str) -> Option<u32> {
+    gfx.strip_prefix(prefix)?.chars().next()?.to_digit(10)
 }
 
 fn probe_gpus_lspci(e: &mut Examination) {
@@ -1564,15 +1584,80 @@ mod tests {
     }
 
     #[test]
-    fn gfx_apu_family_classification() {
-        // Mirrors examine.py's `gfx11[05]\d` regex exactly (faithful parity),
-        // including that it matches gfx1100 — diagnose.py is written against
-        // this behavior, so we reproduce it rather than "correct" it.
-        assert!(gfx_is_apu_family("gfx1151"));
+    fn gfx_apu_family_neighboring_contract() {
+        // gfx110x straddles two silicon families: gfx1100/gfx1101/gfx1102 are
+        // discrete RDNA3 parts (Navi 31/32/33 -> Radeon RX 7900/7800/7600),
+        // while gfx1103 (Phoenix / Hawk Point) is an APU. gfx115x (Strix Point
+        // / Strix Halo) are APUs. Target->product mapping per LLVM AMDGPUUsage.
+        //
+        // The discrete neighbors must NOT be classified as an APU family: they
+        // drive `has_discrete_amd`, which gates the iGPU+dGPU collision fix.
+        assert!(!gfx_is_apu_family("gfx1100"));
+        assert!(!gfx_is_apu_family("gfx1101"));
+        assert!(!gfx_is_apu_family("gfx1102"));
+        // Integrated APUs (every gfx115x part plus gfx1103+).
         assert!(gfx_is_apu_family("gfx1103"));
-        assert!(gfx_is_apu_family("gfx1100"));
+        assert!(gfx_is_apu_family("gfx1150"));
+        assert!(gfx_is_apu_family("gfx1151"));
+        assert!(gfx_is_apu_family("gfx1152"));
+        // Unrelated families are never APUs.
         assert!(!gfx_is_apu_family("gfx1200"));
         assert!(!gfx_is_apu_family("gfx942"));
+        // A trailing gcnArchName feature suffix must not change the verdict.
+        assert!(gfx_is_apu_family("gfx1103:sramecc+:xnack-"));
+        assert!(!gfx_is_apu_family("gfx1100:xnack-"));
+        // Degenerate inputs never match.
+        assert!(!gfx_is_apu_family("gfx110"));
+        assert!(!gfx_is_apu_family(""));
+    }
+
+    #[test]
+    fn apu_plus_discrete_neighbor_sets_both_category_flags() {
+        // A machine with a real APU (gfx1103 Phoenix) and its discrete RDNA3
+        // neighbor (gfx1100 Navi 31) must report BOTH an APU and a discrete
+        // AMD GPU. Before the gfx110x carve-out, gfx1100 was tagged an APU
+        // too, so `has_discrete_amd` stayed false and the iGPU+dGPU collision
+        // fix was silently suppressed for exactly this pairing.
+        let mut e = Examination {
+            gpus: vec![
+                Gpu {
+                    gfx_target: "gfx1103".to_owned(),
+                    is_amd: true,
+                    is_apu: Some(gfx_is_apu_family("gfx1103")),
+                    ..Gpu::default()
+                },
+                Gpu {
+                    gfx_target: "gfx1100".to_owned(),
+                    is_amd: true,
+                    is_apu: Some(gfx_is_apu_family("gfx1100")),
+                    ..Gpu::default()
+                },
+            ],
+            ..Examination::default()
+        };
+        summarise_gpu_categories(&mut e);
+        assert!(e.has_apu, "gfx1103 APU should set has_apu");
+        assert!(
+            e.has_discrete_amd,
+            "gfx1100 dGPU should set has_discrete_amd"
+        );
+    }
+
+    #[test]
+    fn lone_discrete_rdna3_is_not_reported_as_apu() {
+        // A box with only a gfx1100 discrete card must not claim to have an APU.
+        let mut e = Examination {
+            gpus: vec![Gpu {
+                gfx_target: "gfx1100".to_owned(),
+                is_amd: true,
+                is_apu: Some(gfx_is_apu_family("gfx1100")),
+                ..Gpu::default()
+            }],
+            ..Examination::default()
+        };
+        summarise_gpu_categories(&mut e);
+        assert!(!e.has_apu, "a lone gfx1100 dGPU must not set has_apu");
+        assert!(e.has_discrete_amd);
     }
 
     #[test]


### PR DESCRIPTION
## EAI-7412 — gfx1100 family misclassified as APU

### Problem
`gfx_is_apu_family` (crates/rocm-core/src/examine.rs) matched the whole `gfx110x` prefix, so the **discrete** RDNA3 parts **gfx1100 / gfx1101 / gfx1102** (Navi 31/32/33 → Radeon RX 7900/7800/7600) were tagged APUs alongside the real APU **gfx1103** (Phoenix) and the **gfx115x** (Strix) parts.

An old test (`gfx_apu_family_classification`) *protected* this wrong behavior, asserting `gfx_is_apu_family("gfx1100") == true` with a comment that it deliberately mirrored `examine.py`'s `gfx11[05]\d` regex bug.

### Impact
`is_apu` → `has_apu` / `has_discrete_amd` (`summarise_gpu_categories`) → gates `check_9_igpu_dgpu_collision` in diagnose.rs. On a real **gfx1103 APU + gfx1100 dGPU** box, both were tagged APU, so `has_discrete_amd` stayed `false` and the iGPU+dGPU collision fix was **silently suppressed** — for exactly the pairing it exists to help. A lone gfx1100 dGPU box also falsely reported "has an APU".

### Fix (test-first)
- **Correct the classification**: within `gfx110x`, only `gfx1103`+ are APUs; `gfx1100/1101/1102` are discrete. All `gfx115x` remain APUs. Trailing gcnArchName feature suffixes (e.g. `:sramecc+:xnack-`) are tolerated.
- **Replace the parity test** with the intended neighboring-family contract; add flag-derivation and lone-dGPU regression tests.
- **Correct the collision-fix note**: it now names the discrete target explicitly instead of the fragile "the higher-numbered gfx target is the dGPU" heuristic, which is *false* on RDNA3 (the APU can outrank its discrete neighbor). Added the previously-missing end-to-end `check_9` regression test.

Target → product mapping verified against LLVM AMDGPUUsage.

### Test plan
- `cargo test -p rocm-core` — 170 pass (RED→GREEN confirmed on the new contract test).
- `cargo test --workspace -- --test-threads=1` — full suite green.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Reviewed via dual adversarial review; HIGH (backwards note) and MEDIUM (missing `check_9` test) findings fixed.

### Follow-ups (out of scope, noted)
- `gfx90c` (Renoir/Cezanne APU) is still unclassified — pre-existing gap, currently inert (`check_9` needs `has_apu`). Worth a separate ticket.
- External `rocm-doctor` `examine.py`/`diagnose.py` (not in this repo) should be updated in lockstep to drop the same bug; the surviving in-repo parity test only checks JSON key shape, not values, so nothing here regresses.