### PR TITLE
ci: cache rustc with sccache on compile-heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,15 +221,17 @@ jobs:
         if: needs.changes.outputs.heavy == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        if: needs.changes.outputs.heavy == 'true'
-
       # Installs the sccache binary and wires it to the GitHub Actions cache
-      # backend. Runs AFTER setup-rust-toolchain so the wrapper is on PATH before
-      # the first cargo compile. Same `heavy` gate as the cargo steps below.
+      # backend. Runs BEFORE setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at
+      # the job level, and setup-rust-toolchain's rust-cache runs `cargo metadata`
+      # (which honours RUSTC_WRAPPER) during setup — so sccache must already be on
+      # PATH by then. Same `heavy` gate as the cargo steps below.
       - name: Set up sccache
         if: needs.changes.outputs.heavy == 'true'
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        if: needs.changes.outputs.heavy == 'true'
 
       # Build the runtime binaries the smoke + acceptance steps below need (every
       # engine binary; smoke hard-fails on a missing one). Unit/integration tests
@@ -372,16 +374,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Installs sccache and wires it to the GitHub Actions cache. Runs BEFORE
+      # setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at the job level and
+      # setup-rust-toolchain's rust-cache runs `cargo metadata` (which honours
+      # RUSTC_WRAPPER) during setup, so sccache must already be on PATH by then.
+      - name: Set up sccache
+        if: needs.changes.outputs.heavy == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
         with:
           cache-on-failure: true
-
-      # Installs sccache and wires it to the GitHub Actions cache. Runs after
-      # setup-rust-toolchain so the wrapper is on PATH before the first compile.
-      - name: Set up sccache
-        if: needs.changes.outputs.heavy == 'true'
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Build
         if: needs.changes.outputs.heavy == 'true'
@@ -495,14 +499,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        if: needs.changes.outputs.rust == 'true'
-
-      # Installs sccache and wires it to the GitHub Actions cache. Runs after
-      # setup-rust-toolchain so the wrapper is on PATH before the first compile.
+      # Installs sccache and wires it to the GitHub Actions cache. Runs BEFORE
+      # setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at the job level and
+      # setup-rust-toolchain's rust-cache runs `cargo metadata` (which honours
+      # RUSTC_WRAPPER) during setup, so sccache must already be on PATH by then.
       - name: Set up sccache
         if: needs.changes.outputs.rust == 'true'
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        if: needs.changes.outputs.rust == 'true'
 
       - name: Clippy
         if: needs.changes.outputs.rust == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,22 @@ jobs:
     # thousands of small per-artifact entries on top of that, which under a full
     # cache are evicted before the next run reads them — leaving the cold-cache
     # penalty (a populating run compiles everything twice over) without the warm
-    # benefit. An external store has no such cap, so entries survive between runs.
+    # benefit. An external store has no such cap, so entries survive between runs
+    # — but nothing evicts them either: SCCACHE_CACHE_SIZE bounds only sccache's
+    # local disk cache, never a cloud backend. Retention is therefore the
+    # container's responsibility and has to come from a blob lifecycle rule
+    # (expire entries untouched for N days), not from anything in this workflow.
+    #
+    # Only trusted events populate the cache. Every branch a contributor can push
+    # receives the credential on its pull_request run, and a shared cache that
+    # such a run may write to is a code-execution path into a later main build:
+    # keys are derived from the compiler, source and flags, so anyone holding the
+    # credential can compute the key a trusted build will look up and store an
+    # arbitrary artifact under it. Limiting writes to push and merge_group leaves
+    # only main and the merge queue able to populate, while pull requests keep the
+    # full read-side speedup — which is where the measured gain comes from anyway.
+    # READ_ONLY also short-circuits the write half of sccache's startup store
+    # check, so the probe below behaves identically on pull requests.
     #
     # RUSTC_WRAPPER is set unconditionally rather than only when the backend is
     # reachable: rust-cache hashes every environment variable starting with
@@ -227,6 +242,7 @@ jobs:
       # Namespaced so the Linux and Windows lanes cannot collide, and so the
       # container stays legible if it is ever shared with another consumer.
       SCCACHE_AZURE_KEY_PREFIX: rocm-cli/build-and-test
+      SCCACHE_AZURE_RW_MODE: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && 'READ_WRITE' || 'READ_ONLY' }}
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch skips this heavy job for a fast loop; the E2E jobs
@@ -271,6 +287,13 @@ jobs:
       # the rust-cache key stays put) that always starts, just without cross-run
       # reuse. Pull requests from forks get empty secrets and take the same path,
       # since sccache treats an empty value as unset.
