### PR TITLE
test(e2e): make XPASS non-fatal for known-flaky xfails

### DIFF
--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -20,6 +20,11 @@
 #   bug = "EAI-NNNN"                  ticket reference (shown in the report)
 #   reason = "..."                    human explanation (shown in the report)
 #   serve_timeout_secs = 90          optional: shorter serve wait for a known bug
+#   flaky = true                     optional: the bug is intermittent, so an XPASS
+#                                     (lucky run where it didn't reproduce) is
+#                                     reported but NON-FATAL. Unexpected-FAIL stays
+#                                     fatal. Use only for genuinely intermittent
+#                                     bugs, never to mask a fixed/stale entry.
 #
 # An empty `when = {}` means "always xfail" (platform-independent bug).
 
@@ -43,6 +48,9 @@ when = { effective_engine = "vllm" }
 bug = "EAI-7333"
 reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completions is refused."
 serve_timeout_secs = 90
+# EAI-7333 is intermittent (flipped across MI300X runs 29404668327 pass / 29413321046 fail);
+# an XPASS is expected noise, not a fix, so keep it xfail'd but non-fatal.
+flaky = true
 
 # Default-engine serve is RECIPE-driven, not host-driven: `rocm serve <model>`
 # with no --engine resolves to the recipe's preferred model+engine. On an Instinct
@@ -94,6 +102,8 @@ when = { effective_engine = "vllm" }
 bug = "EAI-7333"
 reason = "CLI reports the vLLM service ready, but an immediate inference request races the model load and intermittently fails."
 serve_timeout_secs = 90
+# Intermittent (see serve-vllm-inference): XPASS is expected noise, non-fatal.
+flaky = true
 
 # On a lemonade LINUX host this scenario does a real lemonade serve, which reaches
 # ready then shuts down immediately (EAI-7423, see serve-lemonade-inference).

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -33,8 +33,13 @@ pub enum Expectation {
     /// Must pass; a failure is a real regression.
     ExpectPass,
     /// Declared known bug that reproduces on this host; failing is the expected
-    /// outcome, passing is an XPASS (stale entry).
-    ExpectXfail { bug: String, reason: String },
+    /// outcome, passing is an XPASS (stale entry). `flaky` marks an intermittent
+    /// bug whose XPASS is non-fatal (see `XfailEntry::flaky`).
+    ExpectXfail {
+        bug: String,
+        reason: String,
+        flaky: bool,
+    },
     /// Not applicable on this host (e.g. required engine can't start); skipped.
     Skip { reason: String },
 }
@@ -173,6 +178,11 @@ pub struct XfailEntry {
     pub reason: String,
     #[serde(default)]
     pub serve_timeout_secs: Option<u64>,
+    /// This xfail is for an intermittent bug: on a lucky run it may not reproduce
+    /// and the scenario passes (XPASS). Such an XPASS is expected noise, so it is
+    /// reported but does NOT fail the suite. Unexpected-FAIL stays fatal always.
+    #[serde(default)]
+    pub flaky: bool,
 }
 
 /// The parsed `expectations.toml`: scenario-id → list of xfail conditions (OR).
@@ -241,7 +251,9 @@ pub struct ResolvedScenario {
 impl ResolvedScenario {
     pub fn new(id: &str, effective_engine: &str, expectation: &Expectation) -> Self {
         let (bug, reason) = match expectation {
-            Expectation::ExpectXfail { bug, reason } => (Some(bug.clone()), Some(reason.clone())),
+            Expectation::ExpectXfail { bug, reason, .. } => {
+                (Some(bug.clone()), Some(reason.clone()))
+            }
             Expectation::Skip { reason } => (None, Some(reason.clone())),
             Expectation::ExpectPass => (None, None),
         };
@@ -325,6 +337,7 @@ pub fn resolve(
                 return Expectation::ExpectXfail {
                     bug: entry.bug.clone(),
                     reason: entry.reason.clone(),
+                    flaky: entry.flaky,
                 };
             }
         }
@@ -332,6 +345,65 @@ pub fn resolve(
 
     // (3) default.
     Expectation::ExpectPass
+}
+
+/// The classified outcome of reconciling actual scenario results against their
+/// resolved expectations. Drives the suite's exit code.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Reconciliation {
+    /// xfails that failed as expected.
+    pub xfail_count: u32,
+    /// Non-flaky xfails that passed (stale entries) — fatal. `"id (BUG)"`.
+    pub xpass: Vec<String>,
+    /// Flaky xfails that passed — reported but non-fatal. `"id (BUG)"`.
+    pub flaky_xpass: Vec<String>,
+    /// Expected-pass scenarios that failed — always fatal.
+    pub unexpected_fail: Vec<String>,
+}
+
+impl Reconciliation {
+    /// The suite must exit non-zero iff there is a non-flaky XPASS or an
+    /// unexpected failure. Flaky XPASS is expected noise and never fatal.
+    pub const fn is_fatal(&self) -> bool {
+        !self.xpass.is_empty() || !self.unexpected_fail.is_empty()
+    }
+}
+
+/// Reconcile actual per-scenario results (id → passed) against their resolved
+/// expectations (id → expectation), classifying each into the exit-code buckets.
+///
+/// A scenario with no recorded resolution (untagged, or ran without an @id match)
+/// is treated as expect-pass: a failure then counts as unexpected. A flaky xfail
+/// that passes is expected noise (the intermittent bug didn't reproduce this run)
+/// — recorded but non-fatal; a non-flaky XPASS is a stale entry and stays fatal.
+pub fn reconcile<'a, I>(actual: I, resolutions: &BTreeMap<String, Expectation>) -> Reconciliation
+where
+    I: IntoIterator<Item = (&'a String, &'a bool)>,
+{
+    let mut r = Reconciliation::default();
+    for (id, passed) in actual {
+        match resolutions.get(id) {
+            Some(Expectation::ExpectXfail { bug, flaky, .. }) => {
+                if *passed {
+                    let entry = format!("{id} ({bug})");
+                    if *flaky {
+                        r.flaky_xpass.push(entry);
+                    } else {
+                        r.xpass.push(entry);
+                    }
+                } else {
+                    r.xfail_count += 1;
+                }
+            }
+            // ExpectPass, Skip, or no recorded resolution (untagged) → must pass.
+            _ => {
+                if !passed {
+                    r.unexpected_fail.push(id.clone());
+                }
+            }
+        }
+    }
+    r
 }
 
 /// Tiny glob: `*` matches any run of chars. Used only for `therock_family`.
@@ -677,6 +749,106 @@ serve_timeout_secs = 90
         );
         // Unknown id → no override.
         assert_eq!(m.serve_timeout_for("nope", &cap("mi300x"), "vllm"), None);
+    }
+
+    #[test]
+    fn flaky_defaults_false_and_parses_true() {
+        let m = Expectations::parse(
+            r#"
+[["a"]]
+when = {}
+bug = "EAI-1"
+reason = "not flaky"
+
+[["b"]]
+when = {}
+bug = "EAI-2"
+reason = "flaky"
+flaky = true
+"#,
+        )
+        .unwrap();
+        assert!(!m.entries_for("a")[0].flaky);
+        assert!(m.entries_for("b")[0].flaky);
+        // The flag propagates into the resolved expectation.
+        let da = decl(&["id:a"]);
+        let db = decl(&["id:b"]);
+        assert_eq!(
+            resolve(&da, &cap("mock"), &m, false),
+            Expectation::ExpectXfail {
+                bug: "EAI-1".into(),
+                reason: "not flaky".into(),
+                flaky: false,
+            }
+        );
+        assert_eq!(
+            resolve(&db, &cap("mock"), &m, false),
+            Expectation::ExpectXfail {
+                bug: "EAI-2".into(),
+                reason: "flaky".into(),
+                flaky: true,
+            }
+        );
+    }
+
+    fn xfail(bug: &str, flaky: bool) -> Expectation {
+        Expectation::ExpectXfail {
+            bug: bug.into(),
+            reason: "r".into(),
+            flaky,
+        }
+    }
+
+    #[test]
+    fn reconcile_flaky_xpass_is_non_fatal() {
+        let mut res = BTreeMap::new();
+        res.insert("flaky-one".to_owned(), xfail("EAI-7333", true));
+        let actual = BTreeMap::from([("flaky-one".to_owned(), true)]);
+        let r = reconcile(actual.iter(), &res);
+        assert_eq!(r.flaky_xpass, vec!["flaky-one (EAI-7333)"]);
+        assert!(r.xpass.is_empty());
+        assert!(!r.is_fatal(), "a flaky XPASS alone must not fail the suite");
+    }
+
+    #[test]
+    fn reconcile_non_flaky_xpass_is_fatal() {
+        let mut res = BTreeMap::new();
+        res.insert("stale".to_owned(), xfail("EAI-9", false));
+        let actual = BTreeMap::from([("stale".to_owned(), true)]);
+        let r = reconcile(actual.iter(), &res);
+        assert_eq!(r.xpass, vec!["stale (EAI-9)"]);
+        assert!(r.flaky_xpass.is_empty());
+        assert!(r.is_fatal(), "a non-flaky XPASS is a stale entry and fatal");
+    }
+
+    #[test]
+    fn reconcile_unexpected_fail_is_always_fatal() {
+        // Even a flaky xfail that *fails* is fine (expected); but an expect-pass
+        // scenario that fails is fatal regardless of any flaky entries present.
+        let mut res = BTreeMap::new();
+        res.insert("flaky-one".to_owned(), xfail("EAI-7333", true));
+        // "clean" has no resolution → treated as expect-pass.
+        let actual = BTreeMap::from([
+            ("flaky-one".to_owned(), false), // xfail failed as expected
+            ("clean".to_owned(), false),     // expect-pass FAILED → fatal
+        ]);
+        let r = reconcile(actual.iter(), &res);
+        assert_eq!(r.xfail_count, 1);
+        assert_eq!(r.unexpected_fail, vec!["clean"]);
+        assert!(r.is_fatal());
+    }
+
+    #[test]
+    fn reconcile_all_expected_is_clean() {
+        let mut res = BTreeMap::new();
+        res.insert("xf".to_owned(), xfail("EAI-1", false));
+        let actual = BTreeMap::from([
+            ("xf".to_owned(), false), // xfail failed as expected
+            ("ok".to_owned(), true),  // untagged pass
+        ]);
+        let r = reconcile(actual.iter(), &res);
+        assert_eq!(r.xfail_count, 1);
+        assert!(!r.is_fatal());
     }
 
     #[test]

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -826,44 +826,37 @@ async fn main() {
     // pass but failed) are failures; expected outcomes are fine. Scenarios that
     // ran but have no id, or ran without a recorded resolution, are treated as
     // expect-pass (a bare failure then fails the run).
-    let mut xpass = Vec::new();
-    let mut unexpected_fail = Vec::new();
-    let mut xfail_count = 0u32;
-    for (id, passed) in &actual {
-        match resolutions.get(id).map(|(exp, _)| exp) {
-            Some(Expectation::ExpectXfail { bug, .. }) => {
-                if *passed {
-                    xpass.push(format!("{id} ({bug})"));
-                } else {
-                    xfail_count += 1;
-                }
-            }
-            // ExpectPass, or no recorded resolution (untagged) → must pass.
-            _ => {
-                if !passed {
-                    unexpected_fail.push(id.clone());
-                }
-            }
-        }
-    }
+    let by_id: BTreeMap<String, Expectation> = resolutions
+        .iter()
+        .map(|(id, (exp, _))| (id.clone(), exp.clone()))
+        .collect();
+    let recon = e2e_cucumber::expectation::reconcile(actual.iter().map(|(id, p)| (id, p)), &by_id);
 
     eprintln!(
-        "Reconciliation: {xfail_count} xfail (failed as expected), {} XPASS, {} unexpected failure(s).",
-        xpass.len(),
-        unexpected_fail.len(),
+        "Reconciliation: {} xfail (failed as expected), {} XPASS ({} flaky, non-fatal), {} unexpected failure(s).",
+        recon.xfail_count,
+        recon.xpass.len() + recon.flaky_xpass.len(),
+        recon.flaky_xpass.len(),
+        recon.unexpected_fail.len(),
     );
-    if !xpass.is_empty() || !unexpected_fail.is_empty() {
-        for x in &xpass {
-            eprintln!(
-                "XPASS: '{x}' is expected to fail on this host but PASSED \u{2014} the bug appears \
-                 fixed here; update expectations.toml.",
-            );
-        }
-        for f in &unexpected_fail {
-            eprintln!(
-                "FAIL: '{f}' was expected to pass on this host but FAILED \u{2014} a regression."
-            );
-        }
+    for x in &recon.flaky_xpass {
+        eprintln!(
+            "XPASS (flaky, non-fatal): '{x}' is a known-flaky xfail that passed this run \u{2014} \
+             the intermittent bug did not reproduce; leaving expectations.toml unchanged.",
+        );
+    }
+    for x in &recon.xpass {
+        eprintln!(
+            "XPASS: '{x}' is expected to fail on this host but PASSED \u{2014} the bug appears \
+             fixed here; update expectations.toml.",
+        );
+    }
+    for f in &recon.unexpected_fail {
+        eprintln!(
+            "FAIL: '{f}' was expected to pass on this host but FAILED \u{2014} a regression."
+        );
+    }
+    if recon.is_fatal() {
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary

The E2E reconciliation gate exits 1 on **any** XPASS. For an intermittent known bug (e.g. EAI-7333 vLLM readiness), a run where the bug doesn't reproduce passes its xfail scenario → counts as XPASS → the required check goes red with **zero real failures**. The `expectations.toml` comments already call these XPASSes "expected and harmless", yet the harness treated them as fatal.

This adds a per-condition `flaky = true` marker so a flaky xfail's XPASS is **reported but non-fatal**. Stale (non-flaky) XPASS and unexpected-FAIL stay fatal, so real regressions and genuinely-fixed bugs are still caught.

## Changes

- **`expectations.toml`**: new optional `flaky = true` key (documented in the grammar header); marked the two EAI-7333 vLLM entries (`serve-vllm-inference`, `serve-readiness-contract`) flaky, citing the runs where they flipped.
- **`src/expectation.rs`**: `flaky` field on `XfailEntry` + `Expectation::ExpectXfail` (`#[serde(default)]`, defaults false). Extracted the exit classification into a pure `reconcile()` → `Reconciliation { is_fatal() }` so the exit-code logic is unit-testable.
- **`tests/e2e.rs`**: exit decision now calls `reconcile()`; flaky XPASS printed as "(flaky, non-fatal)" and excluded from the exit-1 set.

Why not just flip the entries to expect-pass: EAI-7333 is genuinely intermittent (still open), so expect-pass would flip the failure to unexpected-FAIL on the next host/run where the bug resurfaces. The xfail is correct; only its XPASS should be non-fatal.

## Test plan

- [x] `cargo test -p e2e-cucumber --lib` — 18 passed (5 new: flaky parse/default, flaky-XPASS non-fatal, non-flaky-XPASS fatal, unexpected-FAIL always fatal, all-expected clean)
- [x] clippy clean
- [x] Full Linux container gate (clippy + workspace tests + mock E2E suite) green; reconciliation line printed `4 xfail, 0 XPASS (0 flaky, non-fatal), 0 unexpected failure(s)`