### PR TITLE
ci(e2e): pre-seed 27B weights into shared HF cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,6 +789,11 @@ jobs:
         with:
           cache: false
 
+      # `uvx` runs the Hugging Face CLI for the weights pre-seed below. `rocm`
+      # downloads its own `uv` into an internal managed cache not on PATH, and the
+      # runner has no guaranteed system python/pip — so provision a pinned `uv`.
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
       # `actions/checkout` runs `git clean -ffdx`, which deletes the gitignored
       # `target/` inside the repo every job → a full ~15min rebuild each run.
       # Point CARGO_TARGET_DIR at a sibling of the checkout ($RUNNER_WORKSPACE is
@@ -854,6 +859,33 @@ jobs:
             fi
           else
             echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
+          fi
+
+          # Pre-seed the large-model weights ONCE into the shared HF cache so the
+          # timed serve-large-model-inference scenario is load-only, not a ~54 GiB
+          # download. A cold pull would risk this job's 90-min cap and blows the
+          # scenario's 2400s serve window. The
+          # serve step (serving_steps.rs setup_large_gpu_model) assumes weights are
+          # already present; nothing else seeds them. Guarded like the runtime
+          # pre-warm: skip when the snapshot exists (persists across runs; weights
+          # are content-addressed/immutable, so a re-fetch is a no-op). Must use
+          # the SAME HF_HOME the harness reads (see e2e.rs isolate_cmd). hf_transfer
+          # speeds the pull; HF_TOKEN (when the secret is set) avoids anonymous HF
+          # Hub rate-limiting — degrades to anonymous for this public model when
+          # unset. This scenario is @nightly, so it only runs here on a dispatch
+          # with include_nightly — gate the seed on E2E_INCLUDE_NIGHTLY so a normal
+          # per-PR run never pays the one-time ~54 GiB pull for a scenario it skips.
+          model_cache="$E2E_SHARED_CACHE_DIR/huggingface/hub/models--Qwen--Qwen3.6-27B"
+          if [ -z "$E2E_INCLUDE_NIGHTLY" ]; then
+            echo "nightly scenarios not included — skipping 27B weights pre-seed"
+          elif [ ! -d "$model_cache" ]; then
+            echo "pre-seeding Qwen/Qwen3.6-27B weights (first run on this runner)…"
+            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            HF_HUB_ENABLE_HF_TRANSFER=1 \
+            HF_TOKEN="${{ secrets.HF_TOKEN }}" \
+              uvx --from "huggingface_hub[hf_transfer]" hf download Qwen/Qwen3.6-27B
+          else
+            echo "27B weights already present at $model_cache — skipping pre-seed"
           fi
 
           # TEMP: optional scenario-name filter for a scoped probe dispatch (same

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -369,6 +369,11 @@ jobs:
         with:
           cache: false
 
+      # `uvx` runs the Hugging Face CLI for the weights pre-seed below. `rocm`
+      # downloads its own `uv` into an internal managed cache not on PATH, and the
+      # runner has no guaranteed system python/pip — so provision a pinned `uv`.
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
       - name: Run full E2E on GPU hardware (incl. nightly-only)
         run: |
           export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
@@ -400,6 +405,28 @@ jobs:
             HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
             UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
               "$ROCM_CLI_BINARY" install sdk
+          fi
+
+          # Pre-seed the large-model weights ONCE into the shared HF cache so the
+          # timed serve-large-model-inference scenario is load-only, not a ~54 GiB
+          # download that can't finish in its 2400s window. The serve step
+          # (serving_steps.rs setup_large_gpu_model)
+          # assumes weights are already present; nothing else seeds them. Guarded
+          # like the runtime pre-warm: skip when the snapshot exists (persists
+          # across runs; weights are content-addressed/immutable, so a re-fetch is
+          # a no-op). Must use the SAME HF_HOME the harness reads (see e2e.rs
+          # isolate_cmd). hf_transfer speeds the pull; HF_TOKEN (when the secret is
+          # set) avoids anonymous HF Hub rate-limiting — degrades to anonymous for
+          # this public model when unset.
+          model_cache="$E2E_SHARED_CACHE_DIR/huggingface/hub/models--Qwen--Qwen3.6-27B"
+          if [ ! -d "$model_cache" ]; then
+            echo "pre-seeding Qwen/Qwen3.6-27B weights (first run on this runner)…"
+            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            HF_HUB_ENABLE_HF_TRANSFER=1 \
+            HF_TOKEN="${{ secrets.HF_TOKEN }}" \
+              uvx --from "huggingface_hub[hf_transfer]" hf download Qwen/Qwen3.6-27B
+          else
+            echo "27B weights already present at $model_cache — skipping pre-seed"
           fi
 
           cargo xtask e2e


### PR DESCRIPTION
## Summary

The nightly `serve-large-model-inference` scenario (`Qwen/Qwen3.6-27B` on vLLM, `@nightly @serve-timeout:2400`) has been failing repeatedly, waiting the full 40 min and then failing with "did not serve model Qwen3.6-27B within 2400s".

Root cause: nothing seeds the ~54 GiB weights into the shared HF cache, so every run does a **cold download at serve time** that can't finish within the 2400s window (worsened by anonymous HF Hub rate-limiting). The serve step (`serving_steps.rs` `setup_large_gpu_model`) already assumes the weights are pre-seeded so the timed serve is load-only. A small vLLM model serves fine on the same host minutes earlier, so this is not GPU/engine/flake — it's missing pre-seeding. **This is not a timeout bump.**

## Changes

Add a guarded, one-time-per-runner weights pre-seed to both self-hosted `amd-gpu` E2E jobs (`e2e-gpu-nightly` in `nightly.yml`, `e2e-gpu` in `ci.yml`):

- Provision a pinned `astral-sh/setup-uv` so `uvx` is on PATH (`rocm` keeps its own `uv` in an internal cache not on PATH; the runner has no guaranteed system python/pip).
- After the existing runtime pre-warm, run `uvx --from "huggingface_hub[hf_transfer]" hf download Qwen/Qwen3.6-27B` into the **same `HF_HOME` the harness reads** (`$E2E_SHARED_CACHE_DIR/huggingface`). Skipped when the snapshot already exists (weights are content-addressed and persist across runs, so a re-fetch is a no-op).
- In `ci.yml` the seed is additionally gated on `E2E_INCLUDE_NIGHTLY`, so a normal per-PR `e2e-gpu` run never pays the download for a `@nightly` scenario it skips. `nightly.yml` always sets `E2E_INCLUDE_NIGHTLY=1`, so the gate is omitted there.

Strix Halo jobs are untouched — the scenario is `@requires-engine:vllm` and doesn't run there.

## Notes

- `HF_TOKEN` (via `secrets.HF_TOKEN`) is passed when the secret is set to avoid anonymous rate-limiting; it degrades to an anonymous pull of this public model when unset. Adding the secret is recommended but not required for the fix.
- Overlaps files with #130 (Strix large-model nightly), which extends coverage but does not fix this timeout. Whichever lands second will need a small rebase.

## Test plan

- YAML parses; both modified `run:` scripts pass `bash -n`.
- Verification requires real MI300X: scoped `workflow_dispatch` of `e2e-gpu` with `include_nightly=true` and the `name_filter` set to the 27B scenario should show the pre-seed run, weights land, and the serve reach ready within 2400s; a second run should log the skip path with no download. Then confirm the next scheduled nightly goes green.