### PR TITLE
test(e2e): cover Strix large model nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,11 @@ on:
         options: [all, mock, app-dev-gpu, strix-ubuntu, strix-windows]
         # No tier input: the harness resolves pass/xfail/skip per scenario, so a
         # platform runs one job covering everything applicable to it.
-      # TEMP (probe): scenario-name regex forwarded to the cucumber harness
-      # (`cargo xtask e2e -- --name <regex>`) so a dispatch can run just a few
-      # scenarios. Empty = full suite. REMOVE after the #23 default-engine
-      # classification is validated on Strix.
+      # Scenario-name regex forwarded to the cucumber harness
+      # (`cargo xtask e2e -- --name <regex>`) so a dispatch can run only the
+      # selected scenarios. Empty = full suite.
       name_filter:
-        description: "TEMP scenario-name regex (cucumber --name); empty = full suite"
+        description: "Scenario-name regex (cucumber --name); empty = full suite"
         type: string
         default: ""
       # Opt a manual dispatch into the expensive `@nightly` scenarios (large-model
@@ -637,7 +636,7 @@ jobs:
       && (github.event_name != 'workflow_dispatch'
           || inputs.platform == 'all' || inputs.platform == 'mock')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Whether the real work runs this time. On push/PR/merge_group: only when
       # build-and-test succeeded and the change is heavy. On workflow_dispatch:
@@ -659,7 +658,7 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: sudo apt-get update && sudo apt-get install -y pkg-config libcap-dev
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: steps.gate.outputs.run == 'true'
 
       # The workspace test job selects only affected crates and runs the cucumber
@@ -718,7 +717,7 @@ jobs:
       # a single nightly scenario (e.g. the 27B serve) without the full nightly run.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Reclaim the GPU before running: a serve leaked by a killed/timed-out prior
       # run (its Drop teardown never executed) can keep an engine process spinning
@@ -785,7 +784,7 @@ jobs:
       # Swatinem/rust-cache otherwise tries to SAVE the large target dir to
       # GitHub's cache service in a post-step (slow/hangs) and its cleanup wipes
       # the local target.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
 
@@ -856,12 +855,11 @@ jobs:
             echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
           fi
 
-          # TEMP: optional scenario-name filter for a scoped probe dispatch (same
-          # as the strix job) — lets a dispatch run just one scenario (e.g. the
-          # 27B nightly) instead of the whole suite. Empty = full suite.
+          # Optional scenario-name filter for a scoped dispatch — lets a manual
+          # run select only the large-model scenario instead of the whole suite.
           NAME_FILTER="${{ github.event.inputs.name_filter }}"
           if [ -n "$NAME_FILTER" ]; then
-            echo "TEMP name filter active: $NAME_FILTER"
+            echo "name filter active: $NAME_FILTER"
             cargo xtask e2e -- --name "$NAME_FILTER"
           else
             cargo xtask e2e
@@ -910,8 +908,11 @@ jobs:
       TMPDIR: /home/ubuntu/actions-runner/tmp
       PIP_CACHE_DIR: /home/ubuntu/actions-runner/pip-cache
       E2E_SERVE_TIMEOUT_SECS: "300"
+      # Match the MI300X dispatch path: opt into the platform-adaptive large-model
+      # scenario only when the manual include_nightly input is enabled.
+      E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Prepare writable dirs on the nvme + reclaim GPU from stray E2E procs
         run: |
@@ -1011,10 +1012,10 @@ jobs:
             echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
           fi
 
-          # TEMP: optional scenario-name filter for a scoped probe dispatch.
+          # Optional scenario-name filter for a scoped manual dispatch.
           NAME_FILTER="${{ github.event.inputs.name_filter }}"
           if [ -n "$NAME_FILTER" ]; then
-            echo "TEMP name filter active: $NAME_FILTER"
+            echo "name filter active: $NAME_FILTER"
             cargo xtask e2e -- --name "$NAME_FILTER"
           else
             cargo xtask e2e
@@ -1050,7 +1051,7 @@ jobs:
       )
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # setup-rust-toolchain runs an internal bash script, which this Windows
       # runner lacks (bash: command not found). Bootstrap rustup with the
@@ -1160,10 +1161,10 @@ jobs:
             Write-Host "shared runtime already present at $env:E2E_SHARED_RUNTIMES_DIR - skipping pre-warm"
           }
 