+      #
+      # Bumping the pinned sccache version above means re-verifying the four
+      # degradation paths this handles (no binary, absent credential, invalid
+      # credential, unreachable backend). Validating the store at server startup
+      # is v0.17.0 behaviour, not a documented contract: a release that validated
+      # lazily instead would turn this step into a silent no-op and move the
+      # hard failure back onto the first cargo step, across three required checks.
       - name: Probe sccache cache backend
         id: sccache_probe
         if: needs.changes.outputs.heavy == 'true'
@@ -282,16 +305,19 @@ jobs:
           if ! command -v sccache >/dev/null; then
             echo "::warning::sccache is not installed; compiling without it."
             echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            # Nothing will read the credential now; don't leave it in the job env.
+            disable
             exit 0
           fi
+          # sccache is the compiler wrapper from here on, remote backend or not,
+          # so there are statistics worth reporting either way.
+          echo "active=true" >> "$GITHUB_OUTPUT"
           if [ -z "${SCCACHE_AZURE_CONNECTION_STRING}" ]; then
             echo "::notice::No cache credential available (expected on forks); compiling without a shared cache."
             disable
             exit 0
           fi
-          if sccache --start-server; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if ! sccache --start-server; then
             echo "::warning::sccache could not reach the cache backend; compiling without a shared cache."
             # Leave no half-started server behind for the cargo steps to find.
             sccache --stop-server || true
@@ -311,10 +337,15 @@ jobs:
         run: cargo build --workspace
 
       # Surface the cache hit rate for the workspace compile so the effect is
-      # visible in the logs. Skipped when the probe left the wrapper off, where
-      # there are no statistics to report.
+      # visible in the logs — including on the local-only path, where a fork PR
+      # still compiles through sccache and its hit rate is the only cache signal
+      # that run produces. Skipped only when the probe found no sccache to ask.
+      #
+      # The action registers a post-job show_stats step of its own, but that runs
+      # once at the end, after `cargo xtask` steps have added their own compiles;
+      # this one reports the workspace build alone. Keep both.
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.enabled == 'true'
+        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.active == 'true'
         run: sccache --show-stats
 
       - name: Local no-fallback smoke
@@ -363,6 +394,14 @@ jobs:
   # (windows-build-and-test) also runs the whole workspace on every change, so it
   # backstops any crate a graph-based selection could miss (e.g. an integration
   # test that drives another crate only at runtime).
+  #
+  # This job is deliberately left off sccache, unlike the other compile-heavy
+  # jobs. On pull requests it compiles a crate subset, and a subset resolves Cargo
+  # features differently than the whole workspace — that changes the rustc command
+  # line, and so the cache key, for much of what it builds, which would therefore
+  # neither hit the build-and-test entries nor be reusable by them. It has its own
+  # rust-cache lane (`cache-key` above) for the same reason. Revisit if this job
+  # becomes a bottleneck.
   test:
     name: Test (affected crates)
     runs-on: ubuntu-latest
@@ -432,12 +471,14 @@ jobs:
       # dominant cost on this runner and rust-cache does not cache workspace
       # crates. CARGO_INCREMENTAL=0 above is required for (and assumed by) sccache.
       # See build-and-test for why the backend is Azure rather than the GitHub
-      # Actions cache, and why the probe below disables the backend rather than
-      # the wrapper.
+      # Actions cache, why the probe below disables the backend rather than the
+      # wrapper, why only push and merge_group may write, and why the container
+      # needs a lifecycle rule of its own.
       RUSTC_WRAPPER: sccache
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.CACHE_AZURE_CONNECTION_STRING }}
       SCCACHE_AZURE_BLOB_CONTAINER: cache
       SCCACHE_AZURE_KEY_PREFIX: rocm-cli/windows-build-and-test
+      SCCACHE_AZURE_RW_MODE: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && 'READ_WRITE' || 'READ_ONLY' }}
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
@@ -470,24 +511,32 @@ jobs:
           # error preference off so a future runner default cannot turn a failed
           # probe into a failed step.
           $PSNativeCommandUseErrorActionPreference = $false
+          # Every Out-File below passes -Encoding utf8 explicitly. PowerShell 7
+          # (`shell: pwsh`) already defaults to UTF-8, but Windows PowerShell 5.1
+          # defaults to UTF-16LE, which the runner cannot parse — so an edit that
+          # switched this step to `shell: powershell` would silently corrupt the
+          # environment file rather than fail visibly.
           function Disable-Backend {
-            "SCCACHE_AZURE_CONNECTION_STRING=" | Out-File -FilePath $env:GITHUB_ENV -Append
-            "SCCACHE_AZURE_BLOB_CONTAINER=" | Out-File -FilePath $env:GITHUB_ENV -Append
+            "SCCACHE_AZURE_CONNECTION_STRING=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            "SCCACHE_AZURE_BLOB_CONTAINER=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           }
           if (-not (Get-Command sccache -ErrorAction SilentlyContinue)) {
             Write-Output "::warning::sccache is not installed; compiling without it."
-            "RUSTC_WRAPPER=" | Out-File -FilePath $env:GITHUB_ENV -Append
+            "RUSTC_WRAPPER=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            # Nothing will read the credential now; don't leave it in the job env.
+            Disable-Backend
             exit 0
           }
