### PR TITLE
Enforce GPU-required serving with a real device probe

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4026,6 +4026,23 @@ fn serve(args: ServeArgs) -> Result<()> {
     // surface the explicit `--gpu` as ignored rather than printing a device the
     // server will not use.
     let cpu_only = matches!(device_policy, DevicePolicy::CpuOnly);
+    // Fail fast under a GPU-required policy when the host has no usable AMD GPU,
+    // BEFORE preparing or launching any engine (no wasted engine download, and an
+    // actionable message instead of a late engine crash). The engine enforces the
+    // same rule as a backstop. Skipped for cpu_only; permissive when availability
+    // cannot be probed on this platform (probe returns `None`).
+    if !cpu_only
+        && let Some(usable) = rocm_core::usable_amd_gpu_indices()
+        && usable.is_empty()
+    {
+        bail!(
+            "no usable AMD GPU detected; `rocm serve` requires a GPU under the {policy} \
+             policy and does not fall back to CPU. Check the driver with `rocm examine`, \
+             confirm /dev/kfd is present, and ensure HIP_VISIBLE_DEVICES / \
+             ROCR_VISIBLE_DEVICES are not masking every device.",
+            policy = device_policy_name(&device_policy)
+        );
+    }
     // `--gpu` selects by the amd-smi `gpu` ordinal but is exported via
     // `HIP_VISIBLE_DEVICES`; those orderings can diverge when
     // `ROCR_VISIBLE_DEVICES`/partitioning is in play, so warn at serve time.

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -15243,7 +15243,10 @@ const AUTO_FREE_VRAM_FRACTION: f64 = 0.90;
 /// Pick a GPU ordinal for `--gpu auto`. Prefers the lowest-numbered GPU that is
 /// idle (free VRAM at or above [`AUTO_FREE_VRAM_FRACTION`]) and not pinned by a
 /// running rocm-cli service; otherwise falls back to the non-busy GPU with the
-/// most free VRAM, then to the first non-busy GPU, then to `[0]`.
+/// most free VRAM, then to the first non-busy GPU. When the GPU count is unknown
+/// (amd-smi unavailable or zero devices) it returns no selection rather than
+/// assuming device 0 — the engine's device probe then pins the first present GPU
+/// or fails fast under the GPU-required policy.
 ///
 /// Selection reads service state without holding a lock, so two near-concurrent
 /// `--gpu auto` launches can race onto the same idle GPU. The VRAM-occupancy
@@ -15268,7 +15271,11 @@ fn select_auto_gpu_index(
 ) -> Vec<u32> {
     let count = detected.unwrap_or(0);
     if count == 0 {
-        return vec![0];
+        // No GPU count from amd-smi (unavailable, or genuinely zero devices). Do
+        // not assume device 0 exists: return no selection and let the engine's
+        // device probe pin the first present GPU or fail fast under the
+        // GPU-required policy (no GPU-0 fallback).
+        return Vec::new();
     }
     let candidates = || (0..count as u32).filter(|index| !busy.contains(index));
     let usage_for = |index: u32| vram.and_then(|rows| rows.iter().find(|row| row.index == index));
@@ -20555,7 +20562,8 @@ install therock";
     #[test]
     fn auto_selection_falls_back_to_first_non_busy_without_vram() {
         assert_eq!(select_auto_gpu_index(Some(4), &[0, 1], None), vec![2]);
-        assert_eq!(select_auto_gpu_index(None, &[], None), vec![0]);
+        // Unknown GPU count: no GPU-0 fallback — defer to the engine device probe.
+        assert_eq!(select_auto_gpu_index(None, &[], None), Vec::<u32>::new());
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3550,16 +3550,26 @@ fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
 }
 
 /// Combine the KFD-topology and DRM-card AMD GPU counts into one "GPUs present"
-/// figure, taking the larger available count. Some hosts (e.g. Strix Halo APUs)
-/// enumerate the GPU only via DRM ip-discovery and report zero KFD GPU nodes, so
-/// relying on KFD alone would wrongly conclude there is no GPU and block serving.
+/// figure. KFD counts *compute* nodes and is authoritative for HIP ordinals, so
+/// it wins whenever it reports at least one GPU. DRM is used only as the
+/// zero-KFD fallback: some hosts (e.g. Strix Halo APUs) enumerate the GPU only
+/// via DRM ip-discovery and report zero KFD GPU nodes, so relying on KFD alone
+/// would wrongly conclude there is no GPU and block serving.
+///
+/// DRM must not *raise* a nonzero KFD count: a display/render-only AMD DRM card
+/// with no KFD compute node (e.g. KFD=1, DRM=2) would otherwise invent a usable
+/// HIP ordinal that passes `--gpu` validation but fails later inside HIP.
+///
 /// `None` only when NEITHER surface could be read (availability truly unknown).
 #[cfg(any(target_os = "linux", test))]
 fn combine_amd_gpu_counts(kfd: Option<usize>, drm: Option<usize>) -> Option<usize> {
-    match (kfd, drm) {
-        (Some(k), Some(d)) => Some(k.max(d)),
-        (Some(n), None) | (None, Some(n)) => Some(n),
-        (None, None) => None,
+    match kfd {
+        // KFD is compute-authoritative: prefer it whenever it sees a GPU.
+        Some(k) if k > 0 => Some(k),
+        // Zero KFD compute nodes: fall back to DRM for the APU shape.
+        Some(_) => Some(drm.unwrap_or(0)),
+        // KFD unreadable: use DRM if it could be read, else availability unknown.
+        None => drm,
     }
 }
 
@@ -8316,7 +8326,16 @@ last_installed_runtime_id = "therock-release"
     }
 
     #[test]
-    fn combine_amd_gpu_counts_takes_larger_and_needs_one_readable_surface() {
+    fn combine_amd_gpu_counts_prefers_compute_authoritative_kfd() {
+        // KFD is compute-authoritative: a nonzero KFD count wins, and DRM must not
+        // raise it. A display/render-only AMD DRM card (KFD=1, DRM=2) must NOT
+        // invent a second usable HIP ordinal, or an explicit `--gpu 1` would pass
+        // validation and then fail inside HIP.
+        assert_eq!(combine_amd_gpu_counts(Some(1), Some(2)), Some(1));
+        // Same principle with more DRM cards: still bounded by the KFD count.
+        assert_eq!(combine_amd_gpu_counts(Some(2), Some(8)), Some(2));
+        // KFD larger than DRM (e.g. multi-partition compute nodes): KFD still wins.
+        assert_eq!(combine_amd_gpu_counts(Some(3), Some(1)), Some(3));
         // Strix Halo shape: KFD reports 0 GPU nodes, DRM sees the iGPU → 1 present.
         assert_eq!(combine_amd_gpu_counts(Some(0), Some(1)), Some(1));
         // Discrete GPUs: both surfaces agree.

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3539,7 +3539,8 @@ pub fn has_usable_amd_gpu() -> bool {
 
 #[cfg(target_os = "linux")]
 fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
-    let present = linux_kfd_gpu_node_count()?;
+    let present =
+        combine_amd_gpu_counts(linux_kfd_gpu_node_count(), linux_drm_amdgpu_card_count())?;
     Some(usable_amd_gpu_indices_from(
         present,
         visibility_mask_from_env(),
@@ -3549,6 +3550,41 @@ fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
 #[cfg(not(target_os = "linux"))]
 fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
     None
+}
+
+/// Combine the KFD-topology and DRM-card AMD GPU counts into one "GPUs present"
+/// figure, taking the larger available count. Some hosts (e.g. Strix Halo APUs)
+/// enumerate the GPU only via DRM ip-discovery and report zero KFD GPU nodes, so
+/// relying on KFD alone would wrongly conclude there is no GPU and block serving.
+/// `None` only when NEITHER surface could be read (availability truly unknown).
+#[cfg(any(target_os = "linux", test))]
+fn combine_amd_gpu_counts(kfd: Option<usize>, drm: Option<usize>) -> Option<usize> {
+    match (kfd, drm) {
+        (Some(k), Some(d)) => Some(k.max(d)),
+        (Some(n), None) | (None, Some(n)) => Some(n),
+        (None, None) => None,
+    }
+}
+
+/// Count AMD (`amdgpu`) primary DRM cards under `/sys/class/drm` (`card0`,
+/// `card1`, …), skipping connector sub-nodes like `card0-DP-1`. `None` when the
+/// DRM class dir can't be read; `Some(0)` when it is readable with no AMD card.
+#[cfg(target_os = "linux")]
+fn linux_drm_amdgpu_card_count() -> Option<usize> {
+    let entries = fs::read_dir(Path::new("/sys/class/drm")).ok()?;
+    let count = entries
+        .flatten()
+        .filter(|entry| {
+            let card_path = entry.path();
+            let Some(name) = card_path.file_name().and_then(|value| value.to_str()) else {
+                return false;
+            };
+            name.starts_with("card")
+                && !name.contains('-')
+                && is_amdgpu_device(&card_path.join("device"))
+        })
+        .count();
+    Some(count)
 }
 
 /// Count AMD GPU nodes in the KFD topology. `Some(0)` is an authoritative "no
@@ -3591,7 +3627,11 @@ fn kfd_gfx_target_version_is_gpu(value: &str) -> bool {
 /// `ROCR_VISIBLE_DEVICES`. `None` when neither is set; an explicitly empty value
 /// is returned as `Some("")` so callers can distinguish "unset" (all visible)
 /// from "set to nothing" (all masked out).
-#[cfg(any(target_os = "linux", test))]
+///
+/// Linux-only: its sole caller is the Linux probe. (Not `+ test` — no test
+/// references it directly, so compiling it into a non-Linux test build would be
+/// dead code, which the workspace lints deny.)
+#[cfg(target_os = "linux")]
 fn visibility_mask_from_env() -> Option<String> {
     ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"]
         .into_iter()
@@ -8275,6 +8315,21 @@ last_installed_runtime_id = "therock-release"
         assert!(!kfd_gfx_target_version_is_gpu("not-a-number"));
         assert!(kfd_gfx_target_version_is_gpu("90402"));
         assert!(kfd_gfx_target_version_is_gpu("110000"));
+    }
+
+    #[test]
+    fn combine_amd_gpu_counts_takes_larger_and_needs_one_readable_surface() {
+        // Strix Halo shape: KFD reports 0 GPU nodes, DRM sees the iGPU → 1 present.
+        assert_eq!(combine_amd_gpu_counts(Some(0), Some(1)), Some(1));
+        // Discrete GPUs: both surfaces agree.
+        assert_eq!(combine_amd_gpu_counts(Some(8), Some(8)), Some(8));
+        // One surface unreadable → use the other.
+        assert_eq!(combine_amd_gpu_counts(None, Some(1)), Some(1));
+        assert_eq!(combine_amd_gpu_counts(Some(2), None), Some(2));
+        // Neither readable → unknown (caller must not treat as zero).
+        assert_eq!(combine_amd_gpu_counts(None, None), None);
+        // Both agree on zero → authoritative no-GPU.
+        assert_eq!(combine_amd_gpu_counts(Some(0), Some(0)), Some(0));
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3513,6 +3513,117 @@ fn detect_linux_kfd_gfx_target() -> Option<String> {
     None
 }
 
+/// AMD GPU device ordinals usable for a GPU-required launch on this host, after
+/// applying the runtime visibility mask (`HIP_VISIBLE_DEVICES`, then
+/// `ROCR_VISIBLE_DEVICES`).
+///
+/// `Some(indices)` is an authoritative answer: an empty vector means no GPU is
+/// usable, so a GPU-required launch must fail rather than fall back to CPU or
+/// assume device 0. `None` means availability could not be probed on this
+/// platform (e.g. the KFD device exists but its topology is unreadable, or a
+/// non-Linux target) and callers should not block a launch on this basis.
+#[must_use]
+pub fn usable_amd_gpu_indices() -> Option<Vec<u32>> {
+    probe_usable_amd_gpu_indices()
+}
+
+/// Whether at least one AMD GPU is usable for a GPU-required launch.
+///
+/// `false` only when the probe authoritatively reports zero usable devices; an
+/// unprobeable platform reports `true` so it does not block launches (see
+/// [`usable_amd_gpu_indices`]).
+#[must_use]
+pub fn has_usable_amd_gpu() -> bool {
+    usable_amd_gpu_indices().is_none_or(|indices| !indices.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
+    let present = linux_kfd_gpu_node_count()?;
+    Some(usable_amd_gpu_indices_from(
+        present,
+        visibility_mask_from_env(),
+    ))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
+    None
+}
+
+/// Count AMD GPU nodes in the KFD topology. `Some(0)` is an authoritative "no
+/// GPU" (topology readable with no GPU node, or no KFD device at all); `None`
+/// means the topology could not be read even though `/dev/kfd` exists, so
+/// availability is unknown and must not be treated as zero.
+#[cfg(target_os = "linux")]
+fn linux_kfd_gpu_node_count() -> Option<usize> {
+    let nodes_dir = Path::new("/sys/class/kfd/kfd/topology/nodes");
+    match fs::read_dir(nodes_dir) {
+        Ok(entries) => Some(
+            entries
+                .flatten()
+                .filter(|entry| kfd_node_is_gpu(&entry.path()))
+                .count(),
+        ),
+        Err(_) if Path::new("/dev/kfd").exists() => None,
+        Err(_) => Some(0),
+    }
+}
+
+/// A KFD topology node is a GPU (not the CPU node) when its
+/// `gfx_target_version` is a nonzero value; CPU nodes report `0`.
+#[cfg(target_os = "linux")]
+fn kfd_node_is_gpu(node_dir: &Path) -> bool {
+    fs::read_to_string(node_dir.join("gfx_target_version"))
+        .ok()
+        .is_some_and(|value| kfd_gfx_target_version_is_gpu(value.trim()))
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn kfd_gfx_target_version_is_gpu(value: &str) -> bool {
+    value
+        .trim()
+        .parse::<u64>()
+        .is_ok_and(|version| version != 0)
+}
+
+/// The active GPU visibility mask, preferring `HIP_VISIBLE_DEVICES` then
+/// `ROCR_VISIBLE_DEVICES`. `None` when neither is set; an explicitly empty value
+/// is returned as `Some("")` so callers can distinguish "unset" (all visible)
+/// from "set to nothing" (all masked out).
+#[cfg(any(target_os = "linux", test))]
+fn visibility_mask_from_env() -> Option<String> {
+    ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"]
+        .into_iter()
+        .find_map(std::env::var_os)
+        .map(|value| value.to_string_lossy().into_owned())
+}
+
+/// Apply a `HIP_VISIBLE_DEVICES`-style `mask` to the present device ordinals
+/// (`0..present`). `None` means no mask is set (every present device is visible).
+/// The mask is a comma-separated ordinal list parsed left to right; a
+/// non-numeric or out-of-range entry terminates the list (earlier entries stay
+/// visible), and an empty value hides every device.
+#[cfg(any(target_os = "linux", test))]
+fn usable_amd_gpu_indices_from(present: usize, mask: Option<String>) -> Vec<u32> {
+    let Some(mask) = mask else {
+        return (0..present as u32).collect();
+    };
+    let mut visible = Vec::new();
+    for token in mask.split(',') {
+        let Ok(index) = token.trim().parse::<u32>() else {
+            break;
+        };
+        if (index as usize) >= present {
+            break;
+        }
+        if !visible.contains(&index) {
+            visible.push(index);
+        }
+    }
+    visible
+}
+
 #[cfg(any(target_os = "linux", test))]
 fn parse_linux_kfd_gfx_target(value: &str) -> Option<String> {
     if let Some(token) = extract_first_gfx_token(value) {
@@ -8153,5 +8264,54 @@ last_installed_runtime_id = "therock-release"
         assert!(!paths.config_path().is_file());
         let _ = fs::remove_dir_all(&root);
         Ok(())
+    }
+
+    #[test]
+    fn kfd_gfx_target_version_distinguishes_gpu_from_cpu_nodes() {
+        // CPU topology nodes report a zero gfx target version; GPU nodes report a
+        // nonzero one.
+        assert!(!kfd_gfx_target_version_is_gpu("0"));
+        assert!(!kfd_gfx_target_version_is_gpu(""));
+        assert!(!kfd_gfx_target_version_is_gpu("not-a-number"));
+        assert!(kfd_gfx_target_version_is_gpu("90402"));
+        assert!(kfd_gfx_target_version_is_gpu("110000"));
+    }
+
+    #[test]
+    fn usable_gpu_indices_unset_mask_returns_all_present_devices() {
+        assert_eq!(usable_amd_gpu_indices_from(0, None), Vec::<u32>::new());
+        assert_eq!(usable_amd_gpu_indices_from(1, None), vec![0]);
+        assert_eq!(usable_amd_gpu_indices_from(3, None), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn usable_gpu_indices_empty_mask_hides_every_device() {
+        // The masked-device path: GPUs are present but fully masked out.
+        assert_eq!(
+            usable_amd_gpu_indices_from(2, Some(String::new())),
+            Vec::<u32>::new()
+        );
+    }
+
+    #[test]
+    fn usable_gpu_indices_honors_partial_and_reordered_mask() {
+        assert_eq!(
+            usable_amd_gpu_indices_from(4, Some("2,0".to_owned())),
+            vec![2, 0]
+        );
+        // Out-of-range and non-numeric entries terminate the visible list.
+        assert_eq!(
+            usable_amd_gpu_indices_from(2, Some("0,5".to_owned())),
+            vec![0]
+        );
+        assert_eq!(
+            usable_amd_gpu_indices_from(2, Some("bogus".to_owned())),
+            Vec::<u32>::new()
+        );
+        // Duplicates are collapsed.
+        assert_eq!(
+            usable_amd_gpu_indices_from(2, Some("1,1".to_owned())),
+            vec![1]
+        );
     }
 }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -3541,10 +3541,7 @@ pub fn has_usable_amd_gpu() -> bool {
 fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
     let present =
         combine_amd_gpu_counts(linux_kfd_gpu_node_count(), linux_drm_amdgpu_card_count())?;
-    Some(usable_amd_gpu_indices_from(
-        present,
-        visibility_mask_from_env(),
-    ))
+    usable_amd_gpu_indices_from(present, visibility_mask_from_env())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -3641,27 +3638,28 @@ fn visibility_mask_from_env() -> Option<String> {
 
 /// Apply a `HIP_VISIBLE_DEVICES`-style `mask` to the present device ordinals
 /// (`0..present`). `None` means no mask is set (every present device is visible).
-/// The mask is a comma-separated ordinal list parsed left to right; a
-/// non-numeric or out-of-range entry terminates the list (earlier entries stay
-/// visible), and an empty value hides every device.
+/// An empty value hides every device. A nonempty mask containing UUIDs or invalid
+/// ordinals returns `None`: the ordinal-only probe cannot interpret it
+/// authoritatively, so callers must not mistake it for "no GPU".
 #[cfg(any(target_os = "linux", test))]
-fn usable_amd_gpu_indices_from(present: usize, mask: Option<String>) -> Vec<u32> {
+fn usable_amd_gpu_indices_from(present: usize, mask: Option<String>) -> Option<Vec<u32>> {
     let Some(mask) = mask else {
-        return (0..present as u32).collect();
+        return Some((0..present as u32).collect());
     };
+    if mask.is_empty() {
+        return Some(Vec::new());
+    }
     let mut visible = Vec::new();
     for token in mask.split(',') {
-        let Ok(index) = token.trim().parse::<u32>() else {
-            break;
-        };
+        let index = token.trim().parse::<u32>().ok()?;
         if (index as usize) >= present {
-            break;
+            return None;
         }
         if !visible.contains(&index) {
             visible.push(index);
         }
     }
-    visible
+    Some(visible)
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -8334,9 +8332,9 @@ last_installed_runtime_id = "therock-release"
 
     #[test]
     fn usable_gpu_indices_unset_mask_returns_all_present_devices() {
-        assert_eq!(usable_amd_gpu_indices_from(0, None), Vec::<u32>::new());
-        assert_eq!(usable_amd_gpu_indices_from(1, None), vec![0]);
-        assert_eq!(usable_amd_gpu_indices_from(3, None), vec![0, 1, 2]);
+        assert_eq!(usable_amd_gpu_indices_from(0, None), Some(Vec::new()));
+        assert_eq!(usable_amd_gpu_indices_from(1, None), Some(vec![0]));
+        assert_eq!(usable_amd_gpu_indices_from(3, None), Some(vec![0, 1, 2]));
     }
 
     #[test]
@@ -8344,29 +8342,29 @@ last_installed_runtime_id = "therock-release"
         // The masked-device path: GPUs are present but fully masked out.
         assert_eq!(
             usable_amd_gpu_indices_from(2, Some(String::new())),
-            Vec::<u32>::new()
+            Some(Vec::new())
         );
     }
 
     #[test]
-    fn usable_gpu_indices_honors_partial_and_reordered_mask() {
+    fn usable_gpu_indices_honors_valid_ordinal_masks() {
         assert_eq!(
             usable_amd_gpu_indices_from(4, Some("2,0".to_owned())),
-            vec![2, 0]
-        );
-        // Out-of-range and non-numeric entries terminate the visible list.
-        assert_eq!(
-            usable_amd_gpu_indices_from(2, Some("0,5".to_owned())),
-            vec![0]
-        );
-        assert_eq!(
-            usable_amd_gpu_indices_from(2, Some("bogus".to_owned())),
-            Vec::<u32>::new()
+            Some(vec![2, 0])
         );
         // Duplicates are collapsed.
         assert_eq!(
             usable_amd_gpu_indices_from(2, Some("1,1".to_owned())),
-            vec![1]
+            Some(vec![1])
+        );
+    }
+
+    #[test]
+    fn usable_gpu_indices_treats_unsupported_masks_as_unprobeable() {
+        assert_eq!(usable_amd_gpu_indices_from(2, Some("0,5".to_owned())), None);
+        assert_eq!(
+            usable_amd_gpu_indices_from(2, Some("GPU-deadbeef".to_owned())),
+            None
         );
     }
 }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -40,7 +40,11 @@ const LLAMACPP_RECIPE: &str = "llamacpp";
 const ROCM_BACKEND_NAME: &str = "rocm";
 /// Preferred llama.cpp backends, best first. Lemonade reports per-GPU support;
 /// we pick the highest-priority backend it considers supported on this host.
-const LLAMACPP_BACKEND_PRIORITY: [&str; 3] = ["rocm", "vulkan", "cpu"];
+/// GPU backends only — `cpu` is intentionally excluded so the router path never
+/// selects CPU under the GPU-required policy (AGENTS.md §6, matching
+/// `DIRECT_LLAMA_SERVER_BACKENDS`). When only CPU is usable, selection returns
+/// `None` and the caller fails with actionable guidance.
+const LLAMACPP_BACKEND_PRIORITY: [&str; 2] = ["rocm", "vulkan"];
 const DEFAULT_LOG_TAIL_LINES: usize = 200;
 const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 /// Maximum bytes to read from the end of a log file when extracting tail lines.
@@ -335,8 +339,8 @@ fn capabilities() -> EngineCapabilities {
         rocm_gpu: true,
         openai_compatible: true,
         tool_calling: true,
-        quantized_models: "GGUF through Lemonade llama.cpp (ROCm/Vulkan/CPU auto-selected)"
-            .to_owned(),
+        quantized_models:
+            "GGUF through Lemonade llama.cpp (ROCm or Vulkan GPU backend auto-selected)".to_owned(),
         reasoning_parser: false,
     }
 }
@@ -373,15 +377,7 @@ fn detect_response() -> DetectResponse {
         python_version: None,
         torch_version: None,
         transformers_version: None,
-        available_devices: vec![EngineDeviceAvailability {
-            kind: "rocm_gpu".to_owned(),
-            available: runtime.is_some(),
-            reason: if runtime.is_some() {
-                None
-            } else {
-                Some("Lemonade embeddable runtime is not installed".to_owned())
-            },
-        }],
+        available_devices: vec![gpu_availability_device(runtime.is_some())],
         capabilities: capabilities(),
         notes,
     }
@@ -450,7 +446,7 @@ fn resolve_model_response(request: ResolveModelRequest) -> Result<ResolveModelRe
         }),
         engine_recipe,
         warnings: vec![
-            "Lemonade auto-selects the best supported llama.cpp backend for this GPU (ROCm, then Vulkan, then CPU)".to_owned(),
+            "Lemonade auto-selects the best supported GPU llama.cpp backend for this host (ROCm, then Vulkan); CPU is never used under the GPU-required policy".to_owned(),
         ],
     })
 }
@@ -515,8 +511,13 @@ fn launch_service(mut request: LaunchRequest) -> Result<LaunchResponse> {
     })
 }
 
-fn serve_http(request: ServeHttpRequest) -> Result<()> {
+fn serve_http(mut request: ServeHttpRequest) -> Result<()> {
     require_gpu_required(&request.device_policy)?;
+    // Verify a real GPU is available before launching anything: zero usable
+    // devices fails fast, `auto` resolves to the first present device (never an
+    // assumed device 0), and an explicit `--gpu` index is rejected when it is not
+    // actually present. This runs before any server process is spawned.
+    request.gpu_indices = resolve_serve_gpu_indices(&request.gpu_indices)?;
     let runtime = resolve_runtime()?;
     let mut process_env = lemonade_process_environment()?;
     process_env.gpu_indices = request.gpu_indices.clone();
@@ -868,7 +869,7 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
         status,
         model_loaded: ready,
         device: if ready {
-            "rocm_gpu".to_owned()
+            reported_device(state.as_ref(), &backend)
         } else {
             "unknown".to_owned()
         },
@@ -877,6 +878,26 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
         last_error: None,
         tokens_per_sec: None,
     })
+}
+
+/// The device string reported once a model is loaded. Reflects the backend that
+/// actually ran (`rocm`, `vulkan`, …) and the pinned GPU ordinal when known,
+/// rather than a hardcoded value, so the report matches observed execution.
+fn reported_device(state: Option<&Value>, backend: &str) -> String {
+    match state.and_then(first_gpu_index_from_state) {
+        Some(index) => format!("{backend} gpu {index}"),
+        None => format!("{backend} gpu"),
+    }
+}
+
+/// The first pinned GPU ordinal recorded in service state, if any.
+fn first_gpu_index_from_state(state: &Value) -> Option<u32> {
+    state
+        .get("gpu_indices")
+        .and_then(Value::as_array)
+        .and_then(|indices| indices.first())
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
 }
 
 fn endpoint_response(request: EndpointRequest) -> Result<EndpointResponse> {
@@ -1017,7 +1038,10 @@ fn ensure_best_llamacpp_backend(
     let backends = parse_llamacpp_backend_statuses(&listing);
     let Some((backend, already_installed)) = select_best_llamacpp_backend(&backends) else {
         bail!(
-            "Lemonade reports no supported llama.cpp backend for this GPU (status: {})",
+            "Lemonade reports no supported GPU llama.cpp backend for this host (status: {}). \
+             The GPU-required policy does not fall back to CPU; install a ROCm or Vulkan \
+             backend (e.g. `rocm engines install lemonade`) or verify the GPU driver with \
+             `rocm examine`.",
             describe_llamacpp_backends(&backends)
         );
     };
@@ -2318,6 +2342,7 @@ fn write_running_state(
             "port": request.port,
             "endpoint_url": endpoint_url(&request.host, request.port),
             "device_policy": device_policy_name(&request.device_policy),
+            "gpu_indices": request.gpu_indices,
             "runtime_id": request.runtime_id.as_deref().unwrap_or(runtime.manifest.env_id.as_str()),
             "env_id": request.env_id.as_deref().unwrap_or(runtime.manifest.env_id.as_str()),
             "runtime_kind": "lemonade_embeddable",
@@ -2499,6 +2524,85 @@ fn require_gpu_required(policy: &DevicePolicy) -> Result<()> {
         DevicePolicy::CpuOnly => {
             bail!("Lemonade adapter requires ROCm GPU execution; no CPU fallback is used")
         }
+    }
+}
+
+/// Probe real GPU availability and resolve the device ordinal(s) to pin before a
+/// GPU-required launch. Returns the resolved indices, or an error that stops
+/// serving before any process is spawned:
+/// - no usable device → fail with actionable guidance (no CPU/GPU-0 fallback);
+/// - `auto` (empty `requested`) → the first present, visible device;
+/// - explicit index not among the usable devices → fail.
+///
+/// When availability cannot be probed on this platform, the requested selection
+/// is passed through unchanged so serving is not blocked on that basis.
+fn resolve_serve_gpu_indices(requested: &[u32]) -> Result<Vec<u32>> {
+    resolve_gpu_indices_against(requested, rocm_core::usable_amd_gpu_indices())
+}
+
+/// Pure resolution used by [`resolve_serve_gpu_indices`], split out so the
+/// auto/explicit/no-device policy can be unit-tested without real hardware.
+/// `usable` is the probe result: `None` (unprobeable) passes the request
+/// through; `Some(_)` is authoritative.
+fn resolve_gpu_indices_against(requested: &[u32], usable: Option<Vec<u32>>) -> Result<Vec<u32>> {
+    let Some(usable) = usable else {
+        return Ok(requested.to_vec());
+    };
+    if usable.is_empty() {
+        bail!(
+            "no usable AMD GPU detected; `rocm serve` requires a GPU under the default \
+             GPU-required policy and does not fall back to CPU. Check the driver with \
+             `rocm examine`, confirm /dev/kfd is present, and ensure HIP_VISIBLE_DEVICES / \
+             ROCR_VISIBLE_DEVICES are not masking every device."
+        );
+    }
+    if requested.is_empty() {
+        return Ok(vec![usable[0]]);
+    }
+    for index in requested {
+        if !usable.contains(index) {
+            let visible = usable
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "requested GPU {index} is not available on this host; usable GPU indices: [{visible}]"
+            );
+        }
+    }
+    Ok(requested.to_vec())
+}
+
+/// GPU device availability for `detect`, sourced from the real device probe. When
+/// the probe is authoritative it reports true/false with a reason; when it cannot
+/// determine availability on this platform, it falls back to whether the runtime
+/// is installed so `detect` stays informative.
+fn gpu_availability_device(runtime_installed: bool) -> EngineDeviceAvailability {
+    match rocm_core::usable_amd_gpu_indices() {
+        Some(indices) if !indices.is_empty() => EngineDeviceAvailability {
+            kind: "rocm_gpu".to_owned(),
+            available: true,
+            reason: None,
+        },
+        Some(_) => EngineDeviceAvailability {
+            kind: "rocm_gpu".to_owned(),
+            available: false,
+            reason: Some(
+                "no AMD GPU detected, or every device is masked by \
+                 HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES"
+                    .to_owned(),
+            ),
+        },
+        None => EngineDeviceAvailability {
+            kind: "rocm_gpu".to_owned(),
+            available: runtime_installed,
+            reason: if runtime_installed {
+                None
+            } else {
+                Some("Lemonade embeddable runtime is not installed".to_owned())
+            },
+        },
     }
 }
 
@@ -2998,21 +3102,76 @@ vllm                rocm        unsupported     Requires Linux                  
     }
 
     #[test]
-    fn selects_cpu_when_no_gpu_backend() {
+    fn never_selects_cpu_when_no_gpu_backend() {
+        // Under the GPU-required policy there is no silent CPU fallback: when only
+        // a CPU backend is usable, selection returns nothing and the caller fails.
         let backends = vec![
             ("rocm".to_owned(), "unsupported".to_owned()),
             ("cpu".to_owned(), "installable".to_owned()),
         ];
-        assert_eq!(
-            select_best_llamacpp_backend(&backends),
-            Some(("cpu".to_owned(), false))
-        );
+        assert_eq!(select_best_llamacpp_backend(&backends), None);
     }
 
     #[test]
     fn selects_nothing_when_all_unsupported() {
         let backends = vec![("rocm".to_owned(), "unsupported".to_owned())];
         assert_eq!(select_best_llamacpp_backend(&backends), None);
+    }
+
+    #[test]
+    fn serve_gpu_resolution_fails_fast_when_no_device_usable() {
+        // No-device / masked-device path: the probe authoritatively reports zero
+        // usable GPUs, so serving is refused before any process is spawned.
+        let error = resolve_gpu_indices_against(&[], Some(vec![]))
+            .expect_err("zero usable devices must be rejected");
+        assert!(error.to_string().contains("no usable AMD GPU"));
+    }
+
+    #[test]
+    fn serve_gpu_resolution_auto_pins_first_present_device() {
+        // `auto` (empty request) resolves to the first present device — never an
+        // assumed device 0 when device 0 is not present.
+        assert_eq!(
+            resolve_gpu_indices_against(&[], Some(vec![1, 2])).unwrap(),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn serve_gpu_resolution_validates_explicit_index() {
+        // An explicitly requested present device is honored.
+        assert_eq!(
+            resolve_gpu_indices_against(&[2], Some(vec![0, 1, 2])).unwrap(),
+            vec![2]
+        );
+        // A requested device that is not present is rejected rather than silently
+        // remapped to another GPU.
+        let error = resolve_gpu_indices_against(&[3], Some(vec![0, 1]))
+            .expect_err("absent device must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("requested GPU 3 is not available")
+        );
+    }
+
+    #[test]
+    fn serve_gpu_resolution_passes_through_when_unprobeable() {
+        // When availability cannot be determined, the request is passed through
+        // unchanged so serving is not blocked on that basis.
+        assert_eq!(
+            resolve_gpu_indices_against(&[], None).unwrap(),
+            Vec::<u32>::new()
+        );
+        assert_eq!(resolve_gpu_indices_against(&[1], None).unwrap(), vec![1]);
+    }
+
+    #[test]
+    fn reported_device_reflects_backend_and_pinned_ordinal() {
+        let state = json!({ "gpu_indices": [1] });
+        assert_eq!(reported_device(Some(&state), "vulkan"), "vulkan gpu 1");
+        // Without a recorded ordinal the backend is still reported truthfully.
+        assert_eq!(reported_device(None, "rocm"), "rocm gpu");
     }
 
     #[test]

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -536,7 +536,9 @@ fn parse_engine_recipe_json(value: Option<String>) -> Result<Option<EngineRecipe
 fn launch_service(request: LaunchRequest) -> Result<LaunchResponse> {
     let device_policy = normalize_vllm_device_policy(request.device_policy)?;
     let engine_recipe = accepted_engine_recipe(request.engine_recipe)?;
-    let gpu_indices = rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref());
+    let requested_gpu_indices =
+        rocm_engine_protocol::launch_gpu_indices(request.gpu_selection.as_ref());
+    let gpu_indices = resolve_serve_gpu_indices(&requested_gpu_indices)?;
     let runtime = resolve_vllm_runtime(request.runtime_id.as_deref())?;
     let state_path = AppPaths::discover()?
         .engine_state_dir(ENGINE_NAME)
@@ -584,7 +586,8 @@ struct ServeHttpRequest {
     engine_recipe: Option<EngineRecipeHint>,
 }
 
-fn serve_http(request: ServeHttpRequest) -> Result<()> {
+fn serve_http(mut request: ServeHttpRequest) -> Result<()> {
+    request.gpu_indices = resolve_serve_gpu_indices(&request.gpu_indices)?;
     let runtime = resolve_vllm_runtime(request.runtime_id.as_deref())?;
     let mut child = spawn_vllm_server(&request, &runtime, request.log_path.as_deref())?;
     write_running_state(&request, &runtime, child.id())?;
@@ -1074,6 +1077,43 @@ fn runtime_matches(manifest: &TheRockRuntimeManifest, requested: Option<&str>) -
         }
     }
     false
+}
+
+/// Resolve and validate the GPU ordinal before spawning vLLM. An authoritative
+/// empty probe result fails under the adapter's GPU-only policy; `auto` selects
+/// the first visible device. Unknown availability remains permissive so WSL and
+/// unsupported probe surfaces are not blocked.
+fn resolve_serve_gpu_indices(requested: &[u32]) -> Result<Vec<u32>> {
+    resolve_gpu_indices_against(requested, rocm_core::usable_amd_gpu_indices())
+}
+
+fn resolve_gpu_indices_against(requested: &[u32], usable: Option<Vec<u32>>) -> Result<Vec<u32>> {
+    let Some(usable) = usable else {
+        return Ok(requested.to_vec());
+    };
+    if usable.is_empty() {
+        bail!(
+            "no usable AMD GPU detected; vLLM requires ROCm GPU execution and does not fall back \
+             to CPU. Check the driver with `rocm examine` and ensure HIP_VISIBLE_DEVICES / \
+             ROCR_VISIBLE_DEVICES are not masking every device."
+        );
+    }
+    if requested.is_empty() {
+        return Ok(vec![usable[0]]);
+    }
+    for index in requested {
+        if !usable.contains(index) {
+            let visible = usable
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "requested GPU {index} is not available on this host; usable GPU indices: [{visible}]"
+            );
+        }
+    }
+    Ok(requested.to_vec())
 }
 
 fn normalize_vllm_device_policy(policy: Option<DevicePolicy>) -> Result<DevicePolicy> {
@@ -1718,6 +1758,37 @@ mod tests {
         assert_eq!(parse_gpu_indices_arg(Some("2")).unwrap(), vec![2]);
         assert!(parse_gpu_selection_arg(Some("nope")).is_err());
         assert!(parse_gpu_selection_arg(Some("0,1")).is_err());
+    }
+
+    #[test]
+    fn gpu_required_launch_rejects_no_usable_device() {
+        let error = resolve_gpu_indices_against(&[], Some(Vec::new()))
+            .expect_err("zero usable devices must be rejected");
+        assert!(error.to_string().contains("no usable AMD GPU"));
+    }
+
+    #[test]
+    fn gpu_required_launch_selects_and_validates_visible_devices() {
+        assert_eq!(
+            resolve_gpu_indices_against(&[], Some(vec![1, 2])).unwrap(),
+            vec![1]
+        );
+        assert_eq!(
+            resolve_gpu_indices_against(&[2], Some(vec![1, 2])).unwrap(),
+            vec![2]
+        );
+        let error = resolve_gpu_indices_against(&[0], Some(vec![1, 2]))
+            .expect_err("masked device must be rejected");
+        assert!(error.to_string().contains("not available"));
+    }
+
+    #[test]
+    fn gpu_required_launch_allows_unprobeable_hosts() {
+        assert_eq!(
+            resolve_gpu_indices_against(&[], None).unwrap(),
+            Vec::<u32>::new()
+        );
+        assert_eq!(resolve_gpu_indices_against(&[3], None).unwrap(), vec![3]);
     }
 
     #[test]

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -115,7 +115,7 @@ Feature: Model serving
   # The masked-device path: on a real GPU host where every device is hidden, the
   # GPU-required serve must treat it as "no GPU" and refuse, not fall back. Runs on
   # GPU hardware (Strix Halo / Instinct).
-  @id:serve-masked-devices-fail @requires-gpu
+  @id:serve-masked-devices-fail @requires-gpu @requires-os:linux
   Scenario: 12 - Serving is refused when every GPU is masked from view
     When the user serves a model with every GPU masked from view
     Then serving is refused before any engine starts
@@ -124,7 +124,7 @@ Feature: Model serving
   # Honest device selection: a `--gpu` index that does not exist on the host is
   # rejected outright, never silently remapped to another device (no device-0
   # fallback). Runs on GPU hardware.
-  @id:serve-absent-gpu-index-rejected @requires-gpu
+  @id:serve-absent-gpu-index-rejected @requires-gpu @requires-os:linux
   Scenario: 13 - Serving pinned to a GPU that does not exist is refused
     When the user serves a model pinned to a GPU index that does not exist
     Then serving is refused before any engine starts

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -101,3 +101,31 @@ Feature: Model serving
     And a model is being served on GPU
     When the CLI reports the service as ready
     Then an inference request succeeds immediately
+
+  # GPU-required enforcement (EAI-7400). Under the GPU-required default, a host
+  # with no usable AMD GPU must refuse to serve — before any engine is prepared or
+  # launched — with an actionable message, never a CPU or device-0 fallback. Runs
+  # on the no-GPU mock host, so it gates every PR (@requires-no-gpu, no GPU needed).
+  @id:serve-no-gpu-fails-fast @requires-no-gpu
+  Scenario: 11 - Serving is refused on a host with no AMD GPU
+    When the user serves a model under the GPU-required default
+    Then serving is refused before any engine starts
+    And the user is told no AMD GPU was detected
+
+  # The masked-device path: on a real GPU host where every device is hidden, the
+  # GPU-required serve must treat it as "no GPU" and refuse, not fall back. Runs on
+  # GPU hardware (Strix Halo / Instinct).
+  @id:serve-masked-devices-fail @requires-gpu
+  Scenario: 12 - Serving is refused when every GPU is masked from view
+    When the user serves a model with every GPU masked from view
+    Then serving is refused before any engine starts
+    And the user is told no AMD GPU was detected
+
+  # Honest device selection: a `--gpu` index that does not exist on the host is
+  # rejected outright, never silently remapped to another device (no device-0
+  # fallback). Runs on GPU hardware.
+  @id:serve-absent-gpu-index-rejected @requires-gpu
+  Scenario: 13 - Serving pinned to a GPU that does not exist is refused
+    When the user serves a model pinned to a GPU index that does not exist
+    Then serving is refused before any engine starts
+    And the user is told that GPU index is unavailable

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -23,6 +23,7 @@ const ID_PREFIX: &str = "id:";
 const REQUIRES_ENGINE_PREFIX: &str = "requires-engine:";
 const REQUIRES_OS_PREFIX: &str = "requires-os:";
 const REQUIRES_GPU_TAG: &str = "requires-gpu";
+const REQUIRES_NO_GPU_TAG: &str = "requires-no-gpu";
 const SERVE_TIMEOUT_PREFIX: &str = "serve-timeout:";
 const NIGHTLY_TAG: &str = "nightly";
 
@@ -43,6 +44,11 @@ pub enum Expectation {
 pub struct ScenarioDecl {
     pub id: Option<String>,
     pub requires_gpu: bool,
+    /// `@requires-no-gpu`: the scenario's premise is a host with NO usable AMD GPU
+    /// (e.g. a GPU-required serve must fail fast). Skipped on any host that has a
+    /// GPU — the inverse of `requires_gpu`. This is how the no-GPU fail-fast path
+    /// gets live coverage: it runs on the GitHub-hosted mock job.
+    pub requires_no_gpu: bool,
     /// Engine the scenario pins via `@requires-engine:<e>` (if any).
     pub requires_engine: Option<String>,
     /// OS the scenario requires via `@requires-os:<os>` (e.g. "linux"), if any —
@@ -66,6 +72,7 @@ impl ScenarioDecl {
     pub fn from_tags<S: AsRef<str>>(tags: &[S]) -> Self {
         let mut id = None;
         let mut requires_gpu = false;
+        let mut requires_no_gpu = false;
         let mut requires_engine = None;
         let mut requires_os = None;
         let mut serve_timeout_secs = None;
@@ -82,6 +89,8 @@ impl ScenarioDecl {
                 serve_timeout_secs = rest.parse::<u64>().ok();
             } else if tag == REQUIRES_GPU_TAG {
                 requires_gpu = true;
+            } else if tag == REQUIRES_NO_GPU_TAG {
+                requires_no_gpu = true;
             } else if tag == NIGHTLY_TAG {
                 nightly = true;
             }
@@ -89,6 +98,7 @@ impl ScenarioDecl {
         Self {
             id,
             requires_gpu,
+            requires_no_gpu,
             requires_engine,
             requires_os,
             serve_timeout_secs,
@@ -281,6 +291,11 @@ pub fn resolve(
     if decl.requires_gpu && !cap.has_amd_gpu {
         return Expectation::Skip {
             reason: "requires an AMD GPU; none detected on this host".to_owned(),
+        };
+    }
+    if decl.requires_no_gpu && cap.has_amd_gpu {
+        return Expectation::Skip {
+            reason: "requires a host with no AMD GPU; this host has one".to_owned(),
         };
     }
     if let Some(os) = &decl.requires_os
@@ -501,6 +516,26 @@ serve_timeout_secs = 90
         let d = decl(&["id:serve-default-engine-inference", "requires-gpu"]);
         assert!(matches!(
             resolve(&d, &cap("mock"), &m, false),
+            Expectation::Skip { .. }
+        ));
+    }
+
+    #[test]
+    fn requires_no_gpu_runs_only_on_hosts_without_a_gpu() {
+        let m = Expectations::default();
+        let d = decl(&["id:serve-no-gpu-fails-fast", "requires-no-gpu"]);
+        // The mock host has no AMD GPU → the no-GPU premise applies → runs.
+        assert_eq!(
+            resolve(&d, &cap("mock"), &m, false),
+            Expectation::ExpectPass
+        );
+        // Every GPU host skips it — the premise can't hold there.
+        assert!(matches!(
+            resolve(&d, &cap("mi300x"), &m, false),
+            Expectation::Skip { .. }
+        ));
+        assert!(matches!(
+            resolve(&d, &cap("strix-ubuntu"), &m, false),
             Expectation::Skip { .. }
         ));
     }

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -398,6 +398,37 @@ pub fn run_rocm(world: &E2eWorld, args: &[&str]) -> (String, String, i32) {
     )
 }
 
+/// Like [`run_rocm`], but with extra environment variables set on the child.
+///
+/// Used by scenarios that must control the device environment the CLI and engine
+/// see — e.g. masking every GPU via `HIP_VISIBLE_DEVICES=""` to prove a
+/// GPU-required serve is refused. The vars are applied on top of the scenario's
+/// isolated config/data/cache env.
+pub fn run_rocm_with_env(
+    world: &E2eWorld,
+    args: &[&str],
+    envs: &[(&str, &str)],
+) -> (String, String, i32) {
+    let binary = rocm_binary();
+    let mut cmd = std::process::Command::new(&binary);
+    cmd.args(args);
+    world.isolate_cmd(&mut cmd);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {binary}: {e}"));
+    let rc = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    record_command(world.current_scenario.as_deref(), args, rc, &stdout);
+    (
+        stdout,
+        String::from_utf8_lossy(&output.stderr).to_string(),
+        rc,
+    )
+}
+
 /// Append one `rocm` invocation to `results/commands.jsonl` so the consolidated
 /// report can build a command × platform coverage table tied to real results.
 /// Best-effort: a recording failure must never fail a scenario.

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -465,6 +465,45 @@ async fn user_sends_completion(world: &mut E2eWorld) {
     crate::send_chat(world).await;
 }
 
+/// Serve under the GPU-required default (no `--device`), pinning the engine to the
+/// host's effective serve engine so the serve reaches GPU enforcement rather than
+/// tripping on engine selection.
+#[when("the user serves a model under the GPU-required default")]
+async fn user_serves_gpu_required(world: &mut E2eWorld) {
+    let (model, engine, _) = host_serve_target();
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["serve", model, "--engine", engine]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+/// Serve with every GPU hidden from the CLI and engine via an empty
+/// `HIP_VISIBLE_DEVICES`, so a GPU host presents as having no usable device.
+#[when("the user serves a model with every GPU masked from view")]
+async fn user_serves_with_masked_gpus(world: &mut E2eWorld) {
+    let (model, engine, _) = host_serve_target();
+    let (stdout, stderr, rc) = crate::run_rocm_with_env(
+        world,
+        &["serve", model, "--engine", engine],
+        &[("HIP_VISIBLE_DEVICES", "")],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+/// Serve pinned to a GPU ordinal far beyond any real device count, so the request
+/// names a device that does not exist on the host.
+#[when("the user serves a model pinned to a GPU index that does not exist")]
+async fn user_serves_absent_gpu_index(world: &mut E2eWorld) {
+    let (model, engine, _) = host_serve_target();
+    let (stdout, stderr, rc) =
+        crate::run_rocm(world, &["serve", model, "--engine", engine, "--gpu", "99"]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
 #[when("the CLI reports the service as ready")]
 async fn when_cli_reports_ready(world: &mut E2eWorld) {
     // Read readiness from the CLI's own view (`services list`), not a direct
@@ -492,6 +531,51 @@ async fn assert_inference_succeeds_now(world: &mut E2eWorld) {
     assert!(
         !content.is_empty(),
         "service reported ready but inference returned no content: {resp}"
+    );
+}
+
+/// The CLI's combined stdout+stderr from the last recorded serve attempt.
+fn serve_output(world: &E2eWorld) -> String {
+    format!(
+        "{}\n{}",
+        world.cli_output.as_deref().unwrap_or(""),
+        world.cli_stderr.as_deref().unwrap_or("")
+    )
+}
+
+#[then("serving is refused before any engine starts")]
+async fn assert_serve_refused(world: &mut E2eWorld) {
+    // A non-zero exit is the observable "refused". The GPU-required pre-flight
+    // rejects the launch before any engine is prepared or spawned, so this fails
+    // fast rather than after a download or a late engine crash.
+    let rc = world.cli_rc.expect("no serve rc recorded");
+    assert!(
+        rc != 0,
+        "expected serving to be refused, but it exited 0:\n{}",
+        serve_output(world)
+    );
+}
+
+#[then("the user is told no AMD GPU was detected")]
+async fn assert_no_gpu_message(world: &mut E2eWorld) {
+    let output = serve_output(world);
+    assert!(
+        output.to_lowercase().contains("no usable amd gpu"),
+        "expected a no-AMD-GPU message, got:\n{output}"
+    );
+}
+
+#[then("the user is told that GPU index is unavailable")]
+async fn assert_absent_index_message(world: &mut E2eWorld) {
+    let output = serve_output(world).to_lowercase();
+    // The named index must appear alongside an unavailability reason — whether the
+    // CLI rejects it against the detected count ("out of range") or the engine's
+    // probe rejects it ("not available") on a host where amd-smi can't count.
+    assert!(
+        output.contains("99")
+            && (output.contains("out of range") || output.contains("not available")),
+        "expected the absent GPU index to be reported unavailable, got:\n{}",
+        serve_output(world)
     );
 }
 


### PR DESCRIPTION
## Summary

Under the GPU-required policy, `rocm serve` (Lemonade) could proceed on a host with no usable AMD GPU, silently fall back to a CPU llama.cpp backend, assume device 0, and report the device as `rocm_gpu` regardless of what ran. This tightens enforcement so "GPU required" means a real GPU was found and used, and the reported backend/device matches execution.

### Enforcement
- **Real device probe** (`rocm-core`): `usable_amd_gpu_indices()` enumerates AMD GPU nodes from the KFD topology and applies the `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` mask. `Some([])` is authoritative "no GPU"; `None` means unprobeable (don't block).
- **CLI pre-flight**: a GPU-required serve fails immediately when the probe reports no usable GPU — before preparing or launching any engine (no wasted engine download; actionable message instead of a late crash).
- **Engine gate** (Lemonade): the serve path re-checks before spawning; `auto` resolves to the first *present* device (no assumed device 0); an explicit `--gpu` index not present is rejected.
- **No CPU backend**: `cpu` dropped from backend selection; when only CPU is usable, serving fails with install guidance instead of degrading silently.
- **Truthful reporting**: healthcheck reports the backend and pinned ordinal that actually ran instead of a hardcoded `rocm_gpu`.
- Removed the CLI GPU-0 fallback when the GPU count is unknown.

### Tests
- Unit tests: mask parsing, auto/explicit/no-device resolution, CPU exclusion, device reporting.
- New E2E scenarios (`model_serving.feature`): no-GPU host refuses to serve (via a new `@requires-no-gpu` gate, runs on the **blocking** mock job), all-GPUs-masked refuses to serve, and a nonexistent `--gpu` index is rejected.
- The no-GPU fail-fast scenario was verified running live on a no-GPU host through the real binary. Masked / absent-index scenarios run on the Strix Halo / Instinct GPU runners.

## Notes / follow-ups
- **AC "reported device matches execution"** is unit-tested only: the healthcheck `device` field isn't surfaced by any user-facing CLI command, so a black-box E2E can't observe it yet. Surfacing backend/device in `rocm services list` would unlock an E2E — deliberately left as a separate change.
- **WSL:** the probe treats an unreadable KFD topology as "unknown" (won't block) when `/dev/kfd` exists; worth confirming on a WSL GPU host.

## Test plan
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets`
- [x] `cargo test` for `rocm-core`, `rocm-engine-lemonade`, `rocm`, `e2e-cucumber`
- [x] E2E no-GPU scenario verified live
- [ ] Strix Halo / Instinct E2E (runs in CI)

