### PR TITLE
test(e2e): scale serve-readiness VRAM floor to device total

### DIFF
--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -122,26 +122,39 @@ async fn ensure_serve_port_free() {
     wait_for_free_vram().await;
 }
 
-/// Minimum free device VRAM (MiB) required before starting a new serve. Sized so
-/// the largest single scenario model can allocate its `gpu-memory-utilization`
-/// share without tripping vLLM's startup memory check. A generous floor: the
-/// suite's biggest model (Qwen3.6-27B, ~54 GiB) plus vLLM's ~0.8-of-total KV
-/// reservation needs the card mostly clear.
-const MIN_FREE_VRAM_MIB: u64 = 150_000;
+/// Upper bound on the free-VRAM floor (MiB). Sized so the largest single
+/// scenario model can allocate its `gpu-memory-utilization` share without
+/// tripping vLLM's startup memory check: the suite's biggest model
+/// (Qwen3.6-27B, ~54 GiB) plus vLLM's ~0.8-of-total KV reservation needs the
+/// card mostly clear. Only a data-center GPU (MI300X, ~192 GiB) has this much,
+/// so on smaller cards the floor is capped to a fraction of the device total
+/// (see [`required_free_vram_mib`]) — otherwise the check could never pass.
+const MAX_FREE_VRAM_FLOOR_MIB: u64 = 150_000;
 
-/// Best-effort: wait until the GPU reports at least [`MIN_FREE_VRAM_MIB`] free,
-/// so a just-killed serve's memory is actually reclaimed before the next serve
-/// starts. Queries `amd-smi` then `rocm-smi`; if neither is present (mock/local,
-/// no ROCm), returns immediately so non-GPU runs are unaffected.
+/// The free-VRAM floor to wait for on this host: the model-sized ceiling, but
+/// never more than 90% of the device's total VRAM. A hardcoded 150 GiB floor is
+/// unreachable on a small card (e.g. Strix Halo's ~48 GiB unified VRAM), so
+/// `wait_for_free_vram` would burn its full deadline on every serve scenario;
+/// scaling to the device keeps the drain-check meaningful everywhere.
+fn required_free_vram_mib(total_mib: u64) -> u64 {
+    MAX_FREE_VRAM_FLOOR_MIB.min(total_mib / 100 * 90)
+}
+
+/// Best-effort: wait until the GPU reports enough free VRAM (see
+/// [`required_free_vram_mib`]), so a just-killed serve's memory is actually
+/// reclaimed before the next serve starts. Queries `amd-smi` then `rocm-smi`;
+/// if neither is present (mock/local, no ROCm), returns immediately so non-GPU
+/// runs are unaffected.
 async fn wait_for_free_vram() {
     // No GPU tooling → nothing to wait on (mock/local). Probe once up front.
-    if free_vram_mib().is_none() {
+    let Some(total) = total_vram_mib() else {
         return;
-    }
+    };
+    let floor = required_free_vram_mib(total);
     let deadline = Instant::now() + Duration::from_mins(2);
     loop {
         match free_vram_mib() {
-            Some(free) if free >= MIN_FREE_VRAM_MIB => return,
+            Some(free) if free >= floor => return,
             _ if Instant::now() >= deadline => return,
             _ => tokio::time::sleep(Duration::from_secs(3)).await,
         }
@@ -151,22 +164,35 @@ async fn wait_for_free_vram() {
 /// Free device VRAM in MiB for GPU 0, via `amd-smi` (then `rocm-smi`). `None`
 /// when no such tool exists or its output can't be parsed.
 fn free_vram_mib() -> Option<u64> {
+    vram_mib().map(|(_total, free)| free)
+}
+
+/// Total device VRAM in MiB for GPU 0. `None` when no GPU tool is available —
+/// used as the "is there a GPU to wait on at all?" probe in mock/local runs.
+fn total_vram_mib() -> Option<u64> {
+    vram_mib().map(|(total, _free)| total)
+}
+
+/// `(total, free)` device VRAM in MiB for GPU 0, via `amd-smi` (then `rocm-smi`).
+/// `None` when no such tool exists or its output can't be parsed.
+fn vram_mib() -> Option<(u64, u64)> {
     use std::process::Command;
-    // amd-smi: a line like "        FREE_VRAM: 196309 MB"
+    // amd-smi: lines like "        TOTAL_VRAM: 196592 MB" / "FREE_VRAM: 196309 MB".
     if let Ok(out) = Command::new("amd-smi").args(["metric", "-m"]).output()
         && out.status.success()
     {
         let text = String::from_utf8_lossy(&out.stdout);
-        if let Some(mib) = text
-            .lines()
-            .find_map(|l| l.trim().strip_prefix("FREE_VRAM:"))
-            .and_then(|v| v.split_whitespace().next())
-            .and_then(|n| n.parse::<u64>().ok())
-        {
-            return Some(mib);
+        let field = |name: &str| {
+            text.lines()
+                .find_map(|l| l.trim().strip_prefix(name))
+                .and_then(|v| v.split_whitespace().next())
+                .and_then(|n| n.parse::<u64>().ok())
+        };
+        if let (Some(total), Some(free)) = (field("TOTAL_VRAM:"), field("FREE_VRAM:")) {
+            return Some((total, free));
         }
     }
-    // rocm-smi fallback: `--showmeminfo vram --json` → vram total/used per card.
+    // rocm-smi fallback: `--showmeminfo vram --csv` → vram total/used per card.
     if let Ok(out) = Command::new("rocm-smi")
         .args(["--showmeminfo", "vram", "--csv"])
         .output()
@@ -184,7 +210,8 @@ fn free_vram_mib() -> Option<u64> {
         let vals: Vec<&str> = row.split(',').collect();
         let total: u64 = vals.get(total_idx)?.trim().parse().ok()?;
         let used: u64 = vals.get(used_idx)?.trim().parse().ok()?;
-        return Some(total.saturating_sub(used) / (1024 * 1024));
+        let mib = 1024 * 1024;
+        return Some((total / mib, total.saturating_sub(used) / mib));
     }
     None
 }


### PR DESCRIPTION
## Summary

The E2E serve-readiness step waits for GPU memory to drain before each serve, but compared against a hardcoded 150 GiB floor (`MIN_FREE_VRAM_MIB`) sized for the 27B model on MI300X. A smaller card (e.g. Strix Halo, ~48 GiB unified VRAM) can never reach that floor, so `wait_for_free_vram` burned its full 2-minute deadline on every serve scenario — pure dead time.

Fix: probe the device's total VRAM and cap the floor at 90% of it (`required_free_vram_mib`). MI300X keeps its 150 GiB floor for the 27B model; smaller cards get a reachable floor that clears promptly once a killed serve drains.

## Changes
- Add `total_vram_mib()` / `vram_mib()` probe (amd-smi `TOTAL_VRAM` + rocm-smi total) alongside the existing free-VRAM read.
- Replace the hardcoded `MIN_FREE_VRAM_MIB` compare with `required_free_vram_mib(total) = min(150_000, total * 0.9)`.

## Test plan
- [x] Linux container gate green: clippy (`--workspace` + `-p e2e-cucumber --test e2e`) and tests under `RUSTFLAGS="-D warnings"`; e2e mock reconciliation 0 unexpected failures.
- [x] Scoped Strix-Ubuntu dispatch: serve-readiness step dropped from ~262s to 91s (the ~120s dead VRAM-drain wait is eliminated); MI300X floor unchanged.
- [ ] Full CI on this PR.