+          # sccache is the compiler wrapper from here on, remote backend or not,
+          # so there are statistics worth reporting either way.
+          "active=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           if (-not $env:SCCACHE_AZURE_CONNECTION_STRING) {
             Write-Output "::notice::No cache credential available (expected on forks); compiling without a shared cache."
             Disable-Backend
             exit 0
           }
           sccache --start-server
-          if ($LASTEXITCODE -eq 0) {
-            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          } else {
+          if ($LASTEXITCODE -ne 0) {
             Write-Output "::warning::sccache could not reach the cache backend; compiling without a shared cache."
             # Leave no half-started server behind for the cargo steps to find.
             sccache --stop-server *> $null
@@ -513,10 +562,12 @@ jobs:
         run: cargo test --workspace --all-targets
 
       # Surface the cache hit rate for the workspace build/test so the effect is
-      # visible in the logs. Skipped when the probe left the wrapper off, where
-      # there are no statistics to report.
+      # visible in the logs, on the local-only path too — see build-and-test for
+      # why this is gated on sccache being present rather than on the remote
+      # backend being up, and why the action's own post-job stats step does not
+      # make this one redundant.
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.enabled == 'true'
+        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.active == 'true'
         shell: pwsh
         run: sccache --show-stats
 
@@ -616,6 +667,7 @@ jobs:
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.CACHE_AZURE_CONNECTION_STRING }}
       SCCACHE_AZURE_BLOB_CONTAINER: cache
       SCCACHE_AZURE_KEY_PREFIX: rocm-cli/build-and-test
+      SCCACHE_AZURE_RW_MODE: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && 'READ_WRITE' || 'READ_ONLY' }}
     needs: changes
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
     if: github.event_name != 'workflow_dispatch'
@@ -648,16 +700,19 @@ jobs:
           if ! command -v sccache >/dev/null; then
             echo "::warning::sccache is not installed; compiling without it."
             echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            # Nothing will read the credential now; don't leave it in the job env.
+            disable
             exit 0
           fi
+          # sccache is the compiler wrapper from here on, remote backend or not,
+          # so there are statistics worth reporting either way.
+          echo "active=true" >> "$GITHUB_OUTPUT"
           if [ -z "${SCCACHE_AZURE_CONNECTION_STRING}" ]; then
             echo "::notice::No cache credential available (expected on forks); compiling without a shared cache."
             disable
             exit 0
           fi
-          if sccache --start-server; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if ! sccache --start-server; then
             echo "::warning::sccache could not reach the cache backend; compiling without a shared cache."
             # Leave no half-started server behind for the cargo steps to find.
             sccache --stop-server || true
@@ -684,10 +739,12 @@ jobs:
         run: cargo xtask manifest --check
 
       # Surface the cache hit rate for the clippy compile so the effect is visible
-      # in the logs. Skipped when the probe left the wrapper off, where there are
-      # no statistics to report.
+      # in the logs, on the local-only path too — see build-and-test for why this
+      # is gated on sccache being present rather than on the remote backend being
+      # up, and why the action's own post-job stats step does not make this one
+      # redundant.
       - name: sccache stats
-        if: needs.changes.outputs.rust == 'true' && steps.sccache_probe.outputs.enabled == 'true'
+        if: needs.changes.outputs.rust == 'true' && steps.sccache_probe.outputs.active == 'true'
         run: sccache --show-stats
 
   third-party-notices:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,18 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # sccache caches each rustc invocation (keyed by source + deps + flags) in the
+    # GitHub Actions cache, so unchanged workspace crates are restored instead of
+    # recompiled across runs. It layers on top of setup-rust-toolchain's rust-cache,
+    # which restores the registry and dependency target/ but deliberately does not
+    # cache workspace crates — the bulk of the build time here. rust-cache also sets
+    # CARGO_INCREMENTAL=0 (which sccache requires) for these steps. These env vars
+    # only take effect where the "Set up sccache" step and the cargo steps run
+    # (both gated on `heavy`), so a skipped/non-heavy run never invokes a missing
+    # sccache binary.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch skips this heavy job for a fast loop; the E2E jobs
@@ -212,6 +224,13 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
 