-          # TEMP: optional scenario-name filter for a scoped probe dispatch.
+          # Optional scenario-name filter for a scoped manual dispatch.
           $nameFilter = "${{ github.event.inputs.name_filter }}"
           if ($nameFilter) {
-            Write-Host "TEMP name filter active: $nameFilter"
+            Write-Host "name filter active: $nameFilter"
             cargo xtask e2e -- --name "$nameFilter"
           } else {
             cargo xtask e2e
@@ -1204,9 +1205,9 @@ jobs:
       && (needs.changes.outputs.heavy == 'true'
         || github.event_name == 'workflow_dispatch')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       # Pull every e2e artifact. Each extracts to e2e-artifacts/<artifact-name>/,
       # which `xtask e2e-report` turns into one labeled platform. The `*-report`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1050,6 +1050,10 @@ jobs:
           && (inputs.platform == 'all' || inputs.platform == 'strix-windows'))
       )
     continue-on-error: true
+    env:
+      # Match the Linux Strix dispatch path: opt into the platform-adaptive
+      # large-model scenario only when the manual input is enabled.
+      E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -412,8 +412,8 @@ jobs:
           path: tests/e2e-cucumber/results/
 
   # Strix Halo counterpart to e2e-gpu-nightly. The same @nightly large-model
-  # scenario selects the featured Lemonade GGUF on this host. Keep the runner's
-  # storage and runtime setup aligned with ci.yml's proven Strix Ubuntu job.
+  # scenario serves the platform-specific Lemonade GGUF on this host. Keep the
+  # runner's storage and runtime setup aligned with ci.yml's proven Strix Ubuntu job.
   e2e-gpu-nightly-strix:
     name: E2E tests (Strix Halo, incl. nightly-only)
     timeout-minutes: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Verify pinned keys match the signing key
         run: cargo xtask verify-pinned-keys
@@ -348,7 +348,7 @@ jobs:
       # model (its cold ~54 GiB load exceeds this default).
       E2E_SERVE_TIMEOUT_SECS: "300"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Reclaim the GPU before running: kill only e2e leftovers scoped to
       # /tmp/rocm-e2e-* and the e2e-target/e2e-shared trees — never the runner or
@@ -365,7 +365,7 @@ jobs:
 
       # cache: false — this self-hosted runner persists the build cache itself via
       # CARGO_TARGET_DIR (below), so the action's rust-cache is pure overhead.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
 
@@ -409,4 +409,104 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-gpu-nightly-report
+          path: tests/e2e-cucumber/results/
+
+  # Strix Halo counterpart to e2e-gpu-nightly. The same @nightly large-model
+  # scenario selects the featured Lemonade GGUF on this host. Keep the runner's
+  # storage and runtime setup aligned with ci.yml's proven Strix Ubuntu job.
+  e2e-gpu-nightly-strix:
+    name: E2E tests (Strix Halo, incl. nightly-only)
+    timeout-minutes: 90
+    runs-on: [self-hosted, linux, strix-halo]
+    continue-on-error: true
+    env:
+      HOME: /home/ubuntu/actions-runner/e2e-home
+      CARGO_HOME: /home/ubuntu/actions-runner/.cargo
+      RUSTUP_HOME: /home/ubuntu/actions-runner/.rustup
+      TMPDIR: /home/ubuntu/actions-runner/tmp
+      PIP_CACHE_DIR: /home/ubuntu/actions-runner/pip-cache
+      E2E_INCLUDE_NIGHTLY: "1"
+      E2E_SERVE_TIMEOUT_SECS: "300"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Prepare writable dirs on the nvme + reclaim GPU from stray E2E procs
+        run: |
+          mkdir -p "$HOME" "$TMPDIR" "$PIP_CACHE_DIR"
+          pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
+          pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
+          pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
+          pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
+          rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
+          echo "prepared + reclaimed"
+
+      - name: GPU preflight (bounded wait for an available GPU)
+        run: |
+          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-8}"
+          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
+          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+          deadline=$(( SECONDS + CEILING_SECS ))
+          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
+            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            if [ -z "$total" ] || [ -z "$used" ]; then
+              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              sleep 5; continue
+            fi
+            free=$(( total - used ))
+            if [ "$free" -ge "$min_free" ]; then
+              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
+              exit 0
+            fi
+            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
+            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
+            sleep 5
+          done
+          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
+          exit 1
+
+      - name: Ensure Rust toolchain
+        run: |
+          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$CARGO_HOME/bin/cargo" ]; then
+            curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+              | sh -s -- -y --no-modify-path --default-toolchain none
+          fi
+          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run E2E tests on Strix Halo (incl. nightly-only)
+        run: |
+          export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
+          export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
+          prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
+          export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
+
+          cargo build --release -p rocm
+          export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+
+          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+            echo "pre-warming shared runtime (first run on this runner)…"
+            mkdir -p "$prewarm"/{data,config,cache}
+            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
+            ROCM_CLI_DATA_DIR="$prewarm/data" \
+            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
+            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+              "$ROCM_CLI_BINARY" install sdk
+            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
+            else
+              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
+            fi
+          else
+            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
+          fi
+
+          cargo xtask e2e
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-gpu-nightly-strix-report
           path: tests/e2e-cucumber/results/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -510,3 +510,109 @@ jobs:
         with:
           name: e2e-gpu-nightly-strix-report
           path: tests/e2e-cucumber/results/
+
+  # Windows counterpart to e2e-gpu-nightly-strix. Keep the PowerShell-native
+  # setup aligned with ci.yml's proven Strix Windows job while opting into the
+  # same platform-adaptive @nightly large-model scenario as the Linux runner.
+  e2e-gpu-nightly-strix-windows:
+    name: E2E tests (Strix Halo, Windows, incl. nightly-only)
+    timeout-minutes: 90
+    runs-on: [self-hosted, windows, strix-halo]
+    continue-on-error: true
+    env:
+      E2E_INCLUDE_NIGHTLY: "1"
+      E2E_SERVE_TIMEOUT_SECS: "300"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Reclaim GPU from stray E2E processes
+        shell: powershell
+        run: |
+          Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match 'rocm-e2e|__engine-serve-http|e2e-target|e2e-shared' -and $_.CommandLine -match 'llama-server|vllm|rocm ' } |
+            ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+          Write-Host "reclaimed"
+
+      # Best-effort when rocm-smi is absent; when present, fail within the bounded
+      # ceiling instead of letting a held or wedged GPU consume the full job cap.
+      - name: GPU preflight (bounded wait for an available GPU)
+        shell: powershell
+        run: |
+          $minFreeGiB = if ($env:GPU_PREFLIGHT_MIN_FREE_GIB) { [int]$env:GPU_PREFLIGHT_MIN_FREE_GIB } else { 8 }
+          $ceilingSecs = if ($env:GPU_PREFLIGHT_CEILING_SECS) { [int]$env:GPU_PREFLIGHT_CEILING_SECS } else { 90 }
+          if (-not (Get-Command rocm-smi -ErrorAction SilentlyContinue)) {
+            Write-Host "rocm-smi not found on this Windows runner; skipping GPU preflight (best-effort)."
+            exit 0
+          }
+          $minFree = [int64]$minFreeGiB * 1GB
+          $deadline = (Get-Date).AddSeconds($ceilingSecs)
+          $reason = "rocm-smi never returned usable VRAM figures"
+          while ((Get-Date) -lt $deadline) {
+            $out = (rocm-smi --showmeminfo vram 2>$null | Out-String)
+            $total = ([regex]::Matches($out, 'VRAM Total Memory \(B\):\s*(\d+)') | Select-Object -First 1).Groups[1].Value
+            $used  = ([regex]::Matches($out, 'VRAM Total Used Memory \(B\):\s*(\d+)') | Select-Object -First 1).Groups[1].Value
+            if (-not $total -or -not $used) {
+              $reason = "rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              Start-Sleep -Seconds 5; continue
+            }
+            $free = [int64]$total - [int64]$used
+            if ($free -ge $minFree) {
+              Write-Host "GPU ready: $([math]::Floor($free/1GB)) GiB free (>= $minFreeGiB GiB)."
+              exit 0
+            }
+            $reason = "VRAM never dropped below the floor: only $([math]::Floor($free/1GB)) GiB free (< $minFreeGiB GiB) - a serve is likely still holding the GPU"
+            Write-Host "waiting: $([math]::Floor($free/1GB)) GiB free (< $minFreeGiB GiB)..."
+            Start-Sleep -Seconds 5
+          }
+          Write-Host "::error::GPU preflight failed after ${ceilingSecs}s: $reason"
+          exit 1
+
+      # setup-rust-toolchain needs bash, which is unavailable on this runner.
+      - name: Ensure Rust toolchain (PowerShell)
+        shell: powershell
+        run: |
+          if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile $env:TEMP\rustup-init.exe
+            & $env:TEMP\rustup-init.exe -y --default-toolchain none
+            "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          }
+
+      - name: Run E2E tests on Strix Halo Windows (incl. nightly-only)
+        shell: powershell
+        run: |
+          # Install the shared runtime in place because its manifest contains
+          # absolute paths. The persistent runner workspace keeps those paths valid
+          # across scenarios and subsequent runs.
+          $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm"
+          $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
+
+          cargo build --release -p rocm
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
+          $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
+
+          if (-not (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry")) {
+            Write-Host "pre-warming shared runtime (first run on this runner)..."
+            New-Item -ItemType Directory -Force -Path "$prewarm\data","$prewarm\config","$prewarm\cache" | Out-Null
+            $env:ROCM_CLI_CONFIG_DIR = "$prewarm\config"
+            $env:ROCM_CLI_DATA_DIR   = "$prewarm\data"
+            $env:ROCM_CLI_CACHE_DIR  = "$prewarm\cache"
+            & $env:ROCM_CLI_BINARY install sdk
+            Remove-Item Env:\ROCM_CLI_CONFIG_DIR,Env:\ROCM_CLI_DATA_DIR,Env:\ROCM_CLI_CACHE_DIR -ErrorAction SilentlyContinue
+            if (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry") {
+              Write-Host "shared runtime pre-warmed at $env:E2E_SHARED_RUNTIMES_DIR"
+            } else {
+              Write-Host "pre-warm did not produce a runtimes registry; scenarios will install their own"
+            }
+          } else {
+            Write-Host "shared runtime already present at $env:E2E_SHARED_RUNTIMES_DIR - skipping pre-warm"
+          }
+
+          cargo xtask e2e
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-gpu-nightly-strix-windows-report
+          path: tests/e2e-cucumber/results/

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -116,10 +116,11 @@ The blocking mock job passes when every applicable scenario is pass-or-xfail wit
 no XPASS or unexpected failure; the GPU jobs are non-blocking. The `e2e-report`
 job consolidates all platforms' results into one cross-platform report.
 
-The nightly workflow adds three non-blocking jobs — MI300X, Strix Halo
-(Ubuntu), and Strix Halo (Windows) — with `E2E_INCLUDE_NIGHTLY=1`. The shared
-large-model scenario serves `Qwen/Qwen3.6-27B` through vLLM on MI300X and
-`unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` through Lemonade on Strix Halo.
+The nightly workflow runs three non-blocking jobs — the existing MI300X job and
+new Strix Halo jobs on Ubuntu and Windows — with `E2E_INCLUDE_NIGHTLY=1`. The
+shared large-model scenario serves `Qwen/Qwen3.6-27B` through vLLM on MI300X and
+the hardware-verified `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` checkpoint
+through Lemonade on Strix Halo.
 
 Use the CI workflow dispatch to run either model independently on a ref:
 
@@ -128,19 +129,19 @@ Use the CI workflow dispatch to run either model independently on a ref:
 gh workflow run ci.yml --ref <ref> \
   -f platform=app-dev-gpu \
   -f include_nightly=true \
-  -f name_filter='large platform-recommended model'
+  -f name_filter='large platform-specific model'
 
 # Strix Halo Linux / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
 gh workflow run ci.yml --ref <ref> \
   -f platform=strix-ubuntu \
   -f include_nightly=true \
-  -f name_filter='large platform-recommended model'
+  -f name_filter='large platform-specific model'
 
 # Strix Halo Windows / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
 gh workflow run ci.yml --ref <ref> \
   -f platform=strix-windows \
   -f include_nightly=true \
-  -f name_filter='large platform-recommended model'
+  -f name_filter='large platform-specific model'
 ```
 
 ## From scenarios to tests

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -94,6 +94,7 @@ Scenarios carry stable-id and capability tags:
 | `@requires-engine:<vllm\|lemonade>` | Pins the serve engine. Resolves to skip where that engine can't start (e.g. vLLM on a lemonade-only Strix host). |
 | `@requires-os:<linux\|windows>` | Premise is OS-specific; skip on other OSes. |
 | `@serve-timeout:<secs>` | Lengthen the serve-readiness wait for a genuinely slow serve (e.g. a large model). |
+| `@nightly` | Expensive scenario skipped by default; included when `E2E_INCLUDE_NIGHTLY=1`. |
 
 Known bugs are **not** tagged in the `.feature` files — they live in
 `expectations.toml`, keyed by `@id`, each with a `when = { ... }` condition (e.g.
@@ -114,6 +115,27 @@ CI runs one job per platform, each executing the full suite:
 The blocking mock job passes when every applicable scenario is pass-or-xfail with
 no XPASS or unexpected failure; the GPU jobs are non-blocking. The `e2e-report`
 job consolidates all platforms' results into one cross-platform report.
+
+The nightly workflow adds non-blocking MI300X and Strix Halo / Ubuntu jobs with
+`E2E_INCLUDE_NIGHTLY=1`. The shared large-model scenario serves
+`Qwen/Qwen3.6-27B` through vLLM on MI300X and
+`unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` through Lemonade on Strix Halo.
+
+Use the CI workflow dispatch to run either model independently on a ref:
+
+```bash
+# MI300X / vLLM / Qwen3.6-27B
+gh workflow run ci.yml --ref <ref> \
+  -f platform=app-dev-gpu \
+  -f include_nightly=true \
+  -f name_filter='large platform-recommended model'
+
+# Strix Halo / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
+gh workflow run ci.yml --ref <ref> \
+  -f platform=strix-ubuntu \
+  -f include_nightly=true \
+  -f name_filter='large platform-recommended model'
+```
 
 ## From scenarios to tests
 

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -116,9 +116,9 @@ The blocking mock job passes when every applicable scenario is pass-or-xfail wit
 no XPASS or unexpected failure; the GPU jobs are non-blocking. The `e2e-report`
 job consolidates all platforms' results into one cross-platform report.
 
-The nightly workflow adds non-blocking MI300X and Strix Halo / Ubuntu jobs with
-`E2E_INCLUDE_NIGHTLY=1`. The shared large-model scenario serves
-`Qwen/Qwen3.6-27B` through vLLM on MI300X and
+The nightly workflow adds three non-blocking jobs — MI300X, Strix Halo
+(Ubuntu), and Strix Halo (Windows) — with `E2E_INCLUDE_NIGHTLY=1`. The shared
+large-model scenario serves `Qwen/Qwen3.6-27B` through vLLM on MI300X and
 `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` through Lemonade on Strix Halo.
 
 Use the CI workflow dispatch to run either model independently on a ref:
@@ -130,9 +130,15 @@ gh workflow run ci.yml --ref <ref> \
   -f include_nightly=true \
   -f name_filter='large platform-recommended model'
 
-# Strix Halo / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
+# Strix Halo Linux / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
 gh workflow run ci.yml --ref <ref> \
   -f platform=strix-ubuntu \
+  -f include_nightly=true \
+  -f name_filter='large platform-recommended model'
+
+# Strix Halo Windows / Lemonade / Qwen3.6-35B-A3B-GGUF (UD-Q4_K_XL)
+gh workflow run ci.yml --ref <ref> \
+  -f platform=strix-windows \
   -f include_nightly=true \
   -f name_filter='large platform-recommended model'
 ```

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -40,13 +40,13 @@ Feature: Model serving
     Then the response contains a model reply
     And the response identifies the correct model
 
-  # Large-model coverage (dogfooding W9): serve a big vLLM model end-to-end at
-  # least once. Qwen/Qwen3.6-27B (BF16, ~54 GiB) fits a single MI300X; pinned to
-  # vLLM so in our fleet it runs only there (Strix Halo is lemonade / too little
-  # VRAM). A cold load of ~54 GiB far exceeds the 600s default, so the scenario
-  # declares a longer serve-readiness timeout. Confirmed working on app-dev MI300X.
-  @id:serve-large-model-inference @requires-gpu @requires-engine:vllm @serve-timeout:2400 @nightly
-  Scenario: 10 - A large vLLM model serves and responds to inference
+  # Large-model coverage (dogfooding W9): serve the featured model for each GPU
+  # platform end-to-end at least once. MI300X uses Qwen/Qwen3.6-27B through vLLM;
+  # Strix Halo uses unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL through Lemonade.
+  # These slow loads stay off the ordinary per-PR path, and the longer readiness
+  # timeout also gives the first inference request enough time to complete.
+  @id:serve-large-model-inference @requires-gpu @serve-timeout:2400 @nightly
+  Scenario: 10 - A large platform-recommended model serves and responds to inference
     Given a managed runtime is active
     And a large model is being served on GPU
     When the user sends a chat completion request

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -40,13 +40,14 @@ Feature: Model serving
     Then the response contains a model reply
     And the response identifies the correct model
 
-  # Large-model coverage (dogfooding W9): serve the featured model for each GPU
-  # platform end-to-end at least once. MI300X uses Qwen/Qwen3.6-27B through vLLM;
-  # Strix Halo uses unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL through Lemonade.
-  # These slow loads stay off the ordinary per-PR path, and the longer readiness
-  # timeout also gives the first inference request enough time to complete.
+  # Large-model coverage (dogfooding W9): serve a representative large model for
+  # each GPU platform end-to-end at least once. MI300X uses Qwen/Qwen3.6-27B through
+  # vLLM; Strix Halo uses the hardware-verified
+  # unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL checkpoint through Lemonade. These slow
+  # loads stay off the ordinary per-PR path, and the longer readiness timeout also
+  # gives the first inference request enough time to complete.
   @id:serve-large-model-inference @requires-gpu @serve-timeout:2400 @nightly
-  Scenario: 10 - A large platform-recommended model serves and responds to inference
+  Scenario: 10 - A large platform-specific model serves and responds to inference
     Given a managed runtime is active
     And a large model is being served on GPU
     When the user sends a chat completion request

--- a/tests/e2e-cucumber/src/lib.rs
+++ b/tests/e2e-cucumber/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod capability;
 pub mod expectation;
 pub mod mock_server;
+pub mod model_id;
 
 pub fn chat_response_is_successful(response: &serde_json::Value) -> bool {
     response

--- a/tests/e2e-cucumber/src/model_id.rs
+++ b/tests/e2e-cucumber/src/model_id.rs
@@ -1,0 +1,79 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+/// Whether a response's model id identifies the model requested by the scenario.
+///
+/// Lemonade may report only a concrete GGUF artifact filename, while vLLM echoes
+/// a fully qualified model id. Quantization and GGUF suffixes are normalized, but
+/// organizations must match when both ids include one.
+pub fn model_ids_match(response: &str, expected: &str) -> bool {
+    let (response_org, response_base) = normalize_model_id(response);
+    let (expected_org, expected_base) = normalize_model_id(expected);
+    if response_base.is_empty() || expected_base.is_empty() {
+        return false;
+    }
+    if let (Some(response_org), Some(expected_org)) = (response_org, expected_org)
+        && response_org != expected_org
+    {
+        return false;
+    }
+    response_base.contains(&expected_base) || expected_base.contains(&response_base)
+}
+
+fn normalize_model_id(id: &str) -> (Option<String>, String) {
+    let without_variant = id.split_once(':').map_or(id, |(model, _)| model);
+    let (org, model) = without_variant
+        .rsplit_once('/')
+        .map_or((None, without_variant), |(org, model)| (Some(org), model));
+    let mut base = model.to_ascii_lowercase();
+    if let Some(stripped) = base.strip_suffix(".gguf") {
+        base = stripped.to_owned();
+    }
+    base = base.replace("-gguf", "");
+    for quant in [
+        "-ud-q4_k_xl",
+        "-q4_0",
+        "-q4_k_m",
+        "-q4_k_s",
+        "-q5_k_m",
+        "-q8_0",
+        "-f16",
+        "-fp16",
+    ] {
+        base = base.replace(quant, "");
+    }
+    (
+        org.map(str::to_ascii_lowercase),
+        base.trim_matches(['-', '_', '.']).to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model_ids_match;
+
+    #[test]
+    fn matches_lemonade_artifact_without_organization() {
+        assert!(model_ids_match(
+            "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+            "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL"
+        ));
+    }
+
+    #[test]
+    fn matches_same_organization_and_normalized_model() {
+        assert!(model_ids_match(
+            "unsloth/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+            "UNSLOTH/Qwen3.6-35B-A3B-GGUF:Q4_K_M"
+        ));
+    }
+
+    #[test]
+    fn rejects_same_model_from_different_organization() {
+        assert!(!model_ids_match(
+            "another-owner/Qwen3.6-35B-A3B-Q4_K_M.gguf",
+            "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M"
+        ));
+    }
+}

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -123,10 +123,10 @@ async fn ensure_serve_port_free() {
 }
 
 /// Upper bound on the free-VRAM floor (MiB). Sized so the largest single
-/// scenario model can allocate its `gpu-memory-utilization` share without
-/// tripping vLLM's startup memory check: the suite's biggest model
-/// (Qwen3.6-27B, ~54 GiB) plus vLLM's ~0.8-of-total KV reservation needs the
-/// card mostly clear. Only a data-center GPU (MI300X, ~192 GiB) has this much,
+/// scenario model can allocate its engine's memory share without tripping its
+/// startup check: Qwen3.6-27B plus vLLM's ~0.8-of-total KV reservation needs the
+/// MI300X mostly clear, while the Strix Halo large-model path is capped to 90%
+/// of its smaller unified-memory pool. Only a data-center GPU has this much,
 /// so on smaller cards the floor is capped to a fraction of the device total
 /// (see [`required_free_vram_mib`]) — otherwise the check could never pass.
 const MAX_FREE_VRAM_FLOOR_MIB: u64 = 150_000;
@@ -346,24 +346,36 @@ async fn setup_lemonade_model(world: &mut E2eWorld) {
 
 #[given("a large model is being served on GPU")]
 async fn setup_large_gpu_model(world: &mut E2eWorld) {
-    // Large-model coverage (dogfooding W9): a big vLLM model, served explicitly
-    // on vLLM (the scenario is @requires-engine:vllm, so this only runs on an
-    // Instinct host). Qwen/Qwen3.6-27B is the catalog's Instinct recommendation
-    // (BF16, ~54 GiB, fits 1x MI300X). The scenario's @serve-timeout tag both
-    // widens the harness poll AND raises the CLI's own vLLM readiness cap via
-    // ROCM_CLI_VLLM_READY_TIMEOUT_SECS (see isolate_cmd) — the 5-min default
-    // would SIGTERM the server mid-load. Weights are pre-seeded in the shared HF
-    // cache so this is load-only, not a 54 GiB download.
-    let model = "Qwen/Qwen3.6-27B";
+    // Large-model nightly coverage follows the host's serving path. MI300X uses
+    // the dense BF16 model through vLLM; Strix Halo uses the requested UD-Q4_K_XL
+    // GGUF through Lemonade. The scenario's @serve-timeout tag widens both the
+    // readiness poll and heavy-model inference timeout. For vLLM it also raises
+    // ROCM_CLI_VLLM_READY_TIMEOUT_SECS (see isolate_cmd), preventing the CLI's
+    // default readiness cap from terminating the server mid-load.
+    let (model, engine, ready_substr) =
+        if e2e_cucumber::capability::host_capability().effective_serve_engine == "lemonade" {
+            // ready_substr is the base name WITHOUT the quant: lemonade renders
+            // its own quant token in the `/v1/models` id (as with the small
+            // `Qwen3-0.6B-GGUF` -> `Qwen3-0.6B-Q4_0.gguf`), so baking the literal
+            // `UD-Q4_K_XL` into the readiness containment check would miss on any
+            // spelling difference and burn the full @serve-timeout before failing.
+            (
+                "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL",
+                "lemonade",
+                "Qwen3.6-35B-A3B",
+            )
+        } else {
+            ("Qwen/Qwen3.6-27B", "vllm", "Qwen3.6-27B")
+        };
     ensure_serve_port_free().await;
     let (stdout, _, rc) =
-        crate::run_rocm(world, &["serve", model, "--engine", "vllm", "--managed"]);
+        crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
     assert!(rc == 0, "rocm serve failed:\n{stdout}");
     world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
     world.model_name = Some(model.to_string());
     wait_for_model(
         "http://127.0.0.1:11435/v1/models",
-        Some("Qwen3.6-27B"),
+        Some(ready_substr),
         serve_timeout_for(world),
     )
     .await;
@@ -709,7 +721,14 @@ fn model_ids_match(resp_model: &str, expected: &str) -> bool {
 }
 
 fn normalize_model_id(id: &str) -> String {
-    let mut s = id.to_ascii_lowercase();
+    let mut s = id
+        .rsplit('/')
+        .next()
+        .unwrap_or(id)
+        .split(':')
+        .next()
+        .unwrap_or(id)
+        .to_ascii_lowercase();
     if let Some(stripped) = s.strip_suffix(".gguf") {
         s = stripped.to_owned();
     }
@@ -717,7 +736,14 @@ fn normalize_model_id(id: &str) -> String {
     // catalog name and the concrete artifact reduce to the same base.
     s = s.replace("-gguf", "");
     for q in [
-        "-q4_0", "-q4_k_m", "-q4_k_s", "-q5_k_m", "-q8_0", "-f16", "-fp16",
+        "-ud-q4_k_xl",
+        "-q4_0",
+        "-q4_k_m",
+        "-q4_k_s",
+        "-q5_k_m",
+        "-q8_0",
+        "-f16",
+        "-fp16",
     ] {
         s = s.replace(q, "");
     }

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -347,11 +347,12 @@ async fn setup_lemonade_model(world: &mut E2eWorld) {
 #[given("a large model is being served on GPU")]
 async fn setup_large_gpu_model(world: &mut E2eWorld) {
     // Large-model nightly coverage follows the host's serving path. MI300X uses
-    // the dense BF16 model through vLLM; Strix Halo uses the requested UD-Q4_K_XL
-    // GGUF through Lemonade. The scenario's @serve-timeout tag widens both the
-    // readiness poll and heavy-model inference timeout. For vLLM it also raises
-    // ROCM_CLI_VLLM_READY_TIMEOUT_SECS (see isolate_cmd), preventing the CLI's
-    // default readiness cap from terminating the server mid-load.
+    // the dense BF16 model through vLLM; Strix Halo uses the hardware-verified
+    // UD-Q4_K_XL GGUF checkpoint through Lemonade. The scenario's @serve-timeout
+    // tag widens both the readiness poll and heavy-model inference timeout. For
+    // vLLM it also raises ROCM_CLI_VLLM_READY_TIMEOUT_SECS (see isolate_cmd),
+    // preventing the CLI's default readiness cap from terminating the server
+    // mid-load.
     let (model, engine, ready_substr) =
         if e2e_cucumber::capability::host_capability().effective_serve_engine == "lemonade" {
             // ready_substr is the base name WITHOUT the quant. lemonade serves
@@ -713,40 +714,5 @@ async fn assert_response_model_correct(world: &mut E2eWorld) {
 /// catalog suffix and quantization tokens like `-q4_0` stripped) and accept a
 /// match in either direction.
 fn model_ids_match(resp_model: &str, expected: &str) -> bool {
-    let a = normalize_model_id(resp_model);
-    let b = normalize_model_id(expected);
-    if a.is_empty() || b.is_empty() {
-        return false;
-    }
-    a.contains(&b) || b.contains(&a)
-}
-
-fn normalize_model_id(id: &str) -> String {
-    let mut s = id
-        .rsplit('/')
-        .next()
-        .unwrap_or(id)
-        .split(':')
-        .next()
-        .unwrap_or(id)
-        .to_ascii_lowercase();
-    if let Some(stripped) = s.strip_suffix(".gguf") {
-        s = stripped.to_owned();
-    }
-    // Drop the catalog `-gguf` marker and common quantization suffixes so the
-    // catalog name and the concrete artifact reduce to the same base.
-    s = s.replace("-gguf", "");
-    for q in [
-        "-ud-q4_k_xl",
-        "-q4_0",
-        "-q4_k_m",
-        "-q4_k_s",
-        "-q5_k_m",
-        "-q8_0",
-        "-f16",
-        "-fp16",
-    ] {
-        s = s.replace(q, "");
-    }
-    s.trim_matches(['-', '_', '.']).to_owned()
+    e2e_cucumber::model_id::model_ids_match(resp_model, expected)
 }

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -125,10 +125,10 @@ async fn ensure_serve_port_free() {
 /// Upper bound on the free-VRAM floor (MiB). Sized so the largest single
 /// scenario model can allocate its engine's memory share without tripping its
 /// startup check: Qwen3.6-27B plus vLLM's ~0.8-of-total KV reservation needs the
-/// MI300X mostly clear, while the Strix Halo large-model path is capped to 90%
-/// of its smaller unified-memory pool. Only a data-center GPU has this much,
-/// so on smaller cards the floor is capped to a fraction of the device total
-/// (see [`required_free_vram_mib`]) — otherwise the check could never pass.
+/// MI300X mostly clear. Only a data-center GPU has this much, so on smaller
+/// cards (e.g. Strix Halo's smaller unified-memory pool) the floor is capped to
+/// 90% of the device total (see [`required_free_vram_mib`]) — otherwise the
+/// check could never pass.
 const MAX_FREE_VRAM_FLOOR_MIB: u64 = 150_000;
 
 /// The free-VRAM floor to wait for on this host: the model-sized ceiling, but
@@ -354,11 +354,12 @@ async fn setup_large_gpu_model(world: &mut E2eWorld) {
     // default readiness cap from terminating the server mid-load.
     let (model, engine, ready_substr) =
         if e2e_cucumber::capability::host_capability().effective_serve_engine == "lemonade" {
-            // ready_substr is the base name WITHOUT the quant: lemonade renders
-            // its own quant token in the `/v1/models` id (as with the small
-            // `Qwen3-0.6B-GGUF` -> `Qwen3-0.6B-Q4_0.gguf`), so baking the literal
-            // `UD-Q4_K_XL` into the readiness containment check would miss on any
-            // spelling difference and burn the full @serve-timeout before failing.
+            // ready_substr is the base name WITHOUT the quant. lemonade serves
+            // this explicit `owner/repo:variant` checkpoint under its verbatim
+            // ref, so the `/v1/models` id keeps the `UD-Q4_K_XL` tag — but matching
+            // only the quant-free base keeps the readiness check robust to any
+            // future id-normalization on the serve path (e.g. the quant rewriting
+            // lemonade applies to shorthand refs like `Qwen3-0.6B-GGUF`).
             (
                 "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL",
                 "lemonade",


### PR DESCRIPTION
## Summary

- Run the nightly large-model inference scenario with the platform-specific serving path: `Qwen/Qwen3.6-27B` through vLLM on MI300X and `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` through Lemonade on Strix Halo.
- Add non-blocking Linux and Windows Strix Halo jobs to the nightly workflow, reusing each runner's established GPU preflight, Rust bootstrap, and persistent managed-runtime setup.
- Allow manual CI dispatches to opt both Strix platforms into `@nightly` scenarios and retain a scenario-name filter for targeted hardware validation.
- Keep the shared scenario platform-adaptive rather than duplicating it by operating system or serving engine.
- Pin the touched GitHub Actions references to immutable commit SHAs.

This keeps large model loads off the ordinary per-PR path while covering the hardware-verified Strix Halo checkpoint on both supported operating systems. Linux and Windows remain separate jobs because their process cleanup, GPU probing, toolchain setup, paths, and shells are platform-specific.

Risk: medium. The change affects non-blocking self-hosted GPU jobs and the existing nightly-only scenario; ordinary PR E2E continues to use the small models.

## Test plan

Local and pre-push checks:

- `cargo test -p e2e-cucumber --lib capability` (10 passed)
- `cargo fmt --all -- --check`
- `actionlint` on `nightly.yml` with the repository's custom self-hosted labels allowed
- repository pre-push hooks, including full `cargo clippy` and `cargo test`
- workflow YAML, commit signature/sign-off, license, conflict-marker, and OSS leak checks

Hardware evidence:

- Strix Halo Linux passed the scoped large-model serve and inference scenario: https://github.com/ROCm/rocm-cli/actions/runs/29605158243
- The existing Windows Strix E2E job is green on this PR, but it predates the Windows nightly opt-in and therefore does not verify the large model.
- MI300X reached the existing `Qwen/Qwen3.6-27B` scenario but timed out waiting for `/v1/models` after 2400 seconds: https://github.com/ROCm/rocm-cli/actions/runs/29605156216. The MI300X model selection and timeout are unchanged by the Windows follow-up.

The new Windows large-model path still requires a self-hosted Strix Halo nightly or scoped dispatch for hardware verification.