### PR TITLE
Authenticate public inference endpoints

### DIFF
--- a/apps/rocm/src/endpoint_keys.rs
+++ b/apps/rocm/src/endpoint_keys.rs
@@ -55,3 +55,67 @@ pub(crate) fn endpoint_key_file_if_present(paths: &AppPaths, service_id: &str) -
 pub(crate) fn clear_endpoint_api_key(paths: &AppPaths, service_id: &str) {
     let _ = std::fs::remove_file(endpoint_key_file_path(paths, service_id));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocm_core::unix_time_millis;
+
+    fn temp_paths(name: &str) -> (PathBuf, AppPaths) {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-endpoint-key-{name}-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("data").join("services")).unwrap();
+        (
+            root.clone(),
+            AppPaths {
+                config_dir: root.join("config"),
+                data_dir: root.join("data"),
+                cache_dir: root.join("cache"),
+            },
+        )
+    }
+
+    #[test]
+    fn store_then_clear_round_trips_and_removes_the_file() {
+        let (root, paths) = temp_paths("roundtrip");
+        let service_id = "svc-1";
+        assert_eq!(endpoint_api_key(&paths, service_id), None);
+        assert_eq!(endpoint_key_file_if_present(&paths, service_id), None);
+
+        store_endpoint_api_key(&paths, service_id, "secret-key").unwrap();
+        assert_eq!(
+            endpoint_api_key(&paths, service_id),
+            Some("secret-key".to_owned())
+        );
+        assert!(endpoint_key_file_if_present(&paths, service_id).is_some());
+
+        // Teardown must leave no plaintext key on disk. This is the whole point of
+        // reusing this managed file for the llama-server fallback rather than a copy.
+        clear_endpoint_api_key(&paths, service_id);
+        assert_eq!(endpoint_api_key(&paths, service_id), None);
+        assert_eq!(endpoint_key_file_if_present(&paths, service_id), None);
+        assert!(!endpoint_key_file_path(&paths, service_id).exists());
+
+        // Clearing again is a no-op, so any stop path can call it unconditionally.
+        clear_endpoint_api_key(&paths, service_id);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stored_key_file_is_owner_only_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let (root, paths) = temp_paths("mode");
+        store_endpoint_api_key(&paths, "svc-mode", "secret-key").unwrap();
+        let mode = std::fs::metadata(endpoint_key_file_path(&paths, "svc-mode"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "endpoint key file must be 0600");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/apps/rocm/src/endpoint_keys.rs
+++ b/apps/rocm/src/endpoint_keys.rs
@@ -22,10 +22,13 @@ use std::path::PathBuf;
 use rocm_core::AppPaths;
 
 /// Deterministic path of the 0600 endpoint key file for `service_id`.
+///
+/// Delegates to the shared helper in `rocm-engine-protocol` so `rocmd` (which
+/// needs the same path to re-thread `ROCM_SERVE_API_KEY_FILE` onto engine
+/// children it spawns) derives an identical path without depending on this
+/// crate-private module.
 pub(crate) fn endpoint_key_file_path(paths: &AppPaths, service_id: &str) -> PathBuf {
-    paths
-        .services_dir()
-        .join(format!("{service_id}.endpoint-key"))
+    rocm_engine_protocol::endpoint_key_file_path(paths, service_id)
 }
 
 /// Persist `key` for `service_id`, creating the file 0600. Overwrites any
@@ -44,9 +47,11 @@ pub(crate) fn endpoint_api_key(paths: &AppPaths, service_id: &str) -> Option<Str
 
 /// The key file path if it exists, for handing to the engine child via
 /// `ROCM_SERVE_API_KEY_FILE`. `None` for loopback services with no stored key.
+///
+/// Delegates to the shared helper in `rocm-engine-protocol` (see
+/// [`endpoint_key_file_path`]).
 pub(crate) fn endpoint_key_file_if_present(paths: &AppPaths, service_id: &str) -> Option<PathBuf> {
-    let path = endpoint_key_file_path(paths, service_id);
-    path.exists().then_some(path)
+    rocm_engine_protocol::endpoint_key_file_if_present(paths, service_id)
 }
 
 /// Remove the stored key for `service_id`. Idempotent and best-effort: a missing

--- a/apps/rocm/src/endpoint_keys.rs
+++ b/apps/rocm/src/endpoint_keys.rs
@@ -1,0 +1,57 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Secure storage for per-service inference-endpoint API keys.
+//!
+//! When `rocm serve` binds a public (non-loopback) interface it protects the
+//! endpoint with an API key (see `resolve_endpoint_auth` in `main.rs`). The key
+//! is stored in a 0600 file under the services directory, keyed by service id.
+//!
+//! A file — not the OS keychain — is deliberate: public binding is overwhelmingly
+//! a *headless server* action (that is what `0.0.0.0` is for), and headless Linux
+//! hosts routinely have no Secret Service / D-Bus session, so a keychain-backed
+//! store would make `rocm serve --host 0.0.0.0` fail on its primary platform. An
+//! owner-only (0600) file under `~/.rocm` satisfies "not persisted insecurely"
+//! while working the same everywhere, and is the same shape (`--api-key-file`)
+//! engines like llama-server already use.
+
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+use rocm_core::AppPaths;
+
+/// Deterministic path of the 0600 endpoint key file for `service_id`.
+pub(crate) fn endpoint_key_file_path(paths: &AppPaths, service_id: &str) -> PathBuf {
+    paths
+        .services_dir()
+        .join(format!("{service_id}.endpoint-key"))
+}
+
+/// Persist `key` for `service_id`, creating the file 0600. Overwrites any
+/// existing value.
+pub(crate) fn store_endpoint_api_key(paths: &AppPaths, service_id: &str, key: &str) -> Result<()> {
+    let path = endpoint_key_file_path(paths, service_id);
+    crate::write_private_file_0600(&path, key.as_bytes())
+        .with_context(|| format!("failed to write endpoint API key file {}", path.display()))
+}
+
+/// Fetch the stored key for `service_id`, or `None` when no key file exists (a
+/// loopback service, or one launched before endpoint auth existed).
+pub(crate) fn endpoint_api_key(paths: &AppPaths, service_id: &str) -> Option<String> {
+    rocm_engine_protocol::endpoint_api_key_from_file(&endpoint_key_file_path(paths, service_id))
+}
+
+/// The key file path if it exists, for handing to the engine child via
+/// `ROCM_SERVE_API_KEY_FILE`. `None` for loopback services with no stored key.
+pub(crate) fn endpoint_key_file_if_present(paths: &AppPaths, service_id: &str) -> Option<PathBuf> {
+    let path = endpoint_key_file_path(paths, service_id);
+    path.exists().then_some(path)
+}
+
+/// Remove the stored key for `service_id`. Idempotent and best-effort: a missing
+/// file is not an error, so this is safe to call unconditionally when any service
+/// stops.
+pub(crate) fn clear_endpoint_api_key(paths: &AppPaths, service_id: &str) {
+    let _ = std::fs::remove_file(endpoint_key_file_path(paths, service_id));
+}

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -7,6 +7,7 @@ mod bootstrap;
 mod comfyui;
 mod dash;
 mod dash_seam;
+mod endpoint_keys;
 mod logging;
 mod provider_keys;
 mod providers;
@@ -335,6 +336,14 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         /// and implies `--enable-auto-tool-choice`. Applies to vLLM only.
         #[arg(long, value_name = "NAME")]
         tool_call_parser: Option<String>,
+        /// API key that clients must present to a public (non-loopback) endpoint.
+        /// When binding a public interface and this is omitted, a strong key is
+        /// generated automatically. Prefer the `ROCM_SERVE_API_KEY` environment
+        /// variable over this flag so the secret does not appear in shell history
+        /// or the process table. Ignored for loopback binds, which stay
+        /// credential-free.
+        #[arg(long)]
+        api_key: Option<String>,
     },
     /// Install, start, stop, or inspect ComfyUI.
     #[command(alias = "comfy")]
@@ -1564,6 +1573,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             no_smoke_test,
             allow_public_bind,
             tool_call_parser,
+            api_key,
         }) => serve(ServeArgs {
             model,
             engine,
@@ -1579,6 +1589,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             no_smoke_test,
             allow_public_bind,
             tool_call_parser,
+            api_key,
         }),
         Some(Command::Comfyui { command }) => comfyui(command),
         Some(Command::Services { command }) => services(command),