+      # Installs the sccache binary and wires it to the GitHub Actions cache
+      # backend. Runs AFTER setup-rust-toolchain so the wrapper is on PATH before
+      # the first cargo compile. Same `heavy` gate as the cargo steps below.
+      - name: Set up sccache
+        if: needs.changes.outputs.heavy == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       # Build the runtime binaries the smoke + acceptance steps below need (every
       # engine binary; smoke hard-fails on a missing one). Unit/integration tests
       # run in the dedicated `test` job on only the crates a change can affect;
@@ -220,6 +239,12 @@ jobs:
       - name: Build
         if: needs.changes.outputs.heavy == 'true'
         run: cargo build --workspace
+
+      # Surface the cache hit rate for the workspace compile so the effect is
+      # visible in the logs.
+      - name: sccache stats
+        if: needs.changes.outputs.heavy == 'true'
+        run: sccache --show-stats
 
       - name: Local no-fallback smoke
         if: needs.changes.outputs.heavy == 'true'
@@ -332,6 +357,14 @@ jobs:
     timeout-minutes: 45
     env:
       CARGO_INCREMENTAL: "0"
+      # Cache each rustc invocation across runs; the full-workspace build is the
+      # dominant cost on this runner and rust-cache does not cache workspace
+      # crates. CARGO_INCREMENTAL=0 above is required for (and assumed by) sccache.
+      # These vars only take effect where the "Set up sccache" step and the cargo
+      # steps run (both gated on `heavy`), so a non-heavy run never invokes a
+      # missing sccache binary.
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
@@ -344,6 +377,12 @@ jobs:
         with:
           cache-on-failure: true
 
+      # Installs sccache and wires it to the GitHub Actions cache. Runs after
+      # setup-rust-toolchain so the wrapper is on PATH before the first compile.
+      - name: Set up sccache
+        if: needs.changes.outputs.heavy == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Build
         if: needs.changes.outputs.heavy == 'true'
         shell: pwsh
@@ -355,6 +394,13 @@ jobs:
         if: needs.changes.outputs.heavy == 'true'
         shell: pwsh
         run: cargo test --workspace --all-targets
+
+      # Surface the cache hit rate for the workspace build/test so the effect is
+      # visible in the logs.
+      - name: sccache stats
+        if: needs.changes.outputs.heavy == 'true'
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Local no-fallback smoke
         if: needs.changes.outputs.heavy == 'true'
@@ -434,6 +480,15 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # sccache caches each rustc invocation across runs (see build-and-test). clippy
+    # compiles the whole workspace with --all-targets, so it benefits too.
+    # rust-cache sets CARGO_INCREMENTAL=0 (required by sccache) for these steps.
+    # These vars only take effect where the "Set up sccache" step and the cargo
+    # steps run (both gated on `rust`), so a non-rust run never invokes a missing
+    # sccache binary.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     needs: changes
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
     if: github.event_name != 'workflow_dispatch'
@@ -442,6 +497,12 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.rust == 'true'
+
+      # Installs sccache and wires it to the GitHub Actions cache. Runs after
+      # setup-rust-toolchain so the wrapper is on PATH before the first compile.
+      - name: Set up sccache
+        if: needs.changes.outputs.rust == 'true'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Clippy
         if: needs.changes.outputs.rust == 'true'
@@ -458,6 +519,12 @@ jobs:
       - name: MANIFEST.md dependency table is current
         if: needs.changes.outputs.rust == 'true'
         run: cargo xtask manifest --check
+
+      # Surface the cache hit rate for the clippy compile so the effect is visible
+      # in the logs.
+      - name: sccache stats
+        if: needs.changes.outputs.rust == 'true'
+        run: sccache --show-stats
 
   third-party-notices:
     name: Third-party notices current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,18 +197,36 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # sccache caches each rustc invocation (keyed by source + deps + flags) in the
-    # GitHub Actions cache, so unchanged workspace crates are restored instead of
+    # sccache caches each rustc invocation (keyed by source + deps + flags) in an
+    # Azure blob container, so unchanged workspace crates are restored instead of
     # recompiled across runs. It layers on top of setup-rust-toolchain's rust-cache,
     # which restores the registry and dependency target/ but deliberately does not
     # cache workspace crates — the bulk of the build time here. rust-cache also sets
