### PR TITLE
fix(serve): gate readiness on an inference probe

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -26,11 +26,11 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use rocm_core::{
     AppPaths, AuditEventRecord, AutomationEventRecord, AutomationProposalRecord,
     AutomationRuntimeState, CodexBridgeEngine, CodexBridgeGpuSnapshot, CodexBridgeSnapshot,
-    DEFAULT_LOCAL_HOST, EndpointReadiness, ExamineSummary, ManagedServiceRecord, ModelRecipeRecord,
-    ModelRecipeRegistry, ModelRecipeRegistrySource, PERMISSIONS_MODE_ASK,
-    PERMISSIONS_MODE_FULL_ACCESS, RocmCliConfig, TELEMETRY_MODE_LOCAL, TELEMETRY_MODE_OFF,
-    WatcherMode, append_audit_event, builtin_model_recipes, builtin_watcher, builtin_watchers,
-    connect_tcp_stream, daemon_binary_path, default_engine_for_platform,
+    DEFAULT_LOCAL_HOST, EndpointReadiness, EndpointReadinessOutcome, ExamineSummary,
+    ManagedServiceRecord, ModelRecipeRecord, ModelRecipeRegistry, ModelRecipeRegistrySource,
+    PERMISSIONS_MODE_ASK, PERMISSIONS_MODE_FULL_ACCESS, RocmCliConfig, TELEMETRY_MODE_LOCAL,
+    TELEMETRY_MODE_OFF, WatcherMode, append_audit_event, builtin_model_recipes, builtin_watcher,
+    builtin_watchers, connect_tcp_stream, daemon_binary_path, default_engine_for_platform,
     default_interactive_shell_program, detect_host_gfx_target, detect_host_gpu_summary,
     engine_binary_path, engine_plugin_dirs, format_host_port, format_http_base_url,
     generate_service_id, interactive_terminal, load_model_recipe_registry,
@@ -4592,7 +4592,9 @@ struct ManagedLaunchReport {
     service_id: String,
     /// `http://host:port/v1`.
     endpoint_url: String,
-    /// `"ready"`, `"starting"`, or the existing service's status.
+    /// `"ready"` (inference confirmed), `"running"` (model listed but not serving
+    /// yet), `"starting"` (endpoint not answering), or the existing service's
+    /// status when nothing was spawned.
     status: String,
     /// True when an equivalent service was already live and nothing was spawned.
     already_running: bool,
@@ -13864,8 +13866,7 @@ fn refresh_managed_service_runtime_liveness(
     // Probe with the service's key so a protected public service is not mistaken
     // for dead (an anonymous /v1/models would 401).
     let endpoint_api_key = endpoint_keys::endpoint_api_key(paths, &record.service_id);
-    let was_verified = record.inference_verified_at_unix_ms.is_some();
-    let readiness = if matches!(record.status.as_str(), "ready" | "running") {
+    let outcome = if matches!(record.status.as_str(), "ready" | "running") {
         managed_service_endpoint_readiness(
             record,
             endpoint_api_key.as_deref(),
@@ -13873,8 +13874,12 @@ fn refresh_managed_service_runtime_liveness(
             rocm_core::INFERENCE_PROBE_TIMEOUT,
         )
     } else {
-        EndpointReadiness::Unreachable
+        EndpointReadinessOutcome {
+            readiness: EndpointReadiness::Unreachable,
+            record_changed: false,
+        }
     };
+    let readiness = outcome.readiness;
     if readiness == EndpointReadiness::Serving {
         // Mirror `providers.rs::ready_local_services()`: a live, probe-passing
         // service should be persisted as "ready", not left stuck at "running".
@@ -13884,15 +13889,17 @@ fn refresh_managed_service_runtime_liveness(
         }
         // A newly latched verification is itself worth persisting, so the next
         // check reads it instead of sending another inference request.
-        return settled_pending_stop || !was_verified;
+        return settled_pending_stop || outcome.record_changed;
     }
     if readiness == EndpointReadiness::Listing {
         // The server is up and advertising the model; the weights are simply not
         // usable yet. Leave the status alone rather than demoting to "starting" —
         // `rocmd` restarts a service that sits in "starting" past its stale
         // window, which for a slow-loading model would restart it mid-load and
-        // begin the wait all over again.
-        return settled_pending_stop;
+        // begin the wait all over again. Still report a change when the probe
+        // bookkeeping moved, so the retry throttle is persisted and the next
+        // process does not spend another full probe timeout.
+        return settled_pending_stop || outcome.record_changed;
     }
 
     let tracked_pids = recorded_service_pids(record);
@@ -17226,32 +17233,38 @@ mod tests {
         // model mid-load and start the wait over.
         let listener = TcpListener::bind(("127.0.0.1", 0))?;
         let port = listener.local_addr()?.port();
-        let server = thread::spawn(move || -> Result<()> {
-            for _ in 0..2 {
-                let (mut stream, _) = listener.accept()?;
+        // Keeps listing the model for as long as the test asks, so a second
+        // readiness check reaches the probe throttle rather than an unanswered
+        // socket. Counts the inference requests that actually got sent.
+        let probes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let server_probes = std::sync::Arc::clone(&probes);
+        let server = thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
                 stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
                 let mut buffer = [0_u8; 1024];
-                let read = stream.read(&mut buffer)?;
+                let Ok(read) = stream.read(&mut buffer) else {
+                    continue;
+                };
                 let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
                 if request.starts_with("POST /v1/chat/completions ") {
+                    server_probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                     let body = r#"{"error":"loading model"}"#;
-                    write!(
+                    let _ = write!(
                         stream,
                         "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                         body.len(),
                         body
-                    )?;
+                    );
                 } else {
                     let body = r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#;
-                    write!(
+                    let _ = write!(
                         stream,
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                         body.len(),
                         body
-                    )?;
+                    );
                 }
             }
-            Ok(())
         });
 
         let (root, paths) = test_paths("liveness-loading-service");
@@ -17275,7 +17288,6 @@ mod tests {
 
         let changed = refresh_managed_service_runtime_liveness(&paths, &mut record);
 
-        assert!(!changed, "a service that is still loading is not a change");
         assert_eq!(
             record.status, "running",
             "a loading service keeps its status rather than being demoted"
@@ -17283,6 +17295,22 @@ mod tests {
         assert!(
             record.inference_verified_at_unix_ms.is_none(),
             "nothing is latched until inference actually answers"
+        );
+        assert!(
+            changed && record.inference_probe_attempted_at_unix_ms.is_some(),
+            "the probe attempt is recorded and reported so the caller persists \
+             the retry throttle"
+        );
+
+        // Second pass, inside the retry interval: the throttle holds, so the
+        // model is not asked to generate again just because someone re-listed.
+        let changed_again = refresh_managed_service_runtime_liveness(&paths, &mut record);
+        assert!(!changed_again, "a throttled check changes nothing");
+        assert_eq!(record.status, "running");
+        assert_eq!(
+            probes.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a warming service must not be re-probed by every poll"
         );
 
         drop(server);

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -26,7 +26,7 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use rocm_core::{
     AppPaths, AuditEventRecord, AutomationEventRecord, AutomationProposalRecord,
     AutomationRuntimeState, CodexBridgeEngine, CodexBridgeGpuSnapshot, CodexBridgeSnapshot,
-    DEFAULT_LOCAL_HOST, ExamineSummary, ManagedServiceRecord, ModelRecipeRecord,
+    DEFAULT_LOCAL_HOST, EndpointReadiness, ExamineSummary, ManagedServiceRecord, ModelRecipeRecord,
     ModelRecipeRegistry, ModelRecipeRegistrySource, PERMISSIONS_MODE_ASK,
     PERMISSIONS_MODE_FULL_ACCESS, RocmCliConfig, TELEMETRY_MODE_LOCAL, TELEMETRY_MODE_OFF,
     WatcherMode, append_audit_event, builtin_model_recipes, builtin_watcher, builtin_watchers,
@@ -35,7 +35,7 @@ use rocm_core::{
     engine_binary_path, engine_plugin_dirs, format_host_port, format_http_base_url,
     generate_service_id, interactive_terminal, load_model_recipe_registry,
     load_recent_audit_events, load_recent_automation_events, load_recent_automation_proposals,
-    managed_pip_cache_dir, managed_service_endpoint_model_ready, model_artifact_cache_status,
+    managed_pip_cache_dir, managed_service_endpoint_readiness, model_artifact_cache_status,
     model_catalog_platforms, model_recipe_featured, model_recipe_target_platform_label,
     normalize_therock_family, platform_matches_gfx_family,
     preferred_serve_engine_for_host_gpu_summary, prepend_runtime_path, process_is_running,
@@ -4831,7 +4831,13 @@ fn start_managed_service(
         Duration::from_secs(45),
         on_wait_tick,
     );
-    record.status = if readiness { "ready" } else { "starting" }.to_owned();
+    let launch_status = status_for_readiness(readiness);
+    record.status = launch_status.to_owned();
+    if readiness == EndpointReadiness::Serving {
+        // Latch the verification the wait just performed, so the readiness checks
+        // behind `services list` and chat read it instead of re-probing.
+        record.inference_verified_at_unix_ms = Some(rocm_core::unix_time_millis() as u64);
+    }
     record.write()?;
     let endpoint_url = format!("{}/v1", format_http_base_url(host, port));
     record_cli_audit_event(
@@ -4841,17 +4847,14 @@ fn start_managed_service(
         "info",
         format!(
             "launched managed service engine={} model={} endpoint={} readiness={}",
-            engine,
-            resolve.canonical_model_id,
-            endpoint_url,
-            if readiness { "ready" } else { "starting" }
+            engine, resolve.canonical_model_id, endpoint_url, launch_status
         ),
         Some(service_id),
     );
     Ok(ManagedLaunchReport {
         service_id: service_id.to_owned(),
         endpoint_url,
-        status: if readiness { "ready" } else { "starting" }.to_owned(),
+        status: launch_status.to_owned(),
         already_running: false,
         child_pid: Some(child_pid),
         log_path: Some(record.log_path),
@@ -13023,20 +13026,22 @@ fn restart_internal_managed_service(
     record.engine_pid = Some(child_pid);
     // Refresh the identity token in lockstep with the restarted child's PID.
     record.supervisor_start_ticks = rocm_core::process_start_ticks(child_pid);
-    record.restart_count = record.restart_count.saturating_add(1);
-    record.last_restart_unix_ms = Some(rocm_core::unix_time_millis());
-    record.status = if wait_for_service_http_ready(
+    // Counts the restart and drops the previous run's inference verification —
+    // the new child has an unloaded model, so the old verdict says nothing about
+    // it.
+    record.reset_for_restart();
+    let readiness = wait_for_service_http_ready(
         &record.engine,
         &record.host,
         record.port,
         &record.canonical_model_id,
         endpoint_api_key.as_deref(),
         Duration::from_secs(45),
-    ) {
-        "ready".to_owned()
-    } else {
-        "starting".to_owned()
-    };
+    );
+    record.status = status_for_readiness(readiness).to_owned();
+    if readiness == EndpointReadiness::Serving {
+        record.inference_verified_at_unix_ms = Some(rocm_core::unix_time_millis() as u64);
+    }
     record.write()?;
     Ok(record)
 }
@@ -13859,20 +13864,34 @@ fn refresh_managed_service_runtime_liveness(
     // Probe with the service's key so a protected public service is not mistaken
     // for dead (an anonymous /v1/models would 401).
     let endpoint_api_key = endpoint_keys::endpoint_api_key(paths, &record.service_id);
-    let endpoint_ready = matches!(record.status.as_str(), "ready" | "running")
-        && managed_service_endpoint_model_ready(
+    let was_verified = record.inference_verified_at_unix_ms.is_some();
+    let readiness = if matches!(record.status.as_str(), "ready" | "running") {
+        managed_service_endpoint_readiness(
             record,
             endpoint_api_key.as_deref(),
             SERVICE_LIVENESS_CHECK_TIMEOUT,
+            rocm_core::INFERENCE_PROBE_TIMEOUT,
         )
-        .unwrap_or(false);
-    if endpoint_ready {
+    } else {
+        EndpointReadiness::Unreachable
+    };
+    if readiness == EndpointReadiness::Serving {
         // Mirror `providers.rs::ready_local_services()`: a live, probe-passing
         // service should be persisted as "ready", not left stuck at "running".
         if record.status == "running" {
             record.status = "ready".to_owned();
             return true;
         }
+        // A newly latched verification is itself worth persisting, so the next
+        // check reads it instead of sending another inference request.
+        return settled_pending_stop || !was_verified;
+    }
+    if readiness == EndpointReadiness::Listing {
+        // The server is up and advertising the model; the weights are simply not
+        // usable yet. Leave the status alone rather than demoting to "starting" —
+        // `rocmd` restarts a service that sits in "starting" past its stale
+        // window, which for a slow-loading model would restart it mid-load and
+        // begin the wait all over again.
         return settled_pending_stop;
     }
 
@@ -16170,7 +16189,7 @@ fn wait_for_service_http_ready(
     canonical_model_id: &str,
     endpoint_api_key: Option<&str>,
     timeout: Duration,
-) -> bool {
+) -> EndpointReadiness {
     wait_for_service_http_ready_with_progress(
         engine,
         host,
@@ -16188,6 +16207,13 @@ fn wait_for_service_http_ready(
 /// each engine to the right health path and normalizes the response to ready/not.
 /// `endpoint_api_key` is sent as a bearer token so the probe still succeeds against
 /// a public endpoint that now requires authentication.
+/// Wait until the service can actually serve, reporting how far it got.
+///
+/// A health or model-listing endpoint answering is not enough to call a service
+/// ready: engines advertise a model within seconds of accepting its name, while
+/// the weights can take minutes to become usable, so a caller that sends its
+/// first request on that signal gets a hang. Only [`EndpointReadiness::Serving`]
+/// — an inference request that came back — means ready.
 fn wait_for_service_http_ready_with_progress(
     engine: &str,
     host: &str,
@@ -16196,30 +16222,59 @@ fn wait_for_service_http_ready_with_progress(
     endpoint_api_key: Option<&str>,
     timeout: Duration,
     on_tick: &mut dyn FnMut(Duration),
-) -> bool {
+) -> EndpointReadiness {
     let start = std::time::Instant::now();
+    let endpoint = format_http_base_url(host, port);
+    let mut best = EndpointReadiness::Unreachable;
     while start.elapsed() < timeout {
-        for path in service_http_readiness_paths(engine) {
-            if let Ok((status, body)) = http_get_local_service(
+        let listed = service_http_readiness_paths(engine).iter().any(|path| {
+            http_get_local_service(
                 host,
                 port,
                 path,
                 endpoint_api_key,
                 Duration::from_millis(750),
-            ) && service_http_readiness_response_ready(
-                engine,
-                path,
-                status,
-                &body,
+            )
+            .is_ok_and(|(status, body)| {
+                service_http_readiness_response_ready(
+                    engine,
+                    path,
+                    status,
+                    &body,
+                    canonical_model_id,
+                )
+            })
+        });
+        if listed {
+            best = EndpointReadiness::Listing;
+            if rocm_core::openai_chat_completion_probe(
+                &endpoint,
                 canonical_model_id,
-            ) {
-                return true;
+                endpoint_api_key,
+                rocm_core::INFERENCE_PROBE_TIMEOUT,
+            )
+            .unwrap_or(false)
+            {
+                return EndpointReadiness::Serving;
             }
         }
         on_tick(start.elapsed());
         thread::sleep(Duration::from_millis(250));
     }
-    false
+    best
+}
+
+/// The record status matching how far the endpoint got.
+///
+/// `Listing` maps to `running`, not `starting`: the engine is up and loading
+/// normally, and `rocmd` restarts a service left in `starting` past its stale
+/// window, which would kill a slow-loading model mid-load.
+const fn status_for_readiness(readiness: EndpointReadiness) -> &'static str {
+    match readiness {
+        EndpointReadiness::Serving => "ready",
+        EndpointReadiness::Listing => "running",
+        EndpointReadiness::Unreachable => "starting",
+    }
 }
 
 fn service_http_readiness_paths(engine: &str) -> &'static [&'static str] {
@@ -17057,17 +17112,199 @@ mod tests {
     }
 
     #[test]
+    fn serve_readiness_wait_withholds_ready_while_the_model_only_lists() -> Result<()> {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        // This is the wait behind `rocm serve`, and its verdict is what
+        // `services list` later prints. A model listing on `/v1/models` while
+        // inference still fails must come back as `Listing` — reporting it ready
+        // is the false positive users and automation trip over.
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        let server = thread::spawn(move || -> Result<()> {
+            // Serve until the wait below gives up and the test drops the socket.
+            while let Ok((mut stream, _)) = listener.accept() {
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut buffer = [0_u8; 1024];
+                let Ok(read) = stream.read(&mut buffer) else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                let (status_line, body) = if request.starts_with("POST /v1/chat/completions ") {
+                    ("HTTP/1.1 503 Service Unavailable", r#"{"error":"loading"}"#)
+                } else {
+                    ("HTTP/1.1 200 OK", r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#)
+                };
+                let _ = write!(
+                    stream,
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+            }
+            Ok(())
+        });
+
+        let readiness = wait_for_service_http_ready(
+            "vllm",
+            "127.0.0.1",
+            port,
+            "Qwen3-0.6B-GGUF",
+            None,
+            Duration::from_millis(600),
+        );
+
+        assert_eq!(
+            readiness,
+            EndpointReadiness::Listing,
+            "a listed-but-unservable model is not ready"
+        );
+        assert_eq!(
+            status_for_readiness(readiness),
+            "running",
+            "a loading service must not be recorded as `starting`, which rocmd \
+             restarts once stale"
+        );
+        drop(server);
+        Ok(())
+    }
+
+    #[test]
+    fn serve_readiness_wait_reports_ready_once_inference_answers() -> Result<()> {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        let server = thread::spawn(move || -> Result<()> {
+            while let Ok((mut stream, _)) = listener.accept() {
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut buffer = [0_u8; 1024];
+                let Ok(read) = stream.read(&mut buffer) else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                let body = if request.starts_with("POST /v1/chat/completions ") {
+                    r#"{"choices":[{"message":{"content":"ok"}}]}"#
+                } else {
+                    r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#
+                };
+                let _ = write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+            }
+            Ok(())
+        });
+
+        let readiness = wait_for_service_http_ready(
+            "vllm",
+            "127.0.0.1",
+            port,
+            "Qwen3-0.6B-GGUF",
+            None,
+            Duration::from_secs(5),
+        );
+
+        assert_eq!(readiness, EndpointReadiness::Serving);
+        assert_eq!(status_for_readiness(readiness), "ready");
+        drop(server);
+        Ok(())
+    }
+
+    #[test]
+    fn a_loading_service_keeps_its_status_instead_of_being_demoted() -> Result<()> {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        // A model that is listed but cannot serve yet is coming up normally. It
+        // must not be demoted to "starting": `rocmd` restarts a service that sits
+        // in "starting" past its stale window, which would kill a slow-loading
+        // model mid-load and start the wait over.
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let port = listener.local_addr()?.port();
+        let server = thread::spawn(move || -> Result<()> {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut buffer = [0_u8; 1024];
+                let read = stream.read(&mut buffer)?;
+                let request = String::from_utf8_lossy(&buffer[..read]).into_owned();
+                if request.starts_with("POST /v1/chat/completions ") {
+                    let body = r#"{"error":"loading model"}"#;
+                    write!(
+                        stream,
+                        "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )?;
+                } else {
+                    let body = r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#;
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )?;
+                }
+            }
+            Ok(())
+        });
+
+        let (root, paths) = test_paths("liveness-loading-service");
+        paths.ensure()?;
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            "svc-loading",
+            "vllm",
+            "Qwen3-0.6B-GGUF",
+            "Qwen3-0.6B-GGUF",
+            "127.0.0.1",
+            port,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            None,
+        );
+        record.status = "running".to_owned();
+        record.write()?;
+
+        let changed = refresh_managed_service_runtime_liveness(&paths, &mut record);
+
+        assert!(!changed, "a service that is still loading is not a change");
+        assert_eq!(
+            record.status, "running",
+            "a loading service keeps its status rather than being demoted"
+        );
+        assert!(
+            record.inference_verified_at_unix_ms.is_none(),
+            "nothing is latched until inference actually answers"
+        );
+
+        drop(server);
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
     fn load_managed_services_promotes_running_to_ready_once_probe_passes() -> Result<()> {
         use std::io::{Read, Write};
         use std::net::TcpListener;
 
         let listener = TcpListener::bind(("127.0.0.1", 0))?;
         let port = listener.local_addr()?.port();
-        // Two probes hit this mock: one from `load_managed_services`, another
-        // from the `load_managed_service` re-read below that verifies the
-        // promotion was actually persisted, not just returned in-memory.
-        let server = thread::spawn(move || -> Result<()> {
-            for _ in 0..2 {
+        // Three requests hit this mock. `load_managed_services` lists the model
+        // and then confirms inference, which promotes the record and latches the
+        // verification; the `load_managed_service` re-read below (which proves the
+        // promotion was persisted, not just returned in-memory) reads that latch
+        // and so only re-lists.
+        let server = thread::spawn(move || -> Result<Vec<String>> {
+            let mut requests = Vec::new();
+            for _ in 0..3 {
                 let (mut stream, _) = listener.accept()?;
                 stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
                 let mut request_bytes = Vec::new();
@@ -17082,15 +17319,21 @@ mod tests {
                         break;
                     }
                 }
-                let body = r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#;
+                let request = String::from_utf8_lossy(&request_bytes).into_owned();
+                let body = if request.starts_with("POST /v1/chat/completions ") {
+                    r#"{"choices":[{"message":{"content":"ok"}}]}"#
+                } else {
+                    r#"{"data":[{"id":"Qwen3-0.6B-GGUF"}]}"#
+                };
                 write!(
                     stream,
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                     body.len(),
                     body
                 )?;
+                requests.push(request);
             }
-            Ok(())
+            Ok(requests)
         });
 
         let (root, paths) = test_paths("load-managed-services-promote-ready");
@@ -17136,8 +17379,25 @@ mod tests {
         // in-memory, since chat's `pick_managed_chat_endpoint` re-reads it.
         let reloaded = load_managed_service(&paths, "svc-qwen-promote")?;
         assert_eq!(reloaded.status, "ready");
+        assert!(
+            reloaded.inference_verified_at_unix_ms.is_some(),
+            "the inference verification is persisted with the promotion"
+        );
 
-        server.join().expect("server thread should not panic")?;
+        let requests = server.join().expect("server thread should not panic")?;
+        let lines: Vec<&str> = requests
+            .iter()
+            .filter_map(|request| request.lines().next())
+            .collect();
+        assert_eq!(
+            lines,
+            vec![
+                "GET /v1/models HTTP/1.1",
+                "POST /v1/chat/completions HTTP/1.1",
+                "GET /v1/models HTTP/1.1",
+            ],
+            "promotion confirms inference once; the re-read reads the latch"
+        );
         fs::remove_dir_all(root).ok();
         Ok(())
     }
@@ -20253,18 +20513,27 @@ install therock";
         paths.ensure()?;
         let listener = TcpListener::bind(("127.0.0.1", 0))?;
         let ready_port = listener.local_addr()?.port();
+        // The ready service is listed and then asked to complete a request:
+        // readiness is not granted on the model listing alone.
         let server = thread::spawn(move || -> Result<()> {
-            let (mut stream, _) = listener.accept()?;
-            stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-            let mut request = [0_u8; 512];
-            let _ = stream.read(&mut request)?;
-            let body = r#"{"data":[{"id":"Qwen/Qwen3.5"}]}"#;
-            write!(
-                stream,
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            )?;
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+                let mut request = [0_u8; 512];
+                let read = stream.read(&mut request)?;
+                let request = String::from_utf8_lossy(&request[..read]).into_owned();
+                let body = if request.starts_with("POST /v1/chat/completions ") {
+                    r#"{"choices":[{"message":{"content":"ok"}}]}"#
+                } else {
+                    r#"{"data":[{"id":"Qwen/Qwen3.5"}]}"#
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )?;
+            }
             Ok(())
         });
         let current_pid = std::process::id();

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -16208,19 +16208,21 @@ fn wait_for_service_http_ready(
     )
 }
 
-/// Poll the engine's health endpoints until the server answers ready or `timeout`
-/// elapses, invoking `on_tick(elapsed)` once per polling iteration so a caller can
-/// animate a spinner. Engine-neutral: `service_http_readiness_paths` already maps
-/// each engine to the right health path and normalizes the response to ready/not.
-/// `endpoint_api_key` is sent as a bearer token so the probe still succeeds against
-/// a public endpoint that now requires authentication.
 /// Wait until the service can actually serve, reporting how far it got.
 ///
 /// A health or model-listing endpoint answering is not enough to call a service
 /// ready: engines advertise a model within seconds of accepting its name, while
 /// the weights can take minutes to become usable, so a caller that sends its
 /// first request on that signal gets a hang. Only [`EndpointReadiness::Serving`]
-/// — an inference request that came back — means ready.
+/// — an inference request that came back — means ready; a service that lists the
+/// model without answering one is [`EndpointReadiness::Listing`], and the best
+/// result seen before `timeout` is what gets returned.
+///
+/// Polls until `timeout` elapses, invoking `on_tick(elapsed)` once per iteration
+/// so a caller can animate a spinner. Engine-neutral: `service_http_readiness_paths`
+/// maps each engine to the right listing path. `endpoint_api_key` is sent as a
+/// bearer token so both the listing check and the inference probe still succeed
+/// against a public endpoint that requires authentication.
 fn wait_for_service_http_ready_with_progress(
     engine: &str,
     host: &str,

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -4,9 +4,10 @@
 
 use anyhow::{Context, Result, bail};
 use rocm_core::{
-    AppPaths, AuditEventRecord, EndpointReadiness, ManagedServiceRecord, RocmCliConfig,
-    append_audit_event, connect_tcp_stream, format_host_port, managed_service_endpoint_readiness,
-    read_tcp_stream_to_string, unix_time_millis, write_all_tcp_stream,
+    AppPaths, AuditEventRecord, EndpointReadiness, EndpointReadinessOutcome, ManagedServiceRecord,
+    RocmCliConfig, append_audit_event, connect_tcp_stream, format_host_port,
+    managed_service_endpoint_readiness, read_tcp_stream_to_string, unix_time_millis,
+    write_all_tcp_stream,
 };
 use std::fs;
 use std::io::{BufRead, BufReader, Read};
@@ -529,24 +530,31 @@ fn ready_local_services(paths: &AppPaths) -> Result<Vec<ManagedServiceRecord>> {
         // filtered out here (an anonymous /v1/models would 401) before
         // `LocalProvider` can send the bearer token.
         let endpoint_api_key = crate::endpoint_keys::endpoint_api_key(paths, &record.service_id);
-        let was_verified = record.inference_verified_at_unix_ms.is_some();
-        if matches!(record.status.as_str(), "ready" | "running")
-            && managed_service_endpoint_readiness(
+        let outcome = if matches!(record.status.as_str(), "ready" | "running") {
+            managed_service_endpoint_readiness(
                 &mut record,
                 endpoint_api_key.as_deref(),
                 LOCAL_SERVICE_READY_TIMEOUT,
                 rocm_core::INFERENCE_PROBE_TIMEOUT,
-            ) == EndpointReadiness::Serving
-        {
-            let status_changed = record.status != "ready";
-            if status_changed {
-                record.status = "ready".to_owned();
+            )
+        } else {
+            EndpointReadinessOutcome {
+                readiness: EndpointReadiness::Unreachable,
+                record_changed: false,
             }
-            // Persist a newly latched verification too, so the next listing reads
-            // it instead of sending another inference request.
-            if status_changed || !was_verified {
-                let _ = record.write();
-            }
+        };
+        let serving = outcome.readiness == EndpointReadiness::Serving;
+        let status_changed = serving && record.status != "ready";
+        if status_changed {
+            record.status = "ready".to_owned();
+        }
+        // Persist the probe bookkeeping even for a service that is not ready:
+        // the retry throttle is stored on the record, and each CLI invocation is
+        // a fresh process, so an unwritten attempt throttles nothing.
+        if status_changed || outcome.record_changed {
+            let _ = record.write();
+        }
+        if serving {
             services.push(record);
         }
     }

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -4,8 +4,8 @@
 
 use anyhow::{Context, Result, bail};
 use rocm_core::{
-    AppPaths, AuditEventRecord, ManagedServiceRecord, RocmCliConfig, append_audit_event,
-    connect_tcp_stream, format_host_port, managed_service_endpoint_model_ready,
+    AppPaths, AuditEventRecord, EndpointReadiness, ManagedServiceRecord, RocmCliConfig,
+    append_audit_event, connect_tcp_stream, format_host_port, managed_service_endpoint_readiness,
     read_tcp_stream_to_string, unix_time_millis, write_all_tcp_stream,
 };
 use std::fs;
@@ -529,16 +529,22 @@ fn ready_local_services(paths: &AppPaths) -> Result<Vec<ManagedServiceRecord>> {
         // filtered out here (an anonymous /v1/models would 401) before
         // `LocalProvider` can send the bearer token.
         let endpoint_api_key = crate::endpoint_keys::endpoint_api_key(paths, &record.service_id);
+        let was_verified = record.inference_verified_at_unix_ms.is_some();
         if matches!(record.status.as_str(), "ready" | "running")
-            && managed_service_endpoint_model_ready(
-                &record,
+            && managed_service_endpoint_readiness(
+                &mut record,
                 endpoint_api_key.as_deref(),
                 LOCAL_SERVICE_READY_TIMEOUT,
-            )
-            .unwrap_or(false)
+                rocm_core::INFERENCE_PROBE_TIMEOUT,
+            ) == EndpointReadiness::Serving
         {
-            if record.status != "ready" {
+            let status_changed = record.status != "ready";
+            if status_changed {
                 record.status = "ready".to_owned();
+            }
+            // Persist a newly latched verification too, so the next listing reads
+            // it instead of sending another inference request.
+            if status_changed || !was_verified {
                 let _ = record.write();
             }
             services.push(record);
@@ -1604,9 +1610,12 @@ mod tests {
         paths.ensure()?;
         let listener = TcpListener::bind("127.0.0.1:0")?;
         let port = listener.local_addr()?.port();
+        // Three requests: the first readiness check lists the model and then
+        // confirms inference, latching the verdict; the second check reads the
+        // latch and only re-lists.
         let server = thread::spawn(move || -> Result<Vec<String>> {
             let mut requests = Vec::new();
-            for _ in 0..2 {
+            for _ in 0..3 {
                 let (mut stream, _) = listener.accept()?;
                 stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
                 let mut request_bytes = Vec::new();
@@ -1623,7 +1632,11 @@ mod tests {
                     }
                 }
                 let request = String::from_utf8_lossy(&request_bytes).into_owned();
-                let body = format!(r#"{{"data":[{{"id":"{LEMONADE_ASSISTANT_MODEL_ID}"}}]}}"#);
+                let body = if request.starts_with("POST /v1/chat/completions ") {
+                    r#"{"choices":[{"message":{"content":"ok"}}]}"#.to_owned()
+                } else {
+                    format!(r#"{{"data":[{{"id":"{LEMONADE_ASSISTANT_MODEL_ID}"}}]}}"#)
+                };
                 write!(
                     stream,
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -1667,11 +1680,18 @@ mod tests {
         let requests = server.join().expect("server thread should not panic")?;
         fs::remove_dir_all(root).ok();
 
-        assert_eq!(requests.len(), 2);
-        assert!(
-            requests
-                .iter()
-                .all(|request| request.starts_with("GET /v1/models HTTP/1.1"))
+        let request_lines: Vec<&str> = requests
+            .iter()
+            .filter_map(|request| request.lines().next())
+            .collect();
+        assert_eq!(
+            request_lines,
+            vec![
+                "GET /v1/models HTTP/1.1",
+                "POST /v1/chat/completions HTTP/1.1",
+                "GET /v1/models HTTP/1.1",
+            ],
+            "readiness confirms inference once, then reads the latch"
         );
         assert_eq!(selected.service_id, "svc-lemonade-ready");
         assert_eq!(selected.status, "ready");
@@ -2066,6 +2086,9 @@ mod tests {
             None,
         );
         ready.status = "ready".to_owned();
+        // Already served inference, so readiness checks read the latch
+        // instead of probing this stub for a completion.
+        ready.inference_verified_at_unix_ms = Some(1);
         ready.write()?;
 
         let response = provider_chat(
@@ -2300,6 +2323,9 @@ mod tests {
             None,
         );
         ready.status = "ready".to_owned();
+        // Already served inference, so readiness checks read the latch
+        // instead of probing this stub for a completion.
+        ready.inference_verified_at_unix_ms = Some(1);
         ready.write()?;
 
         let response = provider_chat(
@@ -2363,6 +2389,9 @@ mod tests {
             None,
         );
         ready.status = "ready".to_owned();
+        // Already served inference, so readiness checks read the latch
+        // instead of probing this stub for a completion.
+        ready.inference_verified_at_unix_ms = Some(1);
         ready.write()?;
 
         let events = provider_stream_chat(
@@ -2466,6 +2495,9 @@ mod tests {
             None,
         );
         ready.status = "ready".to_owned();
+        // Already served inference, so readiness checks read the latch
+        // instead of probing this stub for a completion.
+        ready.inference_verified_at_unix_ms = Some(1);
         ready.write()?;
         let mut events = Vec::new();
 
@@ -2551,6 +2583,9 @@ mod tests {
             None,
         );
         ready.status = "ready".to_owned();
+        // Already served inference, so readiness checks read the latch
+        // instead of probing this stub for a completion.
+        ready.inference_verified_at_unix_ms = Some(1);
         ready.write()?;
 
         let events = provider_stream_chat(

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -166,10 +166,19 @@ pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
         );
     }
     if !ready && !summary.already_running {
+        // Two different ways to miss "ready", and conflating them misleads: a
+        // `running` service answered and advertised the model but could not serve
+        // a request yet, which is also why the metrics rows are empty — the smoke
+        // test only runs against a service that can actually serve.
+        let explanation = if summary.status == "running" {
+            "the server is up and lists the model, but it could not serve a request yet, \
+             so no smoke test was run; it is most likely still loading"
+        } else {
+            "the server did not report ready before the startup timeout; it may still be loading"
+        };
         let _ = writeln!(
             out,
-            "  note: the server did not report ready before the startup timeout; \
-             it may still be loading — check `rocm logs --service {}` or `rocm services list`",
+            "  note: {explanation} — check `rocm logs --service {}` or `rocm services list`",
             summary.service_id
         );
     }
@@ -439,6 +448,28 @@ mod tests {
         assert!(rendered.contains("not ready yet"), "heading: {rendered}");
         assert!(rendered.contains("did not report ready"));
         assert!(rendered.contains("rocm logs --service"));
+    }
+
+    #[test]
+    fn a_still_loading_launch_explains_the_missing_smoke_test() {
+        // A launch whose model lists but cannot serve yet lands at "running". The
+        // smoke test is skipped by design (there is nothing to measure), so the
+        // empty metrics rows must be explained rather than left to read as a
+        // failed measurement against a healthy server.
+        let mut summary = base_summary();
+        summary.status = "running".to_owned();
+        summary.metrics = SmokeMetrics::default();
+        let rendered = render_summary(&summary);
+        assert!(rendered.contains("not ready yet"), "heading: {rendered}");
+        assert!(
+            rendered.contains("no smoke test was run"),
+            "the skipped smoke test must be explained: {rendered}"
+        );
+        assert!(
+            rendered.contains("still loading"),
+            "the user needs to know this resolves on its own: {rendered}"
+        );
+        assert!(rendered.contains("rocm services list"));
     }
 
     #[test]

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -7048,6 +7048,29 @@ mod tests {
 
         response.status = "loading_model".to_owned();
         assert!(!healthcheck_response_recoverable(&response));
+
+        // The status the engines report for a model that is listed but has not
+        // yet served an inference request. Restarting it would kill a model
+        // mid-load and start the wait over.
+        response.status = "loading".to_owned();
+        assert!(!healthcheck_response_recoverable(&response));
+    }
+
+    #[test]
+    fn healthcheck_readiness_withheld_while_the_model_only_lists() {
+        // What an engine reports once `/v1/models` answers but inference has not:
+        // not ready, so `rocm serve` keeps waiting instead of handing the caller
+        // an endpoint that will hang on its first request.
+        let listing_only = HealthcheckResponse {
+            status: "loading".to_owned(),
+            model_loaded: false,
+            device: "unknown".to_owned(),
+            uptime_sec: 1,
+            queue_depth: 0,
+            last_error: None,
+            tokens_per_sec: None,
+        };
+        assert!(!healthcheck_response_ready(&listing_only));
     }
 
     #[test]

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -4823,8 +4823,13 @@ fn restart_managed_service(_paths: &AppPaths, record: &mut ManagedServiceRecord)
         .context("failed to clone service log file handle")?;
 
     record.status = "recovering".to_owned();
-    record.restart_count = record.restart_count.saturating_add(1);
-    record.last_restart_unix_ms = Some(unix_time_millis());
+    // Counts the restart and drops the previous run's inference verification.
+    // The respawned child writes a fresh record of its own, and "recovering" is
+    // outside the statuses that probe, so a stale verdict would not currently be
+    // acted on — but this record is written again below, after the spawn, and
+    // that write can land after the child's. Clearing here keeps the invariant
+    // true at the one site that reuses a record across restarts.
+    record.reset_for_restart();
     record.supervisor_pid = std::process::id();
     record.write()?;
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -190,6 +190,125 @@ pub fn http_get_text_with_auth(
     Ok(body.to_owned())
 }
 
+/// POST a JSON body and return the response status line plus body.
+///
+/// The POST sibling of [`http_get_text_with_auth`]. Unlike the GET helper this
+/// does not treat a non-200 as an error: callers that probe an endpoint need to
+/// tell "the server answered, with a refusal" apart from "the server never
+/// answered", and only the former proves the request path is alive.
+pub fn http_post_json_with_auth(
+    endpoint_url: &str,
+    path: &str,
+    body: &serde_json::Value,
+    endpoint_api_key: Option<&str>,
+    timeout: Duration,
+) -> Result<HttpResponseParts> {
+    let (host, port) = parse_http_endpoint(endpoint_url)
+        .with_context(|| format!("unsupported endpoint URL `{endpoint_url}`"))?;
+    let mut stream = connect_tcp_stream(&host, port, timeout)?;
+    let host_header = format_host_port(&host, port);
+    let auth_header = match endpoint_api_key {
+        Some(key) => format!("Authorization: Bearer {key}\r\n"),
+        None => String::new(),
+    };
+    let payload = serde_json::to_string(body).context("failed to serialize HTTP JSON body")?;
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nAccept: application/json\r\nContent-Length: {}\r\n{auth_header}Connection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    write_all_tcp_stream(&mut stream, request.as_bytes())
+        .with_context(|| format!("failed to write HTTP POST {path}"))?;
+    let response = read_tcp_stream_to_string(&mut stream)
+        .with_context(|| format!("failed to read HTTP POST {path}"))?;
+    let (headers, body) = response
+        .split_once("\r\n\r\n")
+        .context("HTTP response was missing a body")?;
+    let status_line = headers.lines().next().unwrap_or_default();
+    let status = http_status_code(status_line)
+        .with_context(|| format!("unparsable HTTP status line `{status_line}`"))?;
+    Ok(HttpResponseParts {
+        status,
+        body: body.to_owned(),
+    })
+}
+
+/// Budget for the single-token chat request that proves a service can serve.
+///
+/// Generously longer than a model-listing timeout: the probe is a real inference
+/// request, and a first request against a freshly loaded model pays for prompt
+/// processing before it answers.
+pub const INFERENCE_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Engine state-file key recording when inference was first confirmed.
+///
+/// Written by the engine healthchecks and adopted by
+/// [`ManagedServiceRecord::refresh_from_engine_state`], so the CLI side does not
+/// re-probe what an engine already verified.
+pub const INFERENCE_VERIFIED_STATE_KEY: &str = "inference_verified_at_unix_ms";
+
+/// The parts of an HTTP response a probe needs: the status code and the body.
+#[derive(Debug, Clone)]
+pub struct HttpResponseParts {
+    pub status: u16,
+    pub body: String,
+}
+
+fn http_status_code(status_line: &str) -> Option<u16> {
+    status_line.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// Ask the endpoint for a single token and report whether it answered.
+///
+/// This is the readiness signal that `/v1/models` cannot give: an engine lists a
+/// model as soon as it accepts the name, which can be minutes before the weights
+/// are resident and the first chat request stops hanging.
+///
+/// "Answered" means a complete HTTP response with a status below 500, not a
+/// successful generation. A `4xx` still proves the inference path is up and the
+/// model is loaded — the request was understood and refused on its merits — while
+/// the failure this guards against is a hang, a dropped connection, or the `5xx`
+/// an engine returns while it is still warming up. Insisting on `200` with
+/// non-empty content would also wrongly fail a reasoning model, which can spend
+/// its whole (tiny) token budget before emitting any content.
+pub fn openai_chat_completion_probe(
+    endpoint_url: &str,
+    model_ref: &str,
+    endpoint_api_key: Option<&str>,
+    timeout: Duration,
+) -> Result<bool> {
+    let status = openai_chat_completion_status(endpoint_url, model_ref, endpoint_api_key, timeout)?;
+    Ok(status < 500)
+}
+
+/// Send the smallest possible chat request and return the HTTP status.
+///
+/// Callers pick their own bar. Readiness ([`openai_chat_completion_probe`]) only
+/// needs to know the inference path answers at all, while a post-load smoke test
+/// wants a real `200` — there, a `4xx` means the model that came up is not the
+/// one that was asked for, which is a failure worth surfacing rather than
+/// tolerating.
+pub fn openai_chat_completion_status(
+    endpoint_url: &str,
+    model_ref: &str,
+    endpoint_api_key: Option<&str>,
+    timeout: Duration,
+) -> Result<u16> {
+    let body = serde_json::json!({
+        "model": model_ref,
+        "messages": [{"role": "user", "content": "Say ok."}],
+        "max_tokens": 2,
+        "stream": false,
+    });
+    let response = http_post_json_with_auth(
+        endpoint_url,
+        "/v1/chat/completions",
+        &body,
+        endpoint_api_key,
+        timeout,
+    )?;
+    Ok(response.status)
+}
+
 pub fn openai_models_endpoint_has_model(
     endpoint_url: &str,
     expected_model: Option<&str>,
@@ -227,6 +346,70 @@ pub fn managed_service_endpoint_model_ready(
         None
     };
     openai_models_endpoint_has_model(&record.endpoint_url, expected, endpoint_api_key, timeout)
+}
+
+/// How far along a managed service's endpoint is.
+///
+/// The middle state is the one that matters: an engine lists a model within
+/// seconds of accepting its name, while the weights can take minutes to become
+/// usable. Callers must not treat `Listing` as ready — nor as dead, since the
+/// service is coming up normally and restarting it would start the wait over.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EndpointReadiness {
+    /// Not answering at all: wrong port, process gone, or nothing bound yet.
+    Unreachable,
+    /// Answering and advertising the model, but inference has not come back.
+    Listing,
+    /// A real inference request has succeeded.
+    Serving,
+}
+
+/// How far along the service's endpoint is, probing inference at most once.
+///
+/// Stronger than [`managed_service_endpoint_model_ready`], which only asks
+/// whether the endpoint lists the model. A service reaches [`Serving`] once a
+/// real inference request has come back, and that verdict is **latched** into
+/// `record.inference_verified_at_unix_ms`: readiness is polled repeatedly (by
+/// `services list`, the dash, and the supervisor), and re-probing on every poll
+/// would queue a generation request behind the user's own traffic. The trade-off
+/// is that a service which degrades after start still reports ready — the same
+/// as before this check existed.
+///
+/// Mutates `record` on first success; the caller is responsible for persisting it
+/// with [`ManagedServiceRecord::write`].
+///
+/// [`Serving`]: EndpointReadiness::Serving
+pub fn managed_service_endpoint_readiness(
+    record: &mut ManagedServiceRecord,
+    endpoint_api_key: Option<&str>,
+    listing_timeout: Duration,
+    probe_timeout: Duration,
+) -> EndpointReadiness {
+    let listed = managed_service_endpoint_model_ready(record, endpoint_api_key, listing_timeout)
+        .unwrap_or(false);
+    if !listed {
+        return EndpointReadiness::Unreachable;
+    }
+    if record.inference_verified_at_unix_ms.is_some() {
+        return EndpointReadiness::Serving;
+    }
+    let model_ref = if record.canonical_model_id.trim().is_empty() {
+        record.model_ref.as_str()
+    } else {
+        record.canonical_model_id.as_str()
+    };
+    if !openai_chat_completion_probe(
+        &record.endpoint_url,
+        model_ref,
+        endpoint_api_key,
+        probe_timeout,
+    )
+    .unwrap_or(false)
+    {
+        return EndpointReadiness::Listing;
+    }
+    record.inference_verified_at_unix_ms = Some(unix_time_millis() as u64);
+    EndpointReadiness::Serving
 }
 
 fn openai_loaded_model_ids(value: &serde_json::Value) -> Vec<String> {
@@ -306,8 +489,11 @@ pub fn connect_tcp_stream(host: &str, port: u16, timeout: Duration) -> Result<Tc
         .with_context(|| format!("failed to resolve {host}:{port}"))?
         .next()
         .with_context(|| format!("no socket addresses resolved for {host}:{port}"))?;
-    let stream =
-        TcpStream::connect(addr).with_context(|| format!("failed to connect to {host}:{port}"))?;
+    // Bound the connect as well as the reads: a probe against an engine that is
+    // pinned solid must fail within the caller's timeout, not sit in the OS
+    // default SYN retry window.
+    let stream = TcpStream::connect_timeout(&addr, timeout)
+        .with_context(|| format!("failed to connect to {host}:{port}"))?;
     stream.set_read_timeout(Some(timeout)).ok();
     stream.set_write_timeout(Some(timeout)).ok();
     Ok(stream)
@@ -5836,6 +6022,13 @@ pub struct ManagedServiceRecord {
     /// the service reaches `ready`, and absent on older on-disk records.
     #[serde(default)]
     pub startup_phase: Option<String>,
+    /// When a real inference request first succeeded against this service. Once
+    /// set, readiness checks stop re-probing and fall back to the cheap endpoint
+    /// query — see [`managed_service_endpoint_readiness`]. Adopted from the
+    /// engine state file when present, and absent on records written before
+    /// readiness was gated on inference.
+    #[serde(default)]
+    pub inference_verified_at_unix_ms: Option<u64>,
     pub manifest_path: PathBuf,
     pub log_path: PathBuf,
     pub engine_state_path: PathBuf,
@@ -5887,11 +6080,28 @@ impl ManagedServiceRecord {
             last_restart_unix_ms: None,
             stop_requested_unix_ms: None,
             startup_phase: None,
+            inference_verified_at_unix_ms: None,
             manifest_path,
             log_path,
             engine_state_path,
             created_at_unix_ms: unix_time_millis(),
         }
+    }
+
+    /// Drop the per-run state that a restart invalidates, and count the restart.
+    ///
+    /// A restart reuses this manifest but spawns a different server with an
+    /// unloaded model, so anything describing the previous run has to go. Chiefly
+    /// the inference verification: left set, it short-circuits readiness straight
+    /// back to "ready" as soon as the new server lists the model, reinstating the
+    /// false positive the probe exists to prevent. The engine's own state file is
+    /// rewritten from scratch on restart, so only this copy needs clearing — and
+    /// [`Self::refresh_from_engine_state`] only ever adopts a verification, never
+    /// clears one, so a stale value here would survive indefinitely.
+    pub fn reset_for_restart(&mut self) {
+        self.inference_verified_at_unix_ms = None;
+        self.restart_count = self.restart_count.saturating_add(1);
+        self.last_restart_unix_ms = Some(unix_time_millis());
     }
 
     pub fn normalize_paths_for_host(&mut self) {
@@ -5965,6 +6175,15 @@ impl ManagedServiceRecord {
         {
             self.engine_pid = Some(pid);
             self.engine_start_ticks = state.get(ticks_key).and_then(serde_json::Value::as_u64);
+        }
+        // Adopt the engine's inference verification so the CLI side does not
+        // re-probe a service the engine healthcheck already confirmed.
+        if self.inference_verified_at_unix_ms.is_none()
+            && let Some(verified_at) = state
+                .get(INFERENCE_VERIFIED_STATE_KEY)
+                .and_then(serde_json::Value::as_u64)
+        {
+            self.inference_verified_at_unix_ms = Some(verified_at);
         }
         Ok(self.status != previous)
     }
@@ -6502,15 +6721,13 @@ mod tests {
         Ok(())
     }
 
-    // EAI-7333: the service healthcheck marks a model "ready" purely from
-    // `/v1/models` listing it (via `openai_models_endpoint_has_model`), without
-    // verifying inference. This test pins that gap: a server that lists the model
-    // on `/v1/models` but is NOT able to serve `/v1/chat/completions` still
-    // reports the model as present. The readiness signal is therefore a false
-    // positive for inference-readiness — a caller must additionally probe
-    // inference before treating a service as usable. When EAI-7333 is fixed
-    // (readiness gated on an inference probe, not just `/v1/models`), the
-    // healthcheck path should no longer rely on this signal alone.
+    // Why readiness is gated on an inference probe (EAI-7333): a server that
+    // lists the model on `/v1/models` but cannot yet serve
+    // `/v1/chat/completions` still reports the model as present. This test pins
+    // that `openai_models_endpoint_has_model` alone is a false positive for
+    // inference-readiness, which is why callers must additionally probe
+    // inference — see `openai_chat_completion_probe` and
+    // `managed_service_endpoint_readiness`.
     #[test]
     fn models_endpoint_readiness_does_not_imply_inference_ready() -> Result<()> {
         // A server that answers `/v1/models` with the model listed, but would
@@ -6552,6 +6769,298 @@ mod tests {
         // models response and closed, so a chat request would not succeed.
         // Readiness based on this signal alone is a false positive (EAI-7333).
         server.join().expect("server thread should not panic")?;
+        Ok(())
+    }
+
+    /// Serve `count` canned HTTP responses on a loopback port, returning the port
+    /// and a handle yielding the requests that were received. Each response is
+    /// `(status_line, body)`; a `None` response accepts the connection and never
+    /// answers, standing in for an engine that hangs.
+    fn spawn_canned_http_server(
+        responses: Vec<Option<(&'static str, &'static str)>>,
+    ) -> Result<(u16, std::thread::JoinHandle<Result<Vec<String>>>)> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let handle = std::thread::spawn(move || -> Result<Vec<String>> {
+            let mut requests = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept()?;
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut request_bytes = Vec::new();
+                let mut buffer = [0_u8; 512];
+                while let Ok(read) = stream.read(&mut buffer) {
+                    if read == 0 {
+                        break;
+                    }
+                    request_bytes.extend_from_slice(&buffer[..read]);
+                    let text = String::from_utf8_lossy(&request_bytes);
+                    // Requests with a body (POST) are complete once the declared
+                    // content length has arrived after the header terminator.
+                    if let Some((headers, body)) = text.split_once("\r\n\r\n") {
+                        let declared = headers
+                            .lines()
+                            .find_map(|line| {
+                                line.strip_prefix("Content-Length: ")?.trim().parse().ok()
+                            })
+                            .unwrap_or(0_usize);
+                        if body.len() >= declared {
+                            break;
+                        }
+                    }
+                }
+                requests.push(String::from_utf8_lossy(&request_bytes).into_owned());
+                let Some((status_line, body)) = response else {
+                    // Hang: hold the connection open without answering until the
+                    // client's read timeout fires, then drop it.
+                    std::thread::sleep(Duration::from_millis(1500));
+                    continue;
+                };
+                write!(
+                    stream,
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )?;
+            }
+            Ok(requests)
+        });
+        Ok((port, handle))
+    }
+
+    const CHAT_OK_BODY: &str = r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#;
+    const MODELS_OK_BODY: &str = r#"{"data":[{"id":"Qwen/Qwen3-0.6B"}]}"#;
+
+    #[test]
+    fn chat_completion_probe_passes_when_the_endpoint_answers() -> Result<()> {
+        let (port, server) =
+            spawn_canned_http_server(vec![Some(("HTTP/1.1 200 OK", CHAT_OK_BODY))])?;
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        assert!(openai_chat_completion_probe(
+            &endpoint,
+            "Qwen/Qwen3-0.6B",
+            None,
+            Duration::from_secs(2)
+        )?);
+
+        let requests = server.join().expect("server thread should not panic")?;
+        let request = requests.first().expect("the probe sends one request");
+        assert!(
+            request.starts_with("POST /v1/chat/completions HTTP/1.1"),
+            "probe must exercise the inference path, got: {request}"
+        );
+        assert!(
+            request.contains("\"model\":\"Qwen/Qwen3-0.6B\"") && request.contains("\"max_tokens\""),
+            "probe asks the served model for a token-capped completion, got: {request}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn chat_completion_probe_separates_a_refusal_from_a_warmup_failure() -> Result<()> {
+        // A refusal proves the inference path is up and the model is resident:
+        // the request was understood and rejected on its merits. A 5xx is what an
+        // engine returns while it is still warming up, which is not ready.
+        let (port, server) = spawn_canned_http_server(vec![
+            Some(("HTTP/1.1 400 Bad Request", r#"{"error":"unsupported"}"#)),
+            Some((
+                "HTTP/1.1 503 Service Unavailable",
+                r#"{"error":"loading model"}"#,
+            )),
+        ])?;
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        assert!(openai_chat_completion_probe(
+            &endpoint,
+            "qwen",
+            None,
+            Duration::from_secs(2)
+        )?);
+        assert!(!openai_chat_completion_probe(
+            &endpoint,
+            "qwen",
+            None,
+            Duration::from_secs(2)
+        )?);
+
+        server.join().expect("server thread should not panic")?;
+        Ok(())
+    }
+
+    #[test]
+    fn chat_completion_probe_fails_on_a_hung_endpoint() -> Result<()> {
+        // The reported symptom: the endpoint accepts the connection and never
+        // answers. The probe must give up within its timeout, not wait forever.
+        let (port, server) = spawn_canned_http_server(vec![None])?;
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        let started = Instant::now();
+        assert!(
+            openai_chat_completion_probe(&endpoint, "qwen", None, Duration::from_millis(300))
+                .is_err(),
+            "a hung endpoint is not inference-ready"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the probe must be bounded by its timeout"
+        );
+
+        server.join().expect("server thread should not panic")?;
+        Ok(())
+    }
+
+    fn probe_test_record(port: u16) -> ManagedServiceRecord {
+        let root = PathBuf::from("/tmp/rocm-inference-probe-test");
+        let paths = AppPaths {
+            config_dir: root.join("config"),
+            data_dir: root.join("data"),
+            cache_dir: root.join("cache"),
+        };
+        ManagedServiceRecord::new(
+            &paths,
+            "svc-probe",
+            "vllm",
+            "Qwen/Qwen3-0.6B",
+            "Qwen/Qwen3-0.6B",
+            "127.0.0.1",
+            port,
+            "serve",
+            4242,
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn inference_readiness_latches_after_the_first_successful_probe() -> Result<()> {
+        // First check: list the model, then probe inference. Second check: the
+        // verdict is latched, so only the cheap listing is re-issued — repeated
+        // `services list` polls must not queue generation work behind real
+        // traffic.
+        let (port, server) = spawn_canned_http_server(vec![
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+            Some(("HTTP/1.1 200 OK", CHAT_OK_BODY)),
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+        ])?;
+        let mut record = probe_test_record(port);
+
+        assert_eq!(
+            managed_service_endpoint_readiness(
+                &mut record,
+                None,
+                Duration::from_secs(2),
+                Duration::from_secs(2)
+            ),
+            EndpointReadiness::Serving
+        );
+        assert!(
+            record.inference_verified_at_unix_ms.is_some(),
+            "a passing probe is recorded so later checks can skip it"
+        );
+
+        assert_eq!(
+            managed_service_endpoint_readiness(
+                &mut record,
+                None,
+                Duration::from_secs(2),
+                Duration::from_secs(2)
+            ),
+            EndpointReadiness::Serving
+        );
+
+        let requests = server.join().expect("server thread should not panic")?;
+        let paths: Vec<&str> = requests
+            .iter()
+            .filter_map(|request| request.lines().next())
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                "GET /v1/models HTTP/1.1",
+                "POST /v1/chat/completions HTTP/1.1",
+                "GET /v1/models HTTP/1.1",
+            ],
+            "the second readiness check must not re-probe inference"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn restarting_drops_the_previous_runs_inference_verification() {
+        // The restarted child is a different server with an unloaded model. If the
+        // verification carried over, readiness would short-circuit to "ready" the
+        // moment the new server listed the model — the original false positive,
+        // reinstated. `refresh_from_engine_state` only ever adopts a verification,
+        // so nothing downstream would clear it.
+        let mut record = probe_test_record(11435);
+        record.inference_verified_at_unix_ms = Some(1);
+        record.restart_count = 2;
+
+        record.reset_for_restart();
+
+        assert_eq!(record.inference_verified_at_unix_ms, None);
+        assert_eq!(record.restart_count, 3);
+        assert!(record.last_restart_unix_ms.is_some());
+    }
+
+    #[test]
+    fn inference_readiness_is_withheld_while_the_model_only_lists() -> Result<()> {
+        // The bug: `/v1/models` answers within seconds while the model loads for
+        // minutes and inference returns nothing. That service is not ready.
+        let (port, server) = spawn_canned_http_server(vec![
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+            Some((
+                "HTTP/1.1 503 Service Unavailable",
+                r#"{"error":"loading model"}"#,
+            )),
+        ])?;
+        let mut record = probe_test_record(port);
+
+        assert_eq!(
+            managed_service_endpoint_readiness(
+                &mut record,
+                None,
+                Duration::from_secs(2),
+                Duration::from_secs(2)
+            ),
+            EndpointReadiness::Listing,
+            "a listed-but-unservable model is coming up, not dead"
+        );
+        assert!(
+            record.inference_verified_at_unix_ms.is_none(),
+            "nothing is latched until inference actually succeeds"
+        );
+
+        server.join().expect("server thread should not panic")?;
+        Ok(())
+    }
+
+    #[test]
+    fn inference_probe_sends_the_service_key_to_a_protected_endpoint() -> Result<()> {
+        let (port, server) = spawn_canned_http_server(vec![
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+            Some(("HTTP/1.1 200 OK", CHAT_OK_BODY)),
+        ])?;
+        let mut record = probe_test_record(port);
+
+        assert_eq!(
+            managed_service_endpoint_readiness(
+                &mut record,
+                Some("test-key"),
+                Duration::from_secs(2),
+                Duration::from_secs(2)
+            ),
+            EndpointReadiness::Serving
+        );
+
+        let requests = server.join().expect("server thread should not panic")?;
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.contains("Authorization: Bearer test-key")),
+            "a protected service must not read as unready for want of its own key"
+        );
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -165,6 +165,7 @@ pub fn http_get_text_with_auth(
     endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<String> {
+    let deadline = Instant::now() + timeout;
     let (host, port) = parse_http_endpoint(endpoint_url)
         .with_context(|| format!("unsupported endpoint URL `{endpoint_url}`"))?;
     let mut stream = connect_tcp_stream(&host, port, timeout)?;
@@ -178,7 +179,7 @@ pub fn http_get_text_with_auth(
     );
     write_all_tcp_stream(&mut stream, request.as_bytes())
         .with_context(|| format!("failed to write HTTP GET {path}"))?;
-    let response = read_tcp_stream_to_string(&mut stream)
+    let response = read_http_response_bounded(&mut stream, deadline)
         .with_context(|| format!("failed to read HTTP GET {path}"))?;
     let (headers, body) = response
         .split_once("\r\n\r\n")
@@ -203,6 +204,7 @@ pub fn http_post_json_with_auth(
     endpoint_api_key: Option<&str>,
     timeout: Duration,
 ) -> Result<HttpResponseParts> {
+    let deadline = Instant::now() + timeout;
     let (host, port) = parse_http_endpoint(endpoint_url)
         .with_context(|| format!("unsupported endpoint URL `{endpoint_url}`"))?;
     let mut stream = connect_tcp_stream(&host, port, timeout)?;
@@ -218,7 +220,7 @@ pub fn http_post_json_with_auth(
     );
     write_all_tcp_stream(&mut stream, request.as_bytes())
         .with_context(|| format!("failed to write HTTP POST {path}"))?;
-    let response = read_tcp_stream_to_string(&mut stream)
+    let response = read_http_response_bounded(&mut stream, deadline)
         .with_context(|| format!("failed to read HTTP POST {path}"))?;
     let (headers, body) = response
         .split_once("\r\n\r\n")
@@ -246,6 +248,105 @@ pub const INFERENCE_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
 /// re-probe what an engine already verified.
 pub const INFERENCE_VERIFIED_STATE_KEY: &str = "inference_verified_at_unix_ms";
 
+/// Engine state-file key recording the last inference probe attempt.
+pub const INFERENCE_PROBE_ATTEMPTED_STATE_KEY: &str = "inference_probe_attempted_at_unix_ms";
+
+/// Minimum gap between inference probes against a service that is still loading.
+///
+/// Only a *successful* probe latches, so without this a warming model would be
+/// re-probed by every readiness poll — and each attempt costs up to
+/// [`INFERENCE_PROBE_TIMEOUT`], which is the whole poll's latency. The
+/// supervisor ticks every few seconds and `services list` sits in front of a
+/// user, so the unthrottled cost lands exactly where it is most visible. The
+/// price of throttling is that readiness can be noticed up to this late.
+pub const INFERENCE_PROBE_RETRY_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Merge `patch`'s top-level keys into the JSON object stored at `path`.
+///
+/// Creates the file (and its parent) when absent, and replaces a non-object
+/// document rather than failing — the caller is recording a fact about a live
+/// service, not validating an existing file.
+pub fn merge_json_state_file(path: &Path, patch: &serde_json::Value) -> Result<()> {
+    let mut value = fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+    let object = value.as_object_mut().expect("object checked above");
+    if let Some(patch) = patch.as_object() {
+        for (key, patch_value) in patch {
+            object.insert(key.clone(), patch_value.clone());
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&value).context("failed to serialize service state")?,
+    )
+    .with_context(|| format!("failed to write {}", path.display()))
+}
+
+/// Whether inference has been confirmed for a service, from its engine state
+/// file — probing at most once, and at most once per
+/// [`INFERENCE_PROBE_RETRY_INTERVAL`] while it is still loading.
+///
+/// Shared by the engine adapters so the latch and backoff bookkeeping has one
+/// implementation: the engines differ in how they decide a model is *listed*,
+/// but not in what confirming inference means.
+///
+/// The attempt is recorded before the probe runs, so a caller killed mid-probe
+/// still leaves the throttle in place instead of freeing the next poll to spend
+/// another full timeout.
+pub fn engine_state_inference_verified(
+    state_path: &Path,
+    state: Option<&serde_json::Value>,
+    endpoint_url: &str,
+    model_ref: &str,
+    endpoint_api_key: Option<&str>,
+) -> bool {
+    let state_u64 = |key: &str| {
+        state
+            .and_then(|value| value.get(key))
+            .and_then(serde_json::Value::as_u64)
+    };
+    if state_u64(INFERENCE_VERIFIED_STATE_KEY).is_some() {
+        return true;
+    }
+    if model_ref.trim().is_empty() {
+        return false;
+    }
+    let now = unix_time_millis() as u64;
+    if let Some(attempted_at) = state_u64(INFERENCE_PROBE_ATTEMPTED_STATE_KEY)
+        && now.saturating_sub(attempted_at) < INFERENCE_PROBE_RETRY_INTERVAL.as_millis() as u64
+    {
+        return false;
+    }
+    let _ = merge_json_state_file(
+        state_path,
+        &serde_json::json!({ INFERENCE_PROBE_ATTEMPTED_STATE_KEY: now }),
+    );
+    if !openai_chat_completion_probe(
+        endpoint_url,
+        model_ref,
+        endpoint_api_key,
+        INFERENCE_PROBE_TIMEOUT,
+    )
+    .unwrap_or(false)
+    {
+        return false;
+    }
+    let _ = merge_json_state_file(
+        state_path,
+        &serde_json::json!({ INFERENCE_VERIFIED_STATE_KEY: unix_time_millis() as u64 }),
+    );
+    true
+}
+
 /// The parts of an HTTP response a probe needs: the status code and the body.
 #[derive(Debug, Clone)]
 pub struct HttpResponseParts {
@@ -270,6 +371,11 @@ fn http_status_code(status_line: &str) -> Option<u16> {
 /// an engine returns while it is still warming up. Insisting on `200` with
 /// non-empty content would also wrongly fail a reasoning model, which can spend
 /// its whole (tiny) token budget before emitting any content.
+///
+/// The rule does mean a `404` reads as serving. That is harmless for the engines
+/// shipped today — both implement `/v1/chat/completions`, and a wrong key fails
+/// the model listing that gates this call — but an engine that does not expose an
+/// OpenAI-shaped chat route would need a different signal rather than this one.
 pub fn openai_chat_completion_probe(
     endpoint_url: &str,
     model_ref: &str,
@@ -364,6 +470,17 @@ pub enum EndpointReadiness {
     Serving,
 }
 
+/// The result of a readiness check, plus whether it left the record dirty.
+#[derive(Debug, Clone, Copy)]
+pub struct EndpointReadinessOutcome {
+    pub readiness: EndpointReadiness,
+    /// The check updated the record's probe bookkeeping. Persist it with
+    /// [`ManagedServiceRecord::write`] — the throttle in
+    /// [`managed_service_endpoint_readiness`] only works if the attempt survives
+    /// the process, since each CLI invocation starts fresh.
+    pub record_changed: bool,
+}
+
 /// How far along the service's endpoint is, probing inference at most once.
 ///
 /// Stronger than [`managed_service_endpoint_model_ready`], which only asks
@@ -375,8 +492,12 @@ pub enum EndpointReadiness {
 /// is that a service which degrades after start still reports ready — the same
 /// as before this check existed.
 ///
-/// Mutates `record` on first success; the caller is responsible for persisting it
-/// with [`ManagedServiceRecord::write`].
+/// A *failed* probe cannot latch, so those are throttled instead: a still-loading
+/// service is re-probed at most once per [`INFERENCE_PROBE_RETRY_INTERVAL`],
+/// which keeps a warming model from costing every caller a full
+/// `probe_timeout`.
+///
+/// Mutates `record` when it probes; persist it when `record_changed` is set.
 ///
 /// [`Serving`]: EndpointReadiness::Serving
 pub fn managed_service_endpoint_readiness(
@@ -384,20 +505,31 @@ pub fn managed_service_endpoint_readiness(
     endpoint_api_key: Option<&str>,
     listing_timeout: Duration,
     probe_timeout: Duration,
-) -> EndpointReadiness {
+) -> EndpointReadinessOutcome {
+    let outcome = |readiness, record_changed| EndpointReadinessOutcome {
+        readiness,
+        record_changed,
+    };
     let listed = managed_service_endpoint_model_ready(record, endpoint_api_key, listing_timeout)
         .unwrap_or(false);
     if !listed {
-        return EndpointReadiness::Unreachable;
+        return outcome(EndpointReadiness::Unreachable, false);
     }
     if record.inference_verified_at_unix_ms.is_some() {
-        return EndpointReadiness::Serving;
+        return outcome(EndpointReadiness::Serving, false);
+    }
+    let now = unix_time_millis() as u64;
+    if let Some(attempted_at) = record.inference_probe_attempted_at_unix_ms
+        && now.saturating_sub(attempted_at) < INFERENCE_PROBE_RETRY_INTERVAL.as_millis() as u64
+    {
+        return outcome(EndpointReadiness::Listing, false);
     }
     let model_ref = if record.canonical_model_id.trim().is_empty() {
         record.model_ref.as_str()
     } else {
         record.canonical_model_id.as_str()
     };
+    record.inference_probe_attempted_at_unix_ms = Some(now);
     if !openai_chat_completion_probe(
         &record.endpoint_url,
         model_ref,
@@ -406,10 +538,10 @@ pub fn managed_service_endpoint_readiness(
     )
     .unwrap_or(false)
     {
-        return EndpointReadiness::Listing;
+        return outcome(EndpointReadiness::Listing, true);
     }
     record.inference_verified_at_unix_ms = Some(unix_time_millis() as u64);
-    EndpointReadiness::Serving
+    outcome(EndpointReadiness::Serving, true)
 }
 
 fn openai_loaded_model_ids(value: &serde_json::Value) -> Vec<String> {
@@ -511,6 +643,75 @@ pub fn read_tcp_stream_to_string(stream: &mut TcpStream) -> Result<String> {
         .read_to_string(&mut response)
         .context("failed to read TCP stream")?;
     Ok(response)
+}
+
+/// Read one HTTP response, bounded by a wall-clock deadline.
+///
+/// Two problems with reading to end-of-stream instead. A response is only
+/// complete at EOF if the peer actually closes: `Connection: close` asks for
+/// that, but nothing obliges a server or an intervening proxy to honor it, so a
+/// service that writes a perfectly good response and holds the socket open would
+/// stall until the read timeout and have its answer thrown away. And a socket
+/// read timeout bounds each `read` call, not the sequence of them, so a
+/// slow-drip responder could stretch the total wait to an arbitrary multiple of
+/// what the caller asked for. This returns as soon as the response is complete by
+/// its own framing, and never runs past `deadline` in total.
+fn read_http_response_bounded(stream: &mut TcpStream, deadline: Instant) -> Result<String> {
+    let mut response = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    while !http_response_is_complete(&response) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!("timed out reading HTTP response");
+        }
+        stream.set_read_timeout(Some(remaining)).ok();
+        match stream.read(&mut chunk) {
+            // Peer closed: whatever arrived is the whole response.
+            Ok(0) => break,
+            Ok(read) => response.extend_from_slice(&chunk[..read]),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                bail!("timed out reading HTTP response");
+            }
+            Err(error) => return Err(error).context("failed to read TCP stream"),
+        }
+    }
+    Ok(String::from_utf8_lossy(&response).into_owned())
+}
+
+/// Whether the bytes so far are a complete HTTP response by their own framing.
+///
+/// `false` for a response that declares neither a length nor chunked encoding —
+/// those are delimited by the connection closing, so the caller must keep reading
+/// until EOF.
+fn http_response_is_complete(response: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(response);
+    let Some((headers, body)) = text.split_once("\r\n\r\n") else {
+        return false;
+    };
+    let header_value = |name: &str| {
+        headers.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            key.trim()
+                .eq_ignore_ascii_case(name)
+                .then(|| value.trim().to_owned())
+        })
+    };
+    if let Some(length) =
+        header_value("Content-Length").and_then(|value| value.parse::<usize>().ok())
+    {
+        return body.len() >= length;
+    }
+    if header_value("Transfer-Encoding")
+        .is_some_and(|value| value.to_ascii_lowercase().contains("chunked"))
+    {
+        return body.ends_with("0\r\n\r\n");
+    }
+    false
 }
 
 #[cfg(windows)]
@@ -6017,6 +6218,12 @@ pub struct ManagedServiceRecord {
     /// existed, which is the safe default (keep the key).
     #[serde(default)]
     pub stop_requested_unix_ms: Option<u128>,
+    /// When the last inference probe was attempted. Throttles re-probing of a
+    /// service that is listed but still loading — see
+    /// [`INFERENCE_PROBE_RETRY_INTERVAL`]. Absent on records written before
+    /// readiness was gated on inference.
+    #[serde(default)]
+    pub inference_probe_attempted_at_unix_ms: Option<u64>,
     /// Coarse startup stage (`downloading`/`loading`/`warmup`) parsed from the
     /// serve process's own log output while it is coming up. Set to `None` once
     /// the service reaches `ready`, and absent on older on-disk records.
@@ -6081,6 +6288,7 @@ impl ManagedServiceRecord {
             stop_requested_unix_ms: None,
             startup_phase: None,
             inference_verified_at_unix_ms: None,
+            inference_probe_attempted_at_unix_ms: None,
             manifest_path,
             log_path,
             engine_state_path,
@@ -6100,6 +6308,7 @@ impl ManagedServiceRecord {
     /// clears one, so a stale value here would survive indefinitely.
     pub fn reset_for_restart(&mut self) {
         self.inference_verified_at_unix_ms = None;
+        self.inference_probe_attempted_at_unix_ms = None;
         self.restart_count = self.restart_count.saturating_add(1);
         self.last_restart_unix_ms = Some(unix_time_millis());
     }
@@ -6888,6 +7097,88 @@ mod tests {
     }
 
     #[test]
+    fn chat_completion_probe_accepts_a_response_from_a_server_that_holds_the_socket() -> Result<()>
+    {
+        // `Connection: close` is a request, not a guarantee — a server or an
+        // intervening proxy may answer in full and keep the socket open. Reading
+        // to EOF would stall until the timeout and throw the answer away, leaving
+        // a perfectly healthy service stuck reporting "not ready".
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let server = std::thread::spawn(move || -> Result<()> {
+            let (mut stream, _) = listener.accept()?;
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            let body = CHAT_OK_BODY;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )?;
+            stream.flush()?;
+            // Hold the connection open past the probe's timeout.
+            std::thread::sleep(Duration::from_secs(3));
+            Ok(())
+        });
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        let started = Instant::now();
+        assert!(
+            openai_chat_completion_probe(&endpoint, "qwen", None, Duration::from_secs(2))?,
+            "a complete response counts even when the peer keeps the socket open"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the framed response is complete, so the probe must not wait for EOF"
+        );
+
+        server.join().expect("server thread should not panic")?;
+        Ok(())
+    }
+
+    #[test]
+    fn http_read_is_bounded_across_reads_not_just_per_read() -> Result<()> {
+        // A socket read timeout bounds each `read`, not the sequence of them. A
+        // server that dribbles bytes forever, each within the per-read timeout,
+        // must still hit the caller's overall budget.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let server = std::thread::spawn(move || -> Result<()> {
+            let (mut stream, _) = listener.accept()?;
+            stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            // Never declares a length and never finishes: one byte at a time,
+            // comfortably inside any per-read timeout.
+            for _ in 0..200 {
+                if stream.write_all(b"x").is_err() || stream.flush().is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Ok(())
+        });
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+
+        let started = Instant::now();
+        assert!(
+            openai_chat_completion_probe(&endpoint, "qwen", None, Duration::from_millis(500))
+                .is_err(),
+            "a response that never completes is not a passing probe"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "the call must honor its own budget, not a multiple of it: took {:?}",
+            started.elapsed()
+        );
+
+        let _ = server.join();
+        Ok(())
+    }
+
+    #[test]
     fn chat_completion_probe_fails_on_a_hung_endpoint() -> Result<()> {
         // The reported symptom: the endpoint accepts the connection and never
         // answers. The probe must give up within its timeout, not wait forever.
@@ -6951,7 +7242,8 @@ mod tests {
                 None,
                 Duration::from_secs(2),
                 Duration::from_secs(2)
-            ),
+            )
+            .readiness,
             EndpointReadiness::Serving
         );
         assert!(
@@ -6965,7 +7257,8 @@ mod tests {
                 None,
                 Duration::from_secs(2),
                 Duration::from_secs(2)
-            ),
+            )
+            .readiness,
             EndpointReadiness::Serving
         );
 
@@ -6987,6 +7280,61 @@ mod tests {
     }
 
     #[test]
+    fn a_warming_service_is_not_re_probed_on_every_poll() -> Result<()> {
+        // Only a successful probe latches, so a model that is listed but still
+        // loading would otherwise be re-probed by every poll — and each attempt
+        // costs the full probe timeout, paid by `services list` and the dash in
+        // front of a user. The second check must cost a listing and nothing more.
+        let (port, server) = spawn_canned_http_server(vec![
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+            Some((
+                "HTTP/1.1 503 Service Unavailable",
+                r#"{"error":"loading model"}"#,
+            )),
+            Some(("HTTP/1.1 200 OK", MODELS_OK_BODY)),
+        ])?;
+        let mut record = probe_test_record(port);
+
+        let first = managed_service_endpoint_readiness(
+            &mut record,
+            None,
+            Duration::from_secs(2),
+            Duration::from_secs(2),
+        );
+        assert_eq!(first.readiness, EndpointReadiness::Listing);
+        assert!(
+            first.record_changed && record.inference_probe_attempted_at_unix_ms.is_some(),
+            "the attempt must be recorded, and persisted by the caller — each CLI \
+             run is a fresh process, so an unwritten attempt throttles nothing"
+        );
+
+        let second = managed_service_endpoint_readiness(
+            &mut record,
+            None,
+            Duration::from_secs(2),
+            Duration::from_secs(2),
+        );
+        assert_eq!(second.readiness, EndpointReadiness::Listing);
+        assert!(!second.record_changed);
+
+        let requests = server.join().expect("server thread should not panic")?;
+        let paths: Vec<&str> = requests
+            .iter()
+            .filter_map(|request| request.lines().next())
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                "GET /v1/models HTTP/1.1",
+                "POST /v1/chat/completions HTTP/1.1",
+                "GET /v1/models HTTP/1.1",
+            ],
+            "the second check must not re-probe inside the retry interval"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn restarting_drops_the_previous_runs_inference_verification() {
         // The restarted child is a different server with an unloaded model. If the
         // verification carried over, readiness would short-circuit to "ready" the
@@ -6995,11 +7343,16 @@ mod tests {
         // so nothing downstream would clear it.
         let mut record = probe_test_record(11435);
         record.inference_verified_at_unix_ms = Some(1);
+        record.inference_probe_attempted_at_unix_ms = Some(1);
         record.restart_count = 2;
 
         record.reset_for_restart();
 
         assert_eq!(record.inference_verified_at_unix_ms, None);
+        assert_eq!(
+            record.inference_probe_attempted_at_unix_ms, None,
+            "the retry throttle is per-run too; the new child deserves an              immediate first probe"
+        );
         assert_eq!(record.restart_count, 3);
         assert!(record.last_restart_unix_ms.is_some());
     }
@@ -7023,7 +7376,8 @@ mod tests {
                 None,
                 Duration::from_secs(2),
                 Duration::from_secs(2)
-            ),
+            )
+            .readiness,
             EndpointReadiness::Listing,
             "a listed-but-unservable model is coming up, not dead"
         );
@@ -7050,7 +7404,8 @@ mod tests {
                 Some("test-key"),
                 Duration::from_secs(2),
                 Duration::from_secs(2)
-            ),
+            )
+            .readiness,
             EndpointReadiness::Serving
         );
 

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -543,7 +543,17 @@ pub struct LaunchResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthcheckResponse {
+    /// Engine-reported service state. `ready` is reserved for a service that has
+    /// served inference; an engine whose model is listed but not yet able to
+    /// answer should report `loading`. Do not report `failed`, `unreachable`, or
+    /// `exited` for a model that is merely still coming up — the supervisor
+    /// treats those as recoverable and will restart the service mid-load.
     pub status: String,
+    /// Whether the model can actually serve requests **now**. This must reflect a
+    /// completed inference request, not the model appearing in `/v1/models`: an
+    /// engine typically lists a model within seconds of accepting its name, while
+    /// the weights can take minutes to become usable, and callers wait on this
+    /// field before sending traffic.
     pub model_loaded: bool,
     pub device: String,
     pub uptime_sec: u64,

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -562,6 +562,44 @@ pub struct HealthcheckResponse {
     pub tokens_per_sec: Option<f32>,
 }
 
+impl HealthcheckResponse {
+    /// Report a service by how far its endpoint got, applying the [`status`] and
+    /// [`model_loaded`] contract above.
+    ///
+    /// `listed` means the endpoint advertises the model; `ready` means an inference
+    /// request has actually come back. The gap between the two is the point: a model
+    /// that lists but cannot yet serve is still coming up, so it reports `loading`
+    /// and never the engine's own status — reporting `failed`/`exited` there would
+    /// have the supervisor restart the service mid-load, which is exactly the
+    /// slow-loading case this signal exists for. `state_status` is therefore
+    /// consulted only when the endpoint is not listing at all, which is where a
+    /// genuine crash surfaces.
+    ///
+    /// Both engines share this mapping; only what counts as *listed*, and how the
+    /// device is named, differ.
+    ///
+    /// [`status`]: Self::status
+    /// [`model_loaded`]: Self::model_loaded
+    pub fn for_readiness(listed: bool, ready: bool, state_status: &str, device: &str) -> Self {
+        let status = if ready {
+            "ready"
+        } else if listed {
+            "loading"
+        } else {
+            state_status
+        };
+        Self {
+            status: status.to_owned(),
+            model_loaded: ready,
+            device: device.to_owned(),
+            uptime_sec: 0,
+            queue_depth: 0,
+            last_error: None,
+            tokens_per_sec: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EndpointResponse {
     pub endpoint_url: String,
@@ -584,6 +622,47 @@ pub struct LogsResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn healthcheck_reports_ready_only_once_inference_has_answered() {
+        let response = HealthcheckResponse::for_readiness(true, true, "running", "rocm_gpu");
+        assert_eq!(response.status, "ready");
+        assert!(
+            response.model_loaded,
+            "a service that answered inference must set model_loaded"
+        );
+    }
+
+    #[test]
+    fn healthcheck_reports_a_listed_but_unservable_model_as_loading() {
+        // The restart-loop hazard: `rocmd` restarts a service left in a recoverable
+        // state, so a model that lists while its weights load must not surface the
+        // engine's own status here — it would be restarted mid-load.
+        let response = HealthcheckResponse::for_readiness(true, false, "failed", "unknown");
+        assert_eq!(
+            response.status, "loading",
+            "a listed-but-unservable model must read as still coming up"
+        );
+        assert!(
+            !response.model_loaded,
+            "listing a model is not being able to serve it"
+        );
+    }
+
+    #[test]
+    fn healthcheck_surfaces_the_engine_status_when_the_endpoint_is_not_listing() {
+        // Not listing at all is where a genuine crash shows up, so the engine's own
+        // status has to survive rather than be masked as `loading`.
+        for state_status in ["failed", "exited", "starting", "unknown"] {
+            let response =
+                HealthcheckResponse::for_readiness(false, false, state_status, "unknown");
+            assert_eq!(
+                response.status, state_status,
+                "a non-listing service must report its engine status verbatim"
+            );
+            assert!(!response.model_loaded);
+        }
+    }
 
     #[test]
     fn endpoint_api_key_from_file_reads_and_trims() {

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -925,37 +925,27 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
     })
 }
 
-/// Whether a real inference request has succeeded against this service, probing
-/// at most once and latching the verdict into the state file.
+/// Whether a real inference request has succeeded against this service.
 ///
-/// Readiness is polled repeatedly — by `services list`, the dash, and the
-/// supervisor — so re-probing every time would queue a generation request behind
-/// the user's own traffic. A service that degrades after start therefore keeps
-/// reporting ready, which is no worse than the pre-probe behavior.
+/// Latch and backoff bookkeeping lives in `rocm-core` so both engines share one
+/// implementation — what counts as *listed* differs per engine, what counts as
+/// *serving* does not.
 fn inference_verified(
     state_path: &Path,
     state: Option<&Value>,
     endpoint_url: &str,
     model_ref: &str,
 ) -> bool {
-    if state
-        .and_then(|value| value.get(rocm_core::INFERENCE_VERIFIED_STATE_KEY))
-        .and_then(Value::as_u64)
-        .is_some()
-    {
-        return true;
-    }
     let Some((host, port)) = parse_http_endpoint(endpoint_url) else {
         return false;
     };
-    if !query_inference_probe_endpoint(&host, port, model_ref).unwrap_or(false) {
-        return false;
-    }
-    let _ = merge_json_state(
+    rocm_core::engine_state_inference_verified(
         state_path,
-        &json!({ rocm_core::INFERENCE_VERIFIED_STATE_KEY: current_unix_millis() as u64 }),
-    );
-    true
+        state,
+        &format_http_base_url(&host, port),
+        model_ref,
+        rocm_engine_protocol::resolve_endpoint_api_key().as_deref(),
+    )
 }
 
 /// The device string reported once a model is loaded. Reflects the backend that
@@ -2920,20 +2910,6 @@ fn query_chat_smoke_endpoint(host: &str, port: u16, model_ref: &str) -> Result<b
         rocm_core::INFERENCE_PROBE_TIMEOUT,
     )?;
     Ok(status == 200)
-}
-
-/// Whether the endpoint can serve inference right now, as opposed to merely
-/// listing the model. Accepts any answered request (see
-/// [`rocm_core::openai_chat_completion_probe`]); the failure this catches is the
-/// endpoint that lists a model within seconds while the weights load for minutes
-/// and every chat request hangs.
-fn query_inference_probe_endpoint(host: &str, port: u16, model_ref: &str) -> Result<bool> {
-    rocm_core::openai_chat_completion_probe(
-        &format_http_base_url(host, port),
-        model_ref,
-        rocm_engine_protocol::resolve_endpoint_api_key().as_deref(),
-        rocm_core::INFERENCE_PROBE_TIMEOUT,
-    )
 }
 
 fn health_has_loaded_model(health: &Value, model_ref: &str, backend: &str) -> bool {

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -900,29 +900,17 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
         && endpoint_url.as_deref().is_some_and(|endpoint| {
             inference_verified(&files.state_path, state.as_ref(), endpoint, &model_ref)
         });
-    let status = if ready {
-        "ready".to_owned()
-    } else if listed {
-        // Loaded enough to list the model, not yet able to serve it. Reported as
-        // still coming up rather than as a failure, so the supervisor lets it
-        // finish instead of restarting a model mid-load.
-        "loading".to_owned()
+    let device = if ready {
+        reported_device(state.as_ref(), &backend)
     } else {
-        state_status
+        "unknown".to_owned()
     };
-    Ok(HealthcheckResponse {
-        status,
-        model_loaded: ready,
-        device: if ready {
-            reported_device(state.as_ref(), &backend)
-        } else {
-            "unknown".to_owned()
-        },
-        uptime_sec: 0,
-        queue_depth: 0,
-        last_error: None,
-        tokens_per_sec: None,
-    })
+    Ok(HealthcheckResponse::for_readiness(
+        listed,
+        ready,
+        &state_status,
+        &device,
+    ))
 }
 
 /// Whether a real inference request has succeeded against this service.

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{
     AppPaths, DEFAULT_LOCAL_PORT, RocmCliConfig, active_managed_therock_environment,
-    download_file_to_path, format_host_port, format_http_base_url, http_get_text_with_auth,
+    download_file_to_path, format_http_base_url, http_get_text_with_auth,
     normalize_runtime_path_for_host, prepend_runtime_paths, require_nonempty, runtime_is_linux,
     runtime_is_windows,
 };
@@ -26,7 +26,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{BufRead, Read, Seek, Write};
-use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -885,7 +885,7 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
         .as_ref()
         .and_then(|value| value_string(value, "backend_requested"))
         .unwrap_or_else(|| ROCM_BACKEND_NAME.to_owned());
-    let ready = state_status == "ready"
+    let listed = state_status == "ready"
         && !model_ref.is_empty()
         && endpoint_url
             .as_deref()
@@ -893,8 +893,20 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
             .transpose()
             .unwrap_or(None)
             .unwrap_or(false);
+    // Listing a model is not the same as being able to serve it: the endpoint can
+    // answer within seconds while the weights load for minutes. Confirm inference
+    // once before reporting ready.
+    let ready = listed
+        && endpoint_url.as_deref().is_some_and(|endpoint| {
+            inference_verified(&files.state_path, state.as_ref(), endpoint, &model_ref)
+        });
     let status = if ready {
         "ready".to_owned()
+    } else if listed {
+        // Loaded enough to list the model, not yet able to serve it. Reported as
+        // still coming up rather than as a failure, so the supervisor lets it
+        // finish instead of restarting a model mid-load.
+        "loading".to_owned()
     } else {
         state_status
     };
@@ -911,6 +923,39 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
         last_error: None,
         tokens_per_sec: None,
     })
+}
+
+/// Whether a real inference request has succeeded against this service, probing
+/// at most once and latching the verdict into the state file.
+///
+/// Readiness is polled repeatedly — by `services list`, the dash, and the
+/// supervisor — so re-probing every time would queue a generation request behind
+/// the user's own traffic. A service that degrades after start therefore keeps
+/// reporting ready, which is no worse than the pre-probe behavior.
+fn inference_verified(
+    state_path: &Path,
+    state: Option<&Value>,
+    endpoint_url: &str,
+    model_ref: &str,
+) -> bool {
+    if state
+        .and_then(|value| value.get(rocm_core::INFERENCE_VERIFIED_STATE_KEY))
+        .and_then(Value::as_u64)
+        .is_some()
+    {
+        return true;
+    }
+    let Some((host, port)) = parse_http_endpoint(endpoint_url) else {
+        return false;
+    };
+    if !query_inference_probe_endpoint(&host, port, model_ref).unwrap_or(false) {
+        return false;
+    }
+    let _ = merge_json_state(
+        state_path,
+        &json!({ rocm_core::INFERENCE_VERIFIED_STATE_KEY: current_unix_millis() as u64 }),
+    );
+    true
 }
 
 /// The device string reported once a model is loaded. Reflects the backend that
@@ -2863,42 +2908,32 @@ fn query_loaded_model_endpoint(endpoint_url: &str, model_ref: &str, backend: &st
     Ok(models_payload_has_ready_model(&models, model_ref, backend))
 }
 
+/// Post-load smoke test: the freshly loaded model must actually complete a chat
+/// request. Deliberately stricter than the readiness probe — only a `200` counts,
+/// so a refusal (wrong model name, unsupported request) fails the serve instead
+/// of being reported as a working service.
 fn query_chat_smoke_endpoint(host: &str, port: u16, model_ref: &str) -> Result<bool> {
-    let addr = (host, port)
-        .to_socket_addrs()
-        .with_context(|| format!("failed to resolve {host}:{port}"))?
-        .next()
-        .with_context(|| format!("no socket addresses resolved for {host}:{port}"))?;
-    let timeout = Duration::from_secs(8);
-    let mut stream = TcpStream::connect_timeout(&addr, timeout)
-        .with_context(|| format!("failed to connect to {host}:{port}"))?;
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream.set_write_timeout(Some(timeout)).ok();
-    let body = json!({
-        "model": model_ref,
-        "messages": [{"role": "user", "content": "Say ok."}],
-        "max_tokens": 2,
-        "stream": false
-    });
-    let body = serde_json::to_string(&body).context("failed to serialize chat smoke request")?;
-    let host_header = format_host_port(host, port);
-    let auth_header = match rocm_engine_protocol::resolve_endpoint_api_key() {
-        Some(key) => format!("Authorization: Bearer {key}\r\n"),
-        None => String::new(),
-    };
-    write!(
-        stream,
-        "POST /v1/chat/completions HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth_header}Connection: close\r\n\r\n{}",
-        body.len(),
-        body
+    let status = rocm_core::openai_chat_completion_status(
+        &format_http_base_url(host, port),
+        model_ref,
+        rocm_engine_protocol::resolve_endpoint_api_key().as_deref(),
+        rocm_core::INFERENCE_PROBE_TIMEOUT,
+    )?;
+    Ok(status == 200)
+}
+
+/// Whether the endpoint can serve inference right now, as opposed to merely
+/// listing the model. Accepts any answered request (see
+/// [`rocm_core::openai_chat_completion_probe`]); the failure this catches is the
+/// endpoint that lists a model within seconds while the weights load for minutes
+/// and every chat request hangs.
+fn query_inference_probe_endpoint(host: &str, port: u16, model_ref: &str) -> Result<bool> {
+    rocm_core::openai_chat_completion_probe(
+        &format_http_base_url(host, port),
+        model_ref,
+        rocm_engine_protocol::resolve_endpoint_api_key().as_deref(),
+        rocm_core::INFERENCE_PROBE_TIMEOUT,
     )
-    .context("failed to write chat smoke request")?;
-    let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .context("failed to read chat smoke response")?;
-    let status_line = response.lines().next().unwrap_or_default();
-    Ok(status_line.contains(" 200 "))
 }
 
 fn health_has_loaded_model(health: &Value, model_ref: &str, backend: &str) -> bool {
@@ -3673,6 +3708,105 @@ mod tests {
             .collect::<Vec<_>>();
         names.sort();
         assert_eq!(names, vec!["model-Q4_0.gguf", "model-Q8_0.gguf"]);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Answer `count` chat requests on a loopback port with the given status,
+    /// recording how many arrived.
+    fn spawn_chat_endpoint(
+        status_line: &'static str,
+        count: usize,
+    ) -> (u16, std::thread::JoinHandle<usize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        let handle = std::thread::spawn(move || {
+            let mut served = 0;
+            for _ in 0..count {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    break;
+                };
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut buffer = [0_u8; 1024];
+                let _ = stream.read(&mut buffer);
+                let body = r#"{"choices":[{"message":{"content":"ok"}}]}"#;
+                let _ = write!(
+                    stream,
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                served += 1;
+            }
+            served
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn inference_verification_latches_into_the_state_file() {
+        // First check probes and records the verdict; the second reads the latch
+        // and leaves the model alone.
+        let (port, server) = spawn_chat_endpoint("HTTP/1.1 200 OK", 1);
+        let dir = scratch_dir("inference-latch");
+        let state_path = dir.join("state.json");
+        fs::write(&state_path, json!({"status": "ready"}).to_string()).expect("seed state");
+        let endpoint = format_http_base_url("127.0.0.1", port);
+
+        let state = read_service_state(&state_path).ok();
+        assert!(inference_verified(
+            &state_path,
+            state.as_ref(),
+            &endpoint,
+            DEFAULT_MODEL
+        ));
+
+        let state = read_service_state(&state_path).expect("state readable");
+        assert!(
+            state
+                .get(rocm_core::INFERENCE_VERIFIED_STATE_KEY)
+                .and_then(Value::as_u64)
+                .is_some(),
+            "a passing probe is latched so later healthchecks skip it"
+        );
+        assert!(inference_verified(
+            &state_path,
+            Some(&state),
+            &endpoint,
+            DEFAULT_MODEL
+        ));
+
+        assert_eq!(
+            server.join().expect("server thread"),
+            1,
+            "the latched check must not send a second inference request"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn inference_verification_withheld_while_the_endpoint_cannot_serve() {
+        // The reported failure: the model is listed but inference still 5xxs.
+        let (port, server) = spawn_chat_endpoint("HTTP/1.1 503 Service Unavailable", 1);
+        let dir = scratch_dir("inference-unverified");
+        let state_path = dir.join("state.json");
+        fs::write(&state_path, json!({"status": "ready"}).to_string()).expect("seed state");
+        let endpoint = format_http_base_url("127.0.0.1", port);
+
+        let state = read_service_state(&state_path).ok();
+        assert!(!inference_verified(
+            &state_path,
+            state.as_ref(),
+            &endpoint,
+            DEFAULT_MODEL
+        ));
+
+        let state = read_service_state(&state_path).expect("state readable");
+        assert!(
+            state.get(rocm_core::INFERENCE_VERIFIED_STATE_KEY).is_none(),
+            "nothing is latched until inference actually answers"
+        );
+
+        server.join().expect("server thread");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1616,43 +1616,24 @@ fn query_inference_probe_endpoint(endpoint_url: &str, model_ref: &str) -> Result
     )
 }
 
-/// Whether a real inference request has succeeded against this service, probing
-/// at most once and latching the verdict into the state file.
+/// Whether a real inference request has succeeded against this service.
 ///
-/// Readiness is polled repeatedly — by `services list`, the dash, and the
-/// supervisor — so re-probing every time would queue a generation request behind
-/// the user's own traffic. A service that degrades after start therefore keeps
-/// reporting ready, which is no worse than the pre-probe behavior.
+/// Latch and backoff bookkeeping lives in `rocm-core` so both engines share one
+/// implementation — what counts as *listed* differs per engine, what counts as
+/// *serving* does not.
 fn inference_verified(
     state_path: &Path,
     state: Option<&Value>,
     endpoint_url: &str,
     model_ref: &str,
 ) -> bool {
-    if state
-        .and_then(|value| value.get(rocm_core::INFERENCE_VERIFIED_STATE_KEY))
-        .and_then(Value::as_u64)
-        .is_some()
-    {
-        return true;
-    }
-    if !query_inference_probe_endpoint(endpoint_url, model_ref).unwrap_or(false) {
-        return false;
-    }
-    let _ = record_inference_verified(state_path);
-    true
-}
-
-fn record_inference_verified(state_path: &Path) -> Result<()> {
-    let mut state = read_service_state(state_path).unwrap_or_else(|_| json!({}));
-    let Some(object) = state.as_object_mut() else {
-        return Ok(());
-    };
-    object.insert(
-        rocm_core::INFERENCE_VERIFIED_STATE_KEY.to_owned(),
-        Value::from(current_unix_millis() as u64),
-    );
-    write_state(state_path, &state)
+    rocm_core::engine_state_inference_verified(
+        state_path,
+        state,
+        endpoint_url,
+        model_ref,
+        rocm_engine_protocol::resolve_endpoint_api_key().as_deref(),
+    )
 }
 
 fn pid_from_state(state: &Value) -> Option<u32> {

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -765,32 +765,21 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
                 model_ref.as_deref().unwrap_or_default(),
             )
         });
-    let status = if ready {
-        "ready".to_owned()
-    } else if listed {
-        // Listing but not yet serving. Reported as still coming up rather than as
-        // a failure, so the supervisor lets the model finish loading instead of
-        // restarting it mid-load.
-        "loading".to_owned()
+    let state_status = state
+        .as_ref()
+        .and_then(|value| value_string(value, "status"))
+        .unwrap_or_else(|| "unknown".to_owned());
+    let device = if state.is_some() {
+        "rocm_gpu"
     } else {
-        state
-            .as_ref()
-            .and_then(|value| value_string(value, "status"))
-            .unwrap_or_else(|| "unknown".to_owned())
+        "unknown"
     };
-    Ok(HealthcheckResponse {
-        status,
-        model_loaded: ready,
-        device: if state.is_some() {
-            "rocm_gpu".to_owned()
-        } else {
-            "unknown".to_owned()
-        },
-        uptime_sec: 0,
-        queue_depth: 0,
-        last_error: None,
-        tokens_per_sec: None,
-    })
+    Ok(HealthcheckResponse::for_readiness(
+        listed,
+        ready,
+        &state_status,
+        device,
+    ))
 }
 
 fn endpoint_response(request: EndpointRequest) -> Result<EndpointResponse> {

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -747,14 +747,31 @@ fn healthcheck_service(request: HealthcheckRequest) -> Result<HealthcheckRespons
     let model_ref = state
         .as_ref()
         .and_then(|value| value_string(value, "model_ref"));
-    let ready = endpoint_url
+    let listed = endpoint_url
         .as_deref()
         .map(|endpoint| query_loaded_model_endpoint(endpoint, model_ref.as_deref()))
         .transpose()
         .unwrap_or(None)
         .unwrap_or(false);
+    // `/v1/models` lists a model as soon as the server accepts its name, which can
+    // be minutes before the weights are resident. Confirm inference once before
+    // reporting ready.
+    let ready = listed
+        && endpoint_url.as_deref().is_some_and(|endpoint| {
+            inference_verified(
+                &files.state_path,
+                state.as_ref(),
+                endpoint,
+                model_ref.as_deref().unwrap_or_default(),
+            )
+        });
     let status = if ready {
         "ready".to_owned()
+    } else if listed {
+        // Listing but not yet serving. Reported as still coming up rather than as
+        // a failure, so the supervisor lets the model finish loading instead of
+        // restarting it mid-load.
+        "loading".to_owned()
     } else {
         state
             .as_ref()
@@ -1582,6 +1599,62 @@ fn query_loaded_model_endpoint(endpoint_url: &str, model_ref: Option<&str>) -> R
     )
 }
 
+/// Whether the endpoint can actually complete a chat request, as opposed to
+/// merely listing the model.
+fn query_inference_probe_endpoint(endpoint_url: &str, model_ref: &str) -> Result<bool> {
+    if model_ref.trim().is_empty() {
+        return Ok(false);
+    }
+    // Send the endpoint key for the same reason the models query does: a 401 from
+    // a correctly-protected server must not read as "cannot serve".
+    let endpoint_api_key = rocm_engine_protocol::resolve_endpoint_api_key();
+    rocm_core::openai_chat_completion_probe(
+        endpoint_url,
+        model_ref,
+        endpoint_api_key.as_deref(),
+        rocm_core::INFERENCE_PROBE_TIMEOUT,
+    )
+}
+
+/// Whether a real inference request has succeeded against this service, probing
+/// at most once and latching the verdict into the state file.
+///
+/// Readiness is polled repeatedly — by `services list`, the dash, and the
+/// supervisor — so re-probing every time would queue a generation request behind
+/// the user's own traffic. A service that degrades after start therefore keeps
+/// reporting ready, which is no worse than the pre-probe behavior.
+fn inference_verified(
+    state_path: &Path,
+    state: Option<&Value>,
+    endpoint_url: &str,
+    model_ref: &str,
+) -> bool {
+    if state
+        .and_then(|value| value.get(rocm_core::INFERENCE_VERIFIED_STATE_KEY))
+        .and_then(Value::as_u64)
+        .is_some()
+    {
+        return true;
+    }
+    if !query_inference_probe_endpoint(endpoint_url, model_ref).unwrap_or(false) {
+        return false;
+    }
+    let _ = record_inference_verified(state_path);
+    true
+}
+
+fn record_inference_verified(state_path: &Path) -> Result<()> {
+    let mut state = read_service_state(state_path).unwrap_or_else(|_| json!({}));
+    let Some(object) = state.as_object_mut() else {
+        return Ok(());
+    };
+    object.insert(
+        rocm_core::INFERENCE_VERIFIED_STATE_KEY.to_owned(),
+        Value::from(current_unix_millis() as u64),
+    );
+    write_state(state_path, &state)
+}
+
 fn pid_from_state(state: &Value) -> Option<u32> {
     state
         .get("pid")?
@@ -1700,9 +1773,14 @@ fn wait_for_vllm_ready(
             );
         }
 
+        // Listing the model is not enough to hand the endpoint to a caller: vLLM
+        // advertises it well before the first request can be served. Only return
+        // once inference has actually answered.
         match query_loaded_model_endpoint(&endpoint, Some(model_ref)) {
-            Ok(true) => return Ok(()),
-            Ok(false) | Err(_) => std::thread::sleep(poll_interval),
+            Ok(true) if query_inference_probe_endpoint(&endpoint, model_ref).unwrap_or(false) => {
+                return Ok(());
+            }
+            _ => std::thread::sleep(poll_interval),
         }
     }
 }
@@ -1767,6 +1845,113 @@ fn tail_lines(path: &Path, limit: usize) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Answer `count` chat requests on a loopback port with the given status,
+    /// reporting how many arrived.
+    fn spawn_chat_endpoint(
+        status_line: &'static str,
+        count: usize,
+    ) -> (u16, std::thread::JoinHandle<usize>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        let handle = std::thread::spawn(move || {
+            let mut served = 0;
+            for _ in 0..count {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    break;
+                };
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                let mut buffer = [0_u8; 1024];
+                let _ = stream.read(&mut buffer);
+                let body = r#"{"choices":[{"message":{"content":"ok"}}]}"#;
+                let _ = write!(
+                    stream,
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                served += 1;
+            }
+            served
+        });
+        (port, handle)
+    }
+
+    fn probe_state_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rocm-vllm-probe-{tag}-{}-{}.json",
+            std::process::id(),
+            current_unix_millis()
+        ))
+    }
+
+    #[test]
+    fn inference_verification_latches_into_the_state_file() -> Result<()> {
+        // First check probes and records the verdict; the second reads the latch
+        // and leaves the model alone.
+        let (port, server) = spawn_chat_endpoint("HTTP/1.1 200 OK", 1);
+        let state_path = probe_state_path("latch");
+        write_state(&state_path, &json!({"status": "running"}))?;
+        let endpoint = endpoint_url("127.0.0.1", port);
+
+        let state = read_service_state(&state_path).ok();
+        assert!(inference_verified(
+            &state_path,
+            state.as_ref(),
+            &endpoint,
+            "facebook/opt-125m"
+        ));
+
+        let state = read_service_state(&state_path)?;
+        assert!(
+            state
+                .get(rocm_core::INFERENCE_VERIFIED_STATE_KEY)
+                .and_then(Value::as_u64)
+                .is_some(),
+            "a passing probe is latched so later healthchecks skip it"
+        );
+        assert!(inference_verified(
+            &state_path,
+            Some(&state),
+            &endpoint,
+            "facebook/opt-125m"
+        ));
+
+        assert_eq!(
+            server.join().expect("server thread"),
+            1,
+            "the latched check must not send a second inference request"
+        );
+        fs::remove_file(&state_path).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn inference_verification_withheld_while_the_model_is_still_loading() -> Result<()> {
+        // The reported failure: `/v1/models` answers but inference does not.
+        let (port, server) = spawn_chat_endpoint("HTTP/1.1 503 Service Unavailable", 1);
+        let state_path = probe_state_path("loading");
+        write_state(&state_path, &json!({"status": "running"}))?;
+        let endpoint = endpoint_url("127.0.0.1", port);
+
+        let state = read_service_state(&state_path).ok();
+        assert!(!inference_verified(
+            &state_path,
+            state.as_ref(),
+            &endpoint,
+            "facebook/opt-125m"
+        ));
+        assert!(
+            read_service_state(&state_path)?
+                .get(rocm_core::INFERENCE_VERIFIED_STATE_KEY)
+                .is_none(),
+            "nothing is latched until inference actually answers"
+        );
+
+        server.join().expect("server thread");
+        fs::remove_file(&state_path).ok();
+        Ok(())
+    }
 
     fn test_engine_recipe(engine: &str, contract_version: &str) -> EngineRecipeHint {
         EngineRecipeHint {

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -42,6 +42,13 @@ reason = "Engines do not report a consistent resolved model name for a short nam
 # Applies wherever the effective serve engine is vLLM. On lemonade-default hosts
 # (e.g. Strix Halo gfx1151, native Windows) these resolve to expected-pass, which
 # is what fixes the Strix-Windows XPASS from run #543.
+#
+# Readiness is now gated on a real inference probe rather than a `/v1/models`
+# listing, which should close this. Held as xfail until a GPU lane confirms it on
+# hardware — the fix is verified by unit tests only, and this bug has already
+# produced one stale "fixed" call (an MI300X XPASS in run 29404668327 that failed
+# again the next run). `flaky = true`, so a pass here is non-fatal: the lane stays
+# green either way, and these entries come out once the hardware run confirms.
 [["serve-vllm-inference"]]
 when = { effective_engine = "vllm" }
 bug = "EAI-7333"
@@ -84,11 +91,11 @@ serve_timeout_secs = 90
 flaky = true
 
 # EAI-7333 (CLI healthcheck reports ready off /v1/models before inference works)
-# on the vLLM path. This scenario is FLAKY, not fixed: it XPASS'd on MI300X once
-# (run 29404668327) but FAILED the next run (29413321046) — a race between the
-# CLI reporting ready and the vLLM model actually being inference-ready. EAI-7333
-# is still OPEN, so keep it xfail'd on the vLLM path; an intermittent known-bug
-# scenario stays xfail (an occasional XPASS is expected and harmless here).
+# on the vLLM path. Readiness now requires an inference request to have come back,
+# which should close this, but it is held as xfail until a GPU lane confirms it:
+# the scenario is intermittent (XPASS on MI300X in run 29404668327, FAILED in
+# 29413321046), and an intermittent known-bug scenario stays xfail while
+# `flaky = true` makes the XPASS a fixed gate would produce harmless.
 [["serve-readiness-contract"]]
 when = { effective_engine = "vllm" }
 bug = "EAI-7333"

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -38,24 +38,6 @@ when = {}
 bug = "EAI-7219"
 reason = "Engines do not report a consistent resolved model name for a short name."
 
-# --- EAI-7333: vLLM reports /v1/models ready but refuses inference. vLLM-only. ---
-# Applies wherever the effective serve engine is vLLM. On lemonade-default hosts
-# (e.g. Strix Halo gfx1151, native Windows) these resolve to expected-pass, which
-# is what fixes the Strix-Windows XPASS from run #543.
-#
-# Readiness is now gated on a real inference probe rather than a `/v1/models`
-# listing, which should close this. Held as xfail until a GPU lane confirms it on
-# hardware — the fix is verified by unit tests only, and this bug has already
-# produced one stale "fixed" call (an MI300X XPASS in run 29404668327 that failed
-# again the next run). `flaky = true`, so a pass here is non-fatal: the lane stays
-# green either way, and these entries come out once the hardware run confirms.
-[["serve-vllm-inference"]]
-when = { effective_engine = "vllm" }
-bug = "EAI-7333"
-reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completions is refused intermittently."
-serve_timeout_secs = 90
-flaky = true
-
 # EAI-7423 was INTERMITTENT on Strix Halo Ubuntu as of 2026-08-05, not fixed:
 # which of its scenarios pass varied run to run (run 30995473578: 2 XPASS; run
 # 30993213188: 3 XPASS; run 30939967076: all 6). A deterministic-XPASS row fails
@@ -87,19 +69,6 @@ flaky = true
 when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so inference never succeeds."
-serve_timeout_secs = 90
-flaky = true
-
-# EAI-7333 (CLI healthcheck reports ready off /v1/models before inference works)
-# on the vLLM path. Readiness now requires an inference request to have come back,
-# which should close this, but it is held as xfail until a GPU lane confirms it:
-# the scenario is intermittent (XPASS on MI300X in run 29404668327, FAILED in
-# 29413321046), and an intermittent known-bug scenario stays xfail while
-# `flaky = true` makes the XPASS a fixed gate would produce harmless.
-[["serve-readiness-contract"]]
-when = { effective_engine = "vllm" }
-bug = "EAI-7333"
-reason = "CLI reports the vLLM service ready, but an immediate inference request races the model load and intermittently fails."
 serve_timeout_secs = 90
 flaky = true
 

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -64,8 +64,8 @@ Feature: Model serving
     And the response identifies the correct model
 
   # Default-engine serve (no --engine): the effective engine is the platform
-  # default from the capability probe. xfail only where that resolves to vLLM
-  # (EAI-7333) — see expectations.toml.
+  # default from the capability probe, so this covers whichever engine the host
+  # would actually pick.
   @id:serve-default-engine-working-endpoint @requires-gpu
   Scenario: 6 - Serving a model without specifying an engine produces a working endpoint
     Given a managed runtime is active
@@ -95,7 +95,8 @@ Feature: Model serving
   # Readiness contract: when the CLI reports a service ready, inference must work.
   # Engine-agnostic — the served model+engine follow the host (see
   # `a model is being served on GPU`), so this holds the contract on every GPU
-  # platform. Where it resolves to vLLM, EAI-7333 makes it xfail (expectations.toml).
+  # platform. Readiness is gated on a real inference probe, which is what makes
+  # this contract hold rather than race the model load.
   @id:serve-readiness-contract @requires-gpu
   Scenario: 8 - A service reported ready can immediately serve inference
     Given a managed runtime is active


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows.

## Summary

A managed service was reported **ready** as soon as its `/v1/models` endpoint listed the model. Engines advertise a model within seconds of accepting its name, while the weights can take minutes to become usable, so anything that waited on readiness before sending traffic — users, automation, the E2E suite — got a hang or a failed first request. One observed lemonade serve listed the model in 4s and could not answer for the next 6 minutes.

**Root cause:** every readiness path treated "the listing endpoint answered" as "the model can serve". The initial serve gate on lemonade did smoke-test inference, but the ongoing healthcheck — the signal `services list` surfaces — did not, and the vLLM path had no inference check at all.

Readiness now requires a completed chat request. The probe lives in `rocm-core` and is shared by all five paths that can report ready: both engine healthchecks, the serve-time wait behind `rocm serve`, the provider listing, and the runtime liveness refresh.

### Non-obvious decisions

- **The verdict is latched per service.** Readiness is polled repeatedly; probing on every poll would queue a generation request behind the user's own traffic. A service is probed until it answers once, then falls back to the cheap listing check. Trade-off: a service that degrades *after* start still reports ready — no worse than before this gate existed. A restart clears the latch, since the new child has an unloaded model.
- **A failed probe cannot latch, so those are throttled.** A still-loading service is re-probed at most once per 15s, and the attempt is persisted — each CLI invocation is a fresh process, so an in-memory throttle would do nothing. Without this, every `services list` against a warming model pays a full probe timeout.
- **A probe passes on any answered request below HTTP 500, not only a `200`.** A `4xx` proves the inference path is up and the model is resident — the request was understood and refused on its merits — while the failure being caught is a hang or the `5xx` an engine returns while warming up. Requiring `200` with content would also wrongly fail a reasoning model, which can spend a two-token budget before emitting any content.
- **Lemonade's post-load smoke test keeps its stricter `200` bar.** It shares the probe's transport but not its acceptance rule: there, a refusal means the model that came up is not the one that was asked for, which should fail the serve rather than be reported as working.
- **A listed-but-unservable model is reported as still coming up, never as failed or stale.** `rocmd` restarts a service left in a recoverable or stale-`starting` state, so a naive gate would have converted this false positive into a restart loop on exactly the slow-loading models that motivated the fix.
- **Responses are read against a deadline, not to end-of-stream.** `Connection: close` is a request, not a guarantee; a server that answers in full and holds the socket open would otherwise stall to the timeout and have its answer discarded. A socket read timeout also bounds each `read`, not the sequence of them.

### Behavior change worth knowing

`rocm serve` still waits a fixed 45s for readiness — the bar is stricter but the budget is unchanged, so a model that needs longer now returns with status `running` instead of a false `ready`. It is promoted to `ready` by the next readiness check once inference answers; nothing is stuck. A launch in that state says so and explains that no smoke test was run, rather than showing empty metrics.

## Verification

The MI300X lane (gfx943, ROCm 7.13.0, vLLM 0.23.0+rocm723, `effective_serve_engine: vllm`) ran both EAI-7333 scenarios and every step passed, with the inference request succeeding **0.4s** after the CLI reported ready:

```
8 - A service reported ready can immediately serve inference
    Given a managed runtime is active              -> passed
    And a model is being served on GPU             -> passed
    When the CLI reports the service as ready      -> passed
    Then an inference request succeeds immediately -> passed
```

Both `expectations.toml` rows are removed on that evidence. Removal also restores the default 600s serve timeout in place of the 90s known-bug cap — worth noting because the confirming run used 69.2s of that 90s, so the cap itself had become a flake risk.

- [x] `cargo test --workspace` — 19 new tests covering the probe's accept/reject rules, the latch, the retry throttle, bounded reads (including a server that answers without closing, and one that dribbles bytes forever), per-engine latch persistence, the serve-time wait, the no-demotion rule, and the restart reset.
- [x] `cargo clippy --workspace --all-targets`, `cargo fmt --check`
- [x] Pre-existing local failures confirmed unrelated: `proc_lifecycle::tree_*` fail identically on an unmodified `main` worktree (WSL2 process-tree signals).

## Risk

Medium. Touches every readiness path. The restart-loop interaction above is the main hazard and is covered by a regression test; the serve-time behavior change is described above.