### PR TITLE
build(deps): pin release Rust toolchain action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Verify pinned keys match the signing key
         run: cargo xtask verify-pinned-keys


### PR DESCRIPTION
## Summary
- Pin the release workflow's Rust toolchain setup action to the full commit SHA for v1.17.0.
- Replace the moving `@v1` tag to align the release workflow with the repository's GitHub Actions supply-chain policy and its other toolchain setup steps.
- Risk: low — this preserves the action version already used elsewhere and changes only dependency resolution from a moving tag to an immutable commit.

This addresses the follow-up concern identified during review of #120.

## Test plan
- Verified upstream tag `v1.17.0` resolves to `166cdcfd11aee3cb47222f9ddb555ce30ddb9659`.
- Ran the configured pre-commit checks for `.github/workflows/release.yml`, including YAML validation.
- Confirmed no `actions-rust-lang/setup-rust-toolchain@v1` moving-tag references remain in `.github/workflows`.
- Confirmed the pre-push signature and DCO checks pass.