@@ -3956,6 +3967,7 @@ struct ServeArgs {
     no_smoke_test: bool,
     allow_public_bind: bool,
     tool_call_parser: Option<String>,
+    api_key: Option<String>,
 }
 
 fn serve(args: ServeArgs) -> Result<()> {
@@ -3974,9 +3986,21 @@ fn serve(args: ServeArgs) -> Result<()> {
         no_smoke_test,
         allow_public_bind,
         tool_call_parser,
+        api_key,
     } = args;
     let _ = managed; // background is now the default; --managed is accepted as an explicit synonym.
     validate_bind_host(&host, allow_public_bind)?;
+    // Loopback stays credential-free; a public bind must be authenticated. Resolve
+    // (or generate) the endpoint key now so every downstream path — engine spawn,
+    // readiness probe, smoke test, and the client-config we print — shares one value.
+    // The `--api-key` flag wins; otherwise fall back to `ROCM_SERVE_API_KEY` (read
+    // here rather than via clap's `env` so it works without clap's `env` feature).
+    let supplied_key = api_key.or_else(|| {
+        std::env::var("ROCM_SERVE_API_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    });
+    let endpoint_auth = resolve_endpoint_auth(&host, supplied_key.as_deref())?;
     let paths = AppPaths::discover()?;
     let mut config = RocmCliConfig::load(&paths)?;
     // Host GPU detection can involve sysfs/WSL probing, so only run it when engine
@@ -4002,6 +4026,10 @@ fn serve(args: ServeArgs) -> Result<()> {
         host_gpu_summary.as_ref(),
     );
     let selected_engine = serve_engine.engine.clone();
+    // Fail closed: a public bind must be authenticated, but Windows managed
+    // Lemonade cannot receive the key (see `ensure_public_bind_engine_supported`),
+    // so refuse rather than launch an open public server.
+    ensure_public_bind_engine_supported(&selected_engine, endpoint_auth.is_some(), cfg!(windows))?;
     let engine_model_ref =
         serve_model_ref_for_engine(&model, shared_recipe.as_ref(), &selected_engine);
     let recipe_hint = shared_recipe
@@ -4153,6 +4181,13 @@ fn serve(args: ServeArgs) -> Result<()> {
     let managed_runtime_id = resolved_selection.runtime_id.clone();
     let managed_env_id = resolved_selection.env_id.clone();
 
+    // Persist the endpoint key (public bind only) in a 0600 file so the engine
+    // child, the restart/recovery path, and inspection commands can retrieve it by
+    // service id. Loopback binds resolve to `None` and store nothing.
+    if let Some(key) = endpoint_auth.as_deref() {
+        endpoint_keys::store_endpoint_api_key(&paths, &service_id, key)?;
+    }
+
     if background {
         let mut spinner =
             serve_summary::Spinner::new(format!("Starting {model} on {selected_engine}…"));
@@ -4169,9 +4204,24 @@ fn serve(args: ServeArgs) -> Result<()> {
             managed_runtime_id.as_deref(),
             managed_env_id.as_deref(),
             resolve.engine_recipe.as_ref(),
+            endpoint_auth.as_deref(),
             &mut |_elapsed| spinner.tick(),
         )?;
         ensure_background_helper_running_quiet(summary_mode)?;
+
+        // An equivalent service was already running, so nothing was spawned and the
+        // freshly generated key is unused — drop it rather than leave it orphaned in
+        // storage. The existing service keeps its own key.
+        if report.already_running && endpoint_auth.is_some() {
+            endpoint_keys::clear_endpoint_api_key(&paths, &service_id);
+        }
+        // Safe to move `endpoint_auth` here: this branch always returns, so the
+        // fall-through (attached) path below never observes it moved.
+        let launched_key = if report.already_running {
+            None
+        } else {
+            endpoint_auth
+        };
 
         if summary_mode {
             // Best-effort inference smoke test, on by default (opt out with
@@ -4179,6 +4229,9 @@ fn serve(args: ServeArgs) -> Result<()> {
             // just launched; skipped when metrics could not be shown anyway.
             let metrics = if !no_smoke_test && !report.already_running && report.status == "ready" {
                 spinner.set_label("Running smoke test…");
+                // The local provider resolves the endpoint key from the keychain by
+                // service id, so the smoke test authenticates against a protected
+                // public endpoint without threading the secret through here.
                 serve_summary::run_smoke_test(&paths, &resolve.canonical_model_id)
             } else {
                 serve_summary::SmokeMetrics::default()
@@ -4201,12 +4254,13 @@ fn serve(args: ServeArgs) -> Result<()> {
                 status: report.status.clone(),
                 already_running: report.already_running,
                 metrics,
+                api_key: launched_key,
                 notes,
             };
             print!("{}", serve_summary::render_summary(&summary));
         } else {
             spinner.clear();
-            print_managed_launch_plain(&report);
+            print_managed_launch_plain(&report, launched_key.as_deref());
         }
         return Ok(());
     }
@@ -4221,6 +4275,7 @@ fn serve(args: ServeArgs) -> Result<()> {
         &gpu_indices,
         resolved_selection.runtime_id.as_deref(),
         resolved_selection.env_id.as_deref(),
+        endpoint_auth.as_deref(),
     )
 }
 
@@ -4267,6 +4322,83 @@ fn validate_bind_host(host: &str, allow_public_bind: bool) -> Result<()> {
 
 fn is_loopback_host(host: &str) -> bool {
     matches!(host, "127.0.0.1" | "localhost" | "::1")
+}
+
+/// Resolve the API key that will guard this endpoint, applying the
+/// loopback-vs-public policy for `rocm serve`.
+///
+/// - **Loopback host** → `None`: local serving stays credential-free (the
+///   unchanged default). Any key supplied for a loopback bind is ignored and
+///   nothing is persisted — loopback needs no auth.
+/// - **Public host** → `Some(key)`: use the user-supplied key when present,
+///   otherwise generate a strong random one so a public endpoint can never come
+///   up anonymous. An empty/whitespace supplied key is rejected rather than
+///   silently treated as "no auth".
+fn resolve_endpoint_auth(host: &str, supplied: Option<&str>) -> Result<Option<String>> {
+    if is_loopback_host(host) {
+        return Ok(None);
+    }
+    match supplied {
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                bail!(
+                    "`rocm serve --api-key` (or ROCM_SERVE_API_KEY) was empty; a public \
+                     endpoint must be protected by a non-empty API key"
+                );
+            }
+            Ok(Some(trimmed.to_owned()))
+        }
+        None => Ok(Some(rocm_core::generate_endpoint_api_key())),
+    }
+}
+
+/// Reject engine/platform combinations that cannot enforce a public endpoint's
+/// API key, so a public bind fails closed instead of coming up unauthenticated.
+///
+/// The one such case today: Windows managed Lemonade. Its server reads the
+/// value-typed `LEMONADE_API_KEY` env var, but the Windows detached-spawn
+/// primitive only carries path-valued env overrides, so the key never reaches it.
+/// vLLM enforces auth on every platform (`VLLM_API_KEY`), and loopback binds
+/// (`public_bind == false`) need no key — both pass. `is_windows` is a parameter
+/// so both branches are unit-testable off-Windows.
+fn ensure_public_bind_engine_supported(
+    engine: &str,
+    public_bind: bool,
+    is_windows: bool,
+) -> Result<()> {
+    if public_bind && is_windows && engine == "lemonade" {
+        bail!(
+            "public binding with the lemonade engine is not supported on Windows: the endpoint \
+             API key cannot be enforced there. Use `--engine vllm`, or bind a loopback host \
+             (the default 127.0.0.1)."
+        );
+    }
+    Ok(())
+}
+
+/// Write `contents` to `path` with owner-only (0600) permissions on Unix so a
+/// secret is not world-readable. On non-Unix, default permissions apply.
+pub(crate) fn write_private_file_0600(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        std::io::Write::write_all(&mut file, contents)?;
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)?;
+    }
+    Ok(())
 }
 
 #[cfg(not(windows))]
@@ -4453,10 +4585,18 @@ fn spawn_managed_engine_child(
         Some(&record.log_path),
     )?;
     let engine_envs_root = env_root_for_service(paths, engine, runtime_id, env_id)?;
+    // Hand the child the *path* to the endpoint key file (public bind only) via the
+    // environment. A path — not the secret value — is what the detached-spawn
+    // primitives accept as an env override, and it keeps the key off both the argv
+    // and the environment block. `serve()` wrote the file before spawning.
+    let endpoint_key_file = endpoint_keys::endpoint_key_file_if_present(paths, service_id);
     #[cfg(windows)]
     let child_pid = {
         let env_values = app_path_env_var_values(paths, engine_envs_root.as_deref());
-        let env_refs = app_path_env_var_refs(&env_values);
+        let mut env_refs = app_path_env_var_refs(&env_values);
+        if let Some(key_file) = endpoint_key_file.as_deref() {
+            env_refs.push((rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file));
+        }
         rocm_core::spawn_detached_no_inherit(&current_exe, &serve_args, &env_refs)
             .context("failed to launch managed engine process")?
     };
@@ -4469,6 +4609,9 @@ fn spawn_managed_engine_child(
         apply_app_path_env(&mut command, paths);
         if let Some(engine_envs_root) = engine_envs_root.as_deref() {
             command.env("ROCM_CLI_ENGINE_ENVS_ROOT", engine_envs_root);
+        }
+        if let Some(key_file) = endpoint_key_file.as_deref() {
+            command.env(rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file);
         }
         let mut child = command
             .spawn()
@@ -4513,6 +4656,7 @@ fn start_managed_service(
     runtime_id: Option<&str>,
     env_id: Option<&str>,
     engine_recipe: Option<&EngineRecipeHint>,
+    endpoint_api_key: Option<&str>,
     on_wait_tick: &mut dyn FnMut(Duration),
 ) -> Result<ManagedLaunchReport> {
     let paths = AppPaths::discover()?;
@@ -4542,6 +4686,7 @@ fn start_managed_service(
         host,
         port,
         &resolve.canonical_model_id,
+        endpoint_api_key,
         Duration::from_secs(45),
         on_wait_tick,
     );
@@ -4577,7 +4722,7 @@ fn start_managed_service(
 /// non-interactive output (piped, CI, the chat assistant's `serve --managed`),
 /// where the animated summary is inappropriate. The interactive path renders the
 /// summary table via [`serve_summary`] instead.
-fn print_managed_launch_plain(report: &ManagedLaunchReport) {
+fn print_managed_launch_plain(report: &ManagedLaunchReport, endpoint_api_key: Option<&str>) {
     if report.already_running {
         println!("managed service already running");
         println!("  service_id: {}", report.service_id);
@@ -4592,6 +4737,9 @@ fn print_managed_launch_plain(report: &ManagedLaunchReport) {
         println!("  process_pid: {child_pid}");
     }
     println!("  endpoint: {}", report.endpoint_url);
+    if let Some(key) = endpoint_api_key {
+        print!("{}", render_endpoint_client_config(&report.endpoint_url, key));
+    }
     if let Some(log_path) = report.log_path.as_deref() {
         println!("  log_path: {}", log_path.display());
     }
@@ -4599,6 +4747,25 @@ fn print_managed_launch_plain(report: &ManagedLaunchReport) {
         println!("  manifest_path: {}", manifest_path.display());
     }
     println!("  readiness: {}", report.status);
+}
+
+/// Render the one-time secure client configuration for a public, authenticated
+/// endpoint. This is the *intended* channel for delivering the key to the user
+/// (unlike logs/status, which must never contain it) — it prints the key once at
+/// launch alongside a ready-to-use example. Callers only invoke this for a
+/// non-loopback bind that generated/received a key.
+fn render_endpoint_client_config(endpoint_url: &str, api_key: &str) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "  api key: {api_key}");
+    let _ = writeln!(
+        out,
+        "  note: this key is shown only now — clients must send `Authorization: Bearer <key>`"
+    );
+    let _ = writeln!(
+        out,
+        "  example: curl -H \"Authorization: Bearer {api_key}\" {endpoint_url}/models"
+    );
+    out
 }
 
 /// The "should we spawn?" decision for [`ensure_background_helper_running`],
@@ -4687,6 +4854,7 @@ fn run_attached_service(
     gpu_indices: &[u32],
     runtime_id: Option<&str>,
     env_id: Option<&str>,
+    endpoint_api_key: Option<&str>,
 ) -> Result<()> {
     let paths = AppPaths::discover()?;
 
@@ -4737,6 +4905,9 @@ fn run_attached_service(
     let endpoint = format!("{}/v1", format_http_base_url(host, port));
     println!("  service_id: {service_id}");
     println!("  endpoint: {endpoint}");
+    if let Some(key) = endpoint_api_key {
+        print!("{}", render_endpoint_client_config(&endpoint, key));
+    }
     println!("  streaming engine logs — Ctrl-D detaches (leaves it running), Ctrl-C stops it");
     println!();
 
@@ -12542,6 +12713,10 @@ fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<s
         record.status = "stopped".to_owned();
     }
     record.write()?;
+    // Drop the endpoint key with the service by deleting its 0600 key file.
+    // Best-effort — a stopped service must not fail to stop just because key
+    // cleanup did.
+    endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
     let engine_stop = match engine_stop {
         Ok(response) => serde_json::json!({
             "attempted": true,
@@ -12619,10 +12794,18 @@ fn restart_internal_managed_service(
         record.runtime_id.as_deref(),
         record.env_id.as_deref(),
     )?;
+    // A restarted public service comes back authenticated: its 0600 key file
+    // persists across restarts (removed only on stop), so hand the child the same
+    // file and reuse the key for the readiness probe.
+    let endpoint_key_file = endpoint_keys::endpoint_key_file_if_present(paths, &record.service_id);
+    let endpoint_api_key = endpoint_keys::endpoint_api_key(paths, &record.service_id);
     #[cfg(windows)]
     let child_pid = {
         let env_values = app_path_env_var_values(paths, engine_envs_root.as_deref());
-        let env_refs = app_path_env_var_refs(&env_values);
+        let mut env_refs = app_path_env_var_refs(&env_values);
+        if let Some(key_file) = endpoint_key_file.as_deref() {
+            env_refs.push((rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file));
+        }
         rocm_core::spawn_detached_no_inherit(&current_exe, &serve_args, &env_refs)
             .context("failed to restart managed engine process")?
     };
@@ -12635,6 +12818,9 @@ fn restart_internal_managed_service(
         apply_app_path_env(&mut command, paths);
         if let Some(engine_envs_root) = engine_envs_root.as_deref() {
             command.env("ROCM_CLI_ENGINE_ENVS_ROOT", engine_envs_root);
+        }
+        if let Some(key_file) = endpoint_key_file.as_deref() {
+            command.env(rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file);
         }
         let mut child = command
             .spawn()
@@ -12667,6 +12853,7 @@ fn restart_internal_managed_service(
         &record.host,
         record.port,
         &record.canonical_model_id,
+        endpoint_api_key.as_deref(),
         Duration::from_secs(45),
     ) {
         "ready".to_owned()
@@ -15735,6 +15922,7 @@ fn wait_for_service_http_ready(
     host: &str,
     port: u16,
     canonical_model_id: &str,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> bool {
     wait_for_service_http_ready_with_progress(
@@ -15742,6 +15930,7 @@ fn wait_for_service_http_ready(
         host,
         port,
         canonical_model_id,
+        endpoint_api_key,
         timeout,
         &mut |_elapsed| {},
     )
@@ -15751,27 +15940,33 @@ fn wait_for_service_http_ready(
 /// elapses, invoking `on_tick(elapsed)` once per polling iteration so a caller can
 /// animate a spinner. Engine-neutral: `service_http_readiness_paths` already maps
 /// each engine to the right health path and normalizes the response to ready/not.
+/// `endpoint_api_key` is sent as a bearer token so the probe still succeeds against
+/// a public endpoint that now requires authentication.
 fn wait_for_service_http_ready_with_progress(
     engine: &str,
     host: &str,
     port: u16,
     canonical_model_id: &str,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
     on_tick: &mut dyn FnMut(Duration),
 ) -> bool {
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
         for path in service_http_readiness_paths(engine) {
-            if let Ok((status, body)) =
-                http_get_local_service(host, port, path, Duration::from_millis(750))
-                && service_http_readiness_response_ready(
-                    engine,
-                    path,
-                    status,
-                    &body,
-                    canonical_model_id,
-                )
-            {
+            if let Ok((status, body)) = http_get_local_service(
+                host,
+                port,
+                path,
+                endpoint_api_key,
+                Duration::from_millis(750),
+            ) && service_http_readiness_response_ready(
+                engine,
+                path,
+                status,
+                &body,
+                canonical_model_id,
+            ) {
                 return true;
             }
         }
@@ -15792,12 +15987,20 @@ fn http_get_local_service(
     host: &str,
     port: u16,
     path: &str,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<(u16, String)> {
     let mut stream = connect_tcp_stream(host, port, timeout)?;
     let host_header = format_host_port(host, port);
-    let request =
-        format!("GET {path} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n\r\n");
+    // Authenticate the probe when the endpoint is protected; loopback endpoints
+    // pass `None` and the header is omitted.
+    let auth_header = match endpoint_api_key {
+        Some(key) => format!("Authorization: Bearer {key}\r\n"),
+        None => String::new(),
+    };
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: {host_header}\r\n{auth_header}Connection: close\r\n\r\n"
+    );
     write_all_tcp_stream(&mut stream, request.as_bytes())
         .context("failed to write service readiness request")?;
     let response = read_tcp_stream_to_string(&mut stream)
@@ -20216,6 +20419,57 @@ install therock";
             "{error:#}"
         );
         validate_bind_host("0.0.0.0", true).unwrap();
+    }
+
+    #[test]
+    fn resolve_endpoint_auth_loopback_stays_credential_free() {
+        // Loopback binds never require auth, even if a key is supplied.
+        for host in ["127.0.0.1", "localhost", "::1"] {
+            assert_eq!(resolve_endpoint_auth(host, None).unwrap(), None);
+            assert_eq!(resolve_endpoint_auth(host, Some("ignored")).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn resolve_endpoint_auth_public_uses_supplied_key_trimmed() {
+        let key = resolve_endpoint_auth("0.0.0.0", Some("  my-key  "))
+            .unwrap()
+            .expect("public bind must have a key");
+        assert_eq!(key, "my-key");
+    }
+
+    #[test]
+    fn resolve_endpoint_auth_public_generates_key_when_absent() {
+        let key = resolve_endpoint_auth("0.0.0.0", None)
+            .unwrap()
+            .expect("public bind must generate a key");
+        assert_eq!(key.len(), 48);
+        assert!(key.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn resolve_endpoint_auth_public_rejects_empty_supplied_key() {
+        let error = resolve_endpoint_auth("0.0.0.0", Some("   ")).unwrap_err();
+        assert!(error.to_string().contains("non-empty"), "{error:#}");
+    }
+
+    #[test]
+    fn public_bind_fails_closed_for_windows_lemonade_only() {
+        // Windows + Lemonade + public bind: refuse (cannot enforce the key).
+        let error = ensure_public_bind_engine_supported("lemonade", true, true).unwrap_err();
+        assert!(error.to_string().contains("lemonade"), "{error:#}");
+        // Every other combination is allowed:
+        ensure_public_bind_engine_supported("vllm", true, true).unwrap(); // vLLM enforces auth on Windows
+        ensure_public_bind_engine_supported("lemonade", true, false).unwrap(); // non-Windows
+        ensure_public_bind_engine_supported("lemonade", false, true).unwrap(); // loopback needs no key
+    }
+
+    #[test]
+    fn endpoint_client_config_shows_key_once_with_bearer_guidance() {
+        let rendered = render_endpoint_client_config("http://0.0.0.0:11435/v1", "secret-123");
+        assert!(rendered.contains("secret-123"), "{rendered}");
+        assert!(rendered.contains("Authorization: Bearer"), "{rendered}");
+        assert!(rendered.contains("shown only now"), "{rendered}");
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4229,9 +4229,10 @@ fn serve(args: ServeArgs) -> Result<()> {
             // just launched; skipped when metrics could not be shown anyway.
             let metrics = if !no_smoke_test && !report.already_running && report.status == "ready" {
                 spinner.set_label("Running smoke test…");
-                // The local provider resolves the endpoint key from the keychain by
-                // service id, so the smoke test authenticates against a protected
-                // public endpoint without threading the secret through here.
+                // The local provider resolves the endpoint key from the per-service
+                // 0600 key file by service id, so the smoke test authenticates
+                // against a protected public endpoint without threading the secret
+                // through here.
                 serve_summary::run_smoke_test(&paths, &resolve.canonical_model_id)
             } else {
                 serve_summary::SmokeMetrics::default()

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4212,8 +4212,12 @@ fn serve(args: ServeArgs) -> Result<()> {
         // An equivalent service was already running, so nothing was spawned and the
         // freshly generated key is unused — drop it rather than leave it orphaned in
         // storage. The existing service keeps its own key.
-        if report.already_running && endpoint_auth.is_some() {
-            endpoint_keys::clear_endpoint_api_key(&paths, &service_id);
+        if report.already_running {
+            drop_orphaned_endpoint_key_on_already_running(
+                &paths,
+                &service_id,
+                endpoint_auth.as_deref(),
+            );
         }
         // Safe to move `endpoint_auth` here: this branch always returns, so the
         // fall-through (attached) path below never observes it moved.
@@ -4361,6 +4365,21 @@ fn resolve_endpoint_auth(host: &str, supplied: Option<&str>) -> Result<Option<St
             Ok(Some(trimmed.to_owned()))
         }
         None => Ok(Some(rocm_core::generate_endpoint_api_key())),
+    }
+}
+
+/// When an equivalent managed service is already running, the endpoint key
+/// serve() freshly stored for this attempt is unused — drop it so it is not
+/// orphaned in storage. The already-running service keeps its own key.
+/// Best-effort and idempotent; a loopback attempt (`freshly_stored == None`)
+/// is a no-op.
+fn drop_orphaned_endpoint_key_on_already_running(
+    paths: &AppPaths,
+    service_id: &str,
+    freshly_stored: Option<&str>,
+) {
+    if freshly_stored.is_some() {
+        endpoint_keys::clear_endpoint_api_key(paths, service_id);
     }
 }
 
@@ -4898,6 +4917,7 @@ fn run_attached_service(
             println!("  status: {}", report.status);
             println!("  logs: rocm logs {}", report.service_id);
             println!("  stop: rocm services stop {} --yes", report.service_id);
+            drop_orphaned_endpoint_key_on_already_running(&paths, service_id, endpoint_api_key);
             return Ok(());
         }
         ManagedSpawn::Spawned { record, child_pid } => {
@@ -20498,6 +20518,33 @@ install therock";
             let error = resolve_endpoint_auth("0.0.0.0", Some(supplied)).unwrap_err();
             assert!(error.to_string().contains("control character"), "{error:#}");
         }
+    }
+
+    #[test]
+    fn drop_orphaned_endpoint_key_on_already_running_clears_stored_key() {
+        let (root, paths) = test_paths("drop-orphaned-key-stored");
+        let service_id = "svc-orphaned";
+        endpoint_keys::store_endpoint_api_key(&paths, service_id, "secret-key").unwrap();
+
+        drop_orphaned_endpoint_key_on_already_running(&paths, service_id, Some("secret-key"));
+
+        assert_eq!(endpoint_keys::endpoint_api_key(&paths, service_id), None);
+        assert!(!endpoint_keys::endpoint_key_file_path(&paths, service_id).exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn drop_orphaned_endpoint_key_on_already_running_is_noop_for_loopback() {
+        // A loopback attempt never stores a key (`freshly_stored == None`), so the
+        // helper must not panic or error, and no file must appear.
+        let (root, paths) = test_paths("drop-orphaned-key-loopback");
+        let service_id = "svc-loopback";
+
+        drop_orphaned_endpoint_key_on_already_running(&paths, service_id, None);
+
+        assert_eq!(endpoint_keys::endpoint_api_key(&paths, service_id), None);
+        assert!(!endpoint_keys::endpoint_key_file_path(&paths, service_id).exists());
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -12907,12 +12907,9 @@ fn restart_internal_managed_service(
 }
 
 fn validate_service_id(service_id: &str) -> Result<()> {
-    if service_id.trim().is_empty() {
-        bail!("service id must not be empty");
-    }
-    if service_id.contains('/') || service_id.contains('\\') {
-        bail!("service id must not contain path separators");
-    }
+    // Single source of truth for what makes an id safe as a filesystem path
+    // component (rejects empty, path separators, `..`, control chars).
+    rocm_core::ServiceId::new(service_id)?;
     Ok(())
 }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4738,7 +4738,10 @@ fn print_managed_launch_plain(report: &ManagedLaunchReport, endpoint_api_key: Op
     }
     println!("  endpoint: {}", report.endpoint_url);
     if let Some(key) = endpoint_api_key {
-        print!("{}", render_endpoint_client_config(&report.endpoint_url, key));
+        print!(
+            "{}",
+            render_endpoint_client_config(&report.endpoint_url, key)
+        );
     }
     if let Some(log_path) = report.log_path.as_deref() {
         println!("  log_path: {}", log_path.display());
@@ -12539,7 +12542,7 @@ fn load_managed_service(paths: &AppPaths, service_id: &str) -> Result<ManagedSer
         .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
     record.normalize_paths_for_host();
     let refreshed_from_engine = record.refresh_from_engine_state().unwrap_or(false);
-    let refreshed_liveness = refresh_managed_service_runtime_liveness(&mut record);
+    let refreshed_liveness = refresh_managed_service_runtime_liveness(paths, &mut record);
     if refreshed_from_engine || refreshed_liveness {
         let _ = record.write();
     }
@@ -12760,7 +12763,15 @@ fn restart_internal_managed_service(
     service_id: &str,
 ) -> Result<ManagedServiceRecord> {
     let mut record = load_managed_service(paths, service_id)?;
+    // Preserve the endpoint key across the restart: `stop_internal_managed_service`
+    // deletes the key file (correct on a real stop), but a restart must bring the
+    // service back on the same public host with the same auth. Capture it first and
+    // re-store it after the stop so the spawn below hands the child the same key.
+    let preserved_endpoint_key = endpoint_keys::endpoint_api_key(paths, service_id);
     let _ = stop_internal_managed_service(paths, service_id);
+    if let Some(key) = preserved_endpoint_key.as_deref() {
+        endpoint_keys::store_endpoint_api_key(paths, service_id, key)?;
+    }
     let policy = parse_device_policy(record.device_policy.as_deref())?;
     fs::OpenOptions::new()
         .create(true)
@@ -13630,14 +13641,24 @@ fn managed_service_running_state(status: &str) -> &'static str {
 
 const SERVICE_LIVENESS_CHECK_TIMEOUT: Duration = Duration::from_millis(750);
 
-fn refresh_managed_service_runtime_liveness(record: &mut ManagedServiceRecord) -> bool {
+fn refresh_managed_service_runtime_liveness(
+    paths: &AppPaths,
+    record: &mut ManagedServiceRecord,
+) -> bool {
     if !managed_service_is_live(record) {
         return false;
     }
 
+    // Probe with the service's key so a protected public service is not mistaken
+    // for dead (an anonymous /v1/models would 401).
+    let endpoint_api_key = endpoint_keys::endpoint_api_key(paths, &record.service_id);
     let endpoint_ready = matches!(record.status.as_str(), "ready" | "running")
-        && managed_service_endpoint_model_ready(record, SERVICE_LIVENESS_CHECK_TIMEOUT)
-            .unwrap_or(false);
+        && managed_service_endpoint_model_ready(
+            record,
+            endpoint_api_key.as_deref(),
+            SERVICE_LIVENESS_CHECK_TIMEOUT,
+        )
+        .unwrap_or(false);
     if endpoint_ready {
         // Mirror `providers.rs::ready_local_services()`: a live, probe-passing
         // service should be persisted as "ready", not left stuck at "running".
@@ -13703,7 +13724,7 @@ pub(crate) fn load_managed_services(paths: &AppPaths) -> Result<Vec<ManagedServi
         if let Ok(mut record) = serde_json::from_slice::<ManagedServiceRecord>(&bytes) {
             record.normalize_paths_for_host();
             let refreshed_from_engine = record.refresh_from_engine_state().unwrap_or(false);
-            let refreshed_liveness = refresh_managed_service_runtime_liveness(&mut record);
+            let refreshed_liveness = refresh_managed_service_runtime_liveness(paths, &mut record);
             if refreshed_from_engine || refreshed_liveness {
                 let _ = record.write();
             }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4348,6 +4348,16 @@ fn resolve_endpoint_auth(host: &str, supplied: Option<&str>) -> Result<Option<St
                      endpoint must be protected by a non-empty API key"
                 );
             }
+            // The key is later interpolated verbatim into raw `Authorization:
+            // Bearer {key}\r\n` header lines; reject a control character (e.g. an
+            // embedded CR/LF) here so a crafted key cannot inject extra headers.
+            if rocm_core::endpoint_api_key_has_forbidden_chars(trimmed) {
+                bail!(
+                    "`rocm serve --api-key` (or ROCM_SERVE_API_KEY) contained a control \
+                     character such as a carriage return or newline; an endpoint API key \
+                     must be a single line of printable characters"
+                );
+            }
             Ok(Some(trimmed.to_owned()))
         }
         None => Ok(Some(rocm_core::generate_endpoint_api_key())),
@@ -20473,6 +20483,21 @@ install therock";
     fn resolve_endpoint_auth_public_rejects_empty_supplied_key() {
         let error = resolve_endpoint_auth("0.0.0.0", Some("   ")).unwrap_err();
         assert!(error.to_string().contains("non-empty"), "{error:#}");
+    }
+
+    #[test]
+    fn resolve_endpoint_auth_public_rejects_embedded_crlf() {
+        // A supplied key survives `trim()` with embedded CR/LF intact and would
+        // otherwise be interpolated into a raw `Authorization: Bearer` header,
+        // injecting an extra header line. It must be rejected at input validation.
+        for supplied in [
+            "good-key\r\nX-Injected: value",
+            "good-key\nmore",
+            "line\rreturn",
+        ] {
+            let error = resolve_endpoint_auth("0.0.0.0", Some(supplied)).unwrap_err();
+            assert!(error.to_string().contains("control character"), "{error:#}");
+        }
     }
 
     #[test]

--- a/apps/rocm/src/provider_keys.rs
+++ b/apps/rocm/src/provider_keys.rs
@@ -251,8 +251,20 @@ fn with_native_entry<T: Send>(
     provider: &str,
     action: impl FnOnce(&Entry) -> Result<T> + Send,
 ) -> Result<T> {
+    with_keyring_entry(PROVIDER_KEY_SERVICE, provider, action)
+}
+
+/// Generic form of [`with_native_entry`] for any keyring `service` namespace and
+/// entry `name`. Shares the same runtime guard (see above) so other secret
+/// stores in this crate (e.g. per-service endpoint keys) reuse the single
+/// platform-specific credential-store chokepoint rather than duplicating it.
+pub(crate) fn with_keyring_entry<T: Send>(
+    service: &str,
+    name: &str,
+    action: impl FnOnce(&Entry) -> Result<T> + Send,
+) -> Result<T> {
     let run = move || {
-        let entry = native_entry(provider)?;
+        let entry = keyring_entry(service, name)?;
         action(&entry)
     };
     if tokio::runtime::Handle::try_current().is_ok() {
@@ -270,13 +282,11 @@ fn with_native_entry<T: Send>(
     }
 }
 
-fn native_entry(provider: &str) -> Result<Entry> {
+fn keyring_entry(service: &str, name: &str) -> Result<Entry> {
     #[cfg(target_os = "windows")]
     {
         let store = windows_native_keyring_store::Store::new().map_err(keyring_anyhow)?;
-        store
-            .build(PROVIDER_KEY_SERVICE, provider, None)
-            .map_err(keyring_anyhow)
+        store.build(service, name, None).map_err(keyring_anyhow)
     }
 
     #[cfg(target_os = "macos")]
@@ -285,9 +295,7 @@ fn native_entry(provider: &str) -> Result<Entry> {
             &std::collections::HashMap::new(),
         )
         .map_err(keyring_anyhow)?;
-        store
-            .build(PROVIDER_KEY_SERVICE, provider, None)
-            .map_err(keyring_anyhow)
+        store.build(service, name, None).map_err(keyring_anyhow)
     }
 
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
@@ -296,9 +304,7 @@ fn native_entry(provider: &str) -> Result<Entry> {
             &std::collections::HashMap::new(),
         )
         .map_err(keyring_anyhow)?;
-        store
-            .build(PROVIDER_KEY_SERVICE, provider, None)
-            .map_err(keyring_anyhow)
+        store.build(service, name, None).map_err(keyring_anyhow)
     }
 
     #[cfg(not(any(
@@ -321,7 +327,7 @@ const fn native_store_label() -> &'static str {
     }
 }
 
-fn keyring_anyhow(error: KeyringError) -> anyhow::Error {
+pub(crate) fn keyring_anyhow(error: KeyringError) -> anyhow::Error {
     anyhow!("{error}")
 }
 

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -307,10 +307,13 @@ impl ProviderAdapter for LocalProvider<'_> {
                 .unwrap_or(&service.canonical_model_id),
             request,
         );
+        let endpoint_api_key =
+            crate::endpoint_keys::endpoint_api_key(self.paths, &service.service_id);
         let response = post_json_to_local_endpoint(
             &service.endpoint_url,
             "/v1/chat/completions",
             &body,
+            endpoint_api_key.as_deref(),
             LOCAL_PROVIDER_HTTP_TIMEOUT,
         )?;
         let (content, tool_calls) = parse_openai_chat_message(&response)?;
@@ -336,10 +339,13 @@ impl ProviderAdapter for LocalProvider<'_> {
                 .unwrap_or(&service.canonical_model_id),
             request,
         );
+        let endpoint_api_key =
+            crate::endpoint_keys::endpoint_api_key(self.paths, &service.service_id);
         stream_json_from_local_endpoint(
             &service.endpoint_url,
             "/v1/chat/completions",
             &body,
+            endpoint_api_key.as_deref(),
             LOCAL_PROVIDER_HTTP_TIMEOUT,
             on_event,
         )?;
@@ -538,16 +544,27 @@ fn post_json_to_local_endpoint(
     endpoint_url: &str,
     path: &str,
     body: &serde_json::Value,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<serde_json::Value> {
-    let body = post_json_to_local_endpoint_body(endpoint_url, path, body, timeout)?;
+    let body = post_json_to_local_endpoint_body(endpoint_url, path, body, endpoint_api_key, timeout)?;
     serde_json::from_str(body.trim()).context("failed to parse local provider chat JSON")
+}
+
+/// `Authorization: Bearer` request-header line for a protected local endpoint, or
+/// an empty string for an unauthenticated (loopback) one.
+fn local_bearer_header(endpoint_api_key: Option<&str>) -> String {
+    match endpoint_api_key {
+        Some(key) => format!("Authorization: Bearer {key}\r\n"),
+        None => String::new(),
+    }
 }
 
 fn post_json_to_local_endpoint_body(
     endpoint_url: &str,
     path: &str,
     body: &serde_json::Value,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<String> {
     let (host, port) = parse_http_endpoint(endpoint_url)
@@ -555,8 +572,9 @@ fn post_json_to_local_endpoint_body(
     let body = serde_json::to_string(body).context("failed to serialize chat request")?;
     let mut stream = connect_tcp_stream(&host, port, timeout)?;
     let host_header = format_host_port(&host, port);
+    let auth_header = local_bearer_header(endpoint_api_key);
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "POST {path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth_header}Connection: close\r\n\r\n{}",
         body.len(),
         body
     );
@@ -579,6 +597,7 @@ fn stream_json_from_local_endpoint(
     endpoint_url: &str,
     path: &str,
     body: &serde_json::Value,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
     on_event: &mut dyn FnMut(ProviderStreamEvent) -> Result<()>,
 ) -> Result<()> {
@@ -587,8 +606,9 @@ fn stream_json_from_local_endpoint(
     let body = serde_json::to_string(body).context("failed to serialize chat request")?;
     let mut stream = connect_tcp_stream(&host, port, timeout)?;
     let host_header = format_host_port(&host, port);
+    let auth_header = local_bearer_header(endpoint_api_key);
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "POST {path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth_header}Connection: close\r\n\r\n{}",
         body.len(),
         body
     );

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -525,9 +525,17 @@ fn ready_local_services(paths: &AppPaths) -> Result<Vec<ManagedServiceRecord>> {
         if record.refresh_from_engine_state().unwrap_or(false) {
             let _ = record.write();
         }
+        // Probe with the service's key so a protected public service is not
+        // filtered out here (an anonymous /v1/models would 401) before
+        // `LocalProvider` can send the bearer token.
+        let endpoint_api_key = crate::endpoint_keys::endpoint_api_key(paths, &record.service_id);
         if matches!(record.status.as_str(), "ready" | "running")
-            && managed_service_endpoint_model_ready(&record, LOCAL_SERVICE_READY_TIMEOUT)
-                .unwrap_or(false)
+            && managed_service_endpoint_model_ready(
+                &record,
+                endpoint_api_key.as_deref(),
+                LOCAL_SERVICE_READY_TIMEOUT,
+            )
+            .unwrap_or(false)
         {
             if record.status != "ready" {
                 record.status = "ready".to_owned();
@@ -547,7 +555,8 @@ fn post_json_to_local_endpoint(
     endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<serde_json::Value> {
-    let body = post_json_to_local_endpoint_body(endpoint_url, path, body, endpoint_api_key, timeout)?;
+    let body =
+        post_json_to_local_endpoint_body(endpoint_url, path, body, endpoint_api_key, timeout)?;
     serde_json::from_str(body.trim()).context("failed to parse local provider chat JSON")
 }
 

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -64,6 +64,10 @@ pub(crate) struct DeploymentSummary {
     /// True when an equivalent server was already running and nothing was spawned.
     pub already_running: bool,
     pub metrics: SmokeMetrics,
+    /// The endpoint API key for a freshly launched *public* server, shown once as
+    /// secure client configuration. `None` for loopback binds (no auth) and for an
+    /// already-running service (whose key was delivered at its own launch).
+    pub api_key: Option<String>,
     /// GPU/device warnings folded in from the serve plan.
     pub notes: Vec<String>,
 }
@@ -150,6 +154,16 @@ pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
     out.push('\n');
     for (label, value) in rows {
         let _ = writeln!(out, "  {label:<label_width$}  {value}");
+    }
+    if let Some(api_key) = summary.api_key.as_deref() {
+        // Secure client configuration: the intended one-time channel for handing
+        // the key to the user. It is printed here to the terminal only — never to
+        // logs, `rocm services`, or `rocm logs`.
+        let _ = writeln!(out, "  api key: {api_key}");
+        let _ = writeln!(
+            out,
+            "  note: this key is shown only now — clients must send `Authorization: Bearer <key>`"
+        );
     }
     if !ready && !summary.already_running {
         let _ = writeln!(
@@ -305,6 +319,7 @@ mod tests {
                 ttft: Some(Duration::from_millis(180)),
                 gen_tps: Some(42.15),
             },
+            api_key: None,
             notes: Vec::new(),
         }
     }
@@ -436,6 +451,20 @@ mod tests {
         let mut summary = base_summary();
         summary.notes = vec!["selected GPU 0 has low free VRAM".to_owned()];
         assert!(render_summary(&summary).contains("note: selected GPU 0 has low free VRAM"));
+    }
+
+    #[test]
+    fn api_key_client_config_shown_only_when_present() {
+        // Loopback / no key: the summary must not mention an api key at all.
+        let plain = render_summary(&base_summary());
+        assert!(!plain.contains("api key"), "{plain}");
+
+        // Public bind: the key is shown once as secure client config.
+        let mut summary = base_summary();
+        summary.api_key = Some("endpoint-secret".to_owned());
+        let rendered = render_summary(&summary);
+        assert!(rendered.contains("api key: endpoint-secret"), "{rendered}");
+        assert!(rendered.contains("shown only now"), "{rendered}");
     }
 
     #[test]

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -3083,7 +3083,8 @@ fn supervise_service(
 
     let rocm_binary =
         std::env::current_exe().context("failed to resolve current rocm executable path")?;
-    let mut child = ProcessCommand::new(rocm_binary)
+    let mut command = ProcessCommand::new(rocm_binary);
+    command
         .args(engine_serve_http_args(
             &engine,
             &record.service_id,
@@ -3099,7 +3100,14 @@ fn supervise_service(
         ))
         .stdin(Stdio::null())
         .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(log_file_err))
+        .stderr(Stdio::from(log_file_err));
+    // Re-thread the endpoint key file (public bind only) onto the engine child,
+    // same as the initial `rocm serve` spawn. This path also runs on daemon
+    // recovery (`restart_managed_service` re-execs `rocmd supervise`), so
+    // without this a previously-authenticated public service would come back
+    // up anonymous after a crash/recover cycle.
+    apply_endpoint_key_env(&mut command, paths, &record.service_id);
+    let mut child = command
         .spawn()
         .with_context(|| format!("failed to spawn engine supervisor child for {engine}"))?;
 
@@ -3113,6 +3121,7 @@ fn supervise_service(
     let ready_service_id = record.service_id.clone();
     let ready_log_path = record.log_path.clone();
     let became_ready = wait_for_service_ready(
+        paths,
         &ready_engine,
         &ready_service_id,
         &ready_log_path,
@@ -4513,7 +4522,7 @@ fn handle_server_recover_event(
         .as_deref()
         .context("server-recover event is missing service_id")?;
     let mut record = load_service_record(paths, service_id)?;
-    if !service_record_matches_recovery_event(&record, event) {
+    if !service_record_matches_recovery_event(paths, &record, event) {
         record_event(
             paths,
             state,
@@ -4532,6 +4541,7 @@ fn handle_server_recover_event(
 }
 
 fn service_record_matches_recovery_event(
+    paths: &AppPaths,
     record: &ManagedServiceRecord,
     event: &AutomationTriggerEvent,
 ) -> bool {
@@ -4541,7 +4551,7 @@ fn service_record_matches_recovery_event(
         }
         "service.endpoint_recoverable" => endpoint_service_recovery_reason(record).is_some(),
         "service.healthcheck_recoverable" => {
-            engine_healthcheck_response(&record.engine, &record.service_id)
+            engine_healthcheck_response(paths, &record.engine, &record.service_id)
                 .is_ok_and(|healthcheck| healthcheck_response_recoverable(&healthcheck))
         }
         _ => false,
@@ -4682,7 +4692,8 @@ fn find_recoverable_service(paths: &AppPaths) -> Result<Option<(ManagedServiceRe
             return Ok(Some((record, reason)));
         }
         if matches!(record.status.as_str(), "ready" | "running") {
-            let Ok(healthcheck) = engine_healthcheck_response(&record.engine, &record.service_id)
+            let Ok(healthcheck) =
+                engine_healthcheck_response(paths, &record.engine, &record.service_id)
             else {
                 if let Some(reason) = endpoint_service_recovery_reason(&record) {
                     return Ok(Some((record, reason)));
@@ -6989,6 +7000,41 @@ mod tests {
     }
 
     #[test]
+    fn apply_endpoint_key_env_sets_var_only_when_key_file_present() {
+        let (_root, paths) = temp_app_paths("apply-endpoint-key-env");
+        let service_id = "svc-endpoint-key-env";
+
+        // Loopback service: no key file has ever been written, so the child's
+        // environment must be left untouched.
+        let mut command = ProcessCommand::new("true");
+        apply_endpoint_key_env(&mut command, &paths, service_id);
+        assert!(
+            command
+                .get_envs()
+                .all(|(key, _)| key != rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV),
+            "loopback service must not receive the endpoint key env var"
+        );
+
+        // Public service: once a key file exists at the deterministic path,
+        // it must be threaded onto the child so the engine's HTTP probe
+        // authenticates.
+        let key_path = rocm_engine_protocol::endpoint_key_file_path(&paths, service_id);
+        fs::create_dir_all(paths.services_dir()).unwrap();
+        fs::write(&key_path, "secret-key").unwrap();
+        let mut command = ProcessCommand::new("true");
+        apply_endpoint_key_env(&mut command, &paths, service_id);
+        let env_value = command
+            .get_envs()
+            .find_map(|(key, value)| {
+                (key == rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV)
+                    .then_some(value)
+                    .flatten()
+            })
+            .expect("endpoint key env var must be set once the key file exists");
+        assert_eq!(env_value, key_path.as_os_str());
+    }
+
+    #[test]
     fn manifest_recovery_policy_covers_terminal_and_stale_transient_states() {
         let (root, paths) = temp_app_paths("manifest-recovery-policy");
         let mut record = ManagedServiceRecord::new(
@@ -8716,6 +8762,7 @@ fn read_new_log_phase(log_path: &Path, pos: &mut u64) -> Option<&'static str> {
 /// timeout elapses), tailing its log file meanwhile and reporting each coarse
 /// startup phase transition via `on_phase`.
 fn wait_for_service_ready(
+    paths: &AppPaths,
     engine: &str,
     service_id: &str,
     log_path: &Path,
@@ -8732,7 +8779,7 @@ fn wait_for_service_ready(
             last_phase = Some(phase);
             on_phase(phase);
         }
-        if engine_healthcheck_ready(engine, service_id).unwrap_or(false) {
+        if engine_healthcheck_ready(paths, engine, service_id).unwrap_or(false) {
             return true;
         }
         thread::sleep(Duration::from_millis(200));
@@ -8740,15 +8787,21 @@ fn wait_for_service_ready(
     false
 }
 
-fn engine_healthcheck_ready(engine: &str, service_id: &str) -> Result<bool> {
+fn engine_healthcheck_ready(paths: &AppPaths, engine: &str, service_id: &str) -> Result<bool> {
     Ok(healthcheck_response_ready(&engine_healthcheck_response(
-        engine, service_id,
+        paths, engine, service_id,
     )?))
 }
 
-fn engine_healthcheck_response(engine: &str, service_id: &str) -> Result<HealthcheckResponse> {
+fn engine_healthcheck_response(
+    paths: &AppPaths,
+    engine: &str,
+    service_id: &str,
+) -> Result<HealthcheckResponse> {
     engine_request::<_, HealthcheckResponse>(
+        paths,
         engine,
+        service_id,
         EngineMethod::Healthcheck,
         &HealthcheckRequest {
             service_id: service_id.to_owned(),
@@ -8767,7 +8820,23 @@ fn healthcheck_response_recoverable(response: &HealthcheckResponse) -> bool {
     )
 }
 
-fn engine_request<T, R>(engine: &str, method: EngineMethod, request: &T) -> Result<R>
+/// Re-thread the endpoint key file (public bind only) onto an engine child's
+/// environment, mirroring the initial `rocm serve` spawn. `None` for a
+/// loopback service with no stored key leaves the command's environment
+/// untouched, matching the unauthenticated default.
+fn apply_endpoint_key_env(command: &mut ProcessCommand, paths: &AppPaths, service_id: &str) {
+    if let Some(key_file) = rocm_engine_protocol::endpoint_key_file_if_present(paths, service_id) {
+        command.env(rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file);
+    }
+}
+
+fn engine_request<T, R>(
+    paths: &AppPaths,
+    engine: &str,
+    service_id: &str,
+    method: EngineMethod,
+    request: &T,
+) -> Result<R>
 where
     T: Serialize,
     R: DeserializeOwned,
@@ -8778,19 +8847,25 @@ where
     };
     let engine_binary =
         std::env::current_exe().context("failed to resolve current rocm executable path")?;
-    let mut child = ProcessCommand::new(&engine_binary)
+    let mut command = ProcessCommand::new(&engine_binary);
+    command
         .arg("__engine-stdio")
         .arg(engine)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| {
-            format!(
-                "failed to spawn engine stdio process {}",
-                engine_binary.display()
-            )
-        })?;
+        .stderr(Stdio::piped());
+    // A protected public endpoint enforces its key on every request, including
+    // this stdio-transported healthcheck — without the carrier the engine
+    // adapter's HTTP probe is unauthenticated and the endpoint looks
+    // unreachable, which would misclassify a healthy protected service as
+    // recoverable.
+    apply_endpoint_key_env(&mut command, paths, service_id);
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "failed to spawn engine stdio process {}",
+            engine_binary.display()
+        )
+    })?;
 
     {
         let stdin = child

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -3358,9 +3358,10 @@ fn local_webhook_event_from_request(
     }
     let service_id = request.service_id.as_deref().map(str::trim);
     if let Some(service_id) = service_id
-        && (service_id.contains('/') || service_id.contains('\\'))
+        && !service_id.is_empty()
     {
-        bail!("service_id must not contain path separators");
+        rocm_core::ServiceId::new(service_id)
+            .with_context(|| format!("invalid service_id `{service_id}`"))?;
     }
     match watcher_hint {
         "server-recover" if service_id.unwrap_or_default().is_empty() => {
@@ -4728,9 +4729,8 @@ fn endpoint_service_recovery_reason(record: &ManagedServiceRecord) -> Option<Str
 }
 
 fn load_service_record(paths: &AppPaths, service_id: &str) -> Result<ManagedServiceRecord> {
-    if service_id.trim().is_empty() || service_id.contains('/') || service_id.contains('\\') {
-        bail!("invalid managed service id `{service_id}`");
-    }
+    rocm_core::ServiceId::new(service_id)
+        .with_context(|| format!("invalid managed service id `{service_id}`"))?;
     let manifest_path = paths.service_manifest_path(service_id);
     let bytes = fs::read(&manifest_path).with_context(|| {
         format!(

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -7887,6 +7887,10 @@ mod tests {
         assert!(key_path.exists());
 
         let result = stop_managed_service(&paths, service_id);
+        // Observe the real filesystem state before the blanket temp-dir cleanup,
+        // otherwise remove_dir_all would delete the key file and mask a missing
+        // production cleanup (the regression this test guards).
+        let key_removed = !key_path.exists();
         fs::remove_dir_all(root).ok();
 
         let value = result?;
@@ -7897,10 +7901,7 @@ mod tests {
                 .and_then(Value::as_str),
             Some("stopped")
         );
-        assert!(
-            !key_path.exists(),
-            "endpoint key file must be removed after stop"
-        );
+        assert!(key_removed, "endpoint key file must be removed after stop");
         Ok(())
     }
 

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -3360,8 +3360,10 @@ fn local_webhook_event_from_request(
     if let Some(service_id) = service_id
         && !service_id.is_empty()
     {
-        rocm_core::ServiceId::new(service_id)
-            .with_context(|| format!("invalid service_id `{service_id}`"))?;
+        // Propagate ServiceId's own message verbatim (e.g. "... must not contain
+        // path separators") rather than wrapping it in context, which anyhow's
+        // top-level Display would otherwise hide.
+        rocm_core::ServiceId::new(service_id)?;
     }
     match watcher_hint {
         "server-recover" if service_id.unwrap_or_default().is_empty() => {

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -2603,6 +2603,14 @@ fn stop_managed_service(paths: &AppPaths, service_id: &str) -> Result<Value> {
     let force_signaled_pids = force_terminate_remaining_processes(&signaled_pids)?;
     record.status = "stopped".to_owned();
     record.write()?;
+    // Best-effort and idempotent: a missing key file is not an error, so this
+    // is safe to call unconditionally on every stop (including loopback
+    // services that never had a key, and repeated stops of an already-stopped
+    // service). Leaving the 0600 key file behind after stop would strand a
+    // plaintext secret on disk for a service that no longer exists.
+    let _ = std::fs::remove_file(rocm_engine_protocol::endpoint_key_file_path(
+        paths, service_id,
+    ));
     Ok(json!({
         "service": record,
         "signaled_pids": signaled_pids,
@@ -7846,6 +7854,98 @@ mod tests {
                     .iter()
                     .any(|pid| pid.as_u64() == Some(u64::from(current_pid))))
         );
+        Ok(())
+    }
+
+    #[test]
+    fn stop_managed_service_removes_endpoint_key_file() -> Result<()> {
+        let (root, paths) = temp_app_paths("stop-removes-endpoint-key");
+        paths.ensure()?;
+        let current_pid = std::process::id();
+        let service_id = "svc-endpoint-key-stop";
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            service_id,
+            "vllm",
+            "qwen",
+            "Qwen/Qwen3.5",
+            "0.0.0.0",
+            11435,
+            "managed",
+            current_pid,
+            None,
+            None,
+            None,
+        );
+        record.engine_pid = Some(current_pid);
+        record.status = "ready".to_owned();
+        record.write()?;
+
+        let key_path = rocm_engine_protocol::endpoint_key_file_path(&paths, service_id);
+        fs::create_dir_all(paths.services_dir())?;
+        fs::write(&key_path, "secret-key")?;
+        assert!(key_path.exists());
+
+        let result = stop_managed_service(&paths, service_id);
+        fs::remove_dir_all(root).ok();
+
+        let value = result?;
+        assert_eq!(
+            value
+                .get("service")
+                .and_then(|service| service.get("status"))
+                .and_then(Value::as_str),
+            Some("stopped")
+        );
+        assert!(
+            !key_path.exists(),
+            "endpoint key file must be removed after stop"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stop_managed_service_without_endpoint_key_file_succeeds() -> Result<()> {
+        let (root, paths) = temp_app_paths("stop-no-endpoint-key");
+        paths.ensure()?;
+        let current_pid = std::process::id();
+        let service_id = "svc-no-endpoint-key-stop";
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            service_id,
+            "vllm",
+            "qwen",
+            "Qwen/Qwen3.5",
+            "127.0.0.1",
+            11435,
+            "managed",
+            current_pid,
+            None,
+            None,
+            None,
+        );
+        record.engine_pid = Some(current_pid);
+        record.status = "ready".to_owned();
+        record.write()?;
+
+        // Loopback service: no endpoint key file was ever written for it.
+        let key_path = rocm_engine_protocol::endpoint_key_file_path(&paths, service_id);
+        assert!(!key_path.exists());
+
+        let result = stop_managed_service(&paths, service_id);
+        let reloaded = load_service_record(&paths, service_id);
+        fs::remove_dir_all(root).ok();
+
+        let value = result?;
+        assert_eq!(
+            value
+                .get("service")
+                .and_then(|service| service.get("status"))
+                .and_then(Value::as_str),
+            Some("stopped")
+        );
+        assert_eq!(reloaded?.status, "stopped");
+        assert!(!key_path.exists());
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5954,6 +5954,68 @@ fn resolve_amd_smi_binary_in_home(home_dir: Option<&Path>) -> OsString {
     "amd-smi".into()
 }
 
+/// A validated managed-service identifier that is safe to use as a single
+/// filesystem path component.
+///
+/// Every managed-service path (e.g. the endpoint-key sidecar) is built as
+/// `services_dir().join(format!("{service_id}..."))`. A `ServiceId` can only be
+/// constructed through [`ServiceId::new`], which rejects path separators, `..`
+/// traversal, and control characters — so a value of this type can never make a
+/// join escape its intended directory. Prefer threading a `ServiceId` (or
+/// validating with it) over passing raw `&str` ids into path builders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceId(String);
+
+impl ServiceId {
+    /// Validate an untrusted string as a service id.
+    ///
+    /// Rejects empty/whitespace-only input, path separators (`/` and `\`), `..`
+    /// traversal sequences, and control characters. Ids produced by
+    /// [`generate_service_id`] are always accepted.
+    ///
+    /// # Errors
+    /// Returns an error describing the first rule the input violates.
+    pub fn new(value: &str) -> Result<Self> {
+        if value.trim().is_empty() {
+            bail!("service id must not be empty");
+        }
+        if value.contains('/') || value.contains('\\') {
+            bail!("service id must not contain path separators");
+        }
+        if value.contains("..") {
+            bail!("service id must not contain `..`");
+        }
+        if value.chars().any(char::is_control) {
+            bail!("service id must not contain control characters");
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::convert::TryFrom<&str> for ServiceId {
+    type Error = anyhow::Error;
+    fn try_from(value: &str) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for ServiceId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 pub fn generate_service_id(engine: &str, model_ref: &str) -> String {
     let model_slug = sanitize_component(model_ref)
         .trim_matches('-')
@@ -5992,6 +6054,39 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
+
+    #[test]
+    fn service_id_accepts_generated_and_plain_ids() {
+        // A freshly generated id must always validate.
+        let generated = generate_service_id("vllm", "Qwen/Qwen3.5");
+        assert!(ServiceId::new(&generated).is_ok());
+        // Plain alphanumeric-with-dashes ids validate and round-trip verbatim.
+        let id = ServiceId::new("svc-vllm-qwen-1730000000000").expect("valid id");
+        assert_eq!(id.as_str(), "svc-vllm-qwen-1730000000000");
+        assert_eq!(id.to_string(), "svc-vllm-qwen-1730000000000");
+    }
+
+    #[test]
+    fn service_id_rejects_traversal_and_separators() {
+        // Anything that could make `services_dir().join(id)` escape the directory
+        // (or otherwise not resolve to a single child component) is rejected.
+        for bad in [
+            "",
+            "   ",
+            "../../etc/passwd",
+            "..",
+            "a/b",
+            "a\\b",
+            "/abs",
+            "svc\r\ninject",
+            "svc\0nul",
+        ] {
+            assert!(
+                ServiceId::new(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
 
     #[test]
     fn generate_endpoint_api_key_is_random_and_alphanumeric() {

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -133,12 +133,30 @@ pub fn download_file_to_path(url: &str, destination: &Path, timeout: Duration) -
 }
 
 pub fn http_get_text(endpoint_url: &str, path: &str, timeout: Duration) -> Result<String> {
+    http_get_text_with_auth(endpoint_url, path, None, timeout)
+}
+
+/// As [`http_get_text`], but authenticated.
+///
+/// Sends `Authorization: Bearer <key>` when `endpoint_api_key` is `Some`. Used to
+/// probe endpoints that `rocm serve` has protected with an API key; `None`
+/// preserves the unauthenticated behavior for loopback endpoints.
+pub fn http_get_text_with_auth(
+    endpoint_url: &str,
+    path: &str,
+    endpoint_api_key: Option<&str>,
+    timeout: Duration,
+) -> Result<String> {
     let (host, port) = parse_http_endpoint(endpoint_url)
         .with_context(|| format!("unsupported endpoint URL `{endpoint_url}`"))?;
     let mut stream = connect_tcp_stream(&host, port, timeout)?;
     let host_header = format_host_port(&host, port);
+    let auth_header = match endpoint_api_key {
+        Some(key) => format!("Authorization: Bearer {key}\r\n"),
+        None => String::new(),
+    };
     let request = format!(
-        "GET {path} HTTP/1.1\r\nHost: {host_header}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
+        "GET {path} HTTP/1.1\r\nHost: {host_header}\r\nAccept: application/json\r\n{auth_header}Connection: close\r\n\r\n"
     );
     write_all_tcp_stream(&mut stream, request.as_bytes())
         .with_context(|| format!("failed to write HTTP GET {path}"))?;
@@ -157,9 +175,10 @@ pub fn http_get_text(endpoint_url: &str, path: &str, timeout: Duration) -> Resul
 pub fn openai_models_endpoint_has_model(
     endpoint_url: &str,
     expected_model: Option<&str>,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<bool> {
-    let body = http_get_text(endpoint_url, "/v1/models", timeout)?;
+    let body = http_get_text_with_auth(endpoint_url, "/v1/models", endpoint_api_key, timeout)?;
     let value = serde_json::from_str::<serde_json::Value>(body.trim())
         .context("failed to parse /v1/models JSON")?;
     let loaded_models = openai_loaded_model_ids(&value);
@@ -176,6 +195,7 @@ pub fn openai_models_endpoint_has_model(
 
 pub fn managed_service_endpoint_model_ready(
     record: &ManagedServiceRecord,
+    endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<bool> {
     if record.endpoint_url.trim().is_empty() {
@@ -188,7 +208,7 @@ pub fn managed_service_endpoint_model_ready(
     } else {
         None
     };
-    openai_models_endpoint_has_model(&record.endpoint_url, expected, timeout)
+    openai_models_endpoint_has_model(&record.endpoint_url, expected, endpoint_api_key, timeout)
 }
 
 fn openai_loaded_model_ids(value: &serde_json::Value) -> Vec<String> {
@@ -6064,11 +6084,72 @@ mod tests {
         assert!(openai_models_endpoint_has_model(
             &endpoint,
             Some("qwen"),
+            None,
             Duration::from_secs(2)
         )?);
 
         let request = server.join().expect("server thread should not panic")?;
         assert!(request.starts_with("GET /v1/models HTTP/1.1"));
+        Ok(())
+    }
+
+    #[test]
+    fn openai_models_endpoint_sends_bearer_when_key_present() -> Result<()> {
+        // A protected endpoint: 200 with the model list only when the request
+        // carries `Authorization: Bearer test-key`, otherwise 401. Serves two
+        // connections — the no-key probe, then the with-key probe.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let server = std::thread::spawn(move || -> Result<()> {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut request_bytes = Vec::new();
+                let mut buffer = [0_u8; 512];
+                loop {
+                    let read = stream.read(&mut buffer)?;
+                    if read == 0 {
+                        break;
+                    }
+                    request_bytes.extend_from_slice(&buffer[..read]);
+                    if String::from_utf8_lossy(&request_bytes).contains("\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&request_bytes).into_owned();
+                if request.contains("Authorization: Bearer test-key") {
+                    let body = r#"{"data":[{"id":"qwen"}]}"#;
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )?;
+                } else {
+                    write!(
+                        stream,
+                        "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )?;
+                }
+            }
+            Ok(())
+        });
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        // Without the key the protected endpoint 401s → treated as not ready.
+        assert!(
+            openai_models_endpoint_has_model(&endpoint, Some("qwen"), None, Duration::from_secs(2))
+                .is_err()
+        );
+        // With the key the bearer header is sent → the model reads as ready.
+        assert!(openai_models_endpoint_has_model(
+            &endpoint,
+            Some("qwen"),
+            Some("test-key"),
+            Duration::from_secs(2)
+        )?);
+
+        server.join().expect("server thread should not panic")?;
         Ok(())
     }
 
@@ -6110,6 +6191,7 @@ mod tests {
         let models_ready = openai_models_endpoint_has_model(
             &endpoint,
             Some("Qwen/Qwen2.5-1.5B-Instruct"),
+            None,
             Duration::from_secs(2),
         )?;
         assert!(

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5157,6 +5157,32 @@ pub fn sign_rsa_pkcs1_sha256_signature(private_key_pem: &str, payload: &[u8]) ->
     Ok(signature.to_bytes().into_vec())
 }
 
+/// Number of random alphanumeric characters in a generated endpoint API key.
+/// 48 chars from a 62-symbol alphabet is ~285 bits of entropy — far beyond what
+/// a bearer token guarding a network endpoint needs, with no padding characters
+/// that would complicate copy/paste into client configs or shell env vars.
+const ENDPOINT_API_KEY_LEN: usize = 48;
+
+/// Generate a fresh, cryptographically-random API key for a public endpoint.
+///
+/// The value is URL-safe alphanumeric (`[A-Za-z0-9]`) so it can be dropped
+/// verbatim into an `Authorization: Bearer` header, a client config file, or an
+/// environment variable without escaping.
+///
+/// Uses the same `rand::thread_rng()` CSPRNG as [`generate_rsa_signing_keypair`];
+/// deliberately *not* derived from `generate_service_id` (a timestamp-based,
+/// guessable identifier — unsuitable as a secret).
+pub fn generate_endpoint_api_key() -> String {
+    use rand::Rng;
+    use rand::distributions::Alphanumeric;
+
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(ENDPOINT_API_KEY_LEN)
+        .map(char::from)
+        .collect()
+}
+
 /// Generate a fresh 2048-bit RSA signing keypair, returned as
 /// `(PKCS#8 private-key PEM, SubjectPublicKeyInfo public-key PEM)` — the same
 /// formats `openssl genpkey` / `openssl rsa -pubout` produce.
@@ -5933,6 +5959,18 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::path::PathBuf;
+
+    #[test]
+    fn generate_endpoint_api_key_is_random_and_alphanumeric() {
+        let key = generate_endpoint_api_key();
+        assert_eq!(key.len(), ENDPOINT_API_KEY_LEN);
+        assert!(
+            key.chars().all(|c| c.is_ascii_alphanumeric()),
+            "key must be URL-safe alphanumeric, got {key:?}"
+        );
+        // Two draws must differ — a constant key would be catastrophic for auth.
+        assert_ne!(generate_endpoint_api_key(), generate_endpoint_api_key());
+    }
 
     // The socket-path precedence is mirrored in `rocm-dash-core`; these tests
     // mirror the ones there so a divergence in either crate is caught.

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5203,6 +5203,19 @@ pub fn generate_endpoint_api_key() -> String {
         .collect()
 }
 
+/// Return `true` if `key` contains a character that must never appear in an API
+/// key used verbatim in an `Authorization: Bearer` header.
+///
+/// The CLI and engine adapters build those header lines by raw string
+/// interpolation (`Authorization: Bearer {key}\r\n`), so an embedded CR or LF in
+/// the key would inject additional header lines (HTTP header injection). A
+/// control character has no legitimate place in a bearer token, so we reject the
+/// whole class rather than only CR/LF. Callers apply this at input validation
+/// (rejecting a supplied key) and defensively when reading the key file.
+pub fn endpoint_api_key_has_forbidden_chars(key: &str) -> bool {
+    key.chars().any(char::is_control)
+}
+
 /// Generate a fresh 2048-bit RSA signing keypair, returned as
 /// `(PKCS#8 private-key PEM, SubjectPublicKeyInfo public-key PEM)` — the same
 /// formats `openssl genpkey` / `openssl rsa -pubout` produce.
@@ -5990,6 +6003,29 @@ mod tests {
         );
         // Two draws must differ — a constant key would be catastrophic for auth.
         assert_ne!(generate_endpoint_api_key(), generate_endpoint_api_key());
+        // A freshly generated key must itself pass the header-safety predicate.
+        assert!(!endpoint_api_key_has_forbidden_chars(
+            &generate_endpoint_api_key()
+        ));
+    }
+
+    #[test]
+    fn endpoint_api_key_has_forbidden_chars_flags_control_chars() {
+        // Control characters (notably CR/LF) enable header injection when the key
+        // is interpolated into a raw `Authorization: Bearer` line.
+        for bad in ["key\r\ninject", "key\nother", "tab\there", "nul\0byte"] {
+            assert!(
+                endpoint_api_key_has_forbidden_chars(bad),
+                "should reject {bad:?}"
+            );
+        }
+        // Ordinary printable keys are accepted.
+        for good in ["my-key", "AbC123._~-", "sk-proj-abcDEF0123456789"] {
+            assert!(
+                !endpoint_api_key_has_forbidden_chars(good),
+                "should accept {good:?}"
+            );
+        }
     }
 
     // The socket-path precedence is mirrored in `rocm-dash-core`; these tests

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -83,6 +83,37 @@ pub fn endpoint_api_key_from_file(path: &std::path::Path) -> Option<String> {
     }
 }
 
+/// Deterministic path of the 0600 endpoint key file for `service_id`.
+///
+/// Shared so both binaries that need to locate a service's key file — `rocm`
+/// (which owns writing and clearing it) and `rocmd` (which only re-threads
+/// [`ENDPOINT_API_KEY_FILE_ENV`] onto engine children it spawns for daemon
+/// recovery and healthchecks) — derive the same path without either depending
+/// on the other's private modules.
+#[must_use]
+pub fn endpoint_key_file_path(paths: &rocm_core::AppPaths, service_id: &str) -> PathBuf {
+    paths
+        .services_dir()
+        .join(format!("{service_id}.endpoint-key"))
+}
+
+/// The key file path if it exists, for handing to an engine child via
+/// [`ENDPOINT_API_KEY_FILE_ENV`]. `None` for loopback services with no stored
+/// key.
+///
+/// This is only an existence check, not a validity check — callers that need
+/// to know whether the file holds a *usable* key (as opposed to deciding
+/// whether to set the env var at all) should read it with
+/// [`endpoint_api_key_from_file`] instead.
+#[must_use]
+pub fn endpoint_key_file_if_present(
+    paths: &rocm_core::AppPaths,
+    service_id: &str,
+) -> Option<PathBuf> {
+    let path = endpoint_key_file_path(paths, service_id);
+    path.exists().then_some(path)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EnginePluginDescriptor {
     pub id: String,
@@ -573,6 +604,53 @@ mod tests {
         std::fs::write(&empty, "\n").unwrap();
         assert_eq!(endpoint_api_key_file_if_valid(&empty), None);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn test_app_paths(label: &str) -> rocm_core::AppPaths {
+        let root = unique_temp_dir(label);
+        std::fs::create_dir_all(root.join("data").join("services")).unwrap();
+        rocm_core::AppPaths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            cache_dir: root.join("cache"),
+        }
+    }
+
+    #[test]
+    fn endpoint_key_file_path_is_deterministic_per_service_under_services_dir() {
+        let paths = test_app_paths("key-file-path");
+        let path = endpoint_key_file_path(&paths, "svc-1");
+        assert_eq!(path, paths.services_dir().join("svc-1.endpoint-key"));
+        // Same inputs, same path: callers on both sides of a spawn (writer and
+        // the env-threading reader) must agree without coordination.
+        assert_eq!(path, endpoint_key_file_path(&paths, "svc-1"));
+        // Different service ids never collide.
+        assert_ne!(path, endpoint_key_file_path(&paths, "svc-2"));
+        std::fs::remove_dir_all(&paths.data_dir).ok();
+    }
+
+    #[test]
+    fn endpoint_key_file_if_present_reflects_existence_only() {
+        let paths = test_app_paths("key-file-if-present");
+        let service_id = "svc-present";
+        // No file written yet: not present, regardless of what a future key
+        // would contain.
+        assert_eq!(endpoint_key_file_if_present(&paths, service_id), None);
+
+        let path = endpoint_key_file_path(&paths, service_id);
+        // Existence is all this helper checks — even an empty file (which
+        // `endpoint_api_key_from_file` would treat as "no key") counts as
+        // present, since callers use it to decide whether to set the env var
+        // at all, not whether the key is valid.
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(
+            endpoint_key_file_if_present(&paths, service_id),
+            Some(path.clone())
+        );
+
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(endpoint_key_file_if_present(&paths, service_id), None);
+        std::fs::remove_dir_all(&paths.data_dir).ok();
     }
 
     #[test]

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -14,6 +14,47 @@ pub const ENGINE_RECIPE_CONTRACT_VERSION: &str = "0.1.0";
 pub const ENGINE_PLUGIN_BINARY_PREFIX: &str = "rocm-engine-";
 pub const DEFAULT_LOG_TAIL_LINES: usize = 80;
 
+/// Environment variable holding a *path* to a 0600 file whose contents are the
+/// endpoint API key.
+///
+/// `rocm serve` sets this explicitly on the internal `__engine-serve-http` child
+/// (never argv), and each engine adapter reads it to decide whether to enforce
+/// authentication. A path — not the secret value — is what the detached-spawn
+/// primitives accept as an env override, and a key file keeps the secret off both
+/// the argv and the environment block.
+///
+/// The adapter reads *only* this explicitly-set carrier, never a value-bearing
+/// variable: the engine child inherits the launching shell's environment, so
+/// reading a variable like `ROCM_SERVE_API_KEY` would let a stray value in the
+/// user's shell silently authenticate an endpoint we intended to leave open
+/// (e.g. a loopback bind).
+pub const ENDPOINT_API_KEY_FILE_ENV: &str = "ROCM_SERVE_API_KEY_FILE";
+
+/// Resolve the endpoint API key an engine adapter must enforce, if any.
+///
+/// Reads the key file named by [`ENDPOINT_API_KEY_FILE_ENV`]. Returns `None` when
+/// the variable is unset or the file is empty/missing — i.e. an unauthenticated
+/// (loopback) endpoint. The value is trimmed of surrounding whitespace/newlines.
+pub fn resolve_endpoint_api_key() -> Option<String> {
+    let path = std::env::var(ENDPOINT_API_KEY_FILE_ENV).ok()?;
+    endpoint_api_key_from_file(std::path::Path::new(&path))
+}
+
+/// Read and trim an endpoint API key from `path`.
+///
+/// Returns `None` for a missing file or empty/whitespace-only contents. Split out
+/// from [`resolve_endpoint_api_key`] so it is testable without mutating the
+/// process environment.
+pub fn endpoint_api_key_from_file(path: &std::path::Path) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EnginePluginDescriptor {
     pub id: String,
@@ -445,6 +486,31 @@ pub struct LogsResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn endpoint_api_key_from_file_reads_and_trims() {
+        let dir = unique_temp_dir("endpoint-key");
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_file = dir.join("endpoint-api-key");
+        std::fs::write(&key_file, "  secret-key-value\n").unwrap();
+        assert_eq!(
+            endpoint_api_key_from_file(&key_file),
+            Some("secret-key-value".to_owned())
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn endpoint_api_key_from_file_none_for_missing_or_empty() {
+        let dir = unique_temp_dir("endpoint-key-empty");
+        std::fs::create_dir_all(&dir).unwrap();
+        let missing = dir.join("does-not-exist");
+        assert_eq!(endpoint_api_key_from_file(&missing), None);
+        let empty = dir.join("empty");
+        std::fs::write(&empty, "   \n").unwrap();
+        assert_eq!(endpoint_api_key_from_file(&empty), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn request_roundtrip_preserves_method() {

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -72,7 +72,11 @@ pub fn endpoint_api_key_file_if_valid(path: &std::path::Path) -> Option<PathBuf>
 pub fn endpoint_api_key_from_file(path: &std::path::Path) -> Option<String> {
     let contents = std::fs::read_to_string(path).ok()?;
     let trimmed = contents.trim();
-    if trimmed.is_empty() {
+    // The key is interpolated verbatim into raw `Authorization: Bearer` header
+    // lines, so a key file holding an embedded control character (e.g. CR/LF) is
+    // treated as no valid key rather than passed through — defense in depth behind
+    // the CLI's input validation, which already rejects such keys before writing.
+    if trimmed.is_empty() || rocm_core::endpoint_api_key_has_forbidden_chars(trimmed) {
         None
     } else {
         Some(trimmed.to_owned())
@@ -533,6 +537,19 @@ mod tests {
         let empty = dir.join("empty");
         std::fs::write(&empty, "   \n").unwrap();
         assert_eq!(endpoint_api_key_from_file(&empty), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn endpoint_api_key_from_file_rejects_embedded_control_chars() {
+        // A key file whose contents carry an embedded CR/LF would, if passed
+        // through, inject extra lines into the raw `Authorization: Bearer` header.
+        // Trimming only strips the ends, so the reader must reject it outright.
+        let dir = unique_temp_dir("endpoint-key-crlf");
+        std::fs::create_dir_all(&dir).unwrap();
+        let key_file = dir.join("endpoint-key");
+        std::fs::write(&key_file, "good-key\r\nX-Injected: value\n").unwrap();
+        assert_eq!(endpoint_api_key_from_file(&key_file), None);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -90,11 +90,22 @@ pub fn endpoint_api_key_from_file(path: &std::path::Path) -> Option<String> {
 /// [`ENDPOINT_API_KEY_FILE_ENV`] onto engine children it spawns for daemon
 /// recovery and healthchecks) — derive the same path without either depending
 /// on the other's private modules.
+///
+/// Callers must pass a validated id (see [`rocm_core::ServiceId`]); as
+/// defense-in-depth this asserts the built path is a direct child of the
+/// services directory, so a stray separator or `..` in `service_id` fails
+/// closed here rather than silently escaping the directory.
 #[must_use]
 pub fn endpoint_key_file_path(paths: &rocm_core::AppPaths, service_id: &str) -> PathBuf {
-    paths
-        .services_dir()
-        .join(format!("{service_id}.endpoint-key"))
+    let services_dir = paths.services_dir();
+    let path = services_dir.join(format!("{service_id}.endpoint-key"));
+    assert_eq!(
+        path.parent(),
+        Some(services_dir.as_path()),
+        "endpoint key path must be a direct child of the services directory; \
+         got service id {service_id:?}"
+    );
+    path
 }
 
 /// The key file path if it exists, for handing to an engine child via

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -40,6 +40,30 @@ pub fn resolve_endpoint_api_key() -> Option<String> {
     endpoint_api_key_from_file(std::path::Path::new(&path))
 }
 
+/// Resolve the *path* to the endpoint API key file, for engines that authenticate
+/// from a file rather than an env var (e.g. llama-server's `--api-key-file`).
+///
+/// Returns the path named by [`ENDPOINT_API_KEY_FILE_ENV`] when it exists and holds
+/// a non-empty key — the same condition under which [`resolve_endpoint_api_key`]
+/// returns `Some`. Handing the child the CLI-managed key file directly (rather than
+/// copying the secret into a second file) keeps the key's lifecycle owned by
+/// `rocm serve`, which creates the file before spawn and deletes it on stop, so no
+/// stale plaintext copy is ever left behind.
+pub fn resolve_endpoint_api_key_file() -> Option<PathBuf> {
+    endpoint_api_key_file_if_valid(&PathBuf::from(
+        std::env::var(ENDPOINT_API_KEY_FILE_ENV).ok()?,
+    ))
+}
+
+/// Return `path` when it holds a non-empty endpoint key, otherwise `None`.
+///
+/// Uses [`endpoint_api_key_from_file`] for the key check. Split out from
+/// [`resolve_endpoint_api_key_file`] so the key-presence gate is testable without
+/// mutating the process environment.
+pub fn endpoint_api_key_file_if_valid(path: &std::path::Path) -> Option<PathBuf> {
+    endpoint_api_key_from_file(path).map(|_| path.to_path_buf())
+}
+
 /// Read and trim an endpoint API key from `path`.
 ///
 /// Returns `None` for a missing file or empty/whitespace-only contents. Split out
@@ -509,6 +533,28 @@ mod tests {
         let empty = dir.join("empty");
         std::fs::write(&empty, "   \n").unwrap();
         assert_eq!(endpoint_api_key_from_file(&empty), None);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn endpoint_api_key_file_if_valid_returns_path_only_when_key_present() {
+        let dir = unique_temp_dir("endpoint-key-file-if-valid");
+        std::fs::create_dir_all(&dir).unwrap();
+        // A file holding a key resolves to that same path — the packaged
+        // llama-server fallback hands this to `--api-key-file` instead of writing a
+        // copy, so cleanup stays owned by the caller's key file.
+        let key_file = dir.join("endpoint-key");
+        std::fs::write(&key_file, "secret-key-value\n").unwrap();
+        assert_eq!(
+            endpoint_api_key_file_if_valid(&key_file),
+            Some(key_file.clone())
+        );
+        // A missing or empty file is an unauthenticated (loopback) endpoint: no
+        // `--api-key-file` should be passed.
+        assert_eq!(endpoint_api_key_file_if_valid(&dir.join("missing")), None);
+        let empty = dir.join("empty");
+        std::fs::write(&empty, "\n").unwrap();
+        assert_eq!(endpoint_api_key_file_if_valid(&empty), None);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -437,9 +437,11 @@ variable, or let one be generated. The key is handed to the engine via a 0600
 key file (never argv), persisted as a 0600 per-service file (not the OS keychain,
 which is unavailable on headless serving hosts), and printed once as client
 configuration — it must never appear in `rocm services`, `rocm logs`, or the
-audit log. Verifying that the running server actually rejects
-unauthenticated requests requires a live engine and is covered by the GPU
-acceptance scripts (`scripts/vllm_therock_gpu_test.py`), not the unit tests.
+audit log. Verifying that the running server actually *rejects* an
+unauthenticated request requires a live engine; that end-to-end assertion is a
+deferred follow-up and is **not yet** exercised by the GPU acceptance scripts
+(`scripts/vllm_therock_gpu_test.py`). The unit tests cover key policy,
+generation, the 0600 key file, key-file resolution, and cleanup on stop.
 
 Windows + Lemonade note: the Windows *managed* native-Lemonade server is launched
 via `spawn_hidden_console_with_log`, whose env-override API is path-valued only,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -419,6 +419,38 @@ cargo test -p rocm --bin rocm serve_engine_selection
 These tests verify that explicit/configured engines still win and shared model
 recipes only choose a preferred engine when no user/default engine is set.
 
+Public-endpoint authentication focused tests:
+
+```bash
+cargo test -p rocm --bin rocm resolve_endpoint_auth
+cargo test -p rocm --bin rocm endpoint_client_config
+cargo test -p rocm --bin rocm api_key_client_config
+cargo test -p rocm --bin rocm public_bind_fails_closed
+cargo test -p rocm-core generate_endpoint_api_key
+cargo test -p rocm-engine-protocol endpoint_api_key
+```
+
+A loopback bind (`rocm serve <model>`, default `127.0.0.1`) stays
+credential-free. A public bind (`--host 0.0.0.0 --allow-public-bind`) requires an
+API key: pass one with `--api-key` / the `ROCM_SERVE_API_KEY` environment
+variable, or let one be generated. The key is handed to the engine via a 0600
+key file (never argv), stored in the OS keychain by service id, and printed once
+as client configuration — it must never appear in `rocm services`, `rocm logs`,
+or the audit log. Verifying that the running server actually rejects
+unauthenticated requests requires a live engine and is covered by the GPU
+acceptance scripts (`scripts/vllm_therock_gpu_test.py`), not the unit tests.
+
+Windows + Lemonade note: the Windows *managed* native-Lemonade server is launched
+via `spawn_hidden_console_with_log`, whose env-override API is path-valued only,
+so it cannot receive the value-typed `LEMONADE_API_KEY` that Lemonade's server
+reads. Rather than launch an unauthenticated public server, `rocm serve` **fails
+closed** on that exact combination (public bind + `--engine lemonade` + Windows)
+and directs the user to `--engine vllm` or a loopback host. vLLM (all platforms,
+via `VLLM_API_KEY`), the packaged llama-server fallback (via `--api-key-file`),
+and Lemonade on non-Windows are all fully supported. Teaching the Windows
+detached-spawn primitive to carry a value-typed override (so Windows Lemonade can
+serve public with auth) is tracked as a separate follow-up.
+
 Engine recipe adapter contract focused tests:
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -434,9 +434,10 @@ A loopback bind (`rocm serve <model>`, default `127.0.0.1`) stays
 credential-free. A public bind (`--host 0.0.0.0 --allow-public-bind`) requires an
 API key: pass one with `--api-key` / the `ROCM_SERVE_API_KEY` environment
 variable, or let one be generated. The key is handed to the engine via a 0600
-key file (never argv), stored in the OS keychain by service id, and printed once
-as client configuration — it must never appear in `rocm services`, `rocm logs`,
-or the audit log. Verifying that the running server actually rejects
+key file (never argv), persisted as a 0600 per-service file (not the OS keychain,
+which is unavailable on headless serving hosts), and printed once as client
+configuration — it must never appear in `rocm services`, `rocm logs`, or the
+audit log. Verifying that the running server actually rejects
 unauthenticated requests requires a live engine and is covered by the GPU
 acceptance scripts (`scripts/vllm_therock_gpu_test.py`), not the unit tests.
 

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{
     AppPaths, DEFAULT_LOCAL_PORT, RocmCliConfig, active_managed_therock_environment,
-    download_file_to_path, format_host_port, format_http_base_url, http_get_text,
+    download_file_to_path, format_host_port, format_http_base_url, http_get_text_with_auth,
     normalize_runtime_path_for_host, prepend_runtime_paths, require_nonempty, runtime_is_linux,
     runtime_is_windows,
 };
@@ -2129,11 +2129,17 @@ fn wait_for_openai_models_ready(
     timeout: Duration,
 ) -> Result<()> {
     let endpoint = format_http_base_url(host, port);
+    let endpoint_api_key = rocm_engine_protocol::resolve_endpoint_api_key();
     let start = std::time::Instant::now();
     let mut last_error = None;
     while start.elapsed() < timeout {
-        match http_get_text(&endpoint, "/v1/models", Duration::from_secs(3))
-            .and_then(|body| parse_models_ready(&body, model_ref))
+        match http_get_text_with_auth(
+            &endpoint,
+            "/v1/models",
+            endpoint_api_key.as_deref(),
+            Duration::from_secs(3),
+        )
+        .and_then(|body| parse_models_ready(&body, model_ref))
         {
             Ok(true) => return Ok(()),
             Ok(false) => last_error = Some("model was not reported by /v1/models".to_owned()),
@@ -2218,8 +2224,14 @@ fn lemonade_model_load_args(host: &str, port: u16, model_ref: &str, backend: &st
 
 fn query_health_json(host: &str, port: u16) -> Result<Value> {
     let endpoint = format_http_base_url(host, port);
-    let body = http_get_text(&endpoint, "/v1/health", Duration::from_secs(3))
-        .with_context(|| format!("failed to query Lemonade health at {endpoint}/v1/health"))?;
+    let endpoint_api_key = rocm_engine_protocol::resolve_endpoint_api_key();
+    let body = http_get_text_with_auth(
+        &endpoint,
+        "/v1/health",
+        endpoint_api_key.as_deref(),
+        Duration::from_secs(3),
+    )
+    .with_context(|| format!("failed to query Lemonade health at {endpoint}/v1/health"))?;
     serde_json::from_str(&body).context("failed to parse Lemonade health JSON")
 }
 
@@ -2236,8 +2248,14 @@ fn query_loaded_model_endpoint(endpoint_url: &str, model_ref: &str, backend: &st
         return Ok(true);
     }
     let endpoint = format_http_base_url(&host, port);
-    let body = http_get_text(&endpoint, "/v1/models", Duration::from_secs(3))
-        .with_context(|| format!("failed to query Lemonade models at {endpoint}/v1/models"))?;
+    let endpoint_api_key = rocm_engine_protocol::resolve_endpoint_api_key();
+    let body = http_get_text_with_auth(
+        &endpoint,
+        "/v1/models",
+        endpoint_api_key.as_deref(),
+        Duration::from_secs(3),
+    )
+    .with_context(|| format!("failed to query Lemonade models at {endpoint}/v1/models"))?;
     let models =
         serde_json::from_str::<Value>(&body).context("failed to parse Lemonade /v1/models JSON")?;
     Ok(models_payload_has_ready_model(&models, model_ref, backend))
@@ -2262,9 +2280,13 @@ fn query_chat_smoke_endpoint(host: &str, port: u16, model_ref: &str) -> Result<b
     });
     let body = serde_json::to_string(&body).context("failed to serialize chat smoke request")?;
     let host_header = format_host_port(host, port);
+    let auth_header = match rocm_engine_protocol::resolve_endpoint_api_key() {
+        Some(key) => format!("Authorization: Bearer {key}\r\n"),
+        None => String::new(),
+    };
     write!(
         stream,
-        "POST /v1/chat/completions HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth_header}Connection: close\r\n\r\n{}",
         body.len(),
         body
     )

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -1497,7 +1497,41 @@ fn lemonade_process_environment_vars(
     if let Some(csv) = rocm_engine_protocol::gpu_indices_to_csv(&env.gpu_indices) {
         vars.push(("HIP_VISIBLE_DEVICES", OsString::from(csv)));
     }
+    // When `rocm serve` protects a public endpoint, the key arrives via
+    // `ROCM_SERVE_API_KEY[_FILE]`. Lemonade's server gates /api,/v0,/v1 on
+    // `LEMONADE_API_KEY`, and its own CLI clients (used here for the readiness
+    // `status` probe) auto-present the same env var — so translating it once here
+    // both secures the server and keeps our readiness checks authenticated.
+    if let Some(api_key) = rocm_engine_protocol::resolve_endpoint_api_key() {
+        vars.push(("LEMONADE_API_KEY", OsString::from(api_key)));
+    }
     Ok(vars)
+}
+
+/// Write `contents` to `path`, creating it with owner-only (0600) permissions on
+/// Unix so a secret (e.g. an endpoint API key) is not world-readable. On other
+/// platforms the file is created with default permissions.
+fn write_private_file(path: &Path, contents: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(contents)?;
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)?;
+    }
+    Ok(())
 }
 
 fn push_existing_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -1743,6 +1777,24 @@ fn serve_direct_llama_server(
         .arg("--alias")
         .arg(&request.model_ref)
         .stdin(Stdio::null());
+    // Packaged llama-server is raw llama.cpp — it does not read `LEMONADE_API_KEY`.
+    // When `rocm serve` protects a public endpoint, write the key to a 0600 file
+    // and pass `--api-key-file` so the secret never lands in the process table
+    // (unlike the bare `--api-key` flag).
+    if let Some(api_key) = rocm_engine_protocol::resolve_endpoint_api_key() {
+        let key_dir = log_path
+            .and_then(Path::parent)
+            .or_else(|| model_path.parent())
+            .unwrap_or_else(|| Path::new("."));
+        let key_file = key_dir.join(".llama-server-api-key");
+        write_private_file(&key_file, api_key.as_bytes()).with_context(|| {
+            format!(
+                "failed to write llama-server API key file {}",
+                key_file.display()
+            )
+        })?;
+        command.arg("--api-key-file").arg(&key_file);
+    }
     if let Some(log_path) = log_path {
         let log = fs::OpenOptions::new()
             .create(true)

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -1508,32 +1508,6 @@ fn lemonade_process_environment_vars(
     Ok(vars)
 }
 
-/// Write `contents` to `path`, creating it with owner-only (0600) permissions on
-/// Unix so a secret (e.g. an endpoint API key) is not world-readable. On other
-/// platforms the file is created with default permissions.
-fn write_private_file(path: &Path, contents: &[u8]) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    #[cfg(unix)]
-    {
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        file.write_all(contents)?;
-    }
-    #[cfg(not(unix))]
-    {
-        fs::write(path, contents)?;
-    }
-    Ok(())
-}
-
 fn push_existing_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     if !path.exists() || paths.iter().any(|existing| existing == &path) {
         return;
@@ -1778,21 +1752,12 @@ fn serve_direct_llama_server(
         .arg(&request.model_ref)
         .stdin(Stdio::null());
     // Packaged llama-server is raw llama.cpp — it does not read `LEMONADE_API_KEY`.
-    // When `rocm serve` protects a public endpoint, write the key to a 0600 file
-    // and pass `--api-key-file` so the secret never lands in the process table
-    // (unlike the bare `--api-key` flag).
-    if let Some(api_key) = rocm_engine_protocol::resolve_endpoint_api_key() {
-        let key_dir = log_path
-            .and_then(Path::parent)
-            .or_else(|| model_path.parent())
-            .unwrap_or_else(|| Path::new("."));
-        let key_file = key_dir.join(".llama-server-api-key");
-        write_private_file(&key_file, api_key.as_bytes()).with_context(|| {
-            format!(
-                "failed to write llama-server API key file {}",
-                key_file.display()
-            )
-        })?;
+    // When `rocm serve` protects a public endpoint, hand llama-server the *existing*
+    // CLI-managed 0600 key file via `--api-key-file` (a path, not the value, so the
+    // secret never lands in the process table). Reusing the managed file rather than
+    // writing a copy keeps the key's lifecycle owned by `rocm serve` — created before
+    // spawn, deleted on stop — with no stale plaintext copy left behind on teardown.
+    if let Some(key_file) = rocm_engine_protocol::resolve_endpoint_api_key_file() {
         command.arg("--api-key-file").arg(&key_file);
     }
     if let Some(log_path) = log_path {

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -713,6 +713,13 @@ the ROCm SDK's bundled numa uses renamed symbol versions and cannot satisfy it, 
     command
         .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
         .stdin(Stdio::null());
+    // When `rocm serve` protects a public endpoint, the key arrives via the
+    // environment / key file (never argv). Hand it to vLLM as `VLLM_API_KEY` so
+    // its OpenAI server rejects unauthenticated requests; passing it through the
+    // env keeps it out of the process table.
+    if let Some(api_key) = rocm_engine_protocol::resolve_endpoint_api_key() {
+        command.env("VLLM_API_KEY", api_key);
+    }
     apply_therock_env(&mut command, runtime)?;
     rocm_engine_protocol::apply_gpu_visibility(&mut command, &request.gpu_indices);
     if let Some(log_path) = log_path {

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1531,9 +1531,13 @@ fn endpoint_url_from_state(state: &Value) -> Option<String> {
 }
 
 fn query_loaded_model_endpoint(endpoint_url: &str, model_ref: Option<&str>) -> Result<bool> {
+    // Send the endpoint key when the server is protected so the healthcheck does
+    // not read a 401 as "not ready" and kill a correctly-authenticated server.
+    let endpoint_api_key = rocm_engine_protocol::resolve_endpoint_api_key();
     openai_models_endpoint_has_model(
         endpoint_url,
         model_ref,
+        endpoint_api_key.as_deref(),
         Duration::from_millis(HEALTHCHECK_TIMEOUT_MS),
     )
 }


### PR DESCRIPTION
## Summary

`rocm serve` no longer launches an anonymous, network-reachable server when bound to a public (non-loopback) interface. Public binds now require an API key; loopback binds stay credential-free (unchanged default).

- **Key policy**: on a public bind the key comes from `--api-key` / `ROCM_SERVE_API_KEY`, or is generated (48-char CSPRNG). An empty supplied key is rejected.
- **Engine enforcement (off-argv)**: vLLM `VLLM_API_KEY`, Lemonade server `LEMONADE_API_KEY`, packaged llama-server fallback `--api-key-file`.
- **CLI self-clients**: readiness probe, startup smoke test, and local `rocm chat` send `Authorization: Bearer` so they keep working against the protected endpoint.
- **Secure delivery + redaction**: the key is printed once as client configuration and never appears in `rocm services`, `rocm logs`, or the audit log.
- **Persistence**: a 0600 per-service key file (not the OS keychain — headless serving hosts routinely lack a Secret Service/D-Bus session); cleared on stop.
- **Fail closed**: Windows managed Lemonade cannot enforce the key through the platform's path-only spawn primitive, so `public bind + --engine lemonade + Windows` is refused with guidance to use vLLM or a loopback host.

## Testing

- New unit tests across `rocm`, `rocm-core`, and `rocm-engine-protocol` (key policy, generator, key-file reader, client-config rendering, redaction, fail-closed guard).
- Full workspace test suites pass; `cargo clippy -D warnings` clean.
- Enforcement of unauthenticated-request rejection is an engine-side behavior verified against a live GPU engine via the acceptance scripts (deferred to a GPU host), as noted in `docs/testing.md`.

## Follow-up

- Teaching the Windows detached-spawn primitive to carry a value-typed env override (so Windows Lemonade can serve public with auth) is left as a separate task; today that combination fails closed.