### PR TITLE
chore: set workspace version to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e-cucumber"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "axum",
  "cucumber",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-report"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "maud",
  "serde",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "rocm"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-core"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-dash-collectors"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "bollard",
  "chrono",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-dash-core"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-dash-daemon"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-dash-tui"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-engine-lemonade"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-engine-protocol"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "rocm-core",
  "serde",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "rocm-engine-vllm"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "rocmd"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5934,7 +5934,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ROCm/rocm-cli"

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 ## Application
 
 - **Name**: rocm-cli
-- **Version**: 0.3.0
+- **Version**: 0.1.0
 - **License**: MIT
 - **Copyright**: Copyright Advanced Micro Devices, Inc.
 - **Repository**: https://github.com/ROCm/rocm-cli


### PR DESCRIPTION
## Summary

- set the workspace and all first-party package versions to `0.1.0`
- update the source repository manifest to report `0.1.0`
- align package metadata with the existing `v0.1.0-rc.1` and `v0.1.0-rc.2` release sequence

## Verification

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --all-targets --offline`
- `python3 scripts/smoke_local.py --skip-build`
- `cargo xtask manifest --check`
- `python3 scripts/release_readiness.py --self-test`
- `cargo run --quiet -p rocm -- version`
- `cargo run --quiet -p rocm -- --version`
- `cargo run --quiet -p rocmd -- --version`

The initial `python3 scripts/smoke_local.py` build step hit a crates.io transfer timeout. Rebuilding the same workspace from the local cache with `--offline`, then running the complete smoke scenarios with `--skip-build`, passed.