### PR TITLE
fix(dash): correct chat and scrollbar scrolling

### DIFF
--- a/crates/rocm-dash-tui/Cargo.toml
+++ b/crates/rocm-dash-tui/Cargo.toml
@@ -19,7 +19,9 @@ rocm-dash-core = { path = "../rocm-dash-core" }
 # Unified dashboard TUI base: ratatui 0.30 + crossterm 0.28 stay
 # confined to this crate. The frozen rocm-cli tui.rs keeps ratatui 0.29; the two
 # majors coexist in the tree, each confined to its own crate.
-ratatui = "0.30"
+# Exact wrapped-row counts must match Ratatui rendering so chat scroll bounds stay correct.
+# `line_count` is currently gated by Ratatui's unstable rendered-line-info feature.
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -498,9 +498,9 @@ pub struct AppState {
     /// them. Cleared and repopulated every `ui::draw`; interior-mutable because
     /// the deep render fns hold `&AppState`.
     pub scrollbars: std::cell::RefCell<Vec<ScrollbarHandle>>,
-    /// The scrollbar currently being dragged (mouse held down on a track), so
-    /// pointer moves keep updating that offset until release.
-    pub scroll_drag: Option<ScrollTarget>,
+    /// Active scrollbar drag, including the pointer's offset inside a multi-cell
+    /// thumb so grabbing it never snaps its leading edge to the pointer.
+    pub scroll_drag: Option<ScrollDrag>,
     /// Chat transcript (TUI-local; never travels over the daemon protocol).
     pub chat: Vec<ChatTurn>,
     /// Pending input buffer for the Chat tab.
@@ -516,6 +516,10 @@ pub struct AppState {
     /// Scroll offset (lines from top) into the chat transcript. Clamped at 0;
     /// the renderer clamps the upper bound against the actual line count.
     pub chat_scroll: u16,
+    /// Maximum valid chat transcript offset measured during the latest render.
+    pub chat_max_scroll: u16,
+    /// Whether new chat rows keep the viewport pinned to its bottom.
+    pub chat_follow: bool,
     /// Resolved chat endpoint (base_url + model + env api_key). `None` when no
     /// endpoint was detected. `api_key` is never rendered or logged.
     pub chat_llm: Option<crate::llm::LlmConfig>,
@@ -682,6 +686,8 @@ impl AppState {
             chat_dispatch: false,
             chat_focused: false,
             chat_scroll: 0,
+            chat_max_scroll: 0,
+            chat_follow: true,
             chat_llm: None,
             chat_consent: ChatConsent::Unavailable,
             chat_detect_offer: None,
@@ -861,16 +867,32 @@ impl AppState {
                 .unwrap_or(u16::MAX);
     }
 
-    /// Arm a scrollbar drag and jump the target surface to `position` (already
-    /// in the target's own offset units — the caller inverts the tail-anchored
-    /// dock). Idempotent, so pointer moves during a drag reuse it.
-    pub(crate) fn apply_scroll_grab(&mut self, target: ScrollTarget, position: usize) {
-        self.scroll_drag = Some(target);
+    /// Apply an absolute chat offset against the latest measured viewport and
+    /// derive follow-tail state from whether the viewport is at its bottom.
+    fn set_chat_scroll(&mut self, position: usize) {
+        self.chat_scroll = u16::try_from(position)
+            .unwrap_or(u16::MAX)
+            .min(self.chat_max_scroll);
+        self.chat_follow = self.chat_scroll == self.chat_max_scroll;
+    }
+
+    /// Arm a scrollbar drag and apply `position` in the target's own offset
+    /// units. The grab offset is retained for subsequent pointer moves.
+    pub(crate) fn apply_scroll_grab(
+        &mut self,
+        target: ScrollTarget,
+        position: usize,
+        grab_offset: u16,
+    ) {
+        self.scroll_drag = Some(ScrollDrag {
+            target,
+            grab_offset,
+        });
         let p = u16::try_from(position).unwrap_or(u16::MAX);
         match target {
             ScrollTarget::Console => self.console_scroll = p,
             ScrollTarget::ConsoleH => self.console_hscroll = p,
-            ScrollTarget::Chat => self.chat_scroll = p,
+            ScrollTarget::Chat => self.set_chat_scroll(position),
             ScrollTarget::BenchDetail => self.bench_detail_scroll = p,
             ScrollTarget::DockLogs => self.dock_logs_scroll = p,
         }
@@ -2593,7 +2615,9 @@ fn apply_action(state: &mut AppState, action: KeyAction) -> bool {
         KeyAction::ScrollModal(_) => {}
         KeyAction::ScrollConsole(dv, dh) => state.scroll_console(dv, dh),
         KeyAction::ScrollDock(dv) => state.scroll_dock(dv),
-        KeyAction::ScrollGrab(target, pos) => state.apply_scroll_grab(target, pos),
+        KeyAction::ScrollGrab(target, pos, grab_offset) => {
+            state.apply_scroll_grab(target, pos, grab_offset);
+        }
         KeyAction::ScrollRelease => state.scroll_drag = None,
         KeyAction::ReplayTogglePause => {
             if let Some(r) = state.replay.as_mut() {
@@ -2636,46 +2660,70 @@ fn apply_action(state: &mut AppState, action: KeyAction) -> bool {
         KeyAction::ChatDetectSave => state.save_detect_offer(),
         KeyAction::ChatDetectDismiss => state.dismiss_detect_offer(),
         KeyAction::ChatScroll(d) => {
-            let next = u16::try_from((i32::from(state.chat_scroll) + i32::from(d)).max(0))
-                .unwrap_or(u16::MAX);
-            state.chat_scroll = next;
+            let next = (i32::from(state.chat_scroll) + i32::from(d)).max(0) as usize;
+            state.set_chat_scroll(next);
         }
         KeyAction::Nothing => {}
     }
     false
 }
 
-/// Translate a mouse event into a `KeyAction` using whatever state context
-/// is needed (last drawn areas, active tab, current modal).
-/// Position (in the target's own offset units) for a scrollbar grabbed at
-/// `(col, row)`, inverting for the tail-anchored dock so dragging down scrolls
-/// toward older lines.
-fn grab_position(h: &ScrollbarHandle, col: u16, row: u16) -> usize {
-    let pos = h.position_at(col, row);
+/// Convert a displayed position to the target's own offset units. Dock logs are
+/// tail-anchored, so their displayed top-to-bottom position is inverted.
+fn target_offset(h: &ScrollbarHandle, displayed: usize) -> usize {
     if h.target == ScrollTarget::DockLogs {
-        h.content_len
-            .saturating_sub(h.viewport_len)
-            .saturating_sub(pos)
+        h.max_position().saturating_sub(displayed)
     } else {
-        pos
+        displayed
     }
 }
 
-/// If `(col, row)` lands on a recorded scrollbar track, the grab action for it.
+fn target_position(state: &AppState, h: &ScrollbarHandle) -> usize {
+    let position = match h.target {
+        ScrollTarget::Console => usize::from(state.console_scroll),
+        ScrollTarget::ConsoleH => usize::from(state.console_hscroll),
+        ScrollTarget::Chat => usize::from(state.chat_scroll),
+        ScrollTarget::BenchDetail => usize::from(state.bench_detail_scroll),
+        ScrollTarget::DockLogs => h
+            .max_position()
+            .saturating_sub(usize::from(state.dock_logs_scroll)),
+    };
+    position.min(h.max_position())
+}
+
+/// If `(col, row)` lands on a recorded scrollbar, preserve a thumb grab or use
+/// a proportional full-track jump for a track click.
 fn scrollbar_hit(state: &AppState, col: u16, row: u16) -> Option<KeyAction> {
     let bars = state.scrollbars.borrow();
     let h = bars.iter().find(|h| point_in(h.track, col, row))?;
-    Some(KeyAction::ScrollGrab(h.target, grab_position(h, col, row)))
+    let displayed = target_position(state, h);
+    let grab_offset = h.grab_offset(col, row, displayed);
+    let next = grab_offset.map_or_else(|| h.track_position_at(col, row), |_| displayed);
+    Some(KeyAction::ScrollGrab(
+        h.target,
+        target_offset(h, next),
+        grab_offset.unwrap_or(0),
+    ))
 }
 
 fn resolve_mouse(me: MouseEvent, state: &AppState) -> KeyAction {
     // A held drag on a scrollbar keeps updating that offset until release, even
     // when the pointer slides off the narrow track.
     if me.kind == MouseEventKind::Drag(MouseButton::Left) {
-        if let Some(t) = state.scroll_drag
-            && let Some(h) = state.scrollbars.borrow().iter().find(|h| h.target == t)
+        if let Some(drag) = state.scroll_drag
+            && let Some(h) = state
+                .scrollbars
+                .borrow()
+                .iter()
+                .find(|h| h.target == drag.target)
         {
-            return KeyAction::ScrollGrab(t, grab_position(h, me.column, me.row));
+            let current = target_position(state, h);
+            let displayed = h.position_at(me.column, me.row, drag.grab_offset, current);
+            return KeyAction::ScrollGrab(
+                drag.target,
+                target_offset(h, displayed),
+                drag.grab_offset,
+            );
         }
         return KeyAction::Nothing;
     }
@@ -2820,6 +2868,13 @@ pub struct FooterChip {
     pub action: KeyAction,
 }
 
+/// Active pointer drag for a scrollbar thumb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollDrag {
+    pub target: ScrollTarget,
+    pub grab_offset: u16,
+}
+
 /// Which scrollable surface a drawn scrollbar controls. Lets a mouse click on a
 /// scrollbar track write the right offset field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2879,26 +2934,114 @@ impl ScrollbarHandle {
         })
     }
 
-    /// Map an absolute mouse `(col, row)` to a clamped scroll position over
-    /// `0..=(content_len - viewport_len)`, proportional to where along the track
-    /// the pointer sits. Off-axis coordinates are ignored.
-    fn position_at(&self, col: u16, row: u16) -> usize {
-        let max_pos = self.content_len.saturating_sub(self.viewport_len);
-        if max_pos == 0 {
-            return 0;
-        }
-        let (coord, start, span) = if self.horizontal {
+    const fn max_position(&self) -> usize {
+        self.content_len.saturating_sub(self.viewport_len)
+    }
+
+    const fn axis(&self, col: u16, row: u16) -> (u16, u16, u16) {
+        if self.horizontal {
             (col, self.track.x, self.track.width)
         } else {
             (row, self.track.y, self.track.height)
-        };
-        if span <= 1 {
+        }
+    }
+
+    /// Ratatui 0.30.2 `Scrollbar::part_lengths` geometry for the logical
+    /// first-visible-unit position used by the dashboard.
+    fn thumb_geometry(&self, logical_position: usize) -> (u16, u16) {
+        let (_, _, span) = self.axis(0, 0);
+        if span == 0 || self.content_len == 0 {
+            return (0, 0);
+        }
+        let track_len = usize::from(span);
+        let rendered_max = self.content_len.saturating_sub(1);
+        let rendered_position =
+            logical_position.min(self.max_position()) * rendered_max / self.max_position().max(1);
+        let denominator = rendered_max.saturating_add(self.viewport_len);
+        let rounded_divide =
+            |numerator: usize| numerator.saturating_add(denominator / 2) / denominator.max(1);
+        let thumb_len =
+            rounded_divide(self.viewport_len.saturating_mul(track_len)).clamp(1, track_len);
+        let thumb_start = rounded_divide(rendered_position.saturating_mul(track_len))
+            .clamp(0, track_len.saturating_sub(thumb_len));
+        (thumb_start as u16, thumb_len as u16)
+    }
+
+    fn grab_offset(&self, col: u16, row: u16, position: usize) -> Option<u16> {
+        let (coord, track_start, _) = self.axis(col, row);
+        let relative = coord.saturating_sub(track_start);
+        let (thumb_start, thumb_len) = self.thumb_geometry(position);
+        (relative >= thumb_start && relative < thumb_start.saturating_add(thumb_len))
+            .then(|| relative - thumb_start)
+    }
+
+    /// Proportional track-click mapping. The endpoints map exactly to the
+    /// logical endpoints and do not depend on thumb geometry.
+    fn track_position_at(&self, col: u16, row: u16) -> usize {
+        let max_position = self.max_position();
+        let (coord, start, span) = self.axis(col, row);
+        if max_position == 0 || span <= 1 {
             return 0;
         }
-        let rel = coord.saturating_sub(start).min(span - 1);
-        // Proportional: last cell of the track = max position.
-        let pos = usize::from(rel) * max_pos / usize::from(span - 1);
-        pos.min(max_pos)
+        usize::from(coord.saturating_sub(start).min(span - 1)) * max_position
+            / usize::from(span - 1)
+    }
+
+    /// Invert Ratatui's rounded thumb-start mapping. When several logical
+    /// positions render at the requested start, retain `current_position` if it
+    /// lies on that plateau; otherwise choose the nearest plateau endpoint.
+    fn position_at(&self, col: u16, row: u16, grab_offset: u16, current_position: usize) -> usize {
+        let max_position = self.max_position();
+        if max_position == 0 {
+            return 0;
+        }
+        let (coord, start, span) = self.axis(col, row);
+        let (_, thumb_len) = self.thumb_geometry(0);
+        let desired_start = coord
+            .saturating_sub(start)
+            .saturating_sub(grab_offset)
+            .min(span.saturating_sub(thumb_len));
+        if desired_start == 0 {
+            return 0;
+        }
+        if desired_start == span.saturating_sub(thumb_len) {
+            return max_position;
+        }
+
+        let first_at_or_after = |wanted: u16| {
+            let mut low = 0usize;
+            let mut high = max_position;
+            while low < high {
+                let mid = low + (high - low) / 2;
+                if self.thumb_geometry(mid).0 < wanted {
+                    low = mid + 1;
+                } else {
+                    high = mid;
+                }
+            }
+            low
+        };
+        let first = first_at_or_after(desired_start);
+        if self.thumb_geometry(first).0 != desired_start {
+            if first == 0 {
+                return 0;
+            }
+            let before = first - 1;
+            let before_start = self.thumb_geometry(before).0;
+            let after_start = self.thumb_geometry(first).0;
+            return if desired_start - before_start <= after_start - desired_start {
+                before
+            } else {
+                first
+            };
+        }
+        let after = first_at_or_after(desired_start.saturating_add(1));
+        let last = if after == max_position && self.thumb_geometry(after).0 == desired_start {
+            after
+        } else {
+            after.saturating_sub(1)
+        };
+        current_position.clamp(first, last)
     }
 }
 
@@ -2936,10 +3079,9 @@ pub enum KeyAction {
     /// Scroll the wide-layout right LOGS dock by N lines (negative = toward the
     /// newest line). No-op when the dock isn't showing.
     ScrollDock(i16),
-    /// Grab a scrollbar and jump its surface to `position` (first visible unit).
-    /// Emitted on a click or drag over a scrollbar track; also arms drag so
-    /// subsequent moves keep tracking the pointer.
-    ScrollGrab(ScrollTarget, usize),
+    /// Grab a scrollbar at `position`, retaining the pointer's offset inside the
+    /// thumb so subsequent drag events track without a jump.
+    ScrollGrab(ScrollTarget, usize, u16),
     /// Release the active scrollbar drag (mouse button up).
     ScrollRelease,
     /// Toggle replay pause / resume. No-op when not replaying.
@@ -3557,12 +3699,10 @@ mod tests {
             viewport_len: 10,
             target: ScrollTarget::Console,
         };
-        // max position = 90; top of track → 0, last cell (row 9) → 90.
-        assert_eq!(h.position_at(50, 0), 0);
-        assert_eq!(h.position_at(50, 9), 90);
-        assert_eq!(h.position_at(50, 5), 90 * 5 / 9);
-        // Below the track clamps to the last cell.
-        assert_eq!(h.position_at(50, 99), 90);
+        assert_eq!(h.track_position_at(50, 0), 0);
+        assert_eq!(h.track_position_at(50, 9), 90);
+        assert_eq!(h.track_position_at(50, 5), 90 * 5 / 9);
+        assert_eq!(h.track_position_at(50, 99), 90);
     }
 
     #[test]
@@ -3578,14 +3718,20 @@ mod tests {
         // Click near the bottom of the track → grab + jump near the end.
         let down = wheel(MouseEventKind::Down(MouseButton::Left), 60, 9);
         let a = resolve_mouse(down, &s);
-        assert_eq!(a, KeyAction::ScrollGrab(ScrollTarget::Console, 90));
+        assert_eq!(a, KeyAction::ScrollGrab(ScrollTarget::Console, 90, 0));
         apply_action(&mut s, a);
         assert_eq!(s.console_scroll, 90);
-        assert_eq!(s.scroll_drag, Some(ScrollTarget::Console));
+        assert_eq!(
+            s.scroll_drag,
+            Some(ScrollDrag {
+                target: ScrollTarget::Console,
+                grab_offset: 0,
+            })
+        );
         // Drag to the top — the off-axis column is ignored, so it still tracks.
         let drag = wheel(MouseEventKind::Drag(MouseButton::Left), 40, 0);
         let a = resolve_mouse(drag, &s);
-        assert_eq!(a, KeyAction::ScrollGrab(ScrollTarget::Console, 0));
+        assert_eq!(a, KeyAction::ScrollGrab(ScrollTarget::Console, 0, 0));
         apply_action(&mut s, a);
         assert_eq!(s.console_scroll, 0);
         // Release clears the drag.
@@ -3594,6 +3740,142 @@ mod tests {
         assert_eq!(a, KeyAction::ScrollRelease);
         apply_action(&mut s, a);
         assert_eq!(s.scroll_drag, None);
+    }
+
+    #[test]
+    fn rendered_thumb_cells_are_grabbable() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        for horizontal in [false, true] {
+            let mut s = AppState::new("t".into(), "default-dark".into());
+            let area = if horizontal {
+                Rect::new(0, 0, 4, 2)
+            } else {
+                Rect::new(0, 0, 2, 4)
+            };
+            let target = if horizontal {
+                ScrollTarget::ConsoleH
+            } else {
+                ScrollTarget::Console
+            };
+            if horizontal {
+                s.console_hscroll = 1;
+            } else {
+                s.console_scroll = 1;
+            }
+            let backend = TestBackend::new(area.width, area.height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            let mut body = area;
+            terminal
+                .draw(|frame| {
+                    body = if horizontal {
+                        crate::ui::panel::horizontal_scrollbar(frame, area, 4, 2, 1, &s.theme)
+                    } else {
+                        crate::ui::panel::vertical_scrollbar(frame, area, 4, 2, 1, &s.theme)
+                    };
+                })
+                .unwrap();
+            s.record_scrollbar(area, body, horizontal, 4, 2, target);
+            let handle = s.scrollbars.borrow()[0];
+            let (thumb_start, thumb_len) = handle.thumb_geometry(1);
+            assert_eq!((thumb_start, thumb_len), (1, 2));
+            for cell in thumb_start..thumb_start + thumb_len {
+                let (col, row) = if horizontal {
+                    (cell, handle.track.y)
+                } else {
+                    (handle.track.x, cell)
+                };
+                assert_eq!(
+                    resolve_mouse(wheel(MouseEventKind::Down(MouseButton::Left), col, row), &s),
+                    KeyAction::ScrollGrab(target, 1, cell - thumb_start)
+                );
+            }
+            let (before_col, before_row) = if horizontal {
+                (0, handle.track.y)
+            } else {
+                (handle.track.x, 0)
+            };
+            assert_eq!(
+                resolve_mouse(
+                    wheel(
+                        MouseEventKind::Down(MouseButton::Left),
+                        before_col,
+                        before_row
+                    ),
+                    &s,
+                ),
+                KeyAction::ScrollGrab(target, 0, 0)
+            );
+            let (after_col, after_row) = if horizontal {
+                (3, handle.track.y)
+            } else {
+                (handle.track.x, 3)
+            };
+            assert_eq!(
+                resolve_mouse(
+                    wheel(
+                        MouseEventKind::Down(MouseButton::Left),
+                        after_col,
+                        after_row
+                    ),
+                    &s,
+                ),
+                KeyAction::ScrollGrab(target, 2, 0)
+            );
+        }
+    }
+
+    #[test]
+    fn stationary_thumb_drag_preserves_logical_position() {
+        for target in [ScrollTarget::Console, ScrollTarget::DockLogs] {
+            let mut s = AppState::new("t".into(), "default-dark".into());
+            s.console_scroll = 5;
+            s.dock_logs_scroll = 5;
+            s.scrollbars.borrow_mut().push(ScrollbarHandle {
+                track: Rect::new(60, 0, 1, 10),
+                horizontal: false,
+                content_len: 20,
+                viewport_len: 10,
+                target,
+            });
+            let down = wheel(MouseEventKind::Down(MouseButton::Left), 60, 4);
+            let action = resolve_mouse(down, &s);
+            apply_action(&mut s, action);
+            let before = if target == ScrollTarget::DockLogs {
+                s.dock_logs_scroll
+            } else {
+                s.console_scroll
+            };
+            let drag = wheel(MouseEventKind::Drag(MouseButton::Left), 60, 4);
+            let action = resolve_mouse(drag, &s);
+            apply_action(&mut s, action);
+            let after = if target == ScrollTarget::DockLogs {
+                s.dock_logs_scroll
+            } else {
+                s.console_scroll
+            };
+            assert_eq!(after, before, "stationary {target:?} drag moved");
+        }
+    }
+
+    #[test]
+    fn horizontal_thumb_drag_tracks_pointer_column() {
+        let mut s = AppState::new("t".into(), "default-dark".into());
+        s.console_hscroll = 20;
+        s.scrollbars.borrow_mut().push(ScrollbarHandle {
+            track: Rect::new(10, 20, 20, 1),
+            horizontal: true,
+            content_len: 100,
+            viewport_len: 20,
+            target: ScrollTarget::ConsoleH,
+        });
+        let action = resolve_mouse(wheel(MouseEventKind::Down(MouseButton::Left), 14, 20), &s);
+        apply_action(&mut s, action);
+        assert_eq!(s.console_hscroll, 20);
+        let action = resolve_mouse(wheel(MouseEventKind::Drag(MouseButton::Left), 19, 99), &s);
+        apply_action(&mut s, action);
+        assert!(s.console_hscroll > 20);
     }
 
     #[test]
@@ -3608,10 +3890,10 @@ mod tests {
         });
         // Top of the bar = oldest lines = fully scrolled up from the tail (max).
         let top = resolve_mouse(wheel(MouseEventKind::Down(MouseButton::Left), 0, 0), &s);
-        assert_eq!(top, KeyAction::ScrollGrab(ScrollTarget::DockLogs, 90));
+        assert_eq!(top, KeyAction::ScrollGrab(ScrollTarget::DockLogs, 90, 0));
         // Bottom of the bar = newest tail = offset 0.
         let bot = resolve_mouse(wheel(MouseEventKind::Down(MouseButton::Left), 0, 9), &s);
-        assert_eq!(bot, KeyAction::ScrollGrab(ScrollTarget::DockLogs, 0));
+        assert_eq!(bot, KeyAction::ScrollGrab(ScrollTarget::DockLogs, 0, 0));
     }
 
     #[test]
@@ -6388,12 +6670,19 @@ mod tests {
     }
 
     #[test]
-    fn chat_scroll_clamps_at_zero_and_pages() {
+    fn chat_scroll_clamps_and_updates_follow_state() {
         let mut s = AppState::new("t".into(), "default-dark".into());
+        s.chat_max_scroll = 20;
+        s.chat_scroll = 20;
         apply_action(&mut s, KeyAction::ChatScroll(-100));
         assert_eq!(s.chat_scroll, 0, "scroll clamps at top");
+        assert!(!s.chat_follow, "scrolling above the bottom disables follow");
         apply_action(&mut s, KeyAction::ChatScroll(7));
         assert_eq!(s.chat_scroll, 7);
+        assert!(!s.chat_follow);
+        apply_action(&mut s, KeyAction::ChatScroll(100));
+        assert_eq!(s.chat_scroll, 20, "scroll clamps at measured bottom");
+        assert!(s.chat_follow, "scrolling to the bottom restores follow");
         // PageUp/PageDown map to ChatScroll on the Chat tab when accepted.
         let accepted = ChatKeyCtx {
             focused: false,
@@ -6418,6 +6707,21 @@ mod tests {
             ),
             KeyAction::ChatScroll(-CHAT_SCROLL_STEP)
         );
+    }
+
+    #[test]
+    fn chat_scrollbar_grab_updates_follow_state() {
+        let mut s = AppState::new("t".into(), "default-dark".into());
+        s.chat_max_scroll = 20;
+        s.chat_scroll = 20;
+
+        s.apply_scroll_grab(ScrollTarget::Chat, 5, 0);
+        assert_eq!(s.chat_scroll, 5);
+        assert!(!s.chat_follow, "dragging above the bottom disables follow");
+
+        s.apply_scroll_grab(ScrollTarget::Chat, 20, 0);
+        assert_eq!(s.chat_scroll, 20);
+        assert!(s.chat_follow, "dragging to the bottom restores follow");
     }
 
     #[tokio::test]

--- a/crates/rocm-dash-tui/src/ui/panel.rs
+++ b/crates/rocm-dash-tui/src/ui/panel.rs
@@ -238,9 +238,12 @@ pub fn vertical_scrollbar(
     if content_len <= viewport_len || area.width < 2 || area.height == 0 {
         return area;
     }
+    let max_position = content_len.saturating_sub(viewport_len);
+    let rendered_position =
+        position.min(max_position) * content_len.saturating_sub(1) / max_position.max(1);
     let mut sb = ScrollbarState::new(content_len)
         .viewport_content_length(viewport_len)
-        .position(position);
+        .position(rendered_position);
     let bar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .begin_symbol(None)
         .end_symbol(None)
@@ -271,9 +274,12 @@ pub fn horizontal_scrollbar(
     if content_len <= viewport_len || area.height < 2 || area.width == 0 {
         return area;
     }
+    let max_position = content_len.saturating_sub(viewport_len);
+    let rendered_position =
+        position.min(max_position) * content_len.saturating_sub(1) / max_position.max(1);
     let mut sb = ScrollbarState::new(content_len)
         .viewport_content_length(viewport_len)
-        .position(position);
+        .position(rendered_position);
     let bar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
         .begin_symbol(None)
         .end_symbol(None)
@@ -427,6 +433,34 @@ mod tests {
         });
         assert_eq!(got.height, 9, "content rect shrinks by the scrollbar row");
         assert_eq!(got.width, area.width, "width unchanged for horizontal bar");
+    }
+
+    #[test]
+    fn vertical_scrollbar_renders_expected_thumb_cells() {
+        let theme = Theme::default_dark();
+        let backend = TestBackend::new(2, 4);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let _ = vertical_scrollbar(f, f.area(), 4, 2, 1, &theme);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let cells: Vec<&str> = (0..4).map(|y| buf.cell((1, y)).unwrap().symbol()).collect();
+        assert_eq!(cells, ["║", "█", "█", "║"]);
+    }
+
+    #[test]
+    fn horizontal_scrollbar_renders_expected_thumb_cells() {
+        let theme = Theme::default_dark();
+        let backend = TestBackend::new(4, 2);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            let _ = horizontal_scrollbar(f, f.area(), 4, 2, 1, &theme);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let cells: Vec<&str> = (0..4).map(|x| buf.cell((x, 1)).unwrap().symbol()).collect();
+        assert_eq!(cells, ["═", "█", "█", "═"]);
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/tabs/chat.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/chat.rs
@@ -16,14 +16,14 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use rocm_dash_core::metrics::InstanceStatus;
 
-use crate::app::{AppState, ChatConsent, ChatRole};
+use crate::app::{AppState, ChatConsent, ChatRole, ChatTurn};
 use crate::ui::panel::{self, BoxRole};
 use crate::ui::theme::Theme;
 
 /// Block glyph used to mark the text-entry caret while focused.
 const CURSOR_GLYPH: &str = "▋";
 
-pub fn draw(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
+pub fn draw(f: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) {
     // Until the user consents to the detected endpoint, the tab shows a gate /
     // empty-state instead of the transcript+input surface.
     if state.chat_consent != ChatConsent::Accepted {
@@ -220,7 +220,42 @@ fn consent_gate_lines<'a>(
 }
 
 /// Render the scrolling transcript. Empty state shows an actionable hint.
-fn draw_transcript(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChatViewport {
+    rendered_rows: usize,
+    viewport_rows: usize,
+    max_scroll: u16,
+    scroll: u16,
+    follow: bool,
+}
+
+impl ChatViewport {
+    fn measure(
+        rendered_rows: usize,
+        viewport_rows: usize,
+        old_scroll: u16,
+        old_follow: bool,
+    ) -> Self {
+        let max_scroll =
+            u16::try_from(rendered_rows.saturating_sub(viewport_rows)).unwrap_or(u16::MAX);
+        let scroll = if old_follow {
+            max_scroll
+        } else {
+            old_scroll.min(max_scroll)
+        };
+        let follow = old_follow || old_scroll > max_scroll;
+        Self {
+            rendered_rows,
+            viewport_rows,
+            max_scroll,
+            scroll,
+            follow,
+        }
+    }
+}
+
+/// Render the scrolling transcript. Empty state shows an actionable hint.
+fn draw_transcript(f: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) {
     let inner = panel::bento(f, area, Some("Chat"), BoxRole::Secondary, false, theme);
 
     let lines = if state.chat.is_empty() {
@@ -236,36 +271,61 @@ fn draw_transcript(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
             )),
         ]
     } else {
-        transcript_lines(state, theme)
+        transcript_lines_from_turns(&state.chat, theme)
     };
+    let wrap = Wrap { trim: false };
+    let unbarred_rows = Paragraph::new(lines.as_slice())
+        .wrap(wrap)
+        .line_count(inner.width);
+    let body_width = if unbarred_rows > usize::from(inner.height) && inner.width >= 2 {
+        inner.width - 1
+    } else {
+        inner.width
+    };
+    let rendered_rows = Paragraph::new(lines.as_slice())
+        .wrap(wrap)
+        .line_count(body_width);
+    let viewport = ChatViewport::measure(
+        rendered_rows,
+        usize::from(inner.height),
+        state.chat_scroll,
+        state.chat_follow,
+    );
+    state.chat_max_scroll = viewport.max_scroll;
+    state.chat_scroll = viewport.scroll;
+    state.chat_follow = viewport.follow;
 
     let body = panel::vertical_scrollbar(
         f,
         inner,
-        lines.len(),
-        inner.height as usize,
-        state.chat_scroll as usize,
+        viewport.rendered_rows,
+        viewport.viewport_rows,
+        usize::from(viewport.scroll),
         theme,
     );
     state.record_scrollbar(
         inner,
         body,
         false,
-        lines.len(),
-        inner.height as usize,
+        viewport.rendered_rows,
+        viewport.viewport_rows,
         crate::app::ScrollTarget::Chat,
     );
-    let p = Paragraph::new(lines)
-        .wrap(Wrap { trim: false })
-        .scroll((state.chat_scroll, 0));
-    f.render_widget(p, body);
+    let paragraph = Paragraph::new(lines)
+        .wrap(wrap)
+        .scroll((viewport.scroll, 0));
+    f.render_widget(paragraph, body);
 }
 
 /// Pure transcript → styled lines mapping. Each turn becomes a role-prefixed,
 /// role-colored line. Kept free of `Frame` so it can be unit-tested.
 pub fn transcript_lines<'a>(state: &'a AppState, theme: &Theme) -> Vec<Line<'a>> {
-    let mut lines: Vec<Line> = Vec::with_capacity(state.chat.len());
-    for turn in &state.chat {
+    transcript_lines_from_turns(&state.chat, theme)
+}
+
+fn transcript_lines_from_turns<'a>(turns: &'a [ChatTurn], theme: &Theme) -> Vec<Line<'a>> {
+    let mut lines = Vec::with_capacity(turns.len());
+    for turn in turns {
         let (prefix, color) = match turn.role {
             ChatRole::User => ("you  ", theme.accent),
             ChatRole::Agent => ("rocm ", theme.fg),
@@ -410,16 +470,17 @@ mod tests {
         use crate::app::ChatConsent;
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
-        let render = |s: &AppState| {
+        let render = |s: &mut AppState| {
             let backend = TestBackend::new(80, 24);
             let mut term = Terminal::new(backend).unwrap();
-            term.draw(|f| draw(f, f.area(), s, &s.theme)).unwrap();
+            let theme = s.theme;
+            term.draw(|f| draw(f, f.area(), s, &theme)).unwrap();
         };
         let mut s = AppState::new("t".into(), "default-dark".into());
         s.active_tab = crate::app::ActiveTab::Chat;
 
         // Unavailable empty-state.
-        render(&s);
+        render(&mut s);
 
         let llm = crate::llm::LlmConfig {
             base_url: "http://127.0.0.1:8000".into(),
@@ -429,10 +490,10 @@ mod tests {
         };
         // Pending consent prompt.
         s.set_chat_config(Some(llm.clone()), false);
-        render(&s);
+        render(&mut s);
         // Declined.
         s.chat_consent = ChatConsent::Declined;
-        render(&s);
+        render(&mut s);
 
         // Accepted: populated transcript + focused input.
         s.set_chat_config(Some(llm), true);
@@ -440,15 +501,16 @@ mod tests {
         s.chat_input = "what's GPU-2 doing?".into();
         s.chat.push(ChatTurn::user("hi"));
         s.chat.push(ChatTurn::agent("echo: hi"));
-        render(&s);
+        render(&mut s);
     }
 
-    fn render_str(s: &AppState) -> String {
+    fn render_str(s: &mut AppState) -> String {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
         let backend = TestBackend::new(80, 24);
         let mut term = Terminal::new(backend).unwrap();
-        term.draw(|f| draw(f, f.area(), s, &s.theme)).unwrap();
+        let theme = s.theme;
+        term.draw(|f| draw(f, f.area(), s, &theme)).unwrap();
         let buf = term.backend().buffer().clone();
         buf.content()
             .iter()
@@ -456,15 +518,126 @@ mod tests {
             .collect()
     }
 
+    fn render_at(s: &mut AppState, width: u16, height: u16) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let backend = TestBackend::new(width, height);
+        let mut term = Terminal::new(backend).unwrap();
+        let theme = s.theme;
+        term.draw(|f| draw(f, f.area(), s, &theme)).unwrap();
+        term.backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
+    }
+
+    #[test]
+    fn deliberate_bottom_position_does_not_enable_follow() {
+        let viewport = ChatViewport::measure(30, 10, 20, false);
+
+        assert_eq!(viewport.scroll, viewport.max_scroll);
+        assert!(!viewport.follow);
+    }
+
+    #[test]
+    fn transcript_segments_remain_borrowed() {
+        use std::borrow::Cow;
+
+        let mut s = AppState::new("t".into(), "default-dark".into());
+        s.chat.push(ChatTurn::agent("borrow me"));
+        let lines = transcript_lines(&s, &s.theme);
+        assert!(matches!(
+            lines[0].spans[1].content,
+            Cow::Borrowed("borrow me")
+        ));
+    }
+
+    #[test]
+    fn wrapped_transcript_records_rendered_rows_for_scrolling() {
+        let mut s = accepted_chat_at_port(8000);
+        s.chat.push(ChatTurn::agent("x".repeat(500)));
+
+        render_at(&mut s, 40, 12);
+
+        let bars = s.scrollbars.borrow();
+        let chat_bar = bars
+            .iter()
+            .find(|bar| bar.target == crate::app::ScrollTarget::Chat)
+            .expect("wrapped transcript should overflow and draw a scrollbar");
+        assert!(chat_bar.content_len > s.chat.len());
+        assert_eq!(s.chat_scroll, s.chat_max_scroll);
+    }
+
+    #[test]
+    fn chat_render_clamps_scroll_to_last_full_viewport() {
+        let mut s = accepted_chat_at_port(8000);
+        for i in 0..30 {
+            s.chat.push(ChatTurn::agent(format!("message {i}")));
+        }
+        s.chat_follow = false;
+        s.chat_scroll = u16::MAX;
+
+        let out = render_at(&mut s, 80, 24);
+
+        assert_eq!(s.chat_scroll, s.chat_max_scroll);
+        assert!(s.chat_follow, "clamping past the bottom restores follow");
+        assert!(out.contains("message 29"), "latest message remains visible");
+    }
+
+    #[test]
+    fn chat_preserves_scrolled_position_but_follows_from_bottom() {
+        let mut s = accepted_chat_at_port(8000);
+        for i in 0..30 {
+            s.chat.push(ChatTurn::agent(format!("message {i}")));
+        }
+        render_at(&mut s, 80, 24);
+        let old_max = s.chat_max_scroll;
+
+        s.chat_follow = false;
+        s.chat_scroll = old_max.saturating_sub(3);
+        s.chat.push(ChatTurn::agent("new while reviewing"));
+        render_at(&mut s, 80, 24);
+        assert_eq!(s.chat_scroll, old_max.saturating_sub(3));
+        assert!(!s.chat_follow);
+
+        s.chat_follow = true;
+        s.chat.push(ChatTurn::agent("new while following"));
+        let out = render_at(&mut s, 80, 24);
+        assert_eq!(s.chat_scroll, s.chat_max_scroll);
+        assert!(out.contains("new while following"));
+    }
+
+    #[test]
+    fn resize_clamp_to_bottom_reenables_chat_follow() {
+        let mut s = accepted_chat_at_port(8000);
+        for i in 0..35 {
+            s.chat.push(ChatTurn::agent(format!("message {i}")));
+        }
+        render_at(&mut s, 50, 14);
+        s.chat_follow = false;
+        s.chat_scroll = s.chat_max_scroll.saturating_sub(2);
+
+        render_at(&mut s, 50, 24);
+        assert_eq!(s.chat_scroll, s.chat_max_scroll);
+        assert!(s.chat_follow);
+
+        s.chat.push(ChatTurn::agent("latest after resize"));
+        let out = render_at(&mut s, 50, 24);
+        assert_eq!(s.chat_scroll, s.chat_max_scroll);
+        assert!(out.contains("latest after resize"));
+    }
+
     #[test]
     fn gate_shows_detect_affordance_and_message() {
         let mut s = AppState::new("t".into(), "default-dark".into());
         s.active_tab = crate::app::ActiveTab::Chat;
         // Unavailable empty-state offers detection.
-        assert!(render_str(&s).contains("detect a local engine"));
+        assert!(render_str(&mut s).contains("detect a local engine"));
         // After a fruitless detect, the message shows.
         s.set_detect_result(None);
-        assert!(render_str(&s).contains("no local engine found"));
+        assert!(render_str(&mut s).contains("no local engine found"));
     }
 
     #[test]
@@ -472,7 +645,7 @@ mod tests {
         let mut s = AppState::new("t".into(), "default-dark".into());
         s.active_tab = crate::app::ActiveTab::Chat;
         s.request_detect();
-        assert!(render_str(&s).contains("Probing for a local engine"));
+        assert!(render_str(&mut s).contains("Probing for a local engine"));
     }
 
     #[test]
@@ -483,7 +656,7 @@ mod tests {
             "http://localhost:13305/v1",
             "Llama-3.2-3B",
         )));
-        let out = render_str(&s);
+        let out = render_str(&mut s);
         assert!(out.contains("Detected a local engine"));
         assert!(out.contains("localhost:13305"));
         assert!(out.contains("Llama-3.2-3B"));
@@ -593,7 +766,7 @@ mod tests {
         let mut s = accepted_chat_at_port(8000);
         s.chat_sending = true;
         set_backing_instance(&mut s, 8000, InstanceStatus::Starting { phase: None });
-        let out = render_str(&s);
+        let out = render_str(&mut s);
         assert!(
             out.contains("starting up"),
             "shows the specific startup reason"
@@ -616,7 +789,7 @@ mod tests {
         };
         s.set_chat_config(Some(llm), true);
         s.chat_sending = true;
-        let out = render_str(&s);
+        let out = render_str(&mut s);
         assert!(
             out.contains("waiting for the agent"),
             "generic spinner remains"

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -905,6 +905,8 @@ mod tests {
             chat_endpoint_rebuild: None,
             chat_focused: false,
             chat_scroll: 0,
+            chat_max_scroll: 0,
+            chat_follow: true,
             chat_llm: None,
             chat_consent: crate::app::ChatConsent::Unavailable,
             chat_detect_offer: None,


### PR DESCRIPTION
## Summary
- measure chat scrolling in wrapped terminal rows and preserve follow-tail state across keyboard, mouse, and resize transitions
- align scrollbar rendering and hit-testing with Ratatui thumb geometry, including pointer-offset dragging and tail-anchored dock inversion
- avoid deep transcript text copies while rendering and add rendered-boundary regressions

## Test plan
- `cargo test -p rocm-dash-tui`
- `cargo clippy -p rocm-dash-tui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 scripts/smoke_local.py`
- `git diff --check origin/main..HEAD`

## Notes
- Scope is limited to the dashboard TUI; engine behavior and GPU-required policy are unchanged.