### PR TITLE
fix(therock): replace Windows PowerShell HTTP with native ureq

### DIFF
--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -2026,9 +2026,6 @@ fn download_file(url: &str, destination: &Path) -> Result<()> {
         .parent()
         .context("download destination has no parent directory")?;
     fs::create_dir_all(parent)?;
-    if use_windows_powershell_http() {
-        return download_file_windows_powershell(url, destination, None);
-    }
     let response = http_get(url, &[], None)?;
     if response.status != 200 {
         bail!("HTTP {} while fetching {url}", response.status);
@@ -2041,9 +2038,6 @@ fn http_get(
     headers: &[(&str, &str)],
     max_time_secs: Option<u64>,
 ) -> Result<HttpResponseBody> {
-    if use_windows_powershell_http() {
-        return http_get_windows_powershell(url, headers, max_time_secs);
-    }
     let timeout = max_time_secs
         .filter(|value| *value > 0)
         .map_or_else(|| Duration::from_mins(10), Duration::from_secs);
@@ -2078,164 +2072,6 @@ fn http_get(
         headers,
         body,
     })
-}
-
-const fn use_windows_powershell_http() -> bool {
-    runtime_is_windows()
-}
-
-#[derive(Deserialize)]
-struct WindowsHttpMetadata {
-    #[serde(rename = "StatusCode")]
-    status_code: u16,
-    #[serde(rename = "Headers")]
-    headers: String,
-}
-
-fn http_get_windows_powershell(
-    url: &str,
-    headers: &[(&str, &str)],
-    max_time_secs: Option<u64>,
-) -> Result<HttpResponseBody> {
-    let temp_dir = windows_http_temp_dir()?;
-    let body_path = temp_dir.join("body.bin");
-    let meta_path = temp_dir.join("meta.json");
-    let script_path = temp_dir.join("http-get.ps1");
-    let timeout = max_time_secs.filter(|value| *value > 0).unwrap_or(600);
-    fs::write(&script_path, windows_http_get_script())
-        .with_context(|| format!("failed to write {}", script_path.display()))?;
-    let mut command = Command::new("powershell.exe");
-    command
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-        ])
-        .arg(windows_child_path(&script_path))
-        .args(["-Url", url])
-        .arg("-BodyPath")
-        .arg(windows_child_path(&body_path))
-        .arg("-MetaPath")
-        .arg(windows_child_path(&meta_path))
-        .args(["-TimeoutSec", &timeout.to_string()]);
-    for (name, value) in headers {
-        command.arg("-Header").arg(format!("{name}={value}"));
-    }
-    let stdout_path = temp_dir.join("stdout.txt");
-    let stderr_path = temp_dir.join("stderr.txt");
-    let stdout_file = fs::File::create(&stdout_path)
-        .with_context(|| format!("failed to create {}", stdout_path.display()))?;
-    let stderr_file = fs::File::create(&stderr_path)
-        .with_context(|| format!("failed to create {}", stderr_path.display()))?;
-    let status = command
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::from(stderr_file))
-        .status()
-        .with_context(|| format!("failed to launch PowerShell HTTP request for {url}"))?;
-    if !windows_child_status_success(status) {
-        let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
-        let stdout = fs::read_to_string(&stdout_path).unwrap_or_default();
-        let temp_note = windows_http_failure_temp_note(&temp_dir);
-        if !windows_http_keep_temp() {
-            let _ = fs::remove_dir_all(&temp_dir);
-        }
-        bail!(
-            "PowerShell HTTP request failed for {url} (status {status}): {}{}{}",
-            stdout.trim(),
-            stderr.trim(),
-            temp_note
-        );
-    }
-    let metadata_bytes = fs::read(&meta_path)
-        .with_context(|| format!("failed to read HTTP metadata {}", meta_path.display()))?;
-    let metadata: WindowsHttpMetadata = serde_json::from_slice(strip_utf8_bom(&metadata_bytes))
-        .context("failed to parse PowerShell HTTP metadata")?;
-    let body = fs::read(&body_path)
-        .with_context(|| format!("failed to read HTTP response body {}", body_path.display()))?;
-    let _ = fs::remove_dir_all(&temp_dir);
-    Ok(HttpResponseBody {
-        status: metadata.status_code,
-        headers: metadata.headers,
-        body,
-    })
-}
-
-fn download_file_windows_powershell(
-    url: &str,
-    destination: &Path,
-    max_time_secs: Option<u64>,
-) -> Result<()> {
-    let parent = destination
-        .parent()
-        .context("download destination has no parent directory")?;
-    fs::create_dir_all(parent)?;
-    let temp_dir = windows_http_temp_dir()?;
-    let script_path = temp_dir.join("download-file.ps1");
-    let meta_path = temp_dir.join("meta.json");
-    let timeout = max_time_secs.filter(|value| *value > 0).unwrap_or(600);
-    fs::write(&script_path, windows_http_get_script())
-        .with_context(|| format!("failed to write {}", script_path.display()))?;
-    let stdout_path = temp_dir.join("stdout.txt");
-    let stderr_path = temp_dir.join("stderr.txt");
-    let stdout_file = fs::File::create(&stdout_path)
-        .with_context(|| format!("failed to create {}", stdout_path.display()))?;
-    let stderr_file = fs::File::create(&stderr_path)
-        .with_context(|| format!("failed to create {}", stderr_path.display()))?;
-    let status = Command::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-File",
-        ])
-        .arg(windows_child_path(&script_path))
-        .args(["-Url", url])
-        .arg("-BodyPath")
-        .arg(windows_child_path(destination))
-        .arg("-MetaPath")
-        .arg(windows_child_path(&meta_path))
-        .args(["-TimeoutSec", &timeout.to_string()])
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::from(stderr_file))
-        .status()
-        .with_context(|| format!("failed to launch PowerShell download for {url}"))?;
-    if !windows_child_status_success(status) {
-        let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
-        let stdout = fs::read_to_string(&stdout_path).unwrap_or_default();
-        let temp_note = windows_http_failure_temp_note(&temp_dir);
-        if !windows_http_keep_temp() {
-            let _ = fs::remove_dir_all(&temp_dir);
-        }
-        bail!(
-            "PowerShell download failed for {url} (status {status}): {}{}{}",
-            stdout.trim(),
-            stderr.trim(),
-            temp_note
-        );
-    }
-    let metadata_bytes = fs::read(&meta_path)
-        .with_context(|| format!("failed to read HTTP metadata {}", meta_path.display()))?;
-    let metadata: WindowsHttpMetadata = serde_json::from_slice(strip_utf8_bom(&metadata_bytes))
-        .context("failed to parse PowerShell HTTP metadata")?;
-    if metadata.status_code != 200 {
-        let _ = fs::remove_dir_all(&temp_dir);
-        let _ = fs::remove_file(destination);
-        bail!("HTTP {} while fetching {url}", metadata.status_code);
-    }
-    let _ = fs::remove_dir_all(&temp_dir);
-    Ok(())
-}
-
-fn windows_http_temp_dir() -> Result<PathBuf> {
-    if !runtime_is_windows() {
-        return linux_temp_dir("rocm-cli-http");
-    }
-    windows_temp_dir("rocm-cli-http")
 }
 
 fn linux_temp_dir(prefix: &str) -> Result<PathBuf> {
@@ -2290,73 +2126,8 @@ fn windows_runtime_temp_root() -> Option<PathBuf> {
     None
 }
 
-fn windows_child_status_success(status: std::process::ExitStatus) -> bool {
-    status.success() || status.code() == Some(0)
-}
-
-fn windows_http_keep_temp() -> bool {
-    std::env::var("ROCM_CLI_DEBUG_WINDOWS_HTTP")
-        .ok()
-        .is_some_and(|value| {
-            let value = value.trim().to_ascii_lowercase();
-            matches!(value.as_str(), "1" | "true" | "yes" | "on")
-        })
-}
-
-fn windows_http_failure_temp_note(temp_dir: &Path) -> String {
-    if windows_http_keep_temp() {
-        format!("; temp files kept at {}", display_child_path(temp_dir))
-    } else {
-        String::new()
-    }
-}
-
-const fn windows_http_get_script() -> &'static str {
-    r#"
-param(
-  [Parameter(Mandatory=$true)][string]$Url,
-  [Parameter(Mandatory=$true)][string]$BodyPath,
-  [Parameter(Mandatory=$true)][string]$MetaPath,
-  [int]$TimeoutSec = 600,
-  [string[]]$Header = @()
-)
-$ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
-$headers = @{}
-foreach ($entry in $Header) {
-  $index = $entry.IndexOf('=')
-  if ($index -gt 0) {
-    $headers[$entry.Substring(0, $index)] = $entry.Substring($index + 1)
-  }
-}
-$response = Invoke-WebRequest -Uri $Url -UseBasicParsing -Headers $headers -OutFile $BodyPath -PassThru -TimeoutSec $TimeoutSec
-$headerLines = @()
-foreach ($key in $response.Headers.Keys) {
-  $headerLines += "${key}: $($response.Headers[$key])"
-}
-$metadata = [pscustomobject]@{
-  StatusCode = [int]$response.StatusCode
-  Headers = ($headerLines -join "`n")
-}
-$json = $metadata | ConvertTo-Json -Compress
-[System.IO.File]::WriteAllText($MetaPath, $json, [System.Text.UTF8Encoding]::new($false))
-"#
-}
-
-fn strip_utf8_bom(bytes: &[u8]) -> &[u8] {
-    bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(bytes)
-}
-
 fn windows_child_path(path: &Path) -> String {
     runtime_path_for_windows_child(path)
-}
-
-fn display_child_path(path: &Path) -> String {
-    if runtime_is_windows() {
-        windows_child_path(path)
-    } else {
-        path.display().to_string()
-    }
 }
 
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -3944,12 +3715,68 @@ echo Python 3.12.10
     }
 
     #[test]
-    fn windows_http_uses_powershell_backend() {
-        if runtime_is_windows() {
-            assert!(use_windows_powershell_http());
-        } else {
-            assert!(!use_windows_powershell_http());
-        }
+    fn native_http_download_and_get_round_trip_without_powershell() -> Result<()> {
+        use std::net::TcpListener;
+        use std::thread;
+
+        // Serve a fixed body from a localhost HTTP/1.1 server so the request
+        // exercises the native `ureq` transport that `http_get`/`download_file`
+        // now use on every platform. This runs under `cargo test` on the
+        // windows-latest CI job, where `runtime_is_windows()` is true and the
+        // removed PowerShell/ExecutionPolicy-Bypass backend used to run — so it
+        // verifies the native replacement on real Windows.
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let body = b"native-http-smoke-body".to_vec();
+        let served = body.clone();
+        // Two requests: one for download_file, one for http_get.
+        let server = thread::spawn(move || -> Result<()> {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let read = stream.read(&mut buffer)?;
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buffer[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    served.len()
+                )?;
+                stream.write_all(&served)?;
+                stream.flush()?;
+            }
+            Ok(())
+        });
+
+        let url = format!("http://127.0.0.1:{port}/artifact.bin");
+
+        let temp = std::env::temp_dir().join(format!(
+            "rocm-cli-native-http-test-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&temp)?;
+        let destination = temp.join("artifact.bin");
+
+        download_file(&url, &destination)?;
+        assert_eq!(fs::read(&destination)?, body);
+
+        let response = http_get(&url, &[], Some(5))?;
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, body);
+
+        server.join().expect("localhost server thread panicked")?;
+        let _ = fs::remove_dir_all(&temp);
+        Ok(())
     }
 
     #[test]

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -3759,8 +3759,8 @@ echo Python 3.12.10
 
         let url = format!("http://127.0.0.1:{port}/artifact.bin");
 
-        let temp = std::env::temp_dir().join(format!(
-            "rocm-cli-native-http-test-{}-{}",
+        let temp = workspace_test_artifact_dir().join(format!(
+            "native-http-{}-{}",
             std::process::id(),
             unix_time_millis()
         ));

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -697,7 +697,7 @@ python scripts/release_readiness.py --self-test
 ROCDXG_CHECKSUM_SELF_TEST=1 bash scripts/wsl_setup_rocdxg.sh
 bash scripts/setup-wsl-portable-build-deps.sh --self-test
 ./scripts/acceptance-install-upgrade-tui-uninstall.sh
-powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\acceptance-install-upgrade-tui-uninstall.ps1
+pwsh -NoProfile -File .\scripts\acceptance-install-upgrade-tui-uninstall.ps1
 ```
 
 The release-readiness self-test is cross-platform and uses only workspace-local

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -697,7 +697,7 @@ python scripts/release_readiness.py --self-test
 ROCDXG_CHECKSUM_SELF_TEST=1 bash scripts/wsl_setup_rocdxg.sh
 bash scripts/setup-wsl-portable-build-deps.sh --self-test
 ./scripts/acceptance-install-upgrade-tui-uninstall.sh
-pwsh -NoProfile -File .\scripts\acceptance-install-upgrade-tui-uninstall.ps1
+.\scripts\acceptance-install-upgrade-tui-uninstall.ps1
 ```
 
 The release-readiness self-test is cross-platform and uses only workspace-local

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -444,15 +444,15 @@ try {
     $httpInstallDir = Join-Path $AcceptanceRoot "http-install\bin"
     $httpPort = Get-FreeTcpPort
     $httpServer = Start-Job -ScriptBlock {
-        param($Root, $Port)
+        $root = $using:DistDir
         $listener = [System.Net.HttpListener]::new()
-        $listener.Prefixes.Add("http://127.0.0.1:$Port/")
+        $listener.Prefixes.Add(('http://127.0.0.1:{0}/' -f $using:httpPort))
         $listener.Start()
         try {
             while ($listener.IsListening) {
                 $context = $listener.GetContext()
                 $relative = $context.Request.Url.AbsolutePath.TrimStart('/')
-                $path = Join-Path $Root $relative
+                $path = Join-Path $root $relative
                 if (Test-Path -LiteralPath $path -PathType Leaf) {
                     $bytes = [System.IO.File]::ReadAllBytes($path)
                     $context.Response.StatusCode = 200
@@ -466,7 +466,7 @@ try {
         } finally {
             $listener.Stop()
         }
-    } -ArgumentList $DistDir, $httpPort
+    }
     try {
         # Wait for the listener to accept connections before installing.
         $ready = $false

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -28,6 +28,7 @@ $PemInstallLog = Join-Path $AcceptanceRoot "pem-install.log"
 $PathUpdateInstallLog = Join-Path $AcceptanceRoot "path-update-install.log"
 $ExamineLog = Join-Path $AcceptanceRoot "examine.log"
 $UninstallLog = Join-Path $AcceptanceRoot "uninstall.log"
+$HttpInstallLog = Join-Path $AcceptanceRoot "http-install.log"
 
 function Fail {
     param([string] $Message)
@@ -46,6 +47,16 @@ function Assert-Missing {
     param([string] $Path)
     if (Test-Path -LiteralPath $Path) {
         Fail "expected path to be removed: $Path"
+    }
+}
+
+function Get-FreeTcpPort {
+    $probe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $probe.Start()
+    try {
+        return [int]$probe.LocalEndpoint.Port
+    } finally {
+        $probe.Stop()
     }
 }
 
@@ -424,6 +435,82 @@ try {
     Assert-File (Join-Path $InstallDir "rocm.exe")
     Assert-File (Join-Path $InstallDir "rocmd.exe")
     Assert-File (Join-Path $InstallDir ".rocm-cli-manifest")
+
+    # EAI-7402: install/download smoke over REAL HTTP (not file://). Serve the
+    # signed dist from a localhost HttpListener so install.ps1 exercises its
+    # native `Invoke-WebRequest` download path (native certificate-store
+    # behavior) end to end, then verify the archive + signature and install.
+    Write-Host "acceptance: install over native HTTP (localhost)"
+    $httpInstallDir = Join-Path $AcceptanceRoot "http-install\bin"
+    $httpPort = Get-FreeTcpPort
+    $httpServer = Start-Job -ScriptBlock {
+        param($Root, $Port)
+        $listener = [System.Net.HttpListener]::new()
+        $listener.Prefixes.Add("http://127.0.0.1:$Port/")
+        $listener.Start()
+        try {
+            while ($listener.IsListening) {
+                $context = $listener.GetContext()
+                $relative = $context.Request.Url.AbsolutePath.TrimStart('/')
+                $path = Join-Path $Root $relative
+                if (Test-Path -LiteralPath $path -PathType Leaf) {
+                    $bytes = [System.IO.File]::ReadAllBytes($path)
+                    $context.Response.StatusCode = 200
+                    $context.Response.ContentLength64 = $bytes.Length
+                    $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+                } else {
+                    $context.Response.StatusCode = 404
+                }
+                $context.Response.OutputStream.Close()
+            }
+        } finally {
+            $listener.Stop()
+        }
+    } -ArgumentList $DistDir, $httpPort
+    try {
+        # Wait for the listener to accept connections before installing.
+        $ready = $false
+        $deadline = (Get-Date).AddSeconds(5)
+        while (-not $ready -and (Get-Date) -lt $deadline) {
+            try {
+                $client = [System.Net.Sockets.TcpClient]::new()
+                $client.Connect("127.0.0.1", $httpPort)
+                $client.Close()
+                $ready = $true
+            } catch {
+                Start-Sleep -Milliseconds 100
+            }
+        }
+        if (-not $ready) {
+            Fail "localhost HTTP server did not start on port $httpPort"
+        }
+
+        $httpInstallArgs = @(
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            (Join-Path $RepoRoot "install.ps1"),
+            "release",
+            "-InstallDir",
+            $httpInstallDir,
+            "-DownloadBase",
+            "http://127.0.0.1:$httpPort",
+            "-SigningPublicKeyPath",
+            $signingPublicKey,
+            "-RequireSignature",
+            "-NoPathUpdate"
+        )
+        Invoke-Checked "acceptance: native HTTP install" $psExe $httpInstallArgs $HttpInstallLog
+        if (-not (Select-String -LiteralPath $HttpInstallLog -Pattern "signature verified" -Quiet)) {
+            Fail "native HTTP installer did not report signature verification"
+        }
+        Assert-File (Join-Path $httpInstallDir "rocm.exe")
+        Assert-File (Join-Path $httpInstallDir ".rocm-cli-manifest")
+    } finally {
+        Stop-Job -Job $httpServer -ErrorAction SilentlyContinue
+        Remove-Job -Job $httpServer -Force -ErrorAction SilentlyContinue
+    }
 
     Write-Host "acceptance: simulate stale prior install entry and reinstall"
     $stalePath = Join-Path $InstallDir "rocm-engine-stale.exe"

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -436,10 +436,10 @@ try {
     Assert-File (Join-Path $InstallDir "rocmd.exe")
     Assert-File (Join-Path $InstallDir ".rocm-cli-manifest")
 
-    # EAI-7402: install/download smoke over REAL HTTP (not file://). Serve the
-    # signed dist from a localhost HttpListener so install.ps1 exercises its
-    # native `Invoke-WebRequest` download path (native certificate-store
-    # behavior) end to end, then verify the archive + signature and install.
+    # Install/download smoke over REAL HTTP (not file://). Serve the signed dist
+    # from a localhost HttpListener so install.ps1 exercises its native
+    # `Invoke-WebRequest` download path (native certificate-store behavior) end
+    # to end, then verify the archive + signature and install.
     Write-Host "acceptance: install over native HTTP (localhost)"
     $httpInstallDir = Join-Path $AcceptanceRoot "http-install\bin"
     $httpPort = Get-FreeTcpPort

--- a/tests/e2e-cucumber/features/networking.feature
+++ b/tests/e2e-cucumber/features/networking.feature
@@ -1,0 +1,30 @@
+Feature: Native HTTP networking
+
+  # EAI-7402: rocm-cli performs downloads and GETs over the native `ureq` stack
+  # (native certificate store), replacing the generated PowerShell script that
+  # used to run under `powershell.exe -ExecutionPolicy Bypass` on Windows. These
+  # scenarios drive the real `rocm` binary end-to-end against the mock server so a
+  # GET/round-trip reaches a local endpoint over the native stack. They run on the
+  # mock (no GPU) on every platform the suite runs on, so a regression back to a
+  # shell-out networking backend surfaces here rather than only in the field.
+
+  # `rocm services list` extracts host:port from the service record and issues a
+  # native HTTP GET to `/v1/models` as its readiness probe (served by the mock).
+  # Listing the model and its endpoint therefore exercises that native GET.
+  @id:networking-native-http-endpoint-reachable
+  Scenario: 1 - The CLI reaches a served endpoint over the native HTTP stack
+    Given a model is being served
+    And the model is registered with the CLI
+    When the user lists running services
+    Then the served model is listed
+    And the served model endpoint is listed
+
+  # A full chat round-trip: the real `rocm chat` command drives the local provider
+  # to GET `/v1/models` and POST `/v1/chat/completions` over the native stack, then
+  # prints the reply — proving the native HTTP client works end-to-end via the CLI.
+  @id:networking-native-http-chat-round-trip
+  Scenario: 2 - A chat round-trip over a local endpoint uses the native HTTP stack
+    Given a model is being served
+    And the model is registered with the CLI
+    When the user sends a one-shot chat prompt through the CLI
+    Then the CLI prints the assistant's reply

--- a/tests/e2e-cucumber/features/networking.feature
+++ b/tests/e2e-cucumber/features/networking.feature
@@ -1,8 +1,8 @@
 Feature: Native HTTP networking
 
-  # EAI-7402: rocm-cli performs downloads and GETs over the native `ureq` stack
-  # (native certificate store), replacing the generated PowerShell script that
-  # used to run under `powershell.exe -ExecutionPolicy Bypass` on Windows. These
+  # rocm-cli performs downloads and GETs over the native `ureq` stack (native
+  # certificate store), replacing the generated PowerShell script that used to
+  # run under `powershell.exe -ExecutionPolicy Bypass` on Windows. These
   # scenarios drive the real `rocm` binary end-to-end against the mock server so a
   # GET/round-trip reaches a local endpoint over the native stack. They run on the
   # mock (no GPU) on every platform the suite runs on, so a regression back to a


### PR DESCRIPTION
## Problem

On Windows, `apps/rocm/src/therock.rs` routed **all** downloads and GETs through a generated PowerShell script run under `powershell.exe -ExecutionPolicy Bypass` (`Invoke-WebRequest`). This was a workaround from before `ureq` used the Windows certificate store.

`ureq` now has `native-certs` enabled across all crates, and `rocm-core`'s downloader is already native — this was the last residual PowerShell-networking site.

## Change

- `http_get` / `download_file` now always use the native `ureq` stack (native certificate-store behavior) on every platform.
- Removed the PowerShell HTTP backend entirely: the generated `.ps1`, `-ExecutionPolicy Bypass`, metadata parsing, temp-dir plumbing, and the `ROCM_CLI_DEBUG_WINDOWS_HTTP` debug hook (net ~150 lines gone).
- Removed the last `-ExecutionPolicy Bypass` guidance from `docs/testing.md` (aligned with how CI invokes the acceptance script).

## Tests

- **Unit smoke test** — localhost `TcpListener` round-trip through `download_file`/`http_get`; runs under `cargo test` on the `windows-latest` CI job, verifying the native path on real Windows.
- **e2e-cucumber** — new `networking.feature` driving the real `rocm` binary over the native stack against the mock server (verified passing locally).
- **Windows acceptance script** — new real-HTTP (localhost `HttpListener`) install exercising `install.ps1`'s native `Invoke-WebRequest` download + signature verify end to end.

Verification: `cargo clippy -p rocm --all-targets` clean; `cargo test -p rocm` (339) and `cargo test -p e2e-cucumber --lib` (24) pass.

## Out of scope

`comfyui.rs`'s `-ExecutionPolicy Bypass` launches a background **process**, not networking; `install.ps1`/README are already bypass-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)