### PR TITLE
ci: pin Strix Halo jobs to the native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,7 +909,9 @@ jobs:
     # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
     # install sdk; the cap must exceed the run so the job writes platform.json.
     timeout-minutes: 35
-    runs-on: [self-hosted, linux, strix-halo]
+    # `native` disambiguates the two Linux Strix runners: the WSL host also
+    # carries `strix-halo`, but the paths below exist only on the native one.
+    runs-on: [self-hosted, linux, strix-halo, native]
     needs: [changes, build-and-test]
     # See `e2e`: dispatch tolerates skipped build-and-test; strix-ubuntu.
     if: >-
@@ -929,7 +931,8 @@ jobs:
     # ~/.cache/pip, ~/.config, and any other $HOME writer — pip's cache under the
     # real /home/ubuntu is what previously failed `install sdk` with ENOSPC),
     # plus the toolchain, temp, and pip cache. The rustup bootstrap still uses
-    # --no-modify-path so it doesn't touch $HOME/.profile.
+    # --no-modify-path so it doesn't touch $HOME/.profile. These paths are
+    # specific to that host, which is why `runs-on` pins `native` above.
     env:
       HOME: /home/ubuntu/actions-runner/e2e-home
       CARGO_HOME: /home/ubuntu/actions-runner/.cargo
@@ -1065,7 +1068,7 @@ jobs:
     # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
     # install sdk; the cap must exceed the run so the job writes platform.json.
     timeout-minutes: 35
-    runs-on: [self-hosted, windows, strix-halo]
+    runs-on: [self-hosted, windows, strix-halo, native]
     needs: [changes, build-and-test]
     # See `e2e`: dispatch tolerates skipped build-and-test; strix-windows.
     if: >-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -417,7 +417,9 @@ jobs:
   e2e-gpu-nightly-strix:
     name: E2E tests (Strix Halo, incl. nightly-only)
     timeout-minutes: 90
-    runs-on: [self-hosted, linux, strix-halo]
+    # `native` disambiguates the two Linux Strix runners: the WSL host also
+    # carries `strix-halo`, but the paths below exist only on the native one.
+    runs-on: [self-hosted, linux, strix-halo, native]
     continue-on-error: true
     env:
       HOME: /home/ubuntu/actions-runner/e2e-home
@@ -517,7 +519,7 @@ jobs:
   e2e-gpu-nightly-strix-windows:
     name: E2E tests (Strix Halo, Windows, incl. nightly-only)
     timeout-minutes: 90
-    runs-on: [self-hosted, windows, strix-halo]
+    runs-on: [self-hosted, windows, strix-halo, native]
     continue-on-error: true
     env:
       E2E_INCLUDE_NIGHTLY: "1"


### PR DESCRIPTION
## Problem

"E2E tests (Strix Halo, Ubuntu)" has been intermittently failing on unrelated
PRs (#139, #140, #141), dying at its very first step with `Permission denied`
on `mkdir`. #143 passed only because it happened to be scheduled elsewhere.

Three self-hosted Strix Halo runners share the `strix-halo` label, and two of
them are Linux: the native Ubuntu host and a WSL host. The job's selector,
`runs-on: [self-hosted, linux, strix-halo]`, matched both, so it landed on
whichever runner was free.

That job's setup hardcodes `/home/ubuntu/actions-runner/...` for `HOME`,
`TMPDIR`, and the pip cache — the native host's root partition is full and
that nvme is the only place with space. On the WSL host the runner executes
as a different user under a different home, so those `mkdir`s fail outright
and the job dies immediately. Failing runs report `runner_name:
strix-halo-wsl`; the passing one reports `strix-halo-ubuntu`.

The nightly Strix job in `nightly.yml` copies the same hardcoded paths and the
same ambiguous selector, so it has the same latent failure — just less
visibly, since it is nightly and non-blocking.

## Change

Add the `native` label to the runner selector for the Strix jobs, making
scheduling deterministic. The Windows jobs are already unambiguous in practice
(the WSL runner is labelled `Linux`, not `Windows`), but they are pinned too so
every Strix selector reads the same way and stays correct if the WSL host ever
gains a Windows label.

The comment above the Ubuntu job's `env:` block now notes that the hardcoded
paths are the reason for the pin, so the coupling is obvious to the next reader.

## Notes

- Requires the `native` label on `strix-halo-ubuntu` and `strix-halo-windows`;
  this is already applied and live.
- Deliberately out of scope: making the hardcoded paths runner-agnostic, and
  adding any job for the WSL runner. Both are separate follow-ups.