-    # CARGO_INCREMENTAL=0 (which sccache requires) for these steps. These env vars
-    # only take effect where the "Set up sccache" step and the cargo steps run
-    # (both gated on `heavy`), so a skipped/non-heavy run never invokes a missing
-    # sccache binary.
+    # CARGO_INCREMENTAL=0 (which sccache requires) for these steps.
+    #
+    # The backend is Azure rather than the GitHub Actions cache because the GHA
+    # cache is capped at 10 GB per repository and this repo already sits at that
+    # ceiling: rust-cache's per-job lanes (two OSes, several jobs) fill it, so
+    # GitHub continuously evicts least-recently-used entries. sccache adds
+    # thousands of small per-artifact entries on top of that, which under a full
+    # cache are evicted before the next run reads them — leaving the cold-cache
+    # penalty (a populating run compiles everything twice over) without the warm
+    # benefit. An external store has no such cap, so entries survive between runs.
+    #
+    # RUSTC_WRAPPER is set unconditionally rather than only when the backend is
+    # reachable: rust-cache hashes every environment variable starting with
+    # "RUST" into its cache key, so a wrapper that comes and goes would change
+    # that key and force a full cold dependency rebuild on the run after any
+    # backend hiccup. Keeping it constant makes the probe below turn the *remote*
+    # backend off (leaving sccache on its local disk cache, which always starts)
+    # instead of the wrapper itself.
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.CACHE_AZURE_CONNECTION_STRING }}
+      SCCACHE_AZURE_BLOB_CONTAINER: cache
+      # Namespaced so the Linux and Windows lanes cannot collide, and so the
+      # container stays legible if it is ever shared with another consumer.
+      SCCACHE_AZURE_KEY_PREFIX: rocm-cli/build-and-test
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch skips this heavy job for a fast loop; the E2E jobs
@@ -221,14 +239,64 @@ jobs:
         if: needs.changes.outputs.heavy == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      # Installs the sccache binary and wires it to the GitHub Actions cache
-      # backend. Runs BEFORE setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at
-      # the job level, and setup-rust-toolchain's rust-cache runs `cargo metadata`
-      # (which honours RUSTC_WRAPPER) during setup — so sccache must already be on
-      # PATH by then. Same `heavy` gate as the cargo steps below.
+      # Installs the sccache binary. Both this and the probe below run BEFORE
+      # setup-rust-toolchain, because its rust-cache step runs `cargo metadata`,
+      # which honours RUSTC_WRAPPER — the wrapper must be resolvable by then.
+      # `version` is pinned: the action defaults to whatever the latest sccache
+      # release happens to be, which would let the compiler wrapper float.
+      #
+      # continue-on-error, because RUSTC_WRAPPER is set for the whole job: if the
+      # download fails (a release blip, a checksum mismatch) the probe below
+      # notices the missing binary and clears the wrapper, rather than the job
+      # dying on an unavailable cache.
       - name: Set up sccache
         if: needs.changes.outputs.heavy == 'true'
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      # Keep the remote backend only if it actually answers.
+      #
+      # sccache verifies the store when its server starts: it reads a probe
+      # object and, for anything other than "not found" or a rate limit, aborts
+      # with a non-zero exit. That aborted startup surfaces as a failure of the
+      # first cargo invocation, so a missing, expired, or rotated credential
+      # would take down every compile-heavy required check at once — turning a
+      # caching problem into a merge-blocking outage.
+      #
+      # Starting the server here converts that into a soft failure. On any
+      # problem the Azure variables are blanked for later steps, which leaves
+      # sccache running against its local disk cache: still a valid wrapper (so
+      # the rust-cache key stays put) that always starts, just without cross-run
+      # reuse. Pull requests from forks get empty secrets and take the same path,
+      # since sccache treats an empty value as unset.
+      - name: Probe sccache cache backend
+        id: sccache_probe
+        if: needs.changes.outputs.heavy == 'true'
+        run: |
+          disable() {
+            echo "SCCACHE_AZURE_CONNECTION_STRING=" >> "$GITHUB_ENV"
+            echo "SCCACHE_AZURE_BLOB_CONTAINER=" >> "$GITHUB_ENV"
+          }
+          if ! command -v sccache >/dev/null; then
+            echo "::warning::sccache is not installed; compiling without it."
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ -z "${SCCACHE_AZURE_CONNECTION_STRING}" ]; then
+            echo "::notice::No cache credential available (expected on forks); compiling without a shared cache."
+            disable
+            exit 0
+          fi
+          if sccache --start-server; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sccache could not reach the cache backend; compiling without a shared cache."
+            # Leave no half-started server behind for the cargo steps to find.
+            sccache --stop-server || true
+            disable
+          fi
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
@@ -243,9 +311,10 @@ jobs:
         run: cargo build --workspace
 
       # Surface the cache hit rate for the workspace compile so the effect is
-      # visible in the logs.
+      # visible in the logs. Skipped when the probe left the wrapper off, where
+      # there are no statistics to report.
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.enabled == 'true'
         run: sccache --show-stats
 
       - name: Local no-fallback smoke
@@ -362,11 +431,13 @@ jobs:
       # Cache each rustc invocation across runs; the full-workspace build is the
       # dominant cost on this runner and rust-cache does not cache workspace
       # crates. CARGO_INCREMENTAL=0 above is required for (and assumed by) sccache.
-      # These vars only take effect where the "Set up sccache" step and the cargo
-      # steps run (both gated on `heavy`), so a non-heavy run never invokes a
-      # missing sccache binary.
+      # See build-and-test for why the backend is Azure rather than the GitHub
+      # Actions cache, and why the probe below disables the backend rather than
+      # the wrapper.
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.CACHE_AZURE_CONNECTION_STRING }}
+      SCCACHE_AZURE_BLOB_CONTAINER: cache
+      SCCACHE_AZURE_KEY_PREFIX: rocm-cli/windows-build-and-test
     # Don't spend per-OS build/test cycles unless the cheap lint gate is green.
     needs: [changes, clippy, prek]
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
@@ -374,13 +445,55 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Installs sccache and wires it to the GitHub Actions cache. Runs BEFORE
-      # setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at the job level and
-      # setup-rust-toolchain's rust-cache runs `cargo metadata` (which honours
-      # RUSTC_WRAPPER) during setup, so sccache must already be on PATH by then.
+      # Installs sccache. Runs BEFORE setup-rust-toolchain, whose rust-cache step
+      # runs `cargo metadata` and honours RUSTC_WRAPPER. `version` is pinned so
+      # the compiler wrapper does not float with the latest sccache release.
+      # continue-on-error for the same reason as build-and-test: a failed install
+      # is handled by the probe, not by failing the job.
       - name: Set up sccache
         if: needs.changes.outputs.heavy == 'true'
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      # Keep the remote backend only if it answers — see the equivalent step in
+      # build-and-test for why this is a probe, and why failure clears the Azure
+      # variables rather than the wrapper.
+      - name: Probe sccache cache backend
+        id: sccache_probe
+        if: needs.changes.outputs.heavy == 'true'
+        shell: pwsh
+        run: |
+          # This script decides whether to use the cache; a non-zero status from
+          # the commands it runs is an answer, not a job failure. Pin the native
+          # error preference off so a future runner default cannot turn a failed
+          # probe into a failed step.
+          $PSNativeCommandUseErrorActionPreference = $false
+          function Disable-Backend {
+            "SCCACHE_AZURE_CONNECTION_STRING=" | Out-File -FilePath $env:GITHUB_ENV -Append
+            "SCCACHE_AZURE_BLOB_CONTAINER=" | Out-File -FilePath $env:GITHUB_ENV -Append
+          }
+          if (-not (Get-Command sccache -ErrorAction SilentlyContinue)) {
+            Write-Output "::warning::sccache is not installed; compiling without it."
+            "RUSTC_WRAPPER=" | Out-File -FilePath $env:GITHUB_ENV -Append
+            exit 0
+          }
+          if (-not $env:SCCACHE_AZURE_CONNECTION_STRING) {
+            Write-Output "::notice::No cache credential available (expected on forks); compiling without a shared cache."
+            Disable-Backend
+            exit 0
+          }
+          sccache --start-server
+          if ($LASTEXITCODE -eq 0) {
+            "enabled=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Output "::warning::sccache could not reach the cache backend; compiling without a shared cache."
+            # Leave no half-started server behind for the cargo steps to find.
+            sccache --stop-server *> $null
+            Disable-Backend
+          }
+          exit 0
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.heavy == 'true'
@@ -400,9 +513,10 @@ jobs:
         run: cargo test --workspace --all-targets
 
       # Surface the cache hit rate for the workspace build/test so the effect is
-      # visible in the logs.
+      # visible in the logs. Skipped when the probe left the wrapper off, where
+      # there are no statistics to report.
       - name: sccache stats
-        if: needs.changes.outputs.heavy == 'true'
+        if: needs.changes.outputs.heavy == 'true' && steps.sccache_probe.outputs.enabled == 'true'
         shell: pwsh
         run: sccache --show-stats
 
@@ -484,28 +598,71 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # sccache caches each rustc invocation across runs (see build-and-test). clippy
-    # compiles the whole workspace with --all-targets, so it benefits too.
-    # rust-cache sets CARGO_INCREMENTAL=0 (required by sccache) for these steps.
-    # These vars only take effect where the "Set up sccache" step and the cargo
-    # steps run (both gated on `rust`), so a non-rust run never invokes a missing
-    # sccache binary.
+    # sccache caches each rustc invocation across runs (see build-and-test for the
+    # choice of backend and the probe). clippy compiles the whole workspace with
+    # --all-targets, so it benefits too. rust-cache sets CARGO_INCREMENTAL=0
+    # (required by sccache) for these steps.
+    #
+    # This job shares build-and-test's key prefix: both compile the same crates
+    # for the same Linux target, so what one caches the other can read. The
+    # overlap is narrower than it looks — clippy builds dependencies without
+    # `--emit=link`, which gives most of them a different cache key than the
+    # build job's, and workspace crates go through clippy-driver, whose hash
+    # differs from rustc's. Crates that must be fully linked for both (proc
+    # macros, and anything a build script needs) do hit. Sharing cannot poison
+    # either job: the compiler binary is part of every key.
     env:
       RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.CACHE_AZURE_CONNECTION_STRING }}
+      SCCACHE_AZURE_BLOB_CONTAINER: cache
+      SCCACHE_AZURE_KEY_PREFIX: rocm-cli/build-and-test
     needs: changes
     # A manual E2E dispatch only exercises the E2E jobs; skip the rest.
     if: github.event_name != 'workflow_dispatch'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Installs sccache and wires it to the GitHub Actions cache. Runs BEFORE
-      # setup-rust-toolchain: RUSTC_WRAPPER=sccache is set at the job level and
-      # setup-rust-toolchain's rust-cache runs `cargo metadata` (which honours
-      # RUSTC_WRAPPER) during setup, so sccache must already be on PATH by then.
+      # Installs sccache. Runs BEFORE setup-rust-toolchain, whose rust-cache step
+      # runs `cargo metadata` and honours RUSTC_WRAPPER. `version` is pinned so
+      # the compiler wrapper does not float with the latest sccache release.
+      # continue-on-error for the same reason as build-and-test: a failed install
+      # is handled by the probe, not by failing the job.
       - name: Set up sccache
         if: needs.changes.outputs.rust == 'true'
-        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
+
+      # Keep the remote backend only if it answers — see the equivalent step in
+      # build-and-test for why this is a probe, and why failure clears the Azure
+      # variables rather than the wrapper.
+      - name: Probe sccache cache backend
+        id: sccache_probe
+        if: needs.changes.outputs.rust == 'true'
+        run: |
+          disable() {
+            echo "SCCACHE_AZURE_CONNECTION_STRING=" >> "$GITHUB_ENV"
+            echo "SCCACHE_AZURE_BLOB_CONTAINER=" >> "$GITHUB_ENV"
+          }
+          if ! command -v sccache >/dev/null; then
+            echo "::warning::sccache is not installed; compiling without it."
+            echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ -z "${SCCACHE_AZURE_CONNECTION_STRING}" ]; then
+            echo "::notice::No cache credential available (expected on forks); compiling without a shared cache."
+            disable
+            exit 0
+          fi
+          if sccache --start-server; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::sccache could not reach the cache backend; compiling without a shared cache."
+            # Leave no half-started server behind for the cargo steps to find.
+            sccache --stop-server || true
+            disable
+          fi
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: needs.changes.outputs.rust == 'true'
@@ -527,9 +684,10 @@ jobs:
         run: cargo xtask manifest --check
 
       # Surface the cache hit rate for the clippy compile so the effect is visible
-      # in the logs.
+      # in the logs. Skipped when the probe left the wrapper off, where there are
+      # no statistics to report.
       - name: sccache stats
-        if: needs.changes.outputs.rust == 'true'
+        if: needs.changes.outputs.rust == 'true' && steps.sccache_probe.outputs.enabled == 'true'
         run: sccache --show-stats
 
   third-party-notices:


### PR DESCRIPTION
## Problem

CI compilation dominates several required jobs, and the existing Rust cache does not preserve workspace crate outputs between runs.

The obvious backend for this is the GitHub Actions cache, but it does not fit: that cache is capped at 10 GB per repository with LRU eviction, and this repository already sits at ~10.6 GB. Adding rustc outputs there would evict the existing Rust and tool caches rather than add to them. The compile cache therefore goes to Azure blob storage, leaving the 10 GB Actions cache to the dependency caches that already rely on it.

## Change

- Install SHA-pinned `mozilla-actions/sccache-action` before Rust cache setup.
- Set `RUSTC_WRAPPER=sccache` in `build-and-test`, `windows-build-and-test`, and `clippy`, pointing sccache at an Azure blob container via `SCCACHE_AZURE_CONNECTION_STRING` (repository secret) and a per-job `SCCACHE_AZURE_KEY_PREFIX`.
- Restrict cache writes to `push` and `merge_group` (`SCCACHE_AZURE_RW_MODE`); pull requests read the cache but never populate it (see below).
- Probe the backend before any cargo step and degrade to a purely local cache if it is unreachable (see below).
- Preserve existing affected-path gates and `CARGO_INCREMENTAL=0` behavior.
- Report `sccache --show-stats` after each compile-heavy job.
- Leave coverage, E2E, signing, legal, and reporting jobs unchanged. The affected-crates `test` job is also deliberately left off sccache: on pull requests it compiles a crate subset, and a subset resolves Cargo features differently than the full workspace, so much of what it builds would get different keys than the compile-heavy jobs' entries and neither hit them nor be reusable by them.

`clippy` deliberately shares the `build-and-test` key prefix. The two jobs do not share most artifacts — clippy omits `--emit=link` for dependencies, which changes the cache key — but fully linked crates such as proc macros and build-script dependencies do hit across them, and the run below confirms it.

### Availability

sccache hard-fails at startup when the storage credential is missing or invalid, and v0.17.0 has no flag to soften that. Left alone, a rotated secret or a fork PR (which receives empty secrets) would red out three required checks for a reason unrelated to the change under test.

So a probe step starts the sccache server first. If the credential is absent or the backend is unreachable, it clears the Azure variables and lets sccache fall back to its always-available local disk cache; the build still runs, just without a shared cache. `RUSTC_WRAPPER` is set at job level and left alone by the probe on every path except the one where the sccache binary is missing altogether — there it must be cleared, because there is no wrapper to run. That distinction matters because `Swatinem/rust-cache` hashes `RUST*` environment variables into both its cache key and its restore key: toggling the wrapper moves those keys and forces a full cold dependency rebuild, so the paths that merely lose the *remote* backend deliberately leave it in place. The install step is `continue-on-error` and the probe checks that the binary exists, so a failed action release cannot break the build either.

Startup-time store validation is v0.17.0 behavior rather than a documented contract, so bumping the pinned version means re-verifying the four degradation paths; the probe comment says so in place.

### Cache write access

Any same-repo branch PR receives the credential, so an unrestricted cache would let anyone who can push a branch write objects that a later `main` build reads back. Keys are derived from the compiler, source, and flags, so a credential holder can compute the key a trusted build will look up and store an arbitrary artifact under it — code execution in that build. `SCCACHE_AZURE_RW_MODE` is therefore `READ_WRITE` only on `push` and `merge_group`, and `READ_ONLY` on pull requests. Pull requests keep the read-side speedup, which is where the measured gain comes from, and sccache skips the write half of its startup store check in read-only mode, so the availability probe above is unaffected.

Two related items are infrastructure follow-ups rather than workflow changes, and are not addressed here:

- **Retention.** The container is unbounded — `SCCACHE_CACHE_SIZE` governs only sccache's local disk cache, and cloud backends never evict. This needs a blob lifecycle rule (expire entries untouched for N days).
- **Credential scope.** `SCCACHE_AZURE_CONNECTION_STRING` currently carries an account key, which grants more than the one container. A container-scoped SAS would narrow that and needs no workflow change: sccache passes the string to OpenDAL, which accepts `SharedAccessSignature=` and prefers it over `AccountKey`.

## Verification

Two CI runs on this branch, cold then warm against the same Azure container:

| Job | Cold | Warm | Speedup | Warm hit rate |
|---|---:|---:|---:|---:|
| clippy | 208s | 106s | 1.96x | 99.90% (1041 hits / 1 miss) |
| Linux build/test | 588s | 126s | 4.67x | 100.00% (26 hits / 0 misses) |
| Windows build/test | 1299s | 418s | 3.11x | 100.00% (51 hits / 0 misses) |

Zero cache errors on every job in both runs, and `sccache --show-stats` reports the Azure backend (`azblob`) in each. The cold Linux run already showed a 38.62% hit rate because clippy had populated the shared prefix earlier in the same run, confirming the cross-job sharing described above.

Those runs predate the read-only restriction, so their warm pass both wrote and read. The speedups are read-side and carry over, but a pull request no longer caches artifacts unique to itself, and until this merges and `main` runs once there is nothing populated for pull requests to read.

The four degradation paths (missing credential, invalid credential, backend unreachable, sccache binary absent) were each exercised against the real v0.17.0 binary in both bash and PowerShell; all four compile successfully without a shared cache. After the probe changed, all four were re-exercised in both shells — this time driving each branch with a stub `sccache`, since branch selection rather than sccache's own behavior is what changed. Every path exits 0 and leaves the expected environment and step outputs, and the PowerShell run writes a plain UTF-8 environment file.

Also verified: workspace clippy with warnings denied, workspace build and smoke test, workflow YAML and action-pin checks, `xtask` workflow-contract tests, signed commits with DCO sign-off, OSS leak scan clean.

One unrelated flake appeared on the warm Windows run: `rocm_core::fix::tests::the_path_fix_finds_the_install_the_rest_of_the_cli_found`, which mutates the process-global `ROCM_PATH`. The Windows lane runs `cargo test` rather than nextest, so it shares one process across threads. The same test passed on the previous attempt with identical code, this PR changes no Rust source, and a re-run was green.

This rebuilds the intent of #71 from current `main`; it does not resolve the stale workflow branch.
