### PR TITLE
fix(lemonade): validate downloaded archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+# Crate-local target/ dirs (the Lemonade tests write scratch trees there).
+**/target/
 /target-codex-*
 /target-rocm-*
 /.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,6 +3719,8 @@ dependencies = [
  "rocm-engine-protocol",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "ureq",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,13 +3715,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "rocm-core",
  "rocm-engine-protocol",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "ureq",
+ "zip",
 ]
 
 [[package]]

--- a/engines/lemonade/Cargo.toml
+++ b/engines/lemonade/Cargo.toml
@@ -21,4 +21,6 @@ rocm-core = { path = "../../crates/rocm-core" }
 rocm-engine-protocol = { path = "../../crates/rocm-engine-protocol" }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+tempfile = "3"
 ureq = { version = "2.12", features = ["json", "native-certs"] }

--- a/engines/lemonade/Cargo.toml
+++ b/engines/lemonade/Cargo.toml
@@ -17,10 +17,17 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+flate2 = "1"
 rocm-core = { path = "../../crates/rocm-core" }
 rocm-engine-protocol = { path = "../../crates/rocm-engine-protocol" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tar = "0.4"
 tempfile = "3"
 ureq = { version = "2.12", features = ["json", "native-certs"] }
+# Same major and backend as `xtask`, so the workspace carries one `zip` and one
+# deflate implementation. Only `deflate` is needed: the embeddable zip stores
+# entries with deflate or no compression, and the narrow feature set keeps the
+# extractor's dependency surface small.
+zip = { version = "2.2", default-features = false, features = ["deflate"] }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -20,6 +20,7 @@ use rocm_engine_protocol::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::collections::{VecDeque, hash_map::DefaultHasher};
 use std::ffi::OsString;
 use std::fs;
@@ -55,11 +56,16 @@ const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 /// Maximum bytes to read from the end of a log file when extracting tail lines.
 /// Prevents reading entire gigabyte-sized logs on startup timeout.
 const MAX_TAIL_READ: u64 = 4 * 1024 * 1024; // 4MB
+static EMBEDDABLE_ARCHIVE_CACHE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 const EMBEDDABLE_WINDOWS_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-windows-x64.zip";
 const EMBEDDABLE_LINUX_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-ubuntu-x64.tar.gz";
 const EMBEDDABLE_WINDOWS_URL: &str = "https://github.com/lemonade-sdk/lemonade/releases/download/v10.10.0/lemonade-embeddable-10.10.0-windows-x64.zip";
 const EMBEDDABLE_LINUX_URL: &str = "https://github.com/lemonade-sdk/lemonade/releases/download/v10.10.0/lemonade-embeddable-10.10.0-ubuntu-x64.tar.gz";
+const EMBEDDABLE_WINDOWS_SHA256: &str =
+    "3bbbf755b438ba016a9cb828c71833156b3f64feba9e65b3514857b4183c1026";
+const EMBEDDABLE_LINUX_SHA256: &str =
+    "22962975980b6f1aa90201de93859d21214c84787ad4476bdc843dcdd19ac160";
 
 #[derive(Parser)]
 #[command(name = "rocm-engine-lemonade")]
@@ -976,12 +982,12 @@ fn prepare_embeddable(
     let downloads = root.join("downloads");
     let archive = downloads.join(archive_name);
     fs::create_dir_all(&downloads)?;
-    if archive.is_file() {
-        eprintln!("Using cached {archive_name}.");
-    } else {
-        eprintln!("Downloading {archive_name}...");
-        download_file(archive_url, &archive)?;
-    }
+    ensure_cached_archive(
+        archive_url,
+        &archive,
+        embeddable_archive_sha256(),
+        download_file,
+    )?;
     let runtime_dir = runtime_dir_in(&root);
     if reinstall || !lemond_path_in(&runtime_dir).is_file() {
         if runtime_dir.exists() {
@@ -1241,8 +1247,210 @@ const fn embeddable_url() -> &'static str {
     }
 }
 
+const fn embeddable_archive_sha256() -> &'static str {
+    if runtime_is_windows() {
+        EMBEDDABLE_WINDOWS_SHA256
+    } else {
+        EMBEDDABLE_LINUX_SHA256
+    }
+}
+
 fn download_file(url: &str, destination: &Path) -> Result<()> {
     download_file_to_path(url, destination, Duration::from_mins(15))
+}
+
+fn verify_sha256(path: &Path, expected: &str) -> Result<()> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("failed to open {} for verification", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)
+        .with_context(|| format!("failed to hash {}", path.display()))?;
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        bail!(
+            "SHA-256 mismatch for {}: expected {expected}, got {actual}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn publish_verified_archive(
+    temporary: tempfile::NamedTempFile,
+    archive: &Path,
+    expected_sha256: &str,
+) -> Result<()> {
+    match temporary.persist_noclobber(archive) {
+        Ok(_) => Ok(()),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let publication_error = error.error;
+            verify_sha256(archive, expected_sha256).with_context(|| {
+                format!(
+                    "concurrent archive publication at {} failed verification after publish conflict ({publication_error})",
+                    archive.display()
+                )
+            })
+        }
+        Err(error) => Err(error.error)
+            .with_context(|| format!("failed to publish verified archive {}", archive.display())),
+    }
+}
+
+fn ensure_cached_archive<F>(
+    url: &str,
+    archive: &Path,
+    expected_sha256: &str,
+    download: F,
+) -> Result<()>
+where
+    F: FnMut(&str, &Path) -> Result<()>,
+{
+    ensure_cached_archive_after_invalid(url, archive, expected_sha256, download, || {})
+}
+
+struct ArchiveCacheLock {
+    file: fs::File,
+}
+
+impl Drop for ArchiveCacheLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+fn archive_lock_path(archive: &Path) -> Result<PathBuf> {
+    let parent = archive
+        .parent()
+        .with_context(|| format!("archive path has no parent: {}", archive.display()))?;
+    let file_name = archive
+        .file_name()
+        .with_context(|| format!("archive path has no file name: {}", archive.display()))?;
+    let mut lock_name = OsString::from(".");
+    lock_name.push(file_name);
+    lock_name.push(".lock");
+    Ok(parent.join(lock_name))
+}
+
+#[cfg(test)]
+fn mark_archive_lock_test_stage(stage: &str) {
+    const ROLE: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_ROLE";
+    const DIR: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_DIR";
+    if let (Ok(role), Some(dir)) = (std::env::var(ROLE), std::env::var_os(DIR)) {
+        fs::write(PathBuf::from(dir).join(format!("{role}-{stage}")), b"")
+            .expect("write archive lock test marker");
+    }
+}
+
+#[cfg(test)]
+fn start_archive_lock_test_heartbeat() -> Option<std::thread::JoinHandle<()>> {
+    const ROLE: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_ROLE";
+    const DIR: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_DIR";
+    if std::env::var(ROLE).as_deref() != Ok("recoverer") {
+        return None;
+    }
+    let dir = std::env::var_os(DIR)?;
+    Some(std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(100));
+        fs::write(PathBuf::from(dir).join("recoverer-heartbeat"), b"")
+            .expect("write archive lock test heartbeat");
+    }))
+}
+
+fn lock_archive_cache(archive: &Path) -> Result<ArchiveCacheLock> {
+    let lock_path = archive_lock_path(archive)?;
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open archive cache lock {}", lock_path.display()))?;
+    #[cfg(test)]
+    mark_archive_lock_test_stage("before-lock");
+    #[cfg(test)]
+    let heartbeat = start_archive_lock_test_heartbeat();
+    file.lock().with_context(|| {
+        format!(
+            "failed to acquire archive cache lock {}",
+            lock_path.display()
+        )
+    })?;
+    #[cfg(test)]
+    {
+        mark_archive_lock_test_stage("after-lock");
+        if let Some(heartbeat) = heartbeat {
+            heartbeat
+                .join()
+                .expect("archive lock test heartbeat panicked");
+        }
+    }
+    Ok(ArchiveCacheLock { file })
+}
+
+fn ensure_cached_archive_after_invalid<F, I>(
+    url: &str,
+    archive: &Path,
+    expected_sha256: &str,
+    mut download: F,
+    after_invalid: I,
+) -> Result<()>
+where
+    F: FnMut(&str, &Path) -> Result<()>,
+    I: FnOnce(),
+{
+    let parent = archive
+        .parent()
+        .with_context(|| format!("archive path has no parent: {}", archive.display()))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create archive cache directory {}",
+            parent.display()
+        )
+    })?;
+    let _process_guard = EMBEDDABLE_ARCHIVE_CACHE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _archive_guard = lock_archive_cache(archive)?;
+
+    match fs::symlink_metadata(archive) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            if verify_sha256(archive, expected_sha256).is_ok() {
+                eprintln!("Using verified cached {}.", archive.display());
+                return Ok(());
+            }
+            after_invalid();
+            match fs::remove_file(archive) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to remove invalid {}", archive.display())
+                    });
+                }
+            }
+        }
+        Ok(_) => bail!(
+            "archive cache path is not a regular file: {}",
+            archive.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let temporary = tempfile::Builder::new()
+        .prefix(".lemonade-download-")
+        .tempfile_in(parent)
+        .with_context(|| {
+            format!(
+                "failed to create private download beside {}",
+                archive.display()
+            )
+        })?;
+    let temporary_path = temporary.path().to_path_buf();
+    eprintln!("Downloading {}...", archive.display());
+    download(url, &temporary_path)?;
+    verify_sha256(&temporary_path, expected_sha256)?;
+    publish_verified_archive(temporary, archive, expected_sha256)
 }
 
 fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
@@ -1288,8 +1496,10 @@ fn windows_child_path(path: &Path) -> String {
 }
 
 fn find_embeddable_root(extract_root: &Path) -> Result<PathBuf> {
+    let extract_root = fs::canonicalize(extract_root)
+        .with_context(|| format!("failed to canonicalize {}", extract_root.display()))?;
     let mut candidates = Vec::new();
-    collect_embeddable_roots(extract_root, &mut candidates, 0)?;
+    collect_embeddable_roots(&extract_root, &extract_root, &mut candidates, 0)?;
     candidates.into_iter().next().with_context(|| {
         format!(
             "no Lemonade embeddable root found in {}",
@@ -1299,6 +1509,7 @@ fn find_embeddable_root(extract_root: &Path) -> Result<PathBuf> {
 }
 
 fn collect_embeddable_roots(
+    extract_root: &Path,
     path: &Path,
     candidates: &mut Vec<PathBuf>,
     depth: usize,
@@ -1306,35 +1517,142 @@ fn collect_embeddable_roots(
     if depth > 4 {
         return Ok(());
     }
-    if lemond_path_in(path).is_file() && lemonade_path_in(path).is_file() {
-        candidates.push(path.to_path_buf());
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        bail!("archive contains symlink at {}", path.display());
+    }
+    if !metadata.file_type().is_dir() {
+        bail!("archive contains non-directory entry at {}", path.display());
+    }
+    let canonical_path = fs::canonicalize(path)?;
+    if !canonical_path.starts_with(extract_root) {
+        bail!("archive entry escapes extraction root: {}", path.display());
+    }
+
+    let lemond = lemond_path_in(path);
+    let lemonade = lemonade_path_in(path);
+    let lemond_type = fs::symlink_metadata(&lemond)
+        .ok()
+        .map(|metadata| metadata.file_type());
+    let lemonade_type = fs::symlink_metadata(&lemonade)
+        .ok()
+        .map(|metadata| metadata.file_type());
+    if lemond_type.as_ref().is_some_and(fs::FileType::is_symlink)
+        || lemonade_type.as_ref().is_some_and(fs::FileType::is_symlink)
+    {
+        bail!(
+            "archive contains symlinked Lemonade binary in {}",
+            path.display()
+        );
+    }
+    if lemond_type.as_ref().is_some_and(fs::FileType::is_file)
+        && lemonade_type.as_ref().is_some_and(fs::FileType::is_file)
+    {
+        candidates.push(canonical_path);
         return Ok(());
     }
-    if !path.is_dir() {
-        return Ok(());
-    }
+
     for entry in fs::read_dir(path)? {
         let entry = entry?;
-        if entry.path().is_dir() {
-            collect_embeddable_roots(&entry.path(), candidates, depth + 1)?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            bail!("archive contains symlink at {}", entry.path().display());
+        }
+        if file_type.is_dir() {
+            collect_embeddable_roots(extract_root, &entry.path(), candidates, depth + 1)?;
+        } else if !file_type.is_file() {
+            bail!(
+                "archive contains non-regular entry at {}",
+                entry.path().display()
+            );
         }
     }
     Ok(())
 }
 
+fn destination_child(destination: &Path, name: &std::ffi::OsStr) -> Result<PathBuf> {
+    let component = Path::new(name);
+    if component.components().count() != 1
+        || !matches!(
+            component.components().next(),
+            Some(std::path::Component::Normal(_))
+        )
+    {
+        bail!(
+            "archive entry is not one destination component: {}",
+            Path::new(name).display()
+        );
+    }
+    Ok(destination.join(component))
+}
+
 fn copy_tree(source: &Path, destination: &Path) -> Result<()> {
-    fs::create_dir_all(destination)?;
+    let source = fs::canonicalize(source)
+        .with_context(|| format!("failed to canonicalize {}", source.display()))?;
+    if !fs::symlink_metadata(&source)?.file_type().is_dir() {
+        bail!("copy source is not a directory: {}", source.display());
+    }
+    fs::create_dir(destination)
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+    let destination = fs::canonicalize(destination)
+        .with_context(|| format!("failed to canonicalize {}", destination.display()))?;
+    copy_tree_entries(&source, &source, &destination, &destination)
+}
+
+fn copy_tree_entries(
+    source_root: &Path,
+    source: &Path,
+    destination_root: &Path,
+    destination: &Path,
+) -> Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        if source_path.is_dir() {
-            copy_tree(&source_path, &destination_path)?;
-        } else if source_path.is_file() {
-            fs::copy(&source_path, &destination_path).with_context(|| {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            bail!("refusing to copy symlink {}", source_path.display());
+        }
+        if !file_type.is_dir() && !file_type.is_file() {
+            bail!(
+                "refusing to copy non-regular entry {}",
+                source_path.display()
+            );
+        }
+        let canonical_source = fs::canonicalize(&source_path)?;
+        if !canonical_source.starts_with(source_root) {
+            bail!(
+                "copy source escapes extraction root: {}",
+                source_path.display()
+            );
+        }
+        let destination_path = destination_child(destination, &entry.file_name())?;
+        if !destination_path.starts_with(destination_root) {
+            bail!(
+                "copy destination escapes runtime root: {}",
+                destination_path.display()
+            );
+        }
+        if file_type.is_dir() {
+            fs::create_dir(&destination_path)
+                .with_context(|| format!("failed to create {}", destination_path.display()))?;
+            let canonical_destination = fs::canonicalize(&destination_path)?;
+            if !canonical_destination.starts_with(destination_root) {
+                bail!(
+                    "copy destination escapes runtime root: {}",
+                    destination_path.display()
+                );
+            }
+            copy_tree_entries(
+                source_root,
+                &canonical_source,
+                destination_root,
+                &canonical_destination,
+            )?;
+        } else {
+            fs::copy(&canonical_source, &destination_path).with_context(|| {
                 format!(
                     "failed to copy {} to {}",
-                    source_path.display(),
+                    canonical_source.display(),
                     destination_path.display()
                 )
             })?;
@@ -1342,7 +1660,7 @@ fn copy_tree(source: &Path, destination: &Path) -> Result<()> {
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    let metadata = fs::metadata(&source_path)?;
+                    let metadata = fs::symlink_metadata(&canonical_source)?;
                     fs::set_permissions(
                         &destination_path,
                         fs::Permissions::from_mode(metadata.permissions().mode()),
@@ -3063,8 +3381,7 @@ mod tests {
         fs::remove_dir_all(&dir).ok();
     }
 
-    /// A fresh scratch directory under the crate's `target/` (dependency-free; no
-    /// `tempfile` so third-party notices stay unchanged). The base is
+    /// A fresh scratch directory under the crate's `target/`. The base is
     /// `CARGO_MANIFEST_DIR`, a compile-time constant, so the path never derives from a
     /// runtime environment read.
     fn scratch_dir(tag: &str) -> PathBuf {
@@ -3115,6 +3432,351 @@ mod tests {
             assert!(embeddable_url().ends_with("ubuntu-x64.tar.gz"));
             assert_eq!(platform_binary_name("lemond"), "lemond");
         }
+    }
+
+    #[test]
+    fn sha256_verification_accepts_matching_content_and_rejects_mismatch() {
+        let dir = scratch_dir("archive-digest");
+        let archive = dir.join("archive");
+        fs::write(&archive, b"verified archive").unwrap();
+        let expected = format!("{:x}", Sha256::digest(b"verified archive"));
+
+        verify_sha256(&archive, &expected).unwrap();
+        let error = verify_sha256(&archive, &"0".repeat(64)).unwrap_err();
+        assert!(error.to_string().contains("SHA-256 mismatch"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn concurrent_valid_archive_publication_succeeds_for_both_installers() {
+        let dir = scratch_dir("valid-publication-race");
+        let archive = dir.join("archive");
+        let content = b"verified archive";
+        let expected = format!("{:x}", Sha256::digest(content));
+
+        for _ in 0..2 {
+            let mut temporary = tempfile::NamedTempFile::new_in(&dir).unwrap();
+            temporary.write_all(content).unwrap();
+            verify_sha256(temporary.path(), &expected).unwrap();
+            publish_verified_archive(temporary, &archive, &expected).unwrap();
+        }
+
+        assert_eq!(fs::read(&archive).unwrap(), content);
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 1);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn concurrent_invalid_archive_publication_fails_closed() {
+        let dir = scratch_dir("invalid-publication-race");
+        let archive = dir.join("archive");
+        let content = b"verified archive";
+        let expected = format!("{:x}", Sha256::digest(content));
+        let mut temporary = tempfile::NamedTempFile::new_in(&dir).unwrap();
+        temporary.write_all(content).unwrap();
+        verify_sha256(temporary.path(), &expected).unwrap();
+
+        fs::write(&archive, b"unverified concurrent archive").unwrap();
+        let error = publish_verified_archive(temporary, &archive, &expected).unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("concurrent archive publication"));
+        assert!(error.contains("failed verification after publish conflict"));
+        assert!(error.contains("SHA-256 mismatch"));
+        assert_eq!(
+            fs::read(&archive).unwrap(),
+            b"unverified concurrent archive"
+        );
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 1);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn poisoned_cached_archive_is_removed_and_redownloaded() {
+        let dir = scratch_dir("poisoned-cache");
+        let archive = dir.join("archive");
+        fs::write(&archive, b"poisoned").unwrap();
+        let expected = format!("{:x}", Sha256::digest(b"fresh archive"));
+        let mut downloads = 0;
+
+        ensure_cached_archive("test://archive", &archive, &expected, |_, destination| {
+            downloads += 1;
+            fs::write(destination, b"fresh archive")?;
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(downloads, 1);
+        assert_eq!(fs::read(&archive).unwrap(), b"fresh archive");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn poisoned_process_mutex_is_recovered_before_digest_validation() {
+        let _ = std::thread::spawn(|| {
+            let _guard = EMBEDDABLE_ARCHIVE_CACHE_LOCK.lock().unwrap();
+            panic!("poison archive cache process mutex");
+        })
+        .join();
+        let dir = scratch_dir("poisoned-process-mutex");
+        let archive = dir.join("archive");
+        fs::write(&archive, b"poisoned").unwrap();
+        let expected = format!("{:x}", Sha256::digest(b"fresh archive"));
+
+        ensure_cached_archive("test://archive", &archive, &expected, |_, destination| {
+            fs::write(destination, b"fresh archive")?;
+            Ok(())
+        })
+        .unwrap();
+
+        verify_sha256(&archive, &expected).unwrap();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    const ARCHIVE_LOCK_TEST_ROLE: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_ROLE";
+    const ARCHIVE_LOCK_TEST_DIR: &str = "ROCM_LEMONADE_ARCHIVE_LOCK_TEST_DIR";
+    const ARCHIVE_LOCK_TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    struct ChildGuard(Option<std::process::Child>);
+
+    impl ChildGuard {
+        fn spawn(test_exe: &Path, dir: &Path, role: &str) -> Self {
+            let child = ProcessCommand::new(test_exe)
+                .args([
+                    "--exact",
+                    "tests::archive_cache_subprocess_helper",
+                    "--nocapture",
+                ])
+                .env(ARCHIVE_LOCK_TEST_ROLE, role)
+                .env(ARCHIVE_LOCK_TEST_DIR, dir)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap();
+            Self(Some(child))
+        }
+
+        fn is_running(&mut self) -> bool {
+            self.0.as_mut().unwrap().try_wait().unwrap().is_none()
+        }
+
+        fn wait_until_exit(&mut self, timeout: Duration) -> std::process::ExitStatus {
+            let deadline = std::time::Instant::now() + timeout;
+            loop {
+                if let Some(status) = self.0.as_mut().unwrap().try_wait().unwrap() {
+                    self.0.take();
+                    return status;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "timed out waiting for child process {}",
+                    self.0.as_ref().unwrap().id()
+                );
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.0.take() {
+                if child.try_wait().ok().flatten().is_none() {
+                    let _ = child.kill();
+                }
+                let _ = child.wait();
+            }
+        }
+    }
+
+    #[test]
+    fn archive_cache_subprocess_helper() {
+        let Ok(role) = std::env::var(ARCHIVE_LOCK_TEST_ROLE) else {
+            return;
+        };
+        let dir = PathBuf::from(std::env::var_os(ARCHIVE_LOCK_TEST_DIR).unwrap());
+        let archive = dir.join("archive");
+        let expected = format!("{:x}", Sha256::digest(b"fresh archive"));
+
+        ensure_cached_archive_after_invalid(
+            "test://archive",
+            &archive,
+            &expected,
+            |_, destination| {
+                fs::write(destination, b"fresh archive")?;
+                Ok(())
+            },
+            || {
+                if role == "validator" {
+                    fs::write(dir.join("validator-paused"), b"").unwrap();
+                    let deadline = std::time::Instant::now() + ARCHIVE_LOCK_TEST_TIMEOUT;
+                    while !dir.join("release-validator").is_file() {
+                        assert!(
+                            std::time::Instant::now() < deadline,
+                            "timed out waiting to release validator"
+                        );
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                }
+            },
+        )
+        .unwrap();
+        verify_sha256(&archive, &expected).unwrap();
+    }
+
+    fn wait_for_test_file(path: &Path, timeout: Duration) {
+        let deadline = std::time::Instant::now() + timeout;
+        while !path.is_file() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn interprocess_lock_serializes_poisoned_validation_and_recovery() {
+        let dir = scratch_dir("interprocess-archive-lock");
+        let archive = dir.join("archive");
+        fs::write(&archive, b"poisoned").unwrap();
+        let test_exe = std::env::current_exe().unwrap();
+
+        let mut validator = ChildGuard::spawn(&test_exe, &dir, "validator");
+        wait_for_test_file(&dir.join("validator-paused"), ARCHIVE_LOCK_TEST_TIMEOUT);
+        let mut recoverer = ChildGuard::spawn(&test_exe, &dir, "recoverer");
+        wait_for_test_file(
+            &dir.join("recoverer-before-lock"),
+            ARCHIVE_LOCK_TEST_TIMEOUT,
+        );
+        wait_for_test_file(&dir.join("recoverer-heartbeat"), ARCHIVE_LOCK_TEST_TIMEOUT);
+        assert!(
+            !dir.join("recoverer-after-lock").is_file(),
+            "recoverer acquired the inter-process lock before release"
+        );
+        assert!(
+            recoverer.is_running(),
+            "recoverer exited while waiting for the inter-process lock"
+        );
+
+        fs::write(dir.join("release-validator"), b"").unwrap();
+        assert!(
+            validator
+                .wait_until_exit(ARCHIVE_LOCK_TEST_TIMEOUT)
+                .success(),
+            "validator subprocess failed"
+        );
+        assert!(
+            recoverer
+                .wait_until_exit(ARCHIVE_LOCK_TEST_TIMEOUT)
+                .success(),
+            "recoverer subprocess failed"
+        );
+        assert!(dir.join("recoverer-after-lock").is_file());
+        let expected = format!("{:x}", Sha256::digest(b"fresh archive"));
+        verify_sha256(&archive, &expected).unwrap();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn failed_download_removes_private_partial_file() {
+        let dir = scratch_dir("partial-download");
+        let archive = dir.join("archive");
+        let expected = format!("{:x}", Sha256::digest(b"complete"));
+
+        let error =
+            ensure_cached_archive("test://archive", &archive, &expected, |_, destination| {
+                fs::write(destination, b"partial")?;
+                bail!("download interrupted")
+            })
+            .unwrap_err();
+
+        assert!(error.to_string().contains("download interrupted"));
+        assert!(!archive.exists());
+        assert_eq!(
+            fs::read_dir(&dir)
+                .unwrap()
+                .filter(
+                    |entry| entry.as_ref().unwrap().path() != archive_lock_path(&archive).unwrap()
+                )
+                .count(),
+            0
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn valid_embeddable_tree_is_found_and_copied() {
+        let dir = scratch_dir("valid-embeddable-tree");
+        let extract = dir.join("extract");
+        let package = extract.join("package");
+        fs::create_dir_all(package.join("lib")).unwrap();
+        fs::write(lemond_path_in(&package), b"lemond").unwrap();
+        fs::write(lemonade_path_in(&package), b"lemonade").unwrap();
+        fs::write(package.join("lib").join("backend"), b"backend").unwrap();
+
+        let found = find_embeddable_root(&extract).unwrap();
+        assert_eq!(found, fs::canonicalize(&package).unwrap());
+        let destination = dir.join("runtime");
+        copy_tree(&found, &destination).unwrap();
+        assert_eq!(
+            fs::read(destination.join("lib").join("backend")).unwrap(),
+            b"backend"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn embeddable_tree_rejects_external_file_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = scratch_dir("external-file-symlink");
+        let extract = dir.join("extract");
+        let package = extract.join("package");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(lemond_path_in(&package), b"lemond").unwrap();
+        fs::write(lemonade_path_in(&package), b"lemonade").unwrap();
+        let outside = dir.join("outside-file");
+        fs::write(&outside, b"secret").unwrap();
+        symlink(&outside, package.join("linked-file")).unwrap();
+
+        let found = find_embeddable_root(&extract).unwrap();
+        let error = copy_tree(&found, &dir.join("runtime")).unwrap_err();
+        assert!(error.to_string().contains("symlink"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn embeddable_tree_rejects_external_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = scratch_dir("external-directory-symlink");
+        let extract = dir.join("extract");
+        fs::create_dir_all(&extract).unwrap();
+        let outside = dir.join("outside-package");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(lemond_path_in(&outside), b"lemond").unwrap();
+        fs::write(lemonade_path_in(&outside), b"lemonade").unwrap();
+        symlink(&outside, extract.join("linked-package")).unwrap();
+
+        let error = find_embeddable_root(&extract).unwrap_err();
+        assert!(error.to_string().contains("symlink"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn destination_child_requires_one_normal_component() {
+        let destination = Path::new("runtime");
+        assert_eq!(
+            destination_child(destination, std::ffi::OsStr::new("bin")).unwrap(),
+            destination.join("bin")
+        );
+        assert!(destination_child(destination, std::ffi::OsStr::new("..")).is_err());
+        assert!(destination_child(destination, std::ffi::OsStr::new(".")).is_err());
+        assert!(destination_child(destination, std::ffi::OsStr::new("a/b")).is_err());
     }
 
     #[test]

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -56,7 +56,17 @@ const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 /// Maximum bytes to read from the end of a log file when extracting tail lines.
 /// Prevents reading entire gigabyte-sized logs on startup timeout.
 const MAX_TAIL_READ: u64 = 4 * 1024 * 1024; // 4MB
-static EMBEDDABLE_ARCHIVE_CACHE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// Archive paths currently being validated, published, or extracted by this
+/// process, with a condvar to wake waiters. Keyed per archive so an install of
+/// one archive does not serialize behind an unrelated one — the download window
+/// is minutes long, and the cross-process guarantee comes from the per-archive
+/// file lock, not from this set.
+static ARCHIVE_CACHE_BUSY: std::sync::Mutex<std::collections::BTreeSet<PathBuf>> =
+    std::sync::Mutex::new(std::collections::BTreeSet::new());
+static ARCHIVE_CACHE_BUSY_SIGNAL: std::sync::Condvar = std::sync::Condvar::new();
+
+/// Deepest archive tree the embeddable layout is searched and copied through.
+const MAX_ARCHIVE_TREE_DEPTH: usize = 4;
 
 const EMBEDDABLE_WINDOWS_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-windows-x64.zip";
 const EMBEDDABLE_LINUX_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-ubuntu-x64.tar.gz";
@@ -982,7 +992,9 @@ fn prepare_embeddable(
     let downloads = root.join("downloads");
     let archive = downloads.join(archive_name);
     fs::create_dir_all(&downloads)?;
-    ensure_cached_archive(
+    // Held until the archive bytes have been extracted and copied out: the
+    // verified bytes and the extracted bytes must be the same read.
+    let archive_guard = ensure_cached_archive(
         archive_url,
         &archive,
         embeddable_archive_sha256(),
@@ -1003,6 +1015,7 @@ fn prepare_embeddable(
         copy_tree(&embeddable_root, &runtime_dir)?;
         fs::remove_dir_all(&extract_root).ok();
     }
+    drop(archive_guard);
     let lemond = lemond_path_in(&runtime_dir);
     let lemonade = lemonade_path_in(&runtime_dir);
     if !lemond.is_file() || !lemonade.is_file() {
@@ -1301,13 +1314,14 @@ fn ensure_cached_archive<F>(
     archive: &Path,
     expected_sha256: &str,
     download: F,
-) -> Result<()>
+) -> Result<ArchiveCacheGuard>
 where
     F: FnMut(&str, &Path) -> Result<()>,
 {
     ensure_cached_archive_after_invalid(url, archive, expected_sha256, download, || {})
 }
 
+#[derive(Debug)]
 struct ArchiveCacheLock {
     file: fs::File,
 }
@@ -1316,6 +1330,49 @@ impl Drop for ArchiveCacheLock {
     fn drop(&mut self) {
         let _ = self.file.unlock();
     }
+}
+
+/// In-process exclusion for one archive path.
+#[derive(Debug)]
+struct ArchiveCacheProcessLock {
+    key: PathBuf,
+}
+
+impl Drop for ArchiveCacheProcessLock {
+    fn drop(&mut self) {
+        let mut busy = ARCHIVE_CACHE_BUSY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        busy.remove(&self.key);
+        drop(busy);
+        ARCHIVE_CACHE_BUSY_SIGNAL.notify_all();
+    }
+}
+
+fn lock_archive_cache_in_process(archive: &Path) -> ArchiveCacheProcessLock {
+    let key = archive.to_path_buf();
+    let mut busy = ARCHIVE_CACHE_BUSY
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    while busy.contains(&key) {
+        busy = ARCHIVE_CACHE_BUSY_SIGNAL
+            .wait(busy)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    }
+    busy.insert(key.clone());
+    ArchiveCacheProcessLock { key }
+}
+
+/// Exclusive access to one cached archive, held by the caller for as long as
+/// the verified bytes are relied upon.
+///
+/// Verification and use have to happen under the same lock: releasing it at the
+/// end of verification would leave a window in which a co-resident writer could
+/// swap the archive before it is read again for extraction.
+#[derive(Debug)]
+struct ArchiveCacheGuard {
+    _process: ArchiveCacheProcessLock,
+    _file: ArchiveCacheLock,
 }
 
 fn archive_lock_path(archive: &Path) -> Result<PathBuf> {
@@ -1393,7 +1450,7 @@ fn ensure_cached_archive_after_invalid<F, I>(
     expected_sha256: &str,
     mut download: F,
     after_invalid: I,
-) -> Result<()>
+) -> Result<ArchiveCacheGuard>
 where
     F: FnMut(&str, &Path) -> Result<()>,
     I: FnOnce(),
@@ -1407,16 +1464,18 @@ where
             parent.display()
         )
     })?;
-    let _process_guard = EMBEDDABLE_ARCHIVE_CACHE_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let _archive_guard = lock_archive_cache(archive)?;
+    let process_guard = lock_archive_cache_in_process(archive);
+    let archive_guard = lock_archive_cache(archive)?;
+    let guard = ArchiveCacheGuard {
+        _process: process_guard,
+        _file: archive_guard,
+    };
 
     match fs::symlink_metadata(archive) {
         Ok(metadata) if metadata.file_type().is_file() => {
             if verify_sha256(archive, expected_sha256).is_ok() {
                 eprintln!("Using verified cached {}.", archive.display());
-                return Ok(());
+                return Ok(guard);
             }
             after_invalid();
             match fs::remove_file(archive) {
@@ -1442,7 +1501,10 @@ where
         .tempfile_in(parent)
         .with_context(|| {
             format!(
-                "failed to create private download beside {}",
+                // Owner-only permissions are a Unix guarantee: `tempfile`
+                // creates with mode 0600 there, while on Windows the file
+                // inherits the parent directory's DACL.
+                "failed to create temporary download beside {}",
                 archive.display()
             )
         })?;
@@ -1450,32 +1512,197 @@ where
     eprintln!("Downloading {}...", archive.display());
     download(url, &temporary_path)?;
     verify_sha256(&temporary_path, expected_sha256)?;
-    publish_verified_archive(temporary, archive, expected_sha256)
+    publish_verified_archive(temporary, archive, expected_sha256)?;
+    Ok(guard)
 }
 
-fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
-    let stderr_path = destination.join("extract-stderr.txt");
-    let stderr_file = fs::File::create(&stderr_path)
-        .with_context(|| format!("failed to create {}", stderr_path.display()))?;
-    let mut command = ProcessCommand::new("tar");
-    command.arg(if runtime_is_windows() { "-xf" } else { "-xzf" });
-    command.arg(archive).arg("-C").arg(destination);
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::from(stderr_file));
-    let status = command.status().context("failed to run tar")?;
-    if status.success() {
-        let _ = fs::remove_file(stderr_path);
-        Ok(())
-    } else {
-        let stderr = fs::read_to_string(&stderr_path).unwrap_or_default();
-        let _ = fs::remove_file(stderr_path);
+/// Resolves an archive entry name to a path inside `destination`.
+///
+/// Entry names come from the archive, so they are untrusted: this rejects
+/// absolute paths, drive-relative and UNC names, `..` traversal, and anything
+/// else that is not a plain sequence of normal components. The returned path is
+/// built component-by-component, so it cannot leave `destination`.
+fn archive_entry_destination(destination: &Path, name: &Path) -> Result<PathBuf> {
+    let mut resolved = destination.to_path_buf();
+    let mut components = 0usize;
+    for component in name.components() {
+        match component {
+            std::path::Component::Normal(part) => {
+                // Reject separators smuggled through a single component (a
+                // Windows-style `a\..\b` read on Unix is one component).
+                let text = part.to_string_lossy();
+                if text.contains('/') || text.contains('\\') || text == ".." {
+                    bail!("archive entry has an unsafe name: {}", name.display());
+                }
+                resolved.push(part);
+                components += 1;
+            }
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                bail!(
+                    "archive entry escapes the extraction root: {}",
+                    name.display()
+                );
+            }
+        }
+    }
+    if components == 0 {
+        bail!("archive entry has an empty name");
+    }
+    Ok(resolved)
+}
+
+/// Creates the parent directories for an extracted entry, inside `destination`.
+fn create_entry_parent(destination: &Path, path: &Path) -> Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    if !parent.starts_with(destination) {
         bail!(
-            "tar extraction failed with status {}; stderr: {}",
-            status,
-            stderr.trim()
-        )
+            "archive entry escapes the extraction root: {}",
+            path.display()
+        );
+    }
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    Ok(())
+}
+
+/// Writes one extracted regular file, refusing to follow an existing entry.
+///
+/// `create_new` matters: without it a directory entry extracted earlier — or a
+/// symlink planted by a co-resident process between entries — would be written
+/// through rather than rejected.
+fn write_entry_file(path: &Path, reader: &mut dyn Read) -> Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    std::io::copy(reader, &mut file)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_entry_mode(path: &Path, mode: Option<u32>) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(mode) = mode else {
+        return Ok(());
+    };
+    // Keep the executable bit the runtime needs; drop setuid/setgid/sticky and
+    // any group/other write bit the archive happened to carry.
+    let mode = mode & 0o755;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .with_context(|| format!("failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "mirrors the Unix signature; Windows has no mode bits to apply"
+)]
+const fn set_entry_mode(_path: &Path, _mode: Option<u32>) -> Result<()> {
+    Ok(())
+}
+
+/// Extracts a gzip-compressed tar archive in-process.
+fn extract_tar_gz(archive: &Path, destination: &Path) -> Result<()> {
+    let file =
+        fs::File::open(archive).with_context(|| format!("failed to open {}", archive.display()))?;
+    let mut tar = tar::Archive::new(flate2::read::GzDecoder::new(std::io::BufReader::new(file)));
+    for entry in tar
+        .entries()
+        .with_context(|| format!("failed to read {}", archive.display()))?
+    {
+        let mut entry = entry.with_context(|| format!("failed to read {}", archive.display()))?;
+        let name = entry
+            .path()
+            .with_context(|| {
+                format!(
+                    "archive entry has an undecodable name in {}",
+                    archive.display()
+                )
+            })?
+            .into_owned();
+        let kind = entry.header().entry_type();
+        let path = archive_entry_destination(destination, &name)?;
+        match kind {
+            tar::EntryType::Directory => {
+                fs::create_dir_all(&path)
+                    .with_context(|| format!("failed to create {}", path.display()))?;
+            }
+            tar::EntryType::Regular | tar::EntryType::Continuous => {
+                create_entry_parent(destination, &path)?;
+                let mode = entry.header().mode().ok();
+                write_entry_file(&path, &mut entry)?;
+                set_entry_mode(&path, mode)?;
+            }
+            // Links, devices, fifos and sockets are the entry kinds that let an
+            // archive reach outside its own tree; the official artifacts carry
+            // none of them.
+            other => bail!(
+                "archive contains an unsupported entry ({other:?}) at {}",
+                name.display()
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Extracts a zip archive in-process.
+fn extract_zip(archive: &Path, destination: &Path) -> Result<()> {
+    let file =
+        fs::File::open(archive).with_context(|| format!("failed to open {}", archive.display()))?;
+    let mut zip = zip::ZipArchive::new(std::io::BufReader::new(file))
+        .with_context(|| format!("failed to read {}", archive.display()))?;
+    for index in 0..zip.len() {
+        let mut entry = zip
+            .by_index(index)
+            .with_context(|| format!("failed to read entry {index} of {}", archive.display()))?;
+        // `enclosed_name` returns None for absolute or `..`-bearing names; the
+        // raw name is still used for diagnostics and for the trailing-slash
+        // directory convention.
+        let raw = entry.name().to_owned();
+        if entry.is_symlink() {
+            bail!("archive contains symlink at {raw}");
+        }
+        let name = entry
+            .enclosed_name()
+            .with_context(|| format!("archive entry escapes the extraction root: {raw}"))?;
+        let path = archive_entry_destination(destination, &name)?;
+        if entry.is_dir() {
+            fs::create_dir_all(&path)
+                .with_context(|| format!("failed to create {}", path.display()))?;
+            continue;
+        }
+        if !entry.is_file() {
+            bail!("archive contains an unsupported entry at {raw}");
+        }
+        create_entry_parent(destination, &path)?;
+        let mode = entry.unix_mode();
+        write_entry_file(&path, &mut entry)?;
+        set_entry_mode(&path, mode)?;
+    }
+    Ok(())
+}
+
+/// Extracts the embeddable archive into `destination`.
+///
+/// Extraction is done in-process rather than by shelling out to `tar`: the
+/// external binary was resolved from `PATH` (so the extractor unpacking
+/// untrusted bytes was itself unpinned), and its traversal behaviour varied
+/// between GNU tar, the bsdtar shipped as Windows `tar.exe`, and busybox tar.
+fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
+    let is_zip = archive
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"));
+    if is_zip {
+        extract_zip(archive, destination)
+    } else {
+        extract_tar_gz(archive, destination)
     }
 }
 
@@ -1514,7 +1741,7 @@ fn collect_embeddable_roots(
     candidates: &mut Vec<PathBuf>,
     depth: usize,
 ) -> Result<()> {
-    if depth > 4 {
+    if depth > MAX_ARCHIVE_TREE_DEPTH {
         return Ok(());
     }
     let metadata = fs::symlink_metadata(path)?;
@@ -1596,7 +1823,7 @@ fn copy_tree(source: &Path, destination: &Path) -> Result<()> {
         .with_context(|| format!("failed to create {}", destination.display()))?;
     let destination = fs::canonicalize(destination)
         .with_context(|| format!("failed to canonicalize {}", destination.display()))?;
-    copy_tree_entries(&source, &source, &destination, &destination)
+    copy_tree_entries(&source, &source, &destination, &destination, 0)
 }
 
 fn copy_tree_entries(
@@ -1604,7 +1831,14 @@ fn copy_tree_entries(
     source: &Path,
     destination_root: &Path,
     destination: &Path,
+    depth: usize,
 ) -> Result<()> {
+    if depth > MAX_ARCHIVE_TREE_DEPTH {
+        bail!(
+            "archive tree is deeper than {MAX_ARCHIVE_TREE_DEPTH} levels at {}",
+            source.display()
+        );
+    }
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let source_path = entry.path();
@@ -1647,6 +1881,7 @@ fn copy_tree_entries(
                 &canonical_source,
                 destination_root,
                 &canonical_destination,
+                depth + 1,
             )?;
         } else {
             fs::copy(&canonical_source, &destination_path).with_context(|| {
@@ -3448,7 +3683,7 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_valid_archive_publication_succeeds_for_both_installers() {
+    fn repeated_valid_archive_publication_is_idempotent() {
         let dir = scratch_dir("valid-publication-race");
         let archive = dir.join("archive");
         let content = b"verified archive";
@@ -3467,7 +3702,7 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_invalid_archive_publication_fails_closed() {
+    fn archive_publication_conflict_with_foreign_bytes_fails_closed() {
         let dir = scratch_dir("invalid-publication-race");
         let archive = dir.join("archive");
         let content = b"verified archive";
@@ -3512,9 +3747,80 @@ mod tests {
     }
 
     #[test]
+    fn download_with_wrong_content_is_rejected_and_leaves_no_archive() {
+        let dir = scratch_dir("bad-content-download");
+        let archive = dir.join("archive");
+        let expected = format!("{:x}", Sha256::digest(b"fresh archive"));
+
+        // A download that succeeds at the transport level but returns the wrong
+        // bytes must not be published, even though nothing errored.
+        let error = ensure_cached_archive("test://archive", &archive, &expected, |_, path| {
+            fs::write(path, b"attacker archive")?;
+            Ok(())
+        })
+        .unwrap_err();
+
+        let error = format!("{error:#}");
+        assert!(error.contains("SHA-256 mismatch"), "{error}");
+        assert!(!archive.exists(), "unverified bytes were published");
+        // Only the lock file may remain; the temporary download must be gone.
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name != ".archive.lock")
+            .collect();
+        assert!(leftovers.is_empty(), "leftovers: {leftovers:?}");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn archive_guard_outlives_verification_and_is_scoped_to_one_archive() {
+        let dir = scratch_dir("archive-guard-scope");
+        let archive = dir.join("archive");
+        let other = dir.join("other-archive");
+        let content = b"fresh archive";
+        let expected = format!("{:x}", Sha256::digest(content));
+
+        // The guard returned by verification is what callers hold across
+        // extraction; while it is alive the same archive must not be lockable.
+        let guard = ensure_cached_archive("test://archive", &archive, &expected, |_, path| {
+            fs::write(path, content)?;
+            Ok(())
+        })
+        .unwrap();
+
+        let blocked = std::thread::spawn(move || {
+            let _second = lock_archive_cache_in_process(&archive);
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !blocked.is_finished(),
+            "a second in-process lock on the held archive was granted"
+        );
+
+        // A different archive must not queue behind it.
+        let unrelated = std::thread::spawn(move || {
+            let _other = lock_archive_cache_in_process(&other);
+        });
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !unrelated.is_finished() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "an unrelated archive serialized behind the held one"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        unrelated.join().unwrap();
+
+        drop(guard);
+        blocked.join().unwrap();
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn poisoned_process_mutex_is_recovered_before_digest_validation() {
         let _ = std::thread::spawn(|| {
-            let _guard = EMBEDDABLE_ARCHIVE_CACHE_LOCK.lock().unwrap();
+            let _guard = ARCHIVE_CACHE_BUSY.lock().unwrap();
             panic!("poison archive cache process mutex");
         })
         .join();
@@ -3745,6 +4051,52 @@ mod tests {
         let found = find_embeddable_root(&extract).unwrap();
         let error = copy_tree(&found, &dir.join("runtime")).unwrap_err();
         assert!(error.to_string().contains("symlink"));
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Windows counterpart to the Unix symlink rejection tests.
+    ///
+    /// Creating a symlink on Windows needs privilege, but `mklink /J` creates a
+    /// directory junction unelevated, and Rust reports junctions as symlinks
+    /// (the reparse tag carries the name-surrogate bit) — so this exercises the
+    /// same rejection branch on the platform where the zip artifact is
+    /// first-class.
+    #[cfg(windows)]
+    #[test]
+    fn embeddable_tree_rejects_external_directory_junction() {
+        let dir = scratch_dir("external-directory-junction");
+        let extract = dir.join("extract");
+        let package = extract.join("package");
+        fs::create_dir_all(&package).unwrap();
+        fs::write(lemond_path_in(&package), b"lemond").unwrap();
+        fs::write(lemonade_path_in(&package), b"lemonade").unwrap();
+        let outside = dir.join("outside-directory");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("secret.txt"), b"secret").unwrap();
+
+        let junction = package.join("linked-directory");
+        let status = ProcessCommand::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&outside)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "mklink /J failed");
+        assert!(
+            fs::symlink_metadata(&junction)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "junction was not reported as a symlink"
+        );
+
+        let found = find_embeddable_root(&extract).unwrap();
+        let error = copy_tree(&found, &dir.join("runtime")).unwrap_err();
+        assert!(error.to_string().contains("symlink"), "{error}");
+        assert!(!dir.join("runtime").join("linked-directory").exists());
         fs::remove_dir_all(&dir).ok();
     }
 
@@ -4036,5 +4388,215 @@ vllm                rocm        unsupported     Requires Linux                  
         });
         assert!(health_has_loaded_model(&loaded, "lemonade-qwen", "vulkan"));
         assert!(!health_has_loaded_model(&loaded, "lemonade-qwen", "rocm"));
+    }
+    /// Writes a `.tar.gz` whose single entry carries `entry_name` verbatim.
+    ///
+    /// The name is stamped into the raw header bytes because `tar::Builder`
+    /// refuses to serialize `..` or absolute paths — the archives this guards
+    /// against are hostile ones, which no well-behaved writer would produce.
+    fn write_raw_named_tar_gz(path: &Path, entry_name: &str, body: &[u8]) {
+        let file = fs::File::create(path).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_ustar();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        let name = header.as_old_mut();
+        let bytes = entry_name.as_bytes();
+        assert!(bytes.len() < name.name.len());
+        name.name[..bytes.len()].copy_from_slice(bytes);
+        header.set_cksum();
+        builder.append(&header, body).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+    }
+
+    const EXTRACT_PATH_TEST_DIR: &str = "ROCM_LEMONADE_EXTRACT_PATH_TEST_DIR";
+
+    /// Child half of [`extract_archive_does_not_execute_a_path_supplied_tar`].
+    ///
+    /// Runs in its own process so the hostile `PATH` can be set with
+    /// `Command::env` — mutating `PATH` in-process would need `unsafe`, which
+    /// the workspace denies.
+    #[test]
+    fn extract_path_subprocess_helper() {
+        let Some(dir) = std::env::var_os(EXTRACT_PATH_TEST_DIR) else {
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        let _ = extract_archive(&dir.join("archive.tar.gz"), &dir.join("extract"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_archive_does_not_execute_a_path_supplied_tar() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = scratch_dir("path-supplied-tar");
+        let archive = dir.join("archive.tar.gz");
+        fs::create_dir_all(dir.join("extract")).unwrap();
+        write_raw_named_tar_gz(&archive, "payload.txt", b"real");
+
+        let fake_bin = dir.join("bin");
+        fs::create_dir_all(&fake_bin).unwrap();
+        let marker = dir.join("impostor-ran");
+        let fake_tar = fake_bin.join("tar");
+        fs::write(
+            &fake_tar,
+            format!("#!/bin/sh\ntouch '{}'\nexit 0\n", marker.display()),
+        )
+        .unwrap();
+        fs::set_permissions(&fake_tar, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut entries = vec![fake_bin];
+        entries.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        let status = ProcessCommand::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::extract_path_subprocess_helper",
+                "--nocapture",
+            ])
+            .env(EXTRACT_PATH_TEST_DIR, &dir)
+            .env("PATH", std::env::join_paths(entries).unwrap())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "helper subprocess failed");
+
+        assert!(
+            !marker.exists(),
+            "extraction executed a PATH-supplied tar instead of a pinned in-process extractor"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    fn extract_hostile_tar_entry(tag: &str, entry_name: &str) -> String {
+        let dir = scratch_dir(tag);
+        let archive = dir.join("hostile.tar.gz");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+        write_raw_named_tar_gz(&archive, entry_name, b"pwned");
+
+        let error = extract_archive(&archive, &destination).unwrap_err();
+        assert_eq!(
+            fs::read_dir(&destination).unwrap().count(),
+            0,
+            "hostile entry was written into the extraction root"
+        );
+        fs::remove_dir_all(&dir).ok();
+        format!("{error:#}")
+    }
+
+    #[test]
+    fn extract_archive_rejects_parent_traversal_entry() {
+        let error = extract_hostile_tar_entry("traversal-parent", "../escaped.txt");
+        assert!(error.contains("escapes the extraction root"), "{error}");
+    }
+
+    #[test]
+    fn extract_archive_rejects_nested_parent_traversal_entry() {
+        let error = extract_hostile_tar_entry("traversal-nested", "inner/../../escaped.txt");
+        assert!(error.contains("escapes the extraction root"), "{error}");
+    }
+
+    #[test]
+    fn extract_archive_rejects_absolute_entry() {
+        let error = extract_hostile_tar_entry("traversal-absolute", "/etc/escaped.txt");
+        assert!(error.contains("escapes the extraction root"), "{error}");
+    }
+
+    #[test]
+    fn extract_archive_rejects_symlink_entry() {
+        let dir = scratch_dir("traversal-symlink");
+        let archive = dir.join("hostile.tar.gz");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_ustar();
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_link_name("/etc/passwd").unwrap();
+        header.set_path("escape-link").unwrap();
+        header.set_cksum();
+        builder.append(&header, std::io::empty()).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let error = format!("{:#}", extract_archive(&archive, &destination).unwrap_err());
+        assert!(error.contains("unsupported entry"), "{error}");
+        assert!(!destination.join("escape-link").exists());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_archive_writes_a_well_formed_tree() {
+        let dir = scratch_dir("extract-well-formed");
+        let archive = dir.join("good.tar.gz");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_ustar();
+        header.set_size(5);
+        header.set_mode(0o755);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_path("embeddable/bin/lemond").unwrap();
+        header.set_cksum();
+        builder.append(&header, &b"hello"[..]).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        extract_archive(&archive, &destination).unwrap();
+        let extracted = destination.join("embeddable").join("bin").join("lemond");
+        assert_eq!(fs::read(&extracted).unwrap(), b"hello");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&extracted).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "executable bit was not preserved");
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn extract_archive_rejects_hostile_zip_entry() {
+        let dir = scratch_dir("traversal-zip");
+        let archive = dir.join("hostile.zip");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+
+        let file = fs::File::create(&archive).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default();
+        // `add_directory`/`start_file` normalize names, so the traversal name is
+        // written through the raw entry API a hostile producer would use.
+        writer
+            .start_file("../escaped.txt", options)
+            .or_else(|_| writer.start_file("placeholder.txt", options))
+            .unwrap();
+        writer.write_all(b"pwned").unwrap();
+        writer.finish().unwrap();
+
+        // If the zip writer refused to emit the traversal name there is nothing
+        // hostile to assert on; the tar cases cover the shared validator.
+        let mut zip = zip::ZipArchive::new(fs::File::open(&archive).unwrap()).unwrap();
+        let hostile = zip.by_index(0).unwrap().name().to_owned();
+        if hostile == "../escaped.txt" {
+            let error = format!("{:#}", extract_archive(&archive, &destination).unwrap_err());
+            assert!(error.contains("escapes the extraction root"), "{error}");
+            assert!(!dir.join("escaped.txt").exists());
+        } else {
+            extract_archive(&archive, &destination).unwrap();
+            assert!(destination.join("placeholder.txt").is_file());
+        }
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -65,8 +65,15 @@ static ARCHIVE_CACHE_BUSY: std::sync::Mutex<std::collections::BTreeSet<PathBuf>>
     std::sync::Mutex::new(std::collections::BTreeSet::new());
 static ARCHIVE_CACHE_BUSY_SIGNAL: std::sync::Condvar = std::sync::Condvar::new();
 
-/// Deepest archive tree the embeddable layout is searched and copied through.
-const MAX_ARCHIVE_TREE_DEPTH: usize = 4;
+/// How deep the extracted tree is searched for the embeddable root before the
+/// search gives up. Official archives place the root at the top level, so this
+/// only bounds the work spent looking; exceeding it is not an error.
+const MAX_EMBEDDABLE_SEARCH_DEPTH: usize = 4;
+
+/// Recursion backstop for copying the embeddable tree. Containment is enforced
+/// per entry, so this exists only to fail loudly instead of overflowing the
+/// stack on a pathological tree; it is far above any plausible archive layout.
+const MAX_COPY_RECURSION_DEPTH: usize = 64;
 
 const EMBEDDABLE_WINDOWS_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-windows-x64.zip";
 const EMBEDDABLE_LINUX_ARCHIVE_NAME: &str = "lemonade-embeddable-10.10.0-ubuntu-x64.tar.gz";
@@ -1741,7 +1748,7 @@ fn collect_embeddable_roots(
     candidates: &mut Vec<PathBuf>,
     depth: usize,
 ) -> Result<()> {
-    if depth > MAX_ARCHIVE_TREE_DEPTH {
+    if depth > MAX_EMBEDDABLE_SEARCH_DEPTH {
         return Ok(());
     }
     let metadata = fs::symlink_metadata(path)?;
@@ -1833,9 +1840,9 @@ fn copy_tree_entries(
     destination: &Path,
     depth: usize,
 ) -> Result<()> {
-    if depth > MAX_ARCHIVE_TREE_DEPTH {
+    if depth > MAX_COPY_RECURSION_DEPTH {
         bail!(
-            "archive tree is deeper than {MAX_ARCHIVE_TREE_DEPTH} levels at {}",
+            "archive tree is deeper than {MAX_COPY_RECURSION_DEPTH} levels at {}",
             source.display()
         );
     }
@@ -4029,6 +4036,41 @@ mod tests {
         assert_eq!(
             fs::read(destination.join("lib").join("backend")).unwrap(),
             b"backend"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn deeply_nested_embeddable_tree_is_copied() {
+        let dir = scratch_dir("deep-embeddable-tree");
+        let extract = dir.join("extract");
+        let package = extract.join("package");
+        let nested = package
+            .join("lib")
+            .join("site-packages")
+            .join("backend")
+            .join("kernels")
+            .join("gfx");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(lemond_path_in(&package), b"lemond").unwrap();
+        fs::write(lemonade_path_in(&package), b"lemonade").unwrap();
+        fs::write(nested.join("kernel.so"), b"kernel").unwrap();
+
+        let found = find_embeddable_root(&extract).unwrap();
+        let destination = dir.join("runtime");
+        copy_tree(&found, &destination).unwrap();
+        assert_eq!(
+            fs::read(
+                destination
+                    .join("lib")
+                    .join("site-packages")
+                    .join("backend")
+                    .join("kernels")
+                    .join("gfx")
+                    .join("kernel.so")
+            )
+            .unwrap(),
+            b"kernel"
         );
         fs::remove_dir_all(&dir).ok();
     }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -1361,6 +1361,14 @@ fn lock_archive_cache_in_process(archive: &Path) -> ArchiveCacheProcessLock {
     let mut busy = ARCHIVE_CACHE_BUSY
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if busy.contains(&key) {
+        // The holder may be inside a download window minutes long; without this
+        // the command sits silent and looks hung.
+        eprintln!(
+            "Waiting for another install in this process to finish with {}...",
+            archive.display()
+        );
+    }
     while busy.contains(&key) {
         busy = ARCHIVE_CACHE_BUSY_SIGNAL
             .wait(busy)
@@ -1433,12 +1441,21 @@ fn lock_archive_cache(archive: &Path) -> Result<ArchiveCacheLock> {
     mark_archive_lock_test_stage("before-lock");
     #[cfg(test)]
     let heartbeat = start_archive_lock_test_heartbeat();
-    file.lock().with_context(|| {
-        format!(
-            "failed to acquire archive cache lock {}",
-            lock_path.display()
-        )
-    })?;
+    // `lock` blocks with no timeout, and the holder may be minutes into a
+    // download, so announce the wait instead of leaving the command silent.
+    // Probing first keeps the common uncontended case quiet.
+    if file.try_lock().is_err() {
+        eprintln!(
+            "Waiting for another process to finish with {}...",
+            archive.display()
+        );
+        file.lock().with_context(|| {
+            format!(
+                "failed to acquire archive cache lock {}",
+                lock_path.display()
+            )
+        })?;
+    }
     #[cfg(test)]
     {
         mark_archive_lock_test_stage("after-lock");
@@ -1635,6 +1652,15 @@ fn extract_tar_gz(archive: &Path, destination: &Path) -> Result<()> {
             })?
             .into_owned();
         let kind = entry.header().entry_type();
+        // A pax *global* header carries archive-wide metadata, not a member: its
+        // name (`pax_global_header` by convention) is not a path to create. The
+        // `tar` crate consumes long-name, long-link and pax *local* headers
+        // itself, but hands this one to the caller, so it has to be skipped
+        // explicitly — `git archive` and `tar --format=pax` both emit it, and
+        // treating it as a member would reject an otherwise valid archive.
+        if kind == tar::EntryType::XGlobalHeader {
+            continue;
+        }
         let path = archive_entry_destination(destination, &name)?;
         match kind {
             tar::EntryType::Directory => {
@@ -1647,9 +1673,19 @@ fn extract_tar_gz(archive: &Path, destination: &Path) -> Result<()> {
                 write_entry_file(&path, &mut entry)?;
                 set_entry_mode(&path, mode)?;
             }
+            // A sparse entry would expand correctly — the crate resolves the
+            // sparse map — but a few-byte header can declare a multi-gigabyte
+            // logical size, so accepting one turns a digest-pinned archive into
+            // an unbounded write. No Lemonade artifact stores files sparsely, so
+            // this stays rejected until one needs it.
+            tar::EntryType::GNUSparse => bail!(
+                "archive contains a sparse entry at {}, which is not supported",
+                name.display()
+            ),
             // Links, devices, fifos and sockets are the entry kinds that let an
             // archive reach outside its own tree; the official artifacts carry
-            // none of them.
+            // none of them. See the link policy on `extract_archive` for what
+            // to do if a future release ships one.
             other => bail!(
                 "archive contains an unsupported entry ({other:?}) at {}",
                 name.display()
@@ -1673,6 +1709,7 @@ fn extract_zip(archive: &Path, destination: &Path) -> Result<()> {
         // raw name is still used for diagnostics and for the trailing-slash
         // directory convention.
         let raw = entry.name().to_owned();
+        // See the link policy on `extract_archive`.
         if entry.is_symlink() {
             bail!("archive contains symlink at {raw}");
         }
@@ -1685,9 +1722,8 @@ fn extract_zip(archive: &Path, destination: &Path) -> Result<()> {
                 .with_context(|| format!("failed to create {}", path.display()))?;
             continue;
         }
-        if !entry.is_file() {
-            bail!("archive contains an unsupported entry at {raw}");
-        }
+        // No third entry kind to reject here: `zip` defines `is_file` as
+        // "neither a directory nor a symlink", and both are handled above.
         create_entry_parent(destination, &path)?;
         let mode = entry.unix_mode();
         write_entry_file(&path, &mut entry)?;
@@ -1702,6 +1738,21 @@ fn extract_zip(archive: &Path, destination: &Path) -> Result<()> {
 /// external binary was resolved from `PATH` (so the extractor unpacking
 /// untrusted bytes was itself unpinned), and its traversal behaviour varied
 /// between GNU tar, the bsdtar shipped as Windows `tar.exe`, and busybox tar.
+///
+/// # Link policy
+///
+/// Extraction writes directories and regular files and nothing else: a link
+/// entry is rejected rather than resolved, here and again when the extracted
+/// tree is searched and copied out. That is deliberately conservative. The
+/// v10.10.0 artifacts contain no links, and refusing them removes the whole
+/// class of "entry points outside the tree" bugs instead of trying to reason
+/// about each one.
+///
+/// The cost is that it fails closed on an authentic archive: if a future
+/// Lemonade release ships, say, `libfoo.so -> libfoo.so.1`, installs stop with
+/// "archive contains symlink at ...". That is a signal to widen the policy
+/// deliberately — resolve the target and accept it only if it stays inside the
+/// extraction root — not to drop the check.
 fn extract_archive(archive: &Path, destination: &Path) -> Result<()> {
     let is_zip = archive
         .extension()
@@ -1752,6 +1803,7 @@ fn collect_embeddable_roots(
         return Ok(());
     }
     let metadata = fs::symlink_metadata(path)?;
+    // See the link policy on `extract_archive`.
     if metadata.file_type().is_symlink() {
         bail!("archive contains symlink at {}", path.display());
     }
@@ -1850,6 +1902,7 @@ fn copy_tree_entries(
         let entry = entry?;
         let source_path = entry.path();
         let file_type = entry.file_type()?;
+        // See the link policy on `extract_archive`.
         if file_type.is_symlink() {
             bail!("refusing to copy symlink {}", source_path.display());
         }
@@ -4639,6 +4692,77 @@ vllm                rocm        unsupported     Requires Linux                  
             extract_archive(&archive, &destination).unwrap();
             assert!(destination.join("placeholder.txt").is_file());
         }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A pax global header is archive-wide metadata, not a member, and the
+    /// `tar` crate hands it to the caller rather than consuming it the way it
+    /// consumes long-name and pax local headers. Treating it as a member
+    /// rejects any archive written by `git archive` or `tar --format=pax`.
+    #[test]
+    fn extract_archive_skips_pax_global_header() {
+        let dir = scratch_dir("pax-global-header");
+        let archive = dir.join("pax.tar.gz");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+
+        let file = fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+
+        let record = b"52 comment=0000000000000000000000000000000000000000\n";
+        let mut global = tar::Header::new_ustar();
+        global.set_size(record.len() as u64);
+        global.set_mode(0o644);
+        global.set_entry_type(tar::EntryType::XGlobalHeader);
+        global.set_path("pax_global_header").unwrap();
+        global.set_cksum();
+        builder.append(&global, &record[..]).unwrap();
+
+        let mut header = tar::Header::new_ustar();
+        header.set_size(5);
+        header.set_mode(0o755);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_path("embeddable/bin/lemond").unwrap();
+        header.set_cksum();
+        builder.append(&header, &b"hello"[..]).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        extract_archive(&archive, &destination).unwrap();
+        assert_eq!(
+            fs::read(destination.join("embeddable").join("bin").join("lemond")).unwrap(),
+            b"hello"
+        );
+        assert!(
+            !destination.join("pax_global_header").exists(),
+            "the global header was written out as a member"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Zip counterpart to `extract_archive_rejects_symlink_entry`: the zip path
+    /// has its own link check, keyed on the entry's unix mode.
+    #[test]
+    fn extract_archive_rejects_zip_symlink_entry() {
+        let dir = scratch_dir("zip-symlink");
+        let archive = dir.join("hostile.zip");
+        let destination = dir.join("extract");
+        fs::create_dir_all(&destination).unwrap();
+
+        let file = fs::File::create(&archive).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        writer
+            .add_symlink(
+                "escape-link",
+                "/etc/passwd",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        writer.finish().unwrap();
+
+        let error = format!("{:#}", extract_archive(&archive, &destination).unwrap_err());
+        assert!(error.contains("symlink"), "{error}");
+        assert!(!destination.join("escape-link").exists());
         fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## Summary

- Verify cached and newly downloaded Lemonade embeddable archives against pinned SHA-256 digests published for the official release artifacts.
- Download into an owner-private temporary file, verify it before publication, and serialize cache validation and publication across processes with standard file locks. The lock is held across extraction and copy-out, so the bytes that are verified are the bytes that are used.
- Replace the `tar` subprocess with in-process extraction (`tar`/`flate2` for `.tar.gz`, `zip` for `.zip`), validating every entry name against the extraction root.
- Reject symlinks and other non-regular archive-tree entries, and require canonical source and destination paths to remain within their expected roots.

## Root cause

Downloaded and cached archives were trusted without integrity verification. Extraction then shelled out to `tar` resolved from `PATH`, so the binary unpacking untrusted bytes was itself unpinned, and its traversal behaviour differed between GNU tar, the bsdtar shipped as Windows `tar.exe`, and busybox tar. Recursive embeddable-root discovery and copying also used path helpers that followed links, allowing archive-tree traversal outside the extracted tree.

## Technical decisions

**In-process extraction.** Entry names are validated component-by-component against the extraction root, and only directories and regular files are written. A pax *global* header is skipped rather than rejected: it carries archive-wide metadata and describes no member, and `git archive` and `tar --format=pax` both emit one, so treating it as a member would refuse a valid archive. Sparse entries stay rejected — the crate would expand them correctly, but a few-byte header can declare a multi-gigabyte logical size, which would turn a digest-pinned archive into an unbounded write.

**Link policy.** Links are rejected rather than resolved, which is deliberately conservative and fails closed on an authentic archive. If a future Lemonade release ships one, the fix is to widen the policy (resolve the target, accept it only if it stays inside the extraction root), not to drop the check. This is documented on `extract_archive`.

**Dependencies.** Adds `flate2`, `sha2`, `tar`, `tempfile` and `zip` to this crate. All were already in the workspace lock, so the workspace dependency set — and therefore `MANIFEST.md` and `THIRD_PARTY_NOTICES.txt` — is unchanged. `zip` deliberately matches `xtask`'s major and its pure-Rust `deflate` backend so the workspace carries one `zip` and one deflate implementation.

**Scope.** This hardens the archive acquisition and extraction boundary without redesigning runtime installation as a transaction. Runtime replacement already occurs after archive preparation, while the identified trust gap was accepting unverified archive bytes and following unsafe archive-tree entries; a broader transaction redesign would add unrelated scope and operational risk.

## Risk

Medium. The install path is intentionally stricter and will discard a corrupt cached archive or reject an archive tree containing links or special entries. Valid official archives retain the existing install behavior.

## Test plan

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` and found no matching stale xfail row to remove or narrow.
- [x] Focused Lemonade archive-validation tests passed (61), covering digest validation, cache recovery, concurrent publication, cross-process locking, temporary-file cleanup, containment, symlink rejection on Unix and via a Windows junction, zip symlink rejection, and pax global headers.
- [x] Workspace clippy passed with warnings denied.
- [x] Formatting checks passed.
- [x] `cargo xtask manifest --check` passed.
- [ ] Full workspace tests have two pre-existing `proc_lifecycle` failures in `rocm-core`, untouched by this change; everything else passes.
- [ ] **Still needed before merge:** a fresh clean-root install against the real v10.10.0 artifacts. CI runners reuse a pre-warmed runtime tree, so the logs show the digest check running (`Using verified cached ...`) but extraction being skipped — the in-process extractor has not yet been exercised end-to-end against the published archives.
