### PR TITLE
fix(install): verify Windows release signatures without openssl

### DIFF
--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -80,7 +80,8 @@ archive's SHA-256 digest, verified against the SubjectPublicKeyInfo
 `openssl`. The Windows installer (`install.ps1`) verifies it with the built-in
 .NET RSA APIs and has no runtime dependency on `openssl`: it parses the public
 key and calls `RSA.VerifyData` with SHA-256 and PKCS#1 v1.5 padding. This works
-on both Windows PowerShell 5.1 (.NET Framework) and PowerShell 7+ (.NET).
+on both Windows PowerShell 5.1 (.NET Framework 4.6+, which the
+`RSA.VerifyData` overload requires) and PowerShell 7+ (.NET).
 `certutil`/`certreq` are not used, because they only verify certificate-backed
 CMS/Authenticode blobs, not a raw detached signature checked against a bare
 public key.

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -74,6 +74,17 @@ local keys. Those keys are test material only; they are not trust roots.
 Installers always verify checksums. Signature verification runs when a public
 key is supplied or `ROCM_CLI_REQUIRE_SIGNATURE=1` is set.
 
+The detached `.sig` sidecar is the raw RSASSA-PKCS#1 v1.5 signature over the
+archive's SHA-256 digest, verified against the SubjectPublicKeyInfo
+(`-----BEGIN PUBLIC KEY-----`) public key. The Linux installer verifies it with
+`openssl`. The Windows installer (`install.ps1`) verifies it with the built-in
+.NET RSA APIs and has no runtime dependency on `openssl`: it parses the public
+key and calls `RSA.VerifyData` with SHA-256 and PKCS#1 v1.5 padding. This works
+on both Windows PowerShell 5.1 (.NET Framework) and PowerShell 7+ (.NET).
+`certutil`/`certreq` are not used, because they only verify certificate-backed
+CMS/Authenticode blobs, not a raw detached signature checked against a bare
+public key.
+
 Linux:
 
 ```bash
@@ -91,8 +102,10 @@ $env:ROCM_CLI_REQUIRE_SIGNATURE = "1"
 
 Developer acceptance covers public-key path and PEM installer inputs, bad
 checksums, bad detached signatures, missing required `.sig` sidecars, and
-required-signature mode without a public key. All of those checks happen before
-activation.
+required-signature mode without a public key. Windows acceptance additionally
+runs a full signed install and a bad-signature rejection with `openssl` scrubbed
+from `PATH`, proving `install.ps1` verifies with native .NET crypto and still
+rejects invalid signatures. All of those checks happen before activation.
 
 ## WSL ROCDXG Package Verification
 

--- a/install.ps1
+++ b/install.ps1
@@ -171,6 +171,11 @@ function Save-File {
     }
 }
 
+function Stop-SigningKeyParsing {
+    param([string] $Message)
+    throw [System.Security.Cryptography.CryptographicException]::new($Message)
+}
+
 # Decode the base64 body of a PEM block (the DER bytes) regardless of the
 # header label. openssl and `cargo xtask keygen` emit SubjectPublicKeyInfo
 # ("BEGIN PUBLIC KEY") PEM; this strips the armor and returns the raw DER.
@@ -195,12 +200,12 @@ function Convert-PemToDer {
         }
     }
     if ($body.Length -eq 0) {
-        Fail "signing public key is not a valid PEM block"
+        Stop-SigningKeyParsing "signing public key is not a valid PEM block"
     }
     try {
         return [System.Convert]::FromBase64String($body.ToString())
     } catch {
-        Fail "signing public key PEM body is not valid base64: $($_.Exception.Message)"
+        Stop-SigningKeyParsing "signing public key PEM body is not valid base64: $($_.Exception.Message)"
     }
 }
 
@@ -216,7 +221,7 @@ function Read-DerTlv {
 
     $start = $Offset.Value
     if ($start + 2 -gt $Bytes.Length) {
-        Fail "signing public key DER is truncated"
+        Stop-SigningKeyParsing "signing public key DER is truncated"
     }
     $tag = $Bytes[$start]
     $index = $start + 1
@@ -227,12 +232,12 @@ function Read-DerTlv {
     } else {
         $byteCount = $lengthByte -band 0x7f
         if ($byteCount -eq 0 -or $byteCount -gt 4) {
-            Fail "signing public key DER has an unsupported length encoding"
+            Stop-SigningKeyParsing "signing public key DER has an unsupported length encoding"
         }
         $length = 0
         for ($i = 0; $i -lt $byteCount; $i++) {
             if ($index -ge $Bytes.Length) {
-                Fail "signing public key DER is truncated"
+                Stop-SigningKeyParsing "signing public key DER is truncated"
             }
             $length = ($length -shl 8) -bor [int] $Bytes[$index]
             $index++
@@ -241,14 +246,14 @@ function Read-DerTlv {
         # it rather than letting the bounds check below pass and then blowing up in
         # the byte[] allocation with an unhandled OverflowException.
         if ($length -lt 0) {
-            Fail "signing public key DER has an unsupported length encoding"
+            Stop-SigningKeyParsing "signing public key DER has an unsupported length encoding"
         }
     }
     $valueStart = $index
     # Compare without adding (`$valueStart + $length` can overflow Int32 for a
     # crafted multi-GB length and wrap negative, silently passing the check).
     if ($length -gt $Bytes.Length - $valueStart) {
-        Fail "signing public key DER is truncated"
+        Stop-SigningKeyParsing "signing public key DER is truncated"
     }
     $value = New-Object byte[] $length
     if ($length -gt 0) {
@@ -287,7 +292,7 @@ function Resolve-RsaVerifier {
     $offset = 0
     $spki = Read-DerTlv $der ([ref] $offset)
     if ($spki.Tag -ne 0x30) {
-        Fail "signing public key is not a SubjectPublicKeyInfo structure"
+        Stop-SigningKeyParsing "signing public key is not a SubjectPublicKeyInfo structure"
     }
 
     # Inside the outer SEQUENCE: AlgorithmIdentifier (SEQUENCE) then the
@@ -295,18 +300,18 @@ function Resolve-RsaVerifier {
     $inner = 0
     $algorithm = Read-DerTlv $spki.Value ([ref] $inner)
     if ($algorithm.Tag -ne 0x30) {
-        Fail "signing public key algorithm identifier is malformed"
+        Stop-SigningKeyParsing "signing public key algorithm identifier is malformed"
     }
     $subjectPublicKey = Read-DerTlv $spki.Value ([ref] $inner)
     if ($subjectPublicKey.Tag -ne 0x03) {
-        Fail "signing public key bit string is malformed"
+        Stop-SigningKeyParsing "signing public key bit string is malformed"
     }
 
     # BIT STRING: first byte is the count of unused bits (0 for a key), the rest
     # is the DER-encoded RSAPublicKey.
     $bitString = $subjectPublicKey.Value
     if ($bitString.Length -lt 1 -or $bitString[0] -ne 0) {
-        Fail "signing public key bit string padding is unsupported"
+        Stop-SigningKeyParsing "signing public key bit string padding is unsupported"
     }
     $rsaKeyDer = New-Object byte[] ($bitString.Length - 1)
     [System.Array]::Copy($bitString, 1, $rsaKeyDer, 0, $rsaKeyDer.Length)
@@ -315,13 +320,13 @@ function Resolve-RsaVerifier {
     $rsaOffset = 0
     $rsaSequence = Read-DerTlv $rsaKeyDer ([ref] $rsaOffset)
     if ($rsaSequence.Tag -ne 0x30) {
-        Fail "signing public key RSA structure is malformed"
+        Stop-SigningKeyParsing "signing public key RSA structure is malformed"
     }
     $rsaInner = 0
     $modulus = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
     $exponent = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
     if ($modulus.Tag -ne 0x02 -or $exponent.Tag -ne 0x02) {
-        Fail "signing public key modulus or exponent is malformed"
+        Stop-SigningKeyParsing "signing public key modulus or exponent is malformed"
     }
 
     $parameters = New-Object System.Security.Cryptography.RSAParameters
@@ -331,9 +336,9 @@ function Resolve-RsaVerifier {
     $rsa = [System.Security.Cryptography.RSA]::Create()
     try {
         $rsa.ImportParameters($parameters)
-    } catch {
+    } catch [System.Security.Cryptography.CryptographicException] {
         $rsa.Dispose()
-        Fail "signing public key could not be imported: $($_.Exception.Message)"
+        Stop-SigningKeyParsing "signing public key could not be imported: $($_.Exception.Message)"
     }
     return $rsa
 }
@@ -358,14 +363,19 @@ function Confirm-ArchiveSignature {
     $padding = [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
 
     foreach ($key in $PublicKeyPaths) {
-        $pem = Get-Content -LiteralPath $key -Raw
-        $rsa = Resolve-RsaVerifier $pem
+        $rsa = $null
         try {
+            $pem = Get-Content -LiteralPath $key -Raw
+            $rsa = Resolve-RsaVerifier $pem
             if ($rsa.VerifyData($archiveBytes, $signatureBytes, $hashAlgorithm, $padding)) {
                 return
             }
+        } catch [System.Security.Cryptography.CryptographicException] {
+            continue
         } finally {
-            $rsa.Dispose()
+            if ($null -ne $rsa) {
+                $rsa.Dispose()
+            }
         }
     }
     Fail "signature verification failed"

--- a/install.ps1
+++ b/install.ps1
@@ -237,9 +237,17 @@ function Read-DerTlv {
             $length = ($length -shl 8) -bor [int] $Bytes[$index]
             $index++
         }
+        # A 4-byte length with the high bit set decodes to a negative Int32; reject
+        # it rather than letting the bounds check below pass and then blowing up in
+        # the byte[] allocation with an unhandled OverflowException.
+        if ($length -lt 0) {
+            Fail "signing public key DER has an unsupported length encoding"
+        }
     }
     $valueStart = $index
-    if ($valueStart + $length -gt $Bytes.Length) {
+    # Compare without adding (`$valueStart + $length` can overflow Int32 for a
+    # crafted multi-GB length and wrap negative, silently passing the check).
+    if ($length -gt $Bytes.Length - $valueStart) {
         Fail "signing public key DER is truncated"
     }
     $value = New-Object byte[] $length

--- a/install.ps1
+++ b/install.ps1
@@ -171,7 +171,7 @@ function Save-File {
     }
 }
 
-function Stop-SigningKeyParsing {
+function FailSigningKeyParsing {
     param([string] $Message)
     throw [System.Security.Cryptography.CryptographicException]::new($Message)
 }
@@ -200,12 +200,12 @@ function Convert-PemToDer {
         }
     }
     if ($body.Length -eq 0) {
-        Stop-SigningKeyParsing "signing public key is not a valid PEM block"
+        FailSigningKeyParsing "signing public key is not a valid PEM block"
     }
     try {
         return [System.Convert]::FromBase64String($body.ToString())
     } catch {
-        Stop-SigningKeyParsing "signing public key PEM body is not valid base64: $($_.Exception.Message)"
+        FailSigningKeyParsing "signing public key PEM body is not valid base64: $($_.Exception.Message)"
     }
 }
 
@@ -221,7 +221,7 @@ function Read-DerTlv {
 
     $start = $Offset.Value
     if ($start + 2 -gt $Bytes.Length) {
-        Stop-SigningKeyParsing "signing public key DER is truncated"
+        FailSigningKeyParsing "signing public key DER is truncated"
     }
     $tag = $Bytes[$start]
     $index = $start + 1
@@ -232,12 +232,12 @@ function Read-DerTlv {
     } else {
         $byteCount = $lengthByte -band 0x7f
         if ($byteCount -eq 0 -or $byteCount -gt 4) {
-            Stop-SigningKeyParsing "signing public key DER has an unsupported length encoding"
+            FailSigningKeyParsing "signing public key DER has an unsupported length encoding"
         }
         $length = 0
         for ($i = 0; $i -lt $byteCount; $i++) {
             if ($index -ge $Bytes.Length) {
-                Stop-SigningKeyParsing "signing public key DER is truncated"
+                FailSigningKeyParsing "signing public key DER is truncated"
             }
             $length = ($length -shl 8) -bor [int] $Bytes[$index]
             $index++
@@ -246,14 +246,14 @@ function Read-DerTlv {
         # it rather than letting the bounds check below pass and then blowing up in
         # the byte[] allocation with an unhandled OverflowException.
         if ($length -lt 0) {
-            Stop-SigningKeyParsing "signing public key DER has an unsupported length encoding"
+            FailSigningKeyParsing "signing public key DER has an unsupported length encoding"
         }
     }
     $valueStart = $index
     # Compare without adding (`$valueStart + $length` can overflow Int32 for a
     # crafted multi-GB length and wrap negative, silently passing the check).
     if ($length -gt $Bytes.Length - $valueStart) {
-        Stop-SigningKeyParsing "signing public key DER is truncated"
+        FailSigningKeyParsing "signing public key DER is truncated"
     }
     $value = New-Object byte[] $length
     if ($length -gt 0) {
@@ -292,7 +292,7 @@ function Resolve-RsaVerifier {
     $offset = 0
     $spki = Read-DerTlv $der ([ref] $offset)
     if ($spki.Tag -ne 0x30) {
-        Stop-SigningKeyParsing "signing public key is not a SubjectPublicKeyInfo structure"
+        FailSigningKeyParsing "signing public key is not a SubjectPublicKeyInfo structure"
     }
 
     # Inside the outer SEQUENCE: AlgorithmIdentifier (SEQUENCE) then the
@@ -300,18 +300,18 @@ function Resolve-RsaVerifier {
     $inner = 0
     $algorithm = Read-DerTlv $spki.Value ([ref] $inner)
     if ($algorithm.Tag -ne 0x30) {
-        Stop-SigningKeyParsing "signing public key algorithm identifier is malformed"
+        FailSigningKeyParsing "signing public key algorithm identifier is malformed"
     }
     $subjectPublicKey = Read-DerTlv $spki.Value ([ref] $inner)
     if ($subjectPublicKey.Tag -ne 0x03) {
-        Stop-SigningKeyParsing "signing public key bit string is malformed"
+        FailSigningKeyParsing "signing public key bit string is malformed"
     }
 
     # BIT STRING: first byte is the count of unused bits (0 for a key), the rest
     # is the DER-encoded RSAPublicKey.
     $bitString = $subjectPublicKey.Value
     if ($bitString.Length -lt 1 -or $bitString[0] -ne 0) {
-        Stop-SigningKeyParsing "signing public key bit string padding is unsupported"
+        FailSigningKeyParsing "signing public key bit string padding is unsupported"
     }
     $rsaKeyDer = New-Object byte[] ($bitString.Length - 1)
     [System.Array]::Copy($bitString, 1, $rsaKeyDer, 0, $rsaKeyDer.Length)
@@ -320,13 +320,13 @@ function Resolve-RsaVerifier {
     $rsaOffset = 0
     $rsaSequence = Read-DerTlv $rsaKeyDer ([ref] $rsaOffset)
     if ($rsaSequence.Tag -ne 0x30) {
-        Stop-SigningKeyParsing "signing public key RSA structure is malformed"
+        FailSigningKeyParsing "signing public key RSA structure is malformed"
     }
     $rsaInner = 0
     $modulus = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
     $exponent = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
     if ($modulus.Tag -ne 0x02 -or $exponent.Tag -ne 0x02) {
-        Stop-SigningKeyParsing "signing public key modulus or exponent is malformed"
+        FailSigningKeyParsing "signing public key modulus or exponent is malformed"
     }
 
     $parameters = New-Object System.Security.Cryptography.RSAParameters
@@ -338,7 +338,7 @@ function Resolve-RsaVerifier {
         $rsa.ImportParameters($parameters)
     } catch [System.Security.Cryptography.CryptographicException] {
         $rsa.Dispose()
-        Stop-SigningKeyParsing "signing public key could not be imported: $($_.Exception.Message)"
+        FailSigningKeyParsing "signing public key could not be imported: $($_.Exception.Message)"
     }
     return $rsa
 }

--- a/install.ps1
+++ b/install.ps1
@@ -171,6 +171,165 @@ function Save-File {
     }
 }
 
+# Decode the base64 body of a PEM block (the DER bytes) regardless of the
+# header label. openssl and `cargo xtask keygen` emit SubjectPublicKeyInfo
+# ("BEGIN PUBLIC KEY") PEM; this strips the armor and returns the raw DER.
+function Convert-PemToDer {
+    param([string] $Pem)
+
+    $lines = $Pem -split "`r?`n"
+    $body = New-Object System.Text.StringBuilder
+    $inBody = $false
+    foreach ($line in $lines) {
+        $trimmed = $line.Trim()
+        if ($trimmed -like "-----BEGIN *-----") {
+            $inBody = $true
+            continue
+        }
+        if ($trimmed -like "-----END *-----") {
+            $inBody = $false
+            continue
+        }
+        if ($inBody -and -not [string]::IsNullOrWhiteSpace($trimmed)) {
+            [void] $body.Append($trimmed)
+        }
+    }
+    if ($body.Length -eq 0) {
+        Fail "signing public key is not a valid PEM block"
+    }
+    try {
+        return [System.Convert]::FromBase64String($body.ToString())
+    } catch {
+        Fail "signing public key PEM body is not valid base64: $($_.Exception.Message)"
+    }
+}
+
+# Minimal DER reader: parse (tag, length, value) triplets. Windows PowerShell 5.1
+# runs on .NET Framework, which lacks RSA.ImportSubjectPublicKeyInfo (.NET Core
+# 3.0+ only), so the SubjectPublicKeyInfo is decoded by hand into RSAParameters.
+# Only the small subset of DER needed for an RSA SPKI is handled.
+function Read-DerTlv {
+    param(
+        [byte[]] $Bytes,
+        [ref] $Offset
+    )
+
+    $start = $Offset.Value
+    if ($start + 2 -gt $Bytes.Length) {
+        Fail "signing public key DER is truncated"
+    }
+    $tag = $Bytes[$start]
+    $index = $start + 1
+    $lengthByte = $Bytes[$index]
+    $index++
+    if ($lengthByte -lt 0x80) {
+        $length = [int] $lengthByte
+    } else {
+        $byteCount = $lengthByte -band 0x7f
+        if ($byteCount -eq 0 -or $byteCount -gt 4) {
+            Fail "signing public key DER has an unsupported length encoding"
+        }
+        $length = 0
+        for ($i = 0; $i -lt $byteCount; $i++) {
+            if ($index -ge $Bytes.Length) {
+                Fail "signing public key DER is truncated"
+            }
+            $length = ($length -shl 8) -bor [int] $Bytes[$index]
+            $index++
+        }
+    }
+    $valueStart = $index
+    if ($valueStart + $length -gt $Bytes.Length) {
+        Fail "signing public key DER is truncated"
+    }
+    $value = New-Object byte[] $length
+    if ($length -gt 0) {
+        [System.Array]::Copy($Bytes, $valueStart, $value, 0, $length)
+    }
+    $Offset.Value = $valueStart + $length
+    return [PSCustomObject]@{
+        Tag   = $tag
+        Value = $value
+    }
+}
+
+# Convert a DER INTEGER value to an unsigned big-endian byte array, dropping the
+# leading 0x00 sign byte that DER inserts when the high bit is set.
+function ConvertFrom-DerInteger {
+    param([byte[]] $Value)
+
+    $bytes = $Value
+    if ($bytes.Length -gt 1 -and $bytes[0] -eq 0) {
+        $trimmed = New-Object byte[] ($bytes.Length - 1)
+        [System.Array]::Copy($bytes, 1, $trimmed, 0, $trimmed.Length)
+        $bytes = $trimmed
+    }
+    return $bytes
+}
+
+# Build an RSA verifier from a SubjectPublicKeyInfo ("BEGIN PUBLIC KEY") PEM.
+# Parses the SPKI DER into modulus/exponent and imports them via RSAParameters,
+# which works on both Windows PowerShell 5.1 (.NET Framework) and PowerShell 7+
+# (.NET). No external process (openssl) is involved.
+function Resolve-RsaVerifier {
+    param([string] $PublicKeyPem)
+
+    $der = Convert-PemToDer $PublicKeyPem
+
+    $offset = 0
+    $spki = Read-DerTlv $der ([ref] $offset)
+    if ($spki.Tag -ne 0x30) {
+        Fail "signing public key is not a SubjectPublicKeyInfo structure"
+    }
+
+    # Inside the outer SEQUENCE: AlgorithmIdentifier (SEQUENCE) then the
+    # public key BIT STRING.
+    $inner = 0
+    $algorithm = Read-DerTlv $spki.Value ([ref] $inner)
+    if ($algorithm.Tag -ne 0x30) {
+        Fail "signing public key algorithm identifier is malformed"
+    }
+    $subjectPublicKey = Read-DerTlv $spki.Value ([ref] $inner)
+    if ($subjectPublicKey.Tag -ne 0x03) {
+        Fail "signing public key bit string is malformed"
+    }
+
+    # BIT STRING: first byte is the count of unused bits (0 for a key), the rest
+    # is the DER-encoded RSAPublicKey.
+    $bitString = $subjectPublicKey.Value
+    if ($bitString.Length -lt 1 -or $bitString[0] -ne 0) {
+        Fail "signing public key bit string padding is unsupported"
+    }
+    $rsaKeyDer = New-Object byte[] ($bitString.Length - 1)
+    [System.Array]::Copy($bitString, 1, $rsaKeyDer, 0, $rsaKeyDer.Length)
+
+    # RSAPublicKey ::= SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+    $rsaOffset = 0
+    $rsaSequence = Read-DerTlv $rsaKeyDer ([ref] $rsaOffset)
+    if ($rsaSequence.Tag -ne 0x30) {
+        Fail "signing public key RSA structure is malformed"
+    }
+    $rsaInner = 0
+    $modulus = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
+    $exponent = Read-DerTlv $rsaSequence.Value ([ref] $rsaInner)
+    if ($modulus.Tag -ne 0x02 -or $exponent.Tag -ne 0x02) {
+        Fail "signing public key modulus or exponent is malformed"
+    }
+
+    $parameters = New-Object System.Security.Cryptography.RSAParameters
+    $parameters.Modulus = ConvertFrom-DerInteger $modulus.Value
+    $parameters.Exponent = ConvertFrom-DerInteger $exponent.Value
+
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try {
+        $rsa.ImportParameters($parameters)
+    } catch {
+        $rsa.Dispose()
+        Fail "signing public key could not be imported: $($_.Exception.Message)"
+    }
+    return $rsa
+}
+
 function Confirm-ArchiveSignature {
     param(
         [string] $ArchivePath,
@@ -178,13 +337,27 @@ function Confirm-ArchiveSignature {
         [string[]] $PublicKeyPaths
     )
 
-    Confirm-Command openssl
+    # The `.sig` sidecar is the raw RSASSA-PKCS#1 v1.5 over SHA-256 signature
+    # bytes (as produced by `cargo xtask sign` / `openssl dgst -sha256 -sign`),
+    # not a PKCS#7/CMS or Authenticode container. certutil/certreq only verify
+    # certificate-backed CMS/Authenticode blobs and cannot check a raw detached
+    # signature against a bare SubjectPublicKeyInfo public key, so verification
+    # uses .NET RSA directly. This keeps the installer free of any openssl
+    # runtime dependency while supporting Windows PowerShell 5.1.
+    $archiveBytes = [System.IO.File]::ReadAllBytes($ArchivePath)
+    $signatureBytes = [System.IO.File]::ReadAllBytes($SignaturePath)
+    $hashAlgorithm = [System.Security.Cryptography.HashAlgorithmName]::SHA256
+    $padding = [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+
     foreach ($key in $PublicKeyPaths) {
-        # Quote every path argument so keys or archives under a directory with
-        # spaces are passed to native openssl as single arguments.
-        & openssl dgst -sha256 -verify "$key" -signature "$SignaturePath" "$ArchivePath" | Out-Null
-        if ($LASTEXITCODE -eq 0) {
-            return
+        $pem = Get-Content -LiteralPath $key -Raw
+        $rsa = Resolve-RsaVerifier $pem
+        try {
+            if ($rsa.VerifyData($archiveBytes, $signatureBytes, $hashAlgorithm, $padding)) {
+                return
+            }
+        } finally {
+            $rsa.Dispose()
         }
     }
     Fail "signature verification failed"

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -152,6 +152,32 @@ function Get-PathWithoutOpenssl {
     return ($entries -join ";")
 }
 
+function Write-PinnedKeyInstaller {
+    param(
+        [string] $Destination,
+        [string] $CurrentKey,
+        [string] $NextKey
+    )
+
+    $installer = Get-Content -LiteralPath (Join-Path $RepoRoot "install.ps1") -Raw
+    foreach ($slot in @(
+        @{ Name = "Current"; Key = $CurrentKey },
+        @{ Name = "Next"; Key = $NextKey }
+    )) {
+        $pattern = '(?s)\$PinnedReleasePublicKey' + $slot.Name + ' = (?:@".*?"@|"")'
+        $replacement = '$PinnedReleasePublicKey' + $slot.Name + " = @`"`r`n" + $slot.Key.Trim() + "`r`n`"@"
+        # Constant replacement (the here-string literal contains `$` sequences, so a
+        # plain string replacement would be treated as `$`-substitutions); a
+        # MatchEvaluator returns it verbatim. It ignores the match, so no param.
+        $updated = [regex]::Replace($installer, $pattern, [System.Text.RegularExpressions.MatchEvaluator] { $replacement }, 1)
+        if ($updated -eq $installer) {
+            Fail "could not replace pinned $($slot.Name.ToLowerInvariant()) key in installer fixture"
+        }
+        $installer = $updated
+    }
+    Set-Content -LiteralPath $Destination -Value $installer -Encoding utf8
+}
+
 function Test-PathInList {
     param(
         [string] $PathList,
@@ -252,6 +278,61 @@ try {
     $downloadBase = ([System.Uri]::new($DistDir + [System.IO.Path]::DirectorySeparatorChar)).AbsoluteUri.TrimEnd("/")
     $pemDownloadBase = ([System.Uri]::new($PemDistDir + [System.IO.Path]::DirectorySeparatorChar)).AbsoluteUri.TrimEnd("/")
     $env:ROCM_CLI_CONFIG_DIR = $ConfigDir
+
+    # A malformed candidate key must not block a valid rotation key. Build test
+    # installer fixtures with controlled pinned-key slots because the public key
+    # override intentionally accepts only one key.
+    $malformedPublicKey = @"
+-----BEGIN PUBLIC KEY-----
+not-valid-base64
+-----END PUBLIC KEY-----
+"@
+    $validPublicKey = Get-Content -LiteralPath $signingPublicKey -Raw
+    $rotationInstaller = Join-Path $AcceptanceRoot "install-key-rotation.ps1"
+    $rotationInstallDir = Join-Path $AcceptanceRoot "key-rotation-install\bin"
+    $rotationInstallLog = Join-Path $AcceptanceRoot "key-rotation-install.log"
+    Write-PinnedKeyInstaller $rotationInstaller $malformedPublicKey $validPublicKey
+    $rotationInstallArgs = @(
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        $rotationInstaller,
+        "release",
+        "-InstallDir",
+        $rotationInstallDir,
+        "-DownloadBase",
+        $downloadBase,
+        "-NoPathUpdate"
+    )
+    Invoke-Checked "acceptance: malformed first key falls through to valid rotation key" $psExe $rotationInstallArgs $rotationInstallLog
+    if (-not (Select-String -LiteralPath $rotationInstallLog -Pattern "signature verified" -Quiet)) {
+        Fail "installer did not verify with the valid rotation key"
+    }
+    Assert-File (Join-Path $rotationInstallDir "rocm.exe")
+
+    $malformedKeysInstaller = Join-Path $AcceptanceRoot "install-malformed-keys.ps1"
+    $malformedKeysInstallDir = Join-Path $AcceptanceRoot "malformed-keys-install\bin"
+    $malformedKeysLog = Join-Path $AcceptanceRoot "malformed-keys.log"
+    Write-PinnedKeyInstaller $malformedKeysInstaller $malformedPublicKey $malformedPublicKey
+    $malformedKeysArgs = @(
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        $malformedKeysInstaller,
+        "release",
+        "-InstallDir",
+        $malformedKeysInstallDir,
+        "-DownloadBase",
+        $downloadBase,
+        "-NoPathUpdate"
+    )
+    Invoke-ExpectFailure "acceptance: all malformed keys fail deterministically" $psExe $malformedKeysArgs $malformedKeysLog
+    if (-not (Select-String -LiteralPath $malformedKeysLog -Pattern "signature verification failed" -Quiet)) {
+        Fail "installer did not report deterministic failure after all candidate keys failed"
+    }
+    Assert-Missing (Join-Path $malformedKeysInstallDir "rocm.exe")
 
     Write-Host "acceptance: default install updates user PATH"
     $originalUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -359,7 +440,7 @@ try {
     $originalProcessPath = $env:Path
     try {
         $env:Path = Get-PathWithoutOpenssl
-        if (Get-Command openssl -ErrorAction SilentlyContinue) {
+        if (Get-Command openssl -CommandType Application -ErrorAction SilentlyContinue) {
             Fail "openssl was still on PATH after scrubbing; cannot prove openssl-free verification"
         }
         Invoke-Checked "acceptance: install with openssl absent" $psExe $noOpensslInstallArgs $NoOpensslInstallLog

--- a/scripts/acceptance-install-upgrade-tui-uninstall.ps1
+++ b/scripts/acceptance-install-upgrade-tui-uninstall.ps1
@@ -128,6 +128,30 @@ function Resolve-CommandPath {
     Fail "missing required command: $Name"
 }
 
+# Build a copy of the current process PATH with every directory that contains an
+# openssl executable removed, so a child install.ps1 cannot find openssl even if
+# the host has it installed. Proves the installer verifies signatures with native
+# crypto only, never shelling out to openssl.
+function Get-PathWithoutOpenssl {
+    $entries = @()
+    foreach ($entry in ($env:Path -split ";")) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+        $hasOpenssl = $false
+        foreach ($candidate in @("openssl.exe", "openssl")) {
+            if (Test-Path -LiteralPath (Join-Path $entry $candidate) -PathType Leaf) {
+                $hasOpenssl = $true
+                break
+            }
+        }
+        if (-not $hasOpenssl) {
+            $entries += $entry
+        }
+    }
+    return ($entries -join ";")
+}
+
 function Test-PathInList {
     param(
         [string] $PathList,
@@ -309,6 +333,77 @@ try {
     if (-not (Select-String -LiteralPath $ConfigFile -Pattern '"default_engine"\s*:\s*"lemonade"' -Quiet)) {
         Fail "installer did not seed minimal config with the expected default engine"
     }
+
+    # Regression: install.ps1 must verify the detached signature with native
+    # crypto and never depend on openssl at runtime. Run a full signed install
+    # with openssl scrubbed from PATH and confirm it still verifies and installs.
+    Write-Host "acceptance: install verifies signature with openssl absent from PATH"
+    $noOpensslInstallDir = Join-Path $AcceptanceRoot "no-openssl-install\bin"
+    $NoOpensslInstallLog = Join-Path $AcceptanceRoot "no-openssl-install.log"
+    $noOpensslInstallArgs = @(
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        (Join-Path $RepoRoot "install.ps1"),
+        "release",
+        "-InstallDir",
+        $noOpensslInstallDir,
+        "-DownloadBase",
+        $downloadBase,
+        "-SigningPublicKeyPath",
+        $signingPublicKey,
+        "-RequireSignature",
+        "-NoPathUpdate"
+    )
+    $originalProcessPath = $env:Path
+    try {
+        $env:Path = Get-PathWithoutOpenssl
+        if (Get-Command openssl -ErrorAction SilentlyContinue) {
+            Fail "openssl was still on PATH after scrubbing; cannot prove openssl-free verification"
+        }
+        Invoke-Checked "acceptance: install with openssl absent" $psExe $noOpensslInstallArgs $NoOpensslInstallLog
+
+        # Invalid signatures must still fail (before activation) with openssl absent.
+        Write-Host "acceptance: reject bad signature with openssl absent from PATH"
+        $noOpensslBadSigDistDir = Join-Path $AcceptanceRoot "no-openssl-bad-sig-dist"
+        $noOpensslBadSigInstallDir = Join-Path $AcceptanceRoot "no-openssl-bad-sig-install\bin"
+        $NoOpensslBadSigLog = Join-Path $AcceptanceRoot "no-openssl-bad-sig.log"
+        New-Item -ItemType Directory -Force -Path $noOpensslBadSigDistDir | Out-Null
+        Copy-Item -LiteralPath (Join-Path $DistDir "$DistName.zip") -Destination (Join-Path $noOpensslBadSigDistDir "$DistName.zip") -Force
+        Copy-Item -LiteralPath (Join-Path $DistDir "$DistName.zip.sha256") -Destination (Join-Path $noOpensslBadSigDistDir "$DistName.zip.sha256") -Force
+        Set-Content -LiteralPath (Join-Path $noOpensslBadSigDistDir "$DistName.zip.sig") -Value "not a real signature" -Encoding ascii
+        $noOpensslBadSigDownloadBase = ([System.Uri]::new($noOpensslBadSigDistDir + [System.IO.Path]::DirectorySeparatorChar)).AbsoluteUri.TrimEnd("/")
+        $noOpensslBadSigArgs = @(
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            (Join-Path $RepoRoot "install.ps1"),
+            "release",
+            "-InstallDir",
+            $noOpensslBadSigInstallDir,
+            "-DownloadBase",
+            $noOpensslBadSigDownloadBase,
+            "-SigningPublicKeyPath",
+            $signingPublicKey,
+            "-RequireSignature",
+            "-NoPathUpdate"
+        )
+        Invoke-ExpectFailure "acceptance: bad signature install with openssl absent" $psExe $noOpensslBadSigArgs $NoOpensslBadSigLog
+    } finally {
+        $env:Path = $originalProcessPath
+    }
+    if (-not (Select-String -LiteralPath $NoOpensslInstallLog -Pattern "signature verified" -Quiet)) {
+        Fail "installer did not verify the signature with openssl absent"
+    }
+    Assert-File (Join-Path $noOpensslInstallDir "rocm.exe")
+    Assert-File (Join-Path $noOpensslInstallDir ".rocm-cli-manifest")
+    if (-not (Select-String -LiteralPath $NoOpensslBadSigLog -Pattern "signature verification failed" -Quiet)) {
+        Fail "installer did not reject a bad signature with openssl absent"
+    }
+    Assert-Missing (Join-Path $noOpensslBadSigInstallDir "rocm.exe")
+    Assert-Missing (Join-Path $noOpensslBadSigInstallDir ".rocm-cli-manifest")
 
     # With a production release key pinned in install.ps1, a release install with
     # no public key supplied falls back to that pinned trust root. The bundle here


### PR DESCRIPTION
## Summary

- The Windows installer (`install.ps1`) now verifies the detached release
  signature using the built-in .NET RSA APIs instead of shelling out to
  `openssl`, removing an undeclared runtime dependency.
- Adds a hand-rolled DER/SubjectPublicKeyInfo parser so the public key can be
  imported on Windows PowerShell 5.1, then verifies with `RSA.VerifyData`
  (SHA-256, PKCS#1 v1.5).
- Documents the verification path in `docs/release-trust.md` and extends the
  Windows acceptance script to prove the installer works with `openssl` removed
  from `PATH` (and still rejects a bad signature).

## Symptom

On a stock Windows host without `openssl` on `PATH`, a signed release install
would abort at signature verification: the installer called `openssl dgst
-verify`, and when `openssl` was absent the required-signature path failed even
though the download and signature were valid. Windows users have no guaranteed
`openssl` in the base image, so signature verification was effectively
unreliable there.

## Root cause

Signature verification was implemented by invoking the external `openssl`
binary. That binary is present on the Linux images but is not a standard part of
Windows, so the installer depended on a tool that may not exist on the target
platform.

## Why native .NET rather than certreq/certutil

The `.sig` sidecar is a raw RSASSA-PKCS#1 v1.5 signature over the archive's
SHA-256 digest, checked against a bare SubjectPublicKeyInfo public key. It is
not a PKCS#7/CMS or Authenticode container. `certreq`/`certutil` only verify
certificate-backed CMS/Authenticode blobs and cannot check a raw detached
signature against a bare public key, so they are not usable here. The .NET RSA
APIs are always available on both Windows PowerShell 5.1 (.NET Framework 4.6+)
and PowerShell 7+ (.NET), need no external process, and verify the exact scheme
the signature uses. Windows PowerShell 5.1 lacks
`RSA.ImportSubjectPublicKeyInfo` (.NET Core 3.0+ only), which is why the SPKI is
parsed by hand into `RSAParameters` before import. The DER length parsing
rejects out-of-range/oversized lengths so a crafted key cannot cause an Int32
overflow or an unhandled allocation error.

## Verification

- PowerShell parse check and PSScriptAnalyzer (repo settings) clean on the
  changed scripts.
- The Windows acceptance script now runs a full signed install and a
  bad-signature rejection with every `openssl` directory scrubbed from `PATH`,
  asserting the installer logs `signature verified`, installs the binary, and
  still emits `signature verification failed` for an invalid signature.
- Note: the Windows end-to-end acceptance runs only in CI (the
  `windows-build-and-test` job on a Windows runner); it cannot be exercised on a
  Linux host, so end-to-end confirmation on Windows is CI-only.

## Risk

Low. The change is confined to the Windows installer's verification routine and
its acceptance coverage; the Linux path still uses `openssl` unchanged, and the
signature scheme and pinned trust root are unchanged. The failure mode is
fail-closed: any parse or verification error aborts the install before
activation.