### PR TITLE
ci: stabilize GPU E2E and merge queue

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+    types: [checks_requested]
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python, rust]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -617,6 +617,9 @@ struct ManifestExpectation {
     bug: Option<String>,
     #[serde(default)]
     reason: Option<String>,
+    /// Non-deterministic known bug: an XPASS is expected and non-fatal.
+    #[serde(default)]
+    flaky: bool,
 }
 
 /// Read a platform's `platform.json` (sibling of `report.json`). Missing =
@@ -639,8 +642,10 @@ enum CellOutcome {
     Skip,
     /// Expected pass, but FAILED — a real regression.
     UnexpectedFail,
-    /// Expected xfail, but PASSED — stale entry (bug fixed here?).
+    /// Expected deterministic xfail, but PASSED — stale entry (bug fixed here?).
     Xpass,
+    /// Flaky xfail passed this run — expected for a non-deterministic known bug.
+    FlakyXpass,
     /// Expected skip, yet a result exists — harness/resolver disagreement.
     RanWhenNa,
     /// Expected to run (pass or xfail) but NO result was recorded — the scenario
@@ -655,12 +660,13 @@ impl CellOutcome {
     /// Reconcile one scenario's expectation against its actual result.
     /// `actual` is `Some(passed)` when the scenario ran, `None` when it did not
     /// appear in `report.json` (filtered out / skipped).
-    fn reconcile(expected: &str, actual: Option<bool>) -> Self {
+    fn reconcile(expected: &str, flaky: bool, actual: Option<bool>) -> Self {
         match (expected, actual) {
             ("pass", Some(true)) => Self::Pass,
             ("pass", Some(false)) => Self::UnexpectedFail,
             ("pass", None) => Self::Absent,
             ("xfail", Some(false)) => Self::Xfail,
+            ("xfail", Some(true)) if flaky => Self::FlakyXpass,
             ("xfail", Some(true)) => Self::Xpass,
             ("xfail", None) => Self::Absent,
             ("skip", None) => Self::Skip,
@@ -686,6 +692,7 @@ impl CellOutcome {
             Self::Skip => "n/a",
             Self::UnexpectedFail => "❌FAIL",
             Self::Xpass => "⚠️XPASS",
+            Self::FlakyXpass => "✅XPASS (flaky)",
             Self::RanWhenNa => "⚠️n/a-ran",
             Self::Absent => "⚠️no-result",
             Self::Missing => "·",
@@ -765,7 +772,8 @@ impl Grid {
                 if !ids.contains(&exp.id) {
                     ids.push(exp.id.clone());
                 }
-                let outcome = CellOutcome::reconcile(&exp.expected, actual.get(&exp.id).copied());
+                let outcome =
+                    CellOutcome::reconcile(&exp.expected, exp.flaky, actual.get(&exp.id).copied());
                 // A real result supersedes a defensive Missing on merge.
                 columns[col_idx]
                     .outcomes
@@ -853,10 +861,11 @@ fn reconciled_tally(json_path: &Path) -> Option<ReconciledTally> {
     let actual = id_pass_map(json_path);
     let mut t = ReconciledTally::default();
     for exp in &manifest.expectations {
-        match CellOutcome::reconcile(&exp.expected, actual.get(&exp.id).copied()) {
+        match CellOutcome::reconcile(&exp.expected, exp.flaky, actual.get(&exp.id).copied()) {
             CellOutcome::Pass => t.pass += 1,
             CellOutcome::Xfail => t.xfail += 1,
             CellOutcome::Skip => t.skip += 1,
+            CellOutcome::FlakyXpass => t.pass += 1,
             CellOutcome::UnexpectedFail
             | CellOutcome::Xpass
             | CellOutcome::RanWhenNa
@@ -2281,18 +2290,20 @@ mod tests {
     #[test]
     fn cell_outcome_reconciliation() {
         use CellOutcome as C;
-        assert_eq!(C::reconcile("pass", Some(true)), C::Pass);
-        assert_eq!(C::reconcile("pass", Some(false)), C::UnexpectedFail);
-        assert_eq!(C::reconcile("xfail", Some(false)), C::Xfail);
-        assert_eq!(C::reconcile("xfail", Some(true)), C::Xpass);
-        assert_eq!(C::reconcile("skip", None), C::Skip);
-        assert_eq!(C::reconcile("skip", Some(true)), C::RanWhenNa);
+        assert_eq!(C::reconcile("pass", false, Some(true)), C::Pass);
+        assert_eq!(C::reconcile("pass", false, Some(false)), C::UnexpectedFail);
+        assert_eq!(C::reconcile("xfail", false, Some(false)), C::Xfail);
+        assert_eq!(C::reconcile("xfail", false, Some(true)), C::Xpass);
+        assert_eq!(C::reconcile("xfail", true, Some(true)), C::FlakyXpass);
+        assert_eq!(C::reconcile("skip", false, None), C::Skip);
+        assert_eq!(C::reconcile("skip", false, Some(true)), C::RanWhenNa);
         // A declared expect-pass/xfail with NO result is Absent (a problem), so a
         // hung/lost-results run reds the platform instead of greenwashing to PASS.
-        assert_eq!(C::reconcile("pass", None), C::Absent);
-        assert_eq!(C::reconcile("xfail", None), C::Absent);
+        assert_eq!(C::reconcile("pass", false, None), C::Absent);
+        assert_eq!(C::reconcile("xfail", true, None), C::Absent);
         assert!(C::UnexpectedFail.is_problem());
         assert!(C::Xpass.is_problem());
+        assert!(!C::FlakyXpass.is_problem());
         assert!(C::RanWhenNa.is_problem());
         assert!(C::Absent.is_problem());
         assert!(!C::Pass.is_problem());
@@ -2360,6 +2371,29 @@ mod tests {
         assert!(
             md.contains("**XPASS** on `strix-halo`: `serve-default` (EAI-7333)"),
             "needs-attention should list the XPASS with bug:\n{md}"
+        );
+    }
+
+    #[test]
+    fn grid_tolerates_flaky_xpass() {
+        let report = feature_json(&[(&["id:serve-flaky"], &["passed"])]);
+        let platform = r#"{
+            "platform_slug": "mi300x",
+            "capability": {"effective_serve_engine": "vllm"},
+            "expectations": [
+                {"id":"serve-flaky","effective_engine":"vllm","expected":"xfail","bug":"EAI-7333","reason":"readiness race","flaky":true}
+            ]
+        }"#;
+        let (_d, path) = write_platform(&report, platform);
+        let inputs = vec![("mi300x".to_string(), path)];
+        let md = consolidated_summary_markdown(&inputs);
+        assert!(
+            md.contains("✅XPASS (flaky)"),
+            "grid should show tolerated flaky XPASS:\n{md}"
+        );
+        assert!(
+            !md.contains("**XPASS** on"),
+            "flaky XPASS must not need attention:\n{md}"
         );
     }
 

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -2300,6 +2300,9 @@ mod tests {
         // A declared expect-pass/xfail with NO result is Absent (a problem), so a
         // hung/lost-results run reds the platform instead of greenwashing to PASS.
         assert_eq!(C::reconcile("pass", false, None), C::Absent);
+        assert_eq!(C::reconcile("xfail", false, None), C::Absent);
+        // Flaky does not excuse a missing result either: it licenses an XPASS,
+        // not the absence of any outcome for a scenario the matrix declares.
         assert_eq!(C::reconcile("xfail", true, None), C::Absent);
         assert!(C::UnexpectedFail.is_problem());
         assert!(C::Xpass.is_problem());

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -100,8 +100,10 @@ Known bugs are **not** tagged in the `.feature` files — they live in
 `expectations.toml`, keyed by `@id`, each with a `when = { ... }` condition (e.g.
 `effective_engine = "vllm"`), a `bug` reference, and a `reason`. A scenario that
 matches a condition is expected to fail (xfail); if it then passes, that is an
-**XPASS** (stale entry — remove it). See `src/expectation.rs` for the resolver
-and `expectations.toml`'s header for the condition grammar.
+**XPASS**. Deterministic XPASS is stale and must be removed; entries marked
+`flaky = true` tolerate either outcome while still reporting the intermittent
+bug. See `src/expectation.rs` for the resolver and `expectations.toml`'s header
+for the condition grammar.
 
 CI runs one job per platform, each executing the full suite:
 

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -105,6 +105,14 @@ matches a condition is expected to fail (xfail); if it then passes, that is an
 bug. See `src/expectation.rs` for the resolver and `expectations.toml`'s header
 for the condition grammar.
 
+On a GPU host, a `serve` precondition that never publishes its model is
+relaunched once — but only for a scenario expected to pass; a known bug keeps its
+shortened `serve_timeout_secs` and fails on the first attempt. The stalled
+service is stopped (whole engine process tree) before the relaunch, so the second
+serve does not compete with the first for device memory, and the failure quotes
+the service log tail plus the device's free-VRAM state, which is where the
+engine's own reason for the stall is recorded.
+
 CI runs one job per platform, each executing the full suite:
 
 | Job | Platform | Blocking |

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -41,19 +41,9 @@ reason = "Engines do not report a consistent resolved model name for a short nam
 [["serve-vllm-inference"]]
 when = { effective_engine = "vllm" }
 bug = "EAI-7333"
-reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completions is refused."
+reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completions is refused intermittently."
 serve_timeout_secs = 90
-
-# Default-engine serve is RECIPE-driven, not host-driven: `rocm serve <model>`
-# with no --engine resolves to the recipe's preferred model+engine. On an Instinct
-# host (effective_engine=vllm) the request resolves to a GGUF recipe on lemonade,
-# whose llama.cpp Vulkan backend hangs on Instinct (EAI-7052) → the endpoint never
-# becomes ready. (Not EAI-7333: the default serve doesn't use vLLM at all here.)
-[["serve-default-engine-working-endpoint"]]
-when = { effective_engine = "vllm" }
-bug = "EAI-7052"
-reason = "Default serve resolves to a GGUF recipe on lemonade; its Vulkan backend hangs on Instinct, so the endpoint never reaches ready."
-serve_timeout_secs = 90
+flaky = true
 
 # On a lemonade-native LINUX host (Strix Halo Ubuntu) the lemonade managed serve
 # loads the model and reaches ready on :8001, then is shut down ~0.08s later, so
@@ -65,12 +55,6 @@ serve_timeout_secs = 90
 when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the endpoint never becomes reachable."
-serve_timeout_secs = 90
-
-[["serve-default-engine-inference"]]
-when = { effective_engine = "vllm" }
-bug = "EAI-7052"
-reason = "Default serve resolves to a GGUF recipe on lemonade; its Vulkan backend hangs on Instinct, so inference never succeeds."
 serve_timeout_secs = 90
 
 # On a lemonade-native LINUX host the served model's endpoint drops before
@@ -94,6 +78,7 @@ when = { effective_engine = "vllm" }
 bug = "EAI-7333"
 reason = "CLI reports the vLLM service ready, but an immediate inference request races the model load and intermittently fails."
 serve_timeout_secs = 90
+flaky = true
 
 # On a lemonade LINUX host this scenario does a real lemonade serve, which reaches
 # ready then shuts down immediately (EAI-7423, see serve-lemonade-inference).

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -33,8 +33,13 @@ pub enum Expectation {
     /// Must pass; a failure is a real regression.
     ExpectPass,
     /// Declared known bug that reproduces on this host; failing is the expected
-    /// outcome, passing is an XPASS (stale entry).
-    ExpectXfail { bug: String, reason: String },
+    /// outcome. A deterministic pass is a stale XPASS; a `flaky` expectation
+    /// tolerates either result while the intermittent bug remains open.
+    ExpectXfail {
+        bug: String,
+        reason: String,
+        flaky: bool,
+    },
     /// Not applicable on this host (e.g. required engine can't start); skipped.
     Skip { reason: String },
 }
@@ -173,6 +178,9 @@ pub struct XfailEntry {
     pub reason: String,
     #[serde(default)]
     pub serve_timeout_secs: Option<u64>,
+    /// Non-deterministic known bug: an XPASS is expected and non-fatal.
+    #[serde(default)]
+    pub flaky: bool,
 }
 
 /// The parsed `expectations.toml`: scenario-id → list of xfail conditions (OR).
@@ -236,14 +244,18 @@ pub struct ResolvedScenario {
     pub bug: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub flaky: bool,
 }
 
 impl ResolvedScenario {
     pub fn new(id: &str, effective_engine: &str, expectation: &Expectation) -> Self {
-        let (bug, reason) = match expectation {
-            Expectation::ExpectXfail { bug, reason } => (Some(bug.clone()), Some(reason.clone())),
-            Expectation::Skip { reason } => (None, Some(reason.clone())),
-            Expectation::ExpectPass => (None, None),
+        let (bug, reason, flaky) = match expectation {
+            Expectation::ExpectXfail { bug, reason, flaky } => {
+                (Some(bug.clone()), Some(reason.clone()), *flaky)
+            }
+            Expectation::Skip { reason } => (None, Some(reason.clone()), false),
+            Expectation::ExpectPass => (None, None, false),
         };
         Self {
             id: id.to_owned(),
@@ -251,6 +263,7 @@ impl ResolvedScenario {
             expected: expectation.label().to_owned(),
             bug,
             reason,
+            flaky,
         }
     }
 }
@@ -325,6 +338,7 @@ pub fn resolve(
                 return Expectation::ExpectXfail {
                     bug: entry.bug.clone(),
                     reason: entry.reason.clone(),
+                    flaky: entry.flaky,
                 };
             }
         }

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -217,6 +217,20 @@ impl Expectations {
             .filter_map(|e| e.serve_timeout_secs)
             .min()
     }
+
+    /// Whether any declared condition for this scenario matches this host — the
+    /// scenario is a known bug here and failing is its expected outcome.
+    ///
+    /// This is the same test [`resolve`] applies in its xfail step, exposed on
+    /// its own so a step can ask "is this run expected to fail?" without
+    /// re-deriving applicability. Steps use it to spend effort where it changes
+    /// a result: a serve backing an expect-pass scenario is worth relaunching
+    /// after a stall, one backing a known bug is not.
+    pub fn is_xfail(&self, id: &str, cap: &HostCapability, effective_engine: &str) -> bool {
+        self.entries_for(id)
+            .iter()
+            .any(|e| e.when.matches(cap, effective_engine))
+    }
 }
 
 /// Serializable outcome label for a resolved scenario (for `platform.json`).
@@ -691,6 +705,28 @@ serve_timeout_secs = 90
         );
         // Unknown id → no override.
         assert_eq!(m.serve_timeout_for("nope", &cap("mi300x"), "vllm"), None);
+    }
+
+    #[test]
+    fn is_xfail_follows_the_matching_condition() {
+        let m = Expectations::parse(
+            r#"
+[["serve-default-engine-inference"]]
+when = { effective_engine = "vllm" }
+bug = "EAI-7333"
+reason = "vLLM readiness gap"
+"#,
+        )
+        .unwrap();
+        assert!(m.is_xfail("serve-default-engine-inference", &cap("mi300x"), "vllm"));
+        // A condition that doesn't match this host leaves the scenario expect-pass.
+        assert!(!m.is_xfail(
+            "serve-default-engine-inference",
+            &cap("strix-windows"),
+            "lemonade"
+        ));
+        // No entry at all → expect-pass.
+        assert!(!m.is_xfail("nope", &cap("mi300x"), "vllm"));
     }
 
     #[test]

--- a/tests/e2e-cucumber/src/lib.rs
+++ b/tests/e2e-cucumber/src/lib.rs
@@ -7,6 +7,7 @@ pub mod expectation;
 pub mod mock_server;
 pub mod model_id;
 pub mod panic_capture;
+pub mod serve_log;
 
 pub fn chat_response_is_successful(response: &serde_json::Value) -> bool {
     response

--- a/tests/e2e-cucumber/src/model_id.rs
+++ b/tests/e2e-cucumber/src/model_id.rs
@@ -22,10 +22,24 @@ pub fn model_ids_match(response: &str, expected: &str) -> bool {
 }
 
 fn normalize_model_id(id: &str) -> (Option<String>, String) {
-    let without_variant = id.split_once(':').map_or(id, |(model, _)| model);
-    let (org, model) = without_variant
-        .rsplit_once('/')
-        .map_or((None, without_variant), |(org, model)| (Some(org), model));
+    // Lemonade may return the absolute cache path to the concrete GGUF rather
+    // than a model id. Normalize Windows separators and treat paths as basename-
+    // only: their parent directories are cache internals, not model organizations.
+    let normalized = id.replace('\\', "/");
+    let slash_count = normalized.matches('/').count();
+    let is_absolute_path = normalized.starts_with('/')
+        || normalized.as_bytes().get(1) == Some(&b':')
+        || slash_count > 1;
+    let (org, model) = if is_absolute_path {
+        (None, normalized.rsplit('/').next().unwrap_or(&normalized))
+    } else {
+        let without_variant = normalized
+            .split_once(':')
+            .map_or(normalized.as_str(), |(model, _)| model);
+        without_variant
+            .rsplit_once('/')
+            .map_or((None, without_variant), |(org, model)| (Some(org), model))
+    };
     let mut base = model.to_ascii_lowercase();
     if let Some(stripped) = base.strip_suffix(".gguf") {
         base = stripped.to_owned();
@@ -58,6 +72,14 @@ mod tests {
         assert!(model_ids_match(
             "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
             "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL"
+        ));
+    }
+
+    #[test]
+    fn matches_windows_cache_path_to_catalog_model() {
+        assert!(model_ids_match(
+            r"C:\WINDOWS\ServiceProfiles\NetworkService\.cache\huggingface\hub\models--unsloth--Qwen3-0.6B-GGUF\snapshots\50968a\Qwen3-0.6B-Q4_0.gguf",
+            "Qwen3-0.6B-GGUF"
         ));
     }
 

--- a/tests/e2e-cucumber/src/model_id.rs
+++ b/tests/e2e-cucumber/src/model_id.rs
@@ -21,17 +21,36 @@ pub fn model_ids_match(response: &str, expected: &str) -> bool {
     response_base.contains(&expected_base) || expected_base.contains(&response_base)
 }
 
+/// The organization a HuggingFace cache path encodes, if any.
+///
+/// The hub stores the repo id `<org>/<model>` as one `models--<org>--<model>`
+/// directory, so a cache path still names the organization even though its own
+/// path separators are cache internals. Recovering it keeps the wrong-org guard
+/// live for path-shaped ids. `None` when no such segment exists, or when the
+/// repo has no organization (`models--gpt2`).
+fn path_organization(path: &str) -> Option<&str> {
+    path.split('/')
+        .find_map(|segment| segment.strip_prefix("models--"))
+        .and_then(|repo| repo.split_once("--"))
+        .map(|(org, _model)| org)
+}
+
 fn normalize_model_id(id: &str) -> (Option<String>, String) {
     // Lemonade may return the absolute cache path to the concrete GGUF rather
-    // than a model id. Normalize Windows separators and treat paths as basename-
-    // only: their parent directories are cache internals, not model organizations.
+    // than a model id. Normalize Windows separators and take the basename as the
+    // model: the parent directories are cache internals. The organization is the
+    // exception — the `models--<org>--<model>` segment carries it, so recover it
+    // rather than dropping the wrong-org check for every path-shaped id.
     let normalized = id.replace('\\', "/");
     let slash_count = normalized.matches('/').count();
     let is_absolute_path = normalized.starts_with('/')
         || normalized.as_bytes().get(1) == Some(&b':')
         || slash_count > 1;
     let (org, model) = if is_absolute_path {
-        (None, normalized.rsplit('/').next().unwrap_or(&normalized))
+        (
+            path_organization(&normalized),
+            normalized.rsplit('/').next().unwrap_or(&normalized),
+        )
     } else {
         let without_variant = normalized
             .split_once(':')
@@ -96,6 +115,35 @@ mod tests {
         assert!(!model_ids_match(
             "another-owner/Qwen3.6-35B-A3B-Q4_K_M.gguf",
             "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M"
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_organization_named_by_a_cache_path() {
+        // The hub encodes the repo id in the `models--<org>--<model>` segment, so
+        // a path-shaped response still names its organization and must be held to
+        // it — otherwise any path would bypass the check above.
+        assert!(!model_ids_match(
+            r"C:\WINDOWS\ServiceProfiles\NetworkService\.cache\huggingface\hub\models--another-owner--Qwen3-0.6B-GGUF\snapshots\50968a\Qwen3-0.6B-Q4_0.gguf",
+            "unsloth/Qwen3-0.6B-GGUF"
+        ));
+    }
+
+    #[test]
+    fn accepts_matching_organization_named_by_a_cache_path() {
+        assert!(model_ids_match(
+            "/home/runner/.cache/huggingface/hub/models--unsloth--Qwen3-0.6B-GGUF/snapshots/50968a/Qwen3-0.6B-Q4_0.gguf",
+            "unsloth/Qwen3-0.6B-GGUF"
+        ));
+    }
+
+    #[test]
+    fn cache_path_without_an_organization_keeps_matching() {
+        // `models--<model>` (no organization) leaves the org unknown rather than
+        // inventing one, so the basename comparison still decides.
+        assert!(model_ids_match(
+            "/root/.cache/huggingface/hub/models--Qwen3-0.6B-GGUF/snapshots/50968a/Qwen3-0.6B-Q4_0.gguf",
+            "unsloth/Qwen3-0.6B-GGUF"
         ));
     }
 }

--- a/tests/e2e-cucumber/src/serve_log.rs
+++ b/tests/e2e-cucumber/src/serve_log.rs
@@ -40,9 +40,19 @@ pub fn service_log_tail(serve_stdout: &str) -> String {
     let Some(path) = parse_log_path(serve_stdout) else {
         return "<no log_path in serve output>".to_owned();
     };
-    match std::fs::read_to_string(path) {
-        Ok(log) if log.trim().is_empty() => format!("<{path} is empty>"),
-        Ok(log) => tail_lines(&log, DEFAULT_TAIL_LINES),
+    // Read bytes, not a `String`: an engine log carries progress bars and ANSI
+    // and can hold a partially written multi-byte sequence, so a strict UTF-8
+    // read would discard the whole tail over one bad byte — in precisely the
+    // failure this exists to explain. Replace the bad bytes and quote the rest.
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let log = String::from_utf8_lossy(&bytes);
+            if log.trim().is_empty() {
+                format!("<{path} is empty>")
+            } else {
+                tail_lines(&log, DEFAULT_TAIL_LINES)
+            }
+        }
         Err(error) => format!("<failed to read {path}: {error}>"),
     }
 }
@@ -95,6 +105,27 @@ managed service launched
         assert_eq!(
             service_log_tail(&stdout),
             "boot\nENGINE ERROR: out of memory"
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_still_yields_the_tail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("service.log");
+        // A truncated multi-byte sequence, as a killed engine's part-written
+        // progress bar leaves behind. The readable lines must survive it.
+        let mut bytes = b"loading weights \xff\xfe\nENGINE ERROR: out of memory\n".to_vec();
+        bytes.extend_from_slice(b"\xe2\x82");
+        std::fs::write(&path, &bytes).expect("write log");
+        let stdout = format!("  log_path: {}\n", path.display());
+        let reported = service_log_tail(&stdout);
+        assert!(
+            reported.contains("ENGINE ERROR: out of memory"),
+            "tail lost to invalid UTF-8: {reported}"
+        );
+        assert!(
+            reported.starts_with("loading weights "),
+            "unexpected tail: {reported}"
         );
     }
 

--- a/tests/e2e-cucumber/src/serve_log.rs
+++ b/tests/e2e-cucumber/src/serve_log.rs
@@ -1,0 +1,123 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Reading back the log a managed serve wrote, for failure diagnostics.
+//!
+//! When `rocm serve --managed` returns `readiness: starting` and the model never
+//! appears on `/v1/models`, the harness sees only a timeout: the engine's own
+//! reason (an out-of-memory at engine init, a stalled weight download, a runtime
+//! that failed to import) is written to the service log in a per-scenario temp
+//! directory that no report artifact captures. Quoting its tail into the failure
+//! is what makes such a stall diagnosable from CI output alone.
+
+/// How many trailing lines of a stalled service's log to quote in a failure.
+const DEFAULT_TAIL_LINES: usize = 40;
+
+/// The `log_path:` a `rocm serve --managed` plan reports for the service it
+/// launched, if the output carries one.
+fn parse_log_path(serve_stdout: &str) -> Option<&str> {
+    serve_stdout
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("log_path:"))
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+}
+
+/// The last `max` lines of `text`.
+fn tail_lines(text: &str, max: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    lines[lines.len().saturating_sub(max)..].join("\n")
+}
+
+/// The tail of the log written by the managed service `serve_stdout` launched.
+///
+/// Never fails: every reason the log can't be quoted (no `log_path` line, the
+/// file is missing or unreadable, the engine wrote nothing) becomes part of the
+/// returned text, because this only ever runs while reporting another failure.
+#[must_use]
+pub fn service_log_tail(serve_stdout: &str) -> String {
+    let Some(path) = parse_log_path(serve_stdout) else {
+        return "<no log_path in serve output>".to_owned();
+    };
+    match std::fs::read_to_string(path) {
+        Ok(log) if log.trim().is_empty() => format!("<{path} is empty>"),
+        Ok(log) => tail_lines(&log, DEFAULT_TAIL_LINES),
+        Err(error) => format!("<failed to read {path}: {error}>"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_log_path, service_log_tail, tail_lines};
+
+    const SERVE_PLAN: &str = "\
+serve plan
+  requested model: Qwen/Qwen3.5-0.8B
+  engine: vllm
+managed service launched
+  service_id: vllm-qwen-qwen3-5-0-8b-1785145816856
+  log_path: /tmp/rocm-e2e-abc123/data/services/vllm-qwen.log
+  readiness: starting
+";
+
+    #[test]
+    fn log_path_is_read_from_the_indented_plan_line() {
+        assert_eq!(
+            parse_log_path(SERVE_PLAN),
+            Some("/tmp/rocm-e2e-abc123/data/services/vllm-qwen.log")
+        );
+    }
+
+    #[test]
+    fn output_without_a_log_path_yields_none() {
+        assert_eq!(parse_log_path("serve plan\n  engine: vllm\n"), None);
+        assert_eq!(parse_log_path("  log_path:   \n"), None);
+    }
+
+    #[test]
+    fn tail_keeps_the_last_lines_and_never_panics_on_short_input() {
+        let text = (1..=5)
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(tail_lines(&text, 2), "4\n5");
+        assert_eq!(tail_lines(&text, 99), text);
+        assert_eq!(tail_lines("", 3), "");
+    }
+
+    #[test]
+    fn tail_of_a_real_file_is_quoted_verbatim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("service.log");
+        std::fs::write(&path, "boot\nENGINE ERROR: out of memory\n").expect("write log");
+        let stdout = format!("managed service launched\n  log_path: {}\n", path.display());
+        assert_eq!(
+            service_log_tail(&stdout),
+            "boot\nENGINE ERROR: out of memory"
+        );
+    }
+
+    #[test]
+    fn every_unreadable_case_explains_itself_instead_of_failing() {
+        assert_eq!(
+            service_log_tail("managed service launched\n"),
+            "<no log_path in serve output>"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let empty = dir.path().join("empty.log");
+        std::fs::write(&empty, "  \n").expect("write log");
+        assert_eq!(
+            service_log_tail(&format!("  log_path: {}\n", empty.display())),
+            format!("<{} is empty>", empty.display())
+        );
+
+        let missing = dir.path().join("missing.log");
+        let reported = service_log_tail(&format!("  log_path: {}\n", missing.display()));
+        assert!(
+            reported.starts_with(&format!("<failed to read {}", missing.display())),
+            "unexpected message: {reported}"
+        );
+    }
+}

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -822,18 +822,23 @@ async fn main() {
         let _ = std::fs::write(dir.join("platform.json"), json);
     }
 
-    // Classify: XPASS (expected xfail but passed) and unexpected-fail (expected
-    // pass but failed) are failures; expected outcomes are fine. Scenarios that
-    // ran but have no id, or ran without a recorded resolution, are treated as
-    // expect-pass (a bare failure then fails the run).
-    let mut xpass = Vec::new();
+    // Classify actual results against the matrix. A deterministic XPASS is
+    // fatal because its expectation is stale. A flaky expectation deliberately
+    // accepts either outcome while keeping the intermittent bug visible.
+    let mut stale_xpass = Vec::new();
+    let mut flaky_xpass = Vec::new();
     let mut unexpected_fail = Vec::new();
     let mut xfail_count = 0u32;
     for (id, passed) in &actual {
         match resolutions.get(id).map(|(exp, _)| exp) {
-            Some(Expectation::ExpectXfail { bug, .. }) => {
+            Some(Expectation::ExpectXfail { bug, flaky, .. }) => {
                 if *passed {
-                    xpass.push(format!("{id} ({bug})"));
+                    let label = format!("{id} ({bug})");
+                    if *flaky {
+                        flaky_xpass.push(label);
+                    } else {
+                        stale_xpass.push(label);
+                    }
                 } else {
                     xfail_count += 1;
                 }
@@ -848,12 +853,19 @@ async fn main() {
     }
 
     eprintln!(
-        "Reconciliation: {xfail_count} xfail (failed as expected), {} XPASS, {} unexpected failure(s).",
-        xpass.len(),
+        "Reconciliation: {xfail_count} xfail (failed as expected), {} XPASS ({} flaky, {} stale), {} unexpected failure(s).",
+        flaky_xpass.len() + stale_xpass.len(),
+        flaky_xpass.len(),
+        stale_xpass.len(),
         unexpected_fail.len(),
     );
-    if !xpass.is_empty() || !unexpected_fail.is_empty() {
-        for x in &xpass {
+    for x in &flaky_xpass {
+        eprintln!(
+            "XPASS (flaky, tolerated): '{x}' passed this run; the intermittent bug remains tracked."
+        );
+    }
+    if !stale_xpass.is_empty() || !unexpected_fail.is_empty() {
+        for x in &stale_xpass {
             eprintln!(
                 "XPASS: '{x}' is expected to fail on this host but PASSED \u{2014} the bug appears \
                  fixed here; update expectations.toml.",

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -363,7 +363,9 @@ impl Drop for E2eWorld {
         // processes, so on a persistent runner they accumulate and hold the GPU.
         // Stop every managed service recorded in this scenario's isolated root
         // before the directory is removed. Best-effort: this is teardown, so any
-        // failure is ignored rather than panicking (which would abort the run).
+        // failure is ignored rather than panicking (which would abort the run) —
+        // hence the returned status is discarded here. The serve retry, where a
+        // failed stop changes the next attempt's meaning, does read it.
         if let Some(root) = &self.isolated_root {
             stop_managed_services(root.path());
         }
@@ -375,23 +377,37 @@ impl Drop for E2eWorld {
 /// `data/services/*.json`, so detached engine processes don't leak past the
 /// scenario. Black-box: reads the service_id from each on-disk record and calls
 /// `rocm services stop <id> --yes` with the same isolated env the scenario used.
-fn stop_managed_services(root: &std::path::Path) {
+///
+/// Returns a one-line account of what it found and how each stop went. Teardown
+/// discards it — there, a failure to stop is unfortunate but has no reader. The
+/// serve retry quotes it, because there this is the load-bearing step: if no
+/// record existed yet, or the stop failed, the next attempt runs against a device
+/// the previous one still owns, and the run must say so rather than let it look
+/// like a genuinely broken serve.
+fn stop_managed_services(root: &std::path::Path) -> String {
     let services_dir = root.join("data").join("services");
-    let Ok(entries) = std::fs::read_dir(&services_dir) else {
-        return;
+    let entries = match std::fs::read_dir(&services_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return format!("no service records: {} ({error})", services_dir.display());
+        }
     };
+    let mut outcomes = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
         let Ok(bytes) = std::fs::read(&path) else {
+            outcomes.push(format!("{}: UNREADABLE record", path.display()));
             continue;
         };
         let Ok(record) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            outcomes.push(format!("{}: UNPARSABLE record", path.display()));
             continue;
         };
         let Some(service_id) = record.get("service_id").and_then(|v| v.as_str()) else {
+            outcomes.push(format!("{}: record has no service_id", path.display()));
             continue;
         };
         // The planted mock record has no real process to stop; skip it.
@@ -403,9 +419,34 @@ fn stop_managed_services(root: &std::path::Path) {
         cmd.env("ROCM_CLI_CONFIG_DIR", root.join("config"));
         cmd.env("ROCM_CLI_DATA_DIR", root.join("data"));
         cmd.env("ROCM_CLI_CACHE_DIR", root.join("cache"));
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
-        let _ = cmd.status();
+        outcomes.push(match cmd.output() {
+            Ok(out) if out.status.success() => format!("{service_id}: stopped"),
+            Ok(out) => format!(
+                "{service_id}: STOP FAILED (rc={}) {}",
+                out.status.code().unwrap_or(-1),
+                last_line(&String::from_utf8_lossy(&out.stderr))
+            ),
+            Err(error) => format!("{service_id}: STOP NOT RUN ({error})"),
+        });
+    }
+    if outcomes.is_empty() {
+        return format!("no services recorded in {}", services_dir.display());
+    }
+    outcomes.join("; ")
+}
+
+/// The last non-blank line of `text`, clipped, for a one-line failure summary.
+fn last_line(text: &str) -> String {
+    let line = text
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("")
+        .trim();
+    if line.chars().count() > 200 {
+        format!("{}…", line.chars().take(200).collect::<String>())
+    } else {
+        line.to_owned()
     }
 }
 

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -56,6 +56,11 @@ pub struct E2eWorld {
     /// fail fast instead of burning the full cold-start window. `None` → the
     /// step's default / `E2E_SERVE_TIMEOUT_SECS`.
     pub serve_timeout_override: Option<u64>,
+    /// Whether `expectations.toml` marks this scenario a known bug on this host,
+    /// set by the `before` hook. Steps use it to avoid spending real GPU time on
+    /// a run whose failure is already the expected outcome — see the relaunch
+    /// budget in `setup_gpu_model`.
+    pub expect_xfail: bool,
     /// The interactive dash/chat TUI spawned under a pseudo-terminal for this
     /// scenario, if any (see `e2e::tui_driver`). Torn down in `Drop` before the
     /// mock server and isolated directory so the child process never outlives
@@ -166,6 +171,7 @@ impl Default for E2eWorld {
             isolated_root: Some(root),
             legacy_rocm_path: None,
             serve_timeout_override: None,
+            expect_xfail: false,
             tui: None,
             chat_use_mock: false,
         }
@@ -734,6 +740,7 @@ async fn main() {
                 world.serve_timeout_override = decl
                     .serve_timeout_secs
                     .or_else(|| matrix.serve_timeout_for(id, cap, engine));
+                world.expect_xfail = matrix.is_xfail(id, cap, engine);
             }
             Box::pin(async {})
         })

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -42,24 +42,31 @@ fn serve_timeout_for(world: &E2eWorld) -> u64 {
 /// scenario A's `rocm` has no record of scenario B's managed service and can't
 /// stop it; a plain 200 check would then proceed against the WRONG model. Wait
 /// for the expected model so the readiness signal reflects this scenario's serve.
-async fn wait_for_model(models_url: &str, expect_model: Option<&str>, timeout_secs: u64) {
+async fn model_is_ready(models_url: &str, expect_model: Option<&str>, timeout_secs: u64) -> bool {
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     while Instant::now() < deadline {
         if let Ok(resp) = reqwest::get(models_url).await
             && resp.status().is_success()
         {
             match expect_model {
-                None => return,
+                None => return true,
                 Some(model) => {
                     if let Ok(body) = resp.text().await
                         && body.contains(model)
                     {
-                        return;
+                        return true;
                     }
                 }
             }
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+    false
+}
+
+async fn wait_for_model(models_url: &str, expect_model: Option<&str>, timeout_secs: u64) {
+    if model_is_ready(models_url, expect_model, timeout_secs).await {
+        return;
     }
     match expect_model {
         Some(m) => panic!("endpoint {models_url} did not serve model {m} within {timeout_secs}s"),
@@ -327,22 +334,32 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
     // linger on the GPU and oversubscribe it (which otherwise piles up serves
     // until the job times out).
     let (model, engine, ready_substr) = host_serve_target();
-    ensure_serve_port_free().await;
-    let (stdout, _, rc) =
-        crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
-    assert!(rc == 0, "rocm serve failed:\n{stdout}");
-    world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
-    world.model_name = Some(model.to_string());
-    // Wait for THIS model specifically: the shared port 11435 may still be
-    // answering from a prior scenario's leaked serve (isolated data dirs mean
-    // this scenario can't stop it), so a plain readiness check could pass against
-    // the wrong model.
-    wait_for_model(
-        "http://127.0.0.1:11435/v1/models",
-        Some(ready_substr),
-        serve_timeout_for(world),
-    )
-    .await;
+    let models_url = "http://127.0.0.1:11435/v1/models";
+    let timeout_secs = serve_timeout_for(world);
+    let mut diagnostics = Vec::new();
+    // A managed vLLM launch can return `status: starting` without publishing the
+    // model within this scenario's readiness budget. Qwen3.5 has both timed out
+    // and served successfully in the same MI300X run, so preserve that coverage
+    // and allow one clean relaunch rather than replacing the model fixture.
+    for attempt in 1..=2 {
+        ensure_serve_port_free().await;
+        let (stdout, stderr, rc) =
+            crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
+        let diagnostic = format!(
+            "attempt {attempt} (rc={rc}):\n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}"
+        );
+        assert!(rc == 0, "rocm serve failed:\n{diagnostic}");
+        diagnostics.push(diagnostic);
+        if model_is_ready(models_url, Some(ready_substr), timeout_secs).await {
+            world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
+            world.model_name = Some(model.to_string());
+            return;
+        }
+    }
+    panic!(
+        "endpoint {models_url} did not serve model {ready_substr} after 2 attempts of {timeout_secs}s each:\n{}",
+        diagnostics.join("\n\n")
+    );
 }
 
 #[given("a GGUF model is being served on lemonade")]

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -446,12 +446,9 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
             world.model_name = Some(model.to_string());
             return;
         }
-        let mut report = format!(
-            "attempt {attempt} (rc={rc}), {device_state}\
-             \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}\
-             \n--- SERVICE LOG (tail) ---\n{}",
-            service_log_tail(&stdout)
-        );
+        // Read the log before stopping the service, so the tail reflects what the
+        // engine wrote on its own rather than anything the stop provokes.
+        let log_tail = service_log_tail(&stdout);
         // Stop THIS attempt's stalled service before doing anything else. A vLLM
         // still in engine init has not bound the serve port yet, so the port kill
         // in `ensure_serve_port_free` cannot see it — it would survive into the
@@ -465,8 +462,12 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
         // written one) or failed means the next attempt did NOT get a clean
         // device, and the failure says so instead of looking like a broken serve.
         let stop_status = stop_scenario_services(world);
-        report.push_str(&format!("\n--- STOP ---\n{stop_status}"));
-        diagnostics.push(report);
+        diagnostics.push(format!(
+            "attempt {attempt} (rc={rc}), {device_state}\
+             \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}\
+             \n--- SERVICE LOG (tail) ---\n{log_tail}\
+             \n--- STOP ---\n{stop_status}"
+        ));
         if attempt == attempts {
             break;
         }

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -8,6 +8,7 @@ use cucumber::{given, then, when};
 
 use crate::E2eWorld;
 use e2e_cucumber::mock_server::MockServer;
+use e2e_cucumber::serve_log::service_log_tail;
 
 /// How long to wait for a freshly served model's endpoint to become ready.
 ///
@@ -93,7 +94,12 @@ const ASSISTANT_PORT: u16 = 8001;
 /// Best-effort: ensure the shared serve port is free before starting a new
 /// serve, so a leaked server from a prior scenario can't linger on the GPU.
 /// Polls until nothing answers on the port (bounded), killing any listener.
-async fn ensure_serve_port_free() {
+///
+/// Returns a one-line description of the device state the next serve starts on
+/// (see [`wait_for_free_vram`]). Callers that only need the reset can ignore it;
+/// a serve that then fails to become ready reports it, because "the previous
+/// engine had not released the GPU yet" is otherwise invisible in the log.
+async fn ensure_serve_port_free() -> String {
     // Always kill any listener on the shared port — NOT just one that already
     // answers /v1/models. A prior scenario's vLLM that is still LOADING holds the
     // port and GPU memory without yet serving /v1/models; if we only checked HTTP
@@ -126,7 +132,7 @@ async fn ensure_serve_port_free() {
     // request, so the next serve dies with "Free memory ... less than desired GPU
     // memory utilization" (engine core init failed). Wait for the device to
     // actually drain before returning.
-    wait_for_free_vram().await;
+    wait_for_free_vram().await
 }
 
 /// Upper bound on the free-VRAM floor (MiB). Sized so the largest single
@@ -147,24 +153,45 @@ fn required_free_vram_mib(total_mib: u64) -> u64 {
     MAX_FREE_VRAM_FLOOR_MIB.min(total_mib / 100 * 90)
 }
 
+/// How long to wait for a stopped engine to hand its device memory back.
+const VRAM_DRAIN_DEADLINE: Duration = Duration::from_mins(2);
+
 /// Best-effort: wait until the GPU reports enough free VRAM (see
 /// [`required_free_vram_mib`]), so a just-killed serve's memory is actually
 /// reclaimed before the next serve starts. Queries `amd-smi` then `rocm-smi`;
 /// if neither is present (mock/local, no ROCm), returns immediately so non-GPU
 /// runs are unaffected.
-async fn wait_for_free_vram() {
+///
+/// The wait is bounded and best-effort: on timeout the serve still starts,
+/// because a stale reading must not turn a slow drain into a hard failure. The
+/// returned line records which of the two happened — an undrained device is the
+/// single most likely reason the serve that follows never becomes ready, and
+/// without it the failure looks identical to a genuinely broken serve.
+async fn wait_for_free_vram() -> String {
     // No GPU tooling → nothing to wait on (mock/local). Probe once up front.
     let Some(total) = total_vram_mib() else {
-        return;
+        return "device state: no GPU tooling (mock/local run)".to_owned();
     };
     let floor = required_free_vram_mib(total);
-    let deadline = Instant::now() + Duration::from_mins(2);
+    let deadline = Instant::now() + VRAM_DRAIN_DEADLINE;
     loop {
-        match free_vram_mib() {
-            Some(free) if free >= floor => return,
-            _ if Instant::now() >= deadline => return,
-            _ => tokio::time::sleep(Duration::from_secs(3)).await,
+        let free = free_vram_mib();
+        if let Some(free) = free
+            && free >= floor
+        {
+            return format!(
+                "device state: drained ({free} MiB free of {total} MiB, floor {floor} MiB)"
+            );
         }
+        if Instant::now() >= deadline {
+            let free = free.map_or_else(|| "unreadable".to_owned(), |mib| format!("{mib} MiB"));
+            return format!(
+                "device state: NOT drained after {}s ({free} free of {total} MiB, floor \
+                 {floor} MiB) — a previous engine is still holding the GPU",
+                VRAM_DRAIN_DEADLINE.as_secs()
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
     }
 }
 
@@ -320,6 +347,15 @@ fn default_engine_serve_target() -> &'static str {
     }
 }
 
+/// Stop every managed service this scenario launched, tree-killing the engine
+/// processes that hold the GPU. Used between serve attempts; the World's `Drop`
+/// runs the same teardown at scenario end.
+fn stop_scenario_services(world: &E2eWorld) {
+    if let Some(root) = &world.isolated_root {
+        crate::stop_managed_services(root.path());
+    }
+}
+
 #[given("a model is being served on GPU")]
 async fn setup_gpu_model(world: &mut E2eWorld) {
     // Serve by the canonical HuggingFace ID (not the `qwen2.5` alias) with an
@@ -341,23 +377,47 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
     // model within this scenario's readiness budget. Qwen3.5 has both timed out
     // and served successfully in the same MI300X run, so preserve that coverage
     // and allow one clean relaunch rather than replacing the model fixture.
-    for attempt in 1..=2 {
-        ensure_serve_port_free().await;
+    //
+    // Only a scenario that is expected to PASS gets that relaunch. Where the
+    // matrix already declares a known bug, the run's failure is the expected
+    // outcome and the deliberately shortened `serve_timeout_secs` says to fail
+    // fast — a second cold start there buys no signal and spends minutes of
+    // serial GPU time (plus another engine load) that the scenarios which do
+    // carry a result have to wait behind.
+    let attempts = if world.expect_xfail { 1 } else { 2 };
+    for attempt in 1..=attempts {
+        let device_state = ensure_serve_port_free().await;
         let (stdout, stderr, rc) =
             crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
-        let diagnostic = format!(
-            "attempt {attempt} (rc={rc}):\n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}"
+        assert!(
+            rc == 0,
+            "rocm serve failed:\nattempt {attempt} (rc={rc}), {device_state}\
+             \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}"
         );
-        assert!(rc == 0, "rocm serve failed:\n{diagnostic}");
-        diagnostics.push(diagnostic);
         if model_is_ready(models_url, Some(ready_substr), timeout_secs).await {
             world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
             world.model_name = Some(model.to_string());
             return;
         }
+        diagnostics.push(format!(
+            "attempt {attempt} (rc={rc}), {device_state}\
+             \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}\
+             \n--- SERVICE LOG (tail) ---\n{}",
+            service_log_tail(&stdout)
+        ));
+        // Stop THIS attempt's stalled service before doing anything else. A vLLM
+        // still in engine init has not bound the serve port yet, so the port kill
+        // in `ensure_serve_port_free` cannot see it — it would survive into the
+        // next attempt, hold its ~0.8-of-device memory reservation, and guarantee
+        // the relaunch dies on vLLM's free-memory check. Going through `rocm
+        // services stop` is what actually clears it: that path signals the whole
+        // process tree (the EngineCore worker pins the allocation, not the parent)
+        // and escalates past the grace period. Without this the retry is not a
+        // retry — it is a second serve competing with the first.
+        stop_scenario_services(world);
     }
     panic!(
-        "endpoint {models_url} did not serve model {ready_substr} after 2 attempts of {timeout_secs}s each:\n{}",
+        "endpoint {models_url} did not serve model {ready_substr} after {attempts} attempt(s) of {timeout_secs}s each:\n{}",
         diagnostics.join("\n\n")
     );
 }

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use cucumber::{given, then, when};
@@ -350,10 +352,50 @@ fn default_engine_serve_target() -> &'static str {
 /// Stop every managed service this scenario launched, tree-killing the engine
 /// processes that hold the GPU. Used between serve attempts; the World's `Drop`
 /// runs the same teardown at scenario end.
-fn stop_scenario_services(world: &E2eWorld) {
-    if let Some(root) = &world.isolated_root {
-        crate::stop_managed_services(root.path());
-    }
+///
+/// Returns the stop's own account of itself (see [`crate::stop_managed_services`]),
+/// which the retry quotes: a stop that found no record or failed means the next
+/// attempt shares the device with this one, and that must be visible in the
+/// failure rather than inferred from a serve that looks broken.
+fn stop_scenario_services(world: &E2eWorld) -> String {
+    world.isolated_root.as_ref().map_or_else(
+        || "not attempted: scenario has no isolated root".to_owned(),
+        |root| crate::stop_managed_services(root.path()),
+    )
+}
+
+/// How many stalled serves one RUN may relaunch, in total.
+///
+/// A relaunch costs a full cold start: the readiness budget
+/// (`E2E_SERVE_TIMEOUT_SECS`, 300s on the GPU lanes) behind the port-free and
+/// VRAM-drain waits ahead of it — roughly eight minutes. Those lanes cap the
+/// whole job at 35 minutes, and a job killed by that cap writes no
+/// `platform.json`: the entire run is lost, including the service-log
+/// diagnostics this step collects. Budgeting relaunches per RUN is what bounds
+/// the added wall clock — a per-scenario cap still multiplies by however many
+/// scenarios stall, which is exactly the double-stall case that would blow the
+/// job. One rescue matches the observed failure (a single scenario stalling in a
+/// run); a run that stalls twice is not one relaunch away from healthy, and is
+/// worth more as a report than as an unfinished job.
+fn relaunch_budget() -> &'static AtomicUsize {
+    static BUDGET: LazyLock<AtomicUsize> = LazyLock::new(|| {
+        AtomicUsize::new(
+            std::env::var("E2E_SERVE_RELAUNCH_BUDGET")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(1),
+        )
+    });
+    &BUDGET
+}
+
+/// Take one relaunch from the run's budget, reporting whether one was left.
+fn claim_relaunch() -> bool {
+    relaunch_budget()
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |left| {
+            left.checked_sub(1)
+        })
+        .is_ok()
 }
 
 #[given("a model is being served on GPU")]
@@ -383,28 +425,33 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
     // outcome and the deliberately shortened `serve_timeout_secs` says to fail
     // fast — a second cold start there buys no signal and spends minutes of
     // serial GPU time (plus another engine load) that the scenarios which do
-    // carry a result have to wait behind.
+    // carry a result have to wait behind. The relaunch is additionally drawn
+    // from a budget shared by the whole run (see `relaunch_budget`), so several
+    // stalling scenarios cannot together push the job past its timeout.
+    //
+    // A failing launch (rc != 0) goes down the same path as a stall rather than
+    // asserting out: the case worth retrying most is vLLM's own free-memory
+    // check rejecting a device the previous attempt has not finished releasing,
+    // and that one exits non-zero. It also gains the service-log tail below,
+    // which an assert would have skipped.
     let attempts = if world.expect_xfail { 1 } else { 2 };
+    let mut made = 0;
     for attempt in 1..=attempts {
+        made = attempt;
         let device_state = ensure_serve_port_free().await;
         let (stdout, stderr, rc) =
             crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
-        assert!(
-            rc == 0,
-            "rocm serve failed:\nattempt {attempt} (rc={rc}), {device_state}\
-             \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}"
-        );
-        if model_is_ready(models_url, Some(ready_substr), timeout_secs).await {
+        if rc == 0 && model_is_ready(models_url, Some(ready_substr), timeout_secs).await {
             world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
             world.model_name = Some(model.to_string());
             return;
         }
-        diagnostics.push(format!(
+        let mut report = format!(
             "attempt {attempt} (rc={rc}), {device_state}\
              \n--- STDOUT ---\n{stdout}\n--- STDERR ---\n{stderr}\
              \n--- SERVICE LOG (tail) ---\n{}",
             service_log_tail(&stdout)
-        ));
+        );
         // Stop THIS attempt's stalled service before doing anything else. A vLLM
         // still in engine init has not bound the serve port yet, so the port kill
         // in `ensure_serve_port_free` cannot see it — it would survive into the
@@ -413,11 +460,28 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
         // services stop` is what actually clears it: that path signals the whole
         // process tree (the EngineCore worker pins the allocation, not the parent)
         // and escalates past the grace period. Without this the retry is not a
-        // retry — it is a second serve competing with the first.
-        stop_scenario_services(world);
+        // retry — it is a second serve competing with the first, which is why its
+        // outcome is quoted: a stop that found no record (the launch had not yet
+        // written one) or failed means the next attempt did NOT get a clean
+        // device, and the failure says so instead of looking like a broken serve.
+        let stop_status = stop_scenario_services(world);
+        report.push_str(&format!("\n--- STOP ---\n{stop_status}"));
+        diagnostics.push(report);
+        if attempt == attempts {
+            break;
+        }
+        if !claim_relaunch() {
+            diagnostics.push(
+                "relaunch not attempted: this run's serve-relaunch budget is spent \
+                 (see E2E_SERVE_RELAUNCH_BUDGET). A second cold start here risks the \
+                 job timeout, which would kill the run before it writes any report."
+                    .to_owned(),
+            );
+            break;
+        }
     }
     panic!(
-        "endpoint {models_url} did not serve model {ready_substr} after {attempts} attempt(s) of {timeout_secs}s each:\n{}",
+        "endpoint {models_url} did not serve model {ready_substr} after {made} attempt(s) of {timeout_secs}s each:\n{}",
         diagnostics.join("\n\n")
     );
 }

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -54,7 +54,7 @@ const DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 /// Default wall-clock budget for a single wait. Generous enough for a cold dash
 /// start plus the embedded-daemon connect, while still turning a genuine hang
 /// into a prompt, diagnosable failure rather than a CI-timeout.
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(20);
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A running `rocm` TUI attached to a pseudo-terminal.
 pub struct TuiSession {

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -67,7 +67,7 @@ pub struct TuiSession {
     /// Set by the reader thread if `vt100::Parser::process` ever panics, before
     /// the thread exits. `wait_for_screen`/`wait_for_exit` check this every poll
     /// so a reader panic (which would otherwise just stop screen updates and
-    /// poison `parser`) is reported directly instead of surfacing as a 20s
+    /// poison `parser`) is reported directly instead of surfacing as a 30s
     /// timeout over an unexplained blank/stale screen.
     reader_panic: Arc<Mutex<Option<String>>>,
     /// Kept alive for the lifetime of the session: the reader/writer are cloned
@@ -219,7 +219,7 @@ impl TuiSession {
     /// Take the reader thread's recorded panic message, if any, clearing it so
     /// it's only reported once. Checked on every poll in `wait_for_screen`/
     /// `wait_for_exit` so a reader-thread fault surfaces immediately with a
-    /// direct diagnostic instead of a 20s timeout over a screen that stopped
+    /// direct diagnostic instead of a 30s timeout over a screen that stopped
     /// updating for an unexplained reason.
     fn take_reader_panic(&self) -> Option<String> {
         self.reader_panic


### PR DESCRIPTION
## Summary

- Make the real-GPU serve relaunch an actual retry: stop the stalled managed service — the whole engine process tree — before relaunching, so the second serve no longer competes with the first for device memory. Spend that relaunch only where it changes a result: a scenario the expectation matrix already declares a known bug keeps its shortened `serve_timeout_secs` and fails on the first attempt.
- Quote the stalled service's log tail and the device's free-VRAM state into the failure, so a serve that never publishes its model is diagnosable from CI output alone.
- Add first-class flaky-xfail semantics across the harness, `platform.json`, and consolidated report. Intermittent known bugs may reproduce or XPASS without reddening the lane, while deterministic XPASS remains fatal as stale metadata.
- Remove stale MI300X EAI-7052 expectations and mark the documented EAI-7333 readiness/inference races flaky.
- Add a checked-in advanced CodeQL workflow with `merge_group` support, replacing default setup so required CodeQL checks are produced in the merge queue.
- Increase the black-box dashboard wait budget from 20 to 30 seconds after the metrics scenario missed a healthy-but-slow frame by the old deadline.

## Root cause

PR and merge-group runs exposed three independent CI issues:

1. A managed vLLM launch can return successfully with status `starting` and never publish the model before the scenario deadline. The relaunch first added here could not rescue it: a vLLM still in engine init has not bound the serve port yet, so the port kill preceding each attempt cannot see it, and the relaunch therefore started while the first attempt still held its ~0.8-of-device memory reservation — dying on vLLM's own free-memory check. Both attempts were spent on a device the first attempt still owned; the exhausted two-minute VRAM-drain deadline before the second attempt is the signature. This failed `chat-end-to-end-local-model` on 3 of the last 17 MI300X runs, most recently dequeuing this PR from the merge queue.
2. The expectation matrix treated documented intermittent EAI-7333 passes as stale XPASS, repeatedly reddening otherwise healthy MI300X runs.
3. Branch protection required CodeQL contexts that GitHub default setup did not emit for `merge_group`; the queue timed out twice despite a green repository CI workflow.

Why a first serve attempt stalls at all remains unknown: the engine writes its reason to a service log in a per-scenario temp directory that no artifact captures, which is what the new log-tail reporting exists to surface.

The recovered dedicated Strix Halo Windows runner is used unchanged. The temporary organization-runner routing, wrapper-cleanup disablement, and Windows Lemonade EAI-7455 xfails have been removed.

## Risk and scope

- Risk: **medium**. Changes are limited to CI workflow triggers and E2E orchestration/reporting; production CLI behavior is unchanged.
- CodeQL remains enabled for actions, Python, and Rust through the checked-in advanced workflow.
- The permanent Windows Lemonade backend-download work remains outside this PR.

## Test plan

- [x] `cargo test -p e2e-cucumber --all-targets` — 38 passed
- [x] `cargo test -p e2e-report` — 34 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Advanced CodeQL passed for actions, Python, and Rust
- [x] Focused MI300X Qwen3.5 dispatch passed
- [x] Merge-group run emits and passes all required CodeQL checks (run 30255191412; that run was then dequeued by the GPU lane failure this PR fixes)
- [x] Dedicated Strix Halo Windows lane passes after runner recovery
- [x] MI300X lane green with the serve fix (run 30261532148): 0 unexpected failures, `chat-end-to-end-local-model` passes, and `chat-tool-definitions-accepted` now reaches its assertion and fails on the real tool-choice error instead of a serve timeout. The lane also drops from 25m09s to 8m22s, since a known-bug serve no longer pays for a second cold start.

The GPU serve path cannot be exercised without an AMD GPU, so CI is the authority for it; everything else above was run locally.
