### PR TITLE
chore: add CODEOWNERS for the maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for ROCm CLI.
+#
+# The last matching pattern wins, so the catch-all below must stay first if any
+# path-specific overrides are added later.
+#
+# @ROCm/rocm-cli-maintainers is requested for review automatically on every pull
+# request, and `main` requires an approval from that team before merge. Manage
+# who reviews by editing the team membership, not this file.
+
+* @ROCm/rocm-cli-maintainers


### PR DESCRIPTION
Pull requests currently get a reviewer only if the author remembers to pick one.

Adds `.github/CODEOWNERS` with a single catch-all entry pointing at `@ROCm/rocm-cli-maintainers`, so GitHub requests a review from the maintainers team on every pull request.

Two supporting changes were made on the repo settings side, since a CODEOWNERS entry is inert without them:

- the `rocm-cli-maintainers` team had no access to this repository, which would have made the entry an invalid owner — it now has write access;
- `main` branch protection will require an approval from a code owner once this lands.

Reviewer membership is managed through the team, not this file.