### PR TITLE
docs: align public guidance with current support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,10 +630,11 @@ jobs:
           BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.merge_group.base_sha }}
         run: cargo xtask verify-commits --base "$BASE" --require-verified
 
-  # Hardware (real AMD GPU / WSL) smoke tests on dedicated self-hosted runners
-  # are intentionally not part of this workflow yet. See
-  # docs/ci-hardware-testing.md for the planned design; they will land in a
-  # follow-up PR.
+  # Hardware (real AMD GPU) smoke tests run on dedicated self-hosted runners —
+  # see the e2e-gpu, e2e-gpu-strix-ubuntu, and e2e-gpu-strix-windows jobs below.
+  # They are non-blocking (continue-on-error) and fork-safe (self-hosted runners
+  # do not execute untrusted fork PRs). See docs/ci-hardware-testing.md for the
+  # design.
 
   # ── E2E tests (cucumber-rs) ───────────────────────────────────────────────
   #

--- a/README.md
+++ b/README.md
@@ -23,9 +23,22 @@ SPDX-License-Identifier: MIT
 ROCm CLI is a command-line tool for setting up and running local AI on AMD GPUs, with a
 full-screen TUI dashboard for GPU telemetry, model serving, and chat.
 
-A single prebuilt binary for Linux and Windows. No Python, Rust, or existing
-ROCm install required. Ships with inference engine adapters for Lemonade and
-vLLM.
+A single prebuilt binary for Linux and Windows (x86_64). No Python, Rust, or
+existing ROCm install required. Ships with inference engine adapters for
+Lemonade and vLLM.
+
+| Platform | Prebuilt binary | Notes |
+|---|---|---|
+| Linux (x86_64) | Yes | Full support, including the live dashboard and both inference engines |
+| Windows (x86_64) | Yes | Full support |
+| WSL2 (x86_64) | Yes (Linux binary) | Full support, including the live dashboard, except Lemonade (see [docs/engine-plugins.md](docs/engine-plugins.md)); see [docs/wsl.md](docs/wsl.md) for setup |
+| macOS | No | No official installer, release, CI, or QA coverage |
+
+Live dashboard telemetry requires Linux or WSL2 (see
+[Interactive interfaces](#interactive-interfaces)). vLLM serving is Linux/WSL2
+only (see [docs/vllm.md](docs/vllm.md)). Lemonade serving works on Windows and
+Linux, but is currently blocked on WSL2 by a documented upstream Lemonade
+GPU-detector issue (see [docs/engine-plugins.md](docs/engine-plugins.md)).
 
 > [!IMPORTANT]
 > **Tech Preview** -- This software is provided as-is, without warranty or
@@ -60,12 +73,6 @@ The installer downloads a prebuilt bundle, verifies its SHA-256 checksum,
 installs the `rocm` and `rocmd` binaries into `~/.local/bin`, and adds that
 directory to your shell `PATH`. Rerun it any time to upgrade.
 
-> [!NOTE]
-> This repository is currently private, so the `curl | sh` one-liner only works
-> once the repo and its release assets are public. Until then, use the
-> **GitHub CLI fallback** in each section, which downloads through your
-> authenticated session.
-
 ### Linux / WSL (x86_64)
 
 Only nightly builds are published today, so pass the `nightly` channel:
@@ -81,29 +88,6 @@ channel instead:
 curl -fsSL https://raw.githubusercontent.com/ROCm/rocm-cli/main/install.sh | sh
 ```
 
-<details>
-<summary>Fallback while the repo is private (GitHub CLI)</summary>
-
-Install the [GitHub CLI](https://cli.github.com/), authenticate once, then pull
-the release bundle through your authenticated session and install both binaries:
-
-```bash
-gh auth login
-gh release download nightly --repo ROCm/rocm-cli \
-  --pattern 'rocm-cli-nightly-linux-amd64.tar.gz' --output /tmp/rocm-cli.tar.gz --clobber
-tar -xzf /tmp/rocm-cli.tar.gz -C /tmp
-mkdir -p ~/.local/bin
-find /tmp -path '*/bin/rocm*' -type f -exec install -m 0755 {} ~/.local/bin/ \;
-```
-
-If `~/.local/bin` is not already on your `PATH`, add it (and persist it):
-
-```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-```
-</details>
-
 ### Windows (x86_64, PowerShell)
 
 ```powershell
@@ -113,22 +97,6 @@ irm https://raw.githubusercontent.com/ROCm/rocm-cli/main/install.ps1 | iex
 
 Drop the `ROCM_CLI_CHANNEL` line to track the default `release` channel once a
 stable release is published.
-
-<details>
-<summary>Fallback while the repo is private (GitHub CLI)</summary>
-
-```powershell
-gh auth login
-gh release download nightly --repo ROCm/rocm-cli `
-  --pattern "rocm-cli-nightly-windows-amd64.zip" --output "$env:TEMP\rocm-cli.zip" --clobber
-Expand-Archive "$env:TEMP\rocm-cli.zip" "$env:TEMP\rocm-cli" -Force
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.local\bin" | Out-Null
-Get-ChildItem "$env:TEMP\rocm-cli" -Recurse -Filter "rocm*.exe" |
-  Copy-Item -Destination "$env:USERPROFILE\.local\bin"
-```
-
-Add `%USERPROFILE%\.local\bin` to your user `PATH` if it is not already there.
-</details>
 
 ## Build from source
 
@@ -332,8 +300,8 @@ engine (Ryzen AI / Radeon) serves llama.cpp **GGUF** models — pass a GGUF repo
 with an explicit quantization variant, e.g.
 `rocm serve unsloth/Qwen3-0.6B-GGUF:Q4_0`. The vLLM engine (Instinct) serves
 **safetensors** repos, e.g. `rocm serve Qwen/Qwen2.5-1.5B-Instruct`. A
-safetensors-only id has no GGUF build, so serving it through Lemonade fails with
-a clear message rather than silently substituting a different model. Short
+safetensors-only id has no GGUF build, so serving it through Lemonade fails
+rather than silently substituting a different model. Short
 aliases from `rocm model` may not resolve with all engines.
 
 Some models (e.g., Llama) are gated and require HuggingFace authentication.

--- a/README.md
+++ b/README.md
@@ -31,14 +31,12 @@ Lemonade and vLLM.
 |---|---|---|
 | Linux (x86_64) | Yes | Full support, including the live dashboard and both inference engines |
 | Windows (x86_64) | Yes | Full support |
-| WSL2 (x86_64) | Yes (Linux binary) | Full support, including the live dashboard, except Lemonade (see [docs/engine-plugins.md](docs/engine-plugins.md)); see [docs/wsl.md](docs/wsl.md) for setup |
+| WSL2 (x86_64) | Yes (Linux binary) | Full support, including the live dashboard; see [docs/wsl.md](docs/wsl.md) for setup |
 | macOS | No | No official installer, release, CI, or QA coverage |
 
 Live dashboard telemetry requires Linux or WSL2 (see
 [Interactive interfaces](#interactive-interfaces)). vLLM serving is Linux/WSL2
-only (see [docs/vllm.md](docs/vllm.md)). Lemonade serving works on Windows and
-Linux, but is currently blocked on WSL2 by a documented upstream Lemonade
-GPU-detector issue (see [docs/engine-plugins.md](docs/engine-plugins.md)).
+only (see [docs/vllm.md](docs/vllm.md)).
 
 > [!IMPORTANT]
 > **Tech Preview** -- This software is provided as-is, without warranty or

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Lemonade and vLLM.
 | Platform | Prebuilt binary | Notes |
 |---|---|---|
 | Linux (x86_64) | Yes | Full support, including the live dashboard and both inference engines |
-| Windows (x86_64) | Yes | Full support |
+| Windows (x86_64) | Yes | CLI and Lemonade serving; no live dashboard or vLLM |
 | WSL2 (x86_64) | Yes (Linux binary) | Full support, including the live dashboard; see [docs/wsl.md](docs/wsl.md) for setup |
 | macOS | No | No official installer, release, CI, or QA coverage |
 

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -59,11 +59,16 @@ the `heavy` gate, with these inputs:
   `strix-windows` to `e2e-gpu-strix-windows`.
 - `name_filter` (string) — a scenario-name regex forwarded to the cucumber
   harness (`cargo xtask e2e -- --name <regex>`) so a dispatch can run a
-  single scenario instead of the full suite. Empty runs everything
-  applicable to the selected platform(s).
+  single scenario instead of the full suite. Only wired into the three
+  self-hosted GPU jobs (`e2e-gpu`, `e2e-gpu-strix-ubuntu`,
+  `e2e-gpu-strix-windows`); `platform=mock` always runs the full mock suite
+  and ignores it. Empty runs everything applicable to the selected
+  platform(s).
 - `include_nightly` (boolean, default `false`) — opts a dispatch into
   `@nightly`-tagged scenarios (e.g. large-model serves, cold installs) that
-  are otherwise skipped on a normal push/PR run to keep it fast.
+  are otherwise skipped on a normal push/PR run to keep it fast. Same scope
+  as `name_filter`: only the three self-hosted GPU jobs read it;
+  `platform=mock` ignores it.
 
 A manual dispatch skips the hosted `build-and-test` job for a faster loop; the
 E2E jobs run directly against the dispatched ref.

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -4,7 +4,7 @@ Copyright © Advanced Micro Devices, Inc., or its affiliates.
 SPDX-License-Identifier: MIT
 -->
 
-# CI hardware (GPU / WSL) testing
+# CI hardware (GPU) testing
 
 The hosted CI (`ubuntu-latest`, `windows-latest`) builds and unit-tests every
 shipping target natively, but GitHub-hosted runners have no AMD GPU. A

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -4,59 +4,93 @@ Copyright © Advanced Micro Devices, Inc., or its affiliates.
 SPDX-License-Identifier: MIT
 -->
 
-# CI hardware (GPU / WSL) testing — planned
+# CI hardware (GPU / WSL) testing
 
 The hosted CI (`ubuntu-latest`, `windows-latest`) builds and unit-tests every
-shipping target natively. By design it cannot exercise two things:
+shipping target natively, but GitHub-hosted runners have no AMD GPU. A
+dedicated hardware layer in `.github/workflows/ci.yml` covers that gap by
+running the same cucumber-rs E2E suite on dedicated self-hosted runners with
+real AMD GPUs.
 
-- **Real AMD GPU execution** — GitHub-hosted runners have no AMD GPU.
-- **Real WSL behaviour** — the Windows↔WSL interop path needs an actual WSL host.
+## Platforms
 
-A dedicated hardware-test layer covers exactly those gaps. It is **not** part of
-the CI workflow yet; it will be introduced in a follow-up PR. This document
-records the intended design so it can be reviewed and wired up as a unit.
+The E2E suite (BDD scenarios in Gherkin `.feature` files backed by Rust step
+functions) runs as one job per platform. Each job's harness resolves every
+scenario to pass / xfail / skip for that host from its `@id` and
+`@requires-*` tags, a capability probe, and `expectations.toml` — there is no
+separate tier flag or tag filter to maintain.
 
-## Design
-
-1. **Build once on hosted runners.** The hosted `build-and-test` (Linux) and
-   `windows-build-and-test` (Windows) jobs publish their per-OS binaries
-   (`rocm`, `rocmd`, `rocm-engine-*`) as workflow artifacts.
-2. **Test on dedicated self-hosted runners.** Hardware-test jobs download those
-   exact artifacts and run only the checks hosted runners cannot: `rocm examine`
-   host/GPU detection, engine `detect`/`capabilities`, the no-CPU-fallback
-   smoke (`scripts/smoke_local.py --skip-build`), and the
-   `scripts/*_therock_gpu_test.py` end-to-end GPU harnesses.
-
-### Targets
-
-| Target | Runner | Notes |
+| Job | Platform | Runner labels |
 |---|---|---|
-| Pure Windows 11 (gfx1151) | self-hosted Windows + AMD GPU | consumes the Windows artifact |
-| AMD Instinct, bare-metal | self-hosted Linux + Instinct GPU | consumes the Linux artifact |
-| Ubuntu on WSL (primary) | self-hosted Windows + WSL | consumes the Linux artifact in WSL |
-| Fedora on WSL (secondary) | self-hosted Windows + WSL | builds in-WSL to match the distro's glibc |
+| `e2e` | Mock (no GPU) | GitHub-hosted `ubuntu-latest` |
+| `e2e-gpu` | MI300X (AMD Instinct, bare-metal Linux) | self-hosted `[self-hosted, linux, amd-gpu]` |
+| `e2e-gpu-strix-ubuntu` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, strix-halo]` |
+| `e2e-gpu-strix-windows` | Strix Halo (gfx1151) on native Windows 11 | self-hosted `[self-hosted, windows, strix-halo]` |
 
-### Guards
+`e2e` is the blocking, GitHub-hosted mock job: `@requires-gpu` scenarios
+resolve to skip here, and known bugs resolve to xfail from
+`expectations.toml`. It is a required check and must stay green.
 
-Each hardware-test job is:
+The three GPU jobs (`e2e-gpu`, `e2e-gpu-strix-ubuntu`, `e2e-gpu-strix-windows`)
+run on dedicated self-hosted runners with a real AMD GPU attached, so they
+exercise host/GPU detection, engine `detect`/`capabilities`, and live serving
+scenarios that the mock job cannot.
 
-- **Opt-in** via a repository/org variable (`ENABLE_WIN11_GPU_CI`,
-  `ENABLE_INSTINCT_CI`, `ENABLE_WSL_UBUNTU_CI`, `ENABLE_WSL_FEDORA_CI`) so it is
-  enabled per target as each runner is wired into the repo.
-- **Non-blocking** (`continue-on-error: true`) — a hardware result never gates a PR.
-- **Fork-safe** — self-hosted runners do not execute untrusted fork PRs.
+An `e2e-report` job consolidates every platform's report — including partial
+or failed runs — into one HTML report and GitHub step summary, joined by
+scenario id, so the (scenario × platform) expectation grid is visible in one
+place.
+
+## Triggers
+
+The GPU jobs run automatically on `push`, `pull_request`, and `merge_group`
+when both of the following hold:
+
+- the `changes` job's `heavy` path filter is `true` (the change touches code
+  that can affect runtime behavior, not just docs or unrelated files), and
+- the hosted `build-and-test` job succeeded.
+
+They can also be triggered manually via `workflow_dispatch`, independent of
+the `heavy` gate, with these inputs:
+
+- `platform` (choice: `all`, `mock`, `app-dev-gpu`, `strix-ubuntu`,
+  `strix-windows`) — which job(s) to run. `mock` maps to `e2e`,
+  `app-dev-gpu` to `e2e-gpu`, `strix-ubuntu` to `e2e-gpu-strix-ubuntu`, and
+  `strix-windows` to `e2e-gpu-strix-windows`.
+- `name_filter` (string) — a scenario-name regex forwarded to the cucumber
+  harness (`cargo xtask e2e -- --name <regex>`) so a dispatch can run a
+  single scenario instead of the full suite. Empty runs everything
+  applicable to the selected platform(s).
+- `include_nightly` (boolean, default `false`) — opts a dispatch into
+  `@nightly`-tagged scenarios (e.g. large-model serves, cold installs) that
+  are otherwise skipped on a normal push/PR run to keep it fast.
+
+A manual dispatch skips the hosted `build-and-test` job for a faster loop; the
+E2E jobs run directly against the dispatched ref.
+
+## Blocking vs. non-blocking
+
+Only `e2e` (the GitHub-hosted mock job) is a required, blocking check. The
+three hardware jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`, and
+`e2e-gpu-strix-windows` — all run with `continue-on-error: true`, so a
+hardware failure never gates a PR merge. Their results still surface in the
+consolidated `e2e-report` for visibility.
+
+## Fork safety
+
+Self-hosted runners are not used for untrusted fork pull requests: GitHub
+does not dispatch self-hosted-runner jobs from an external fork's
+`pull_request` event without explicit approval. The hardware jobs only run
+against branches and PRs within the repository (and on `workflow_dispatch`,
+which requires write access to trigger).
 
 ## Notes
 
-- These jobs run **debug** binaries: they assert functional behaviour (device
-  detection, engine launch, policy enforcement), not performance, so the
-  debug-vs-release difference does not affect what they check. Release-fidelity,
-  optimized validation already lives in the nightly/release pipeline, which
-  builds `manylinux2014` (glibc 2.17) binaries.
-- Linux artifacts are built on `ubuntu-latest`; a consuming runner on an older
-  distro must have a compatible (≥) glibc, otherwise it should build in-place
-  (as the Fedora-on-WSL target does).
-
-The layer will be enabled end-to-end in a follow-up PR once the self-hosted
-runners are connected to the repository and each path has been validated against
-real hardware.
+- The hardware jobs build and run **release** binaries: they assert
+  functional behavior (device detection, engine launch, policy enforcement),
+  not performance, so this is not a performance benchmark. Release-fidelity,
+  `manylinux2014` (glibc 2.17) packaging validation is handled separately by
+  the nightly/release pipeline.
+- `e2e-report` collects whatever ran, including partial results from a
+  cancelled or failed job, and renders one HTML report plus a step summary so
+  all platforms are visible together.

--- a/docs/engine-plugins.md
+++ b/docs/engine-plugins.md
@@ -28,9 +28,9 @@ only the built-in `lemonade` and `vllm` engines. Discovery still lists external
 plugins under the search directories above, but selecting one by name from the
 CLI is not supported while the engine set is limited to the two built-ins.
 
-The `lemonade` adapter uses Lemonade embeddable and requires Lemonade's
-`llamacpp:rocm` backend. rocm-cli does not use a CPU or Vulkan fallback for
-this path.
+The `lemonade` adapter uses Lemonade embeddable and prefers Lemonade's
+`llamacpp:rocm` backend, falling back to `llamacpp:vulkan` when ROCm is
+unsupported. rocm-cli does not use a CPU fallback for this path.
 
 `rocm engines list` shows the exact plugin directories for the current host.
 The same output is available in the TUI with `/engine`.

--- a/docs/engine-plugins.md
+++ b/docs/engine-plugins.md
@@ -29,10 +29,8 @@ plugins under the search directories above, but selecting one by name from the
 CLI is not supported while the engine set is limited to the two built-ins.
 
 The `lemonade` adapter uses Lemonade embeddable and requires Lemonade's
-`llamacpp:rocm` backend. Windows ROCm serving is validated. WSL is currently
-blocked by Lemonade v10.6.0 reporting no AMD GPU through its own detector even
-when TheRock/librocdxg works; rocm-cli does not use CPU or Vulkan fallback for
-that path.
+`llamacpp:rocm` backend. rocm-cli does not use a CPU or Vulkan fallback for
+this path.
 
 `rocm engines list` shows the exact plugin directories for the current host.
 The same output is available in the TUI with `/engine`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -84,9 +84,9 @@ cargo build --workspace --release
 cargo test --workspace
 ```
 
-On WSL/Linux, build and run the native Linux binary directly (no APE launcher
-prefix is required). The examine output on WSL must include `os: linux` and
-`wsl: true`, and must not include `os: windows`.
+On WSL/Linux, build and run the native Linux binary directly. The examine
+output on WSL must include `os: linux` and `wsl: true`, and must not include
+`os: windows`.
 
 Use isolated `ROCM_CLI_CONFIG_DIR`, `ROCM_CLI_DATA_DIR`, and
 `ROCM_CLI_CACHE_DIR` roots for smoke tests, then delete those roots after the


### PR DESCRIPTION
## Summary
- replace obsolete private-repository installation guidance with the public installer paths
- document current platform and inference-engine support boundaries
- update hardware CI documentation to match the existing self-hosted GPU jobs and remove obsolete APE-era wording
- Why: public documentation still described earlier private and planned states that no longer match the repository
- Risk: low — documentation and workflow comments only; no CI behavior changes

## Test plan
- `prek run --all-files --no-group local-tools`
- verified Markdown headers and relative links
- cross-checked platform claims against the installers, engine documentation, dashboard transport, and release targets
- cross-checked hardware job names, runner labels, trigger gates, and blocking behavior against `.github/workflows/ci.yml`
- scanned the final diff for stale wording and non-public references

## Scope
- leaves the existing release-trust, security, and contribution policies unchanged because their current-state guidance remains accurate