### PR TITLE
fix(serve): keep a public endpoint authenticated across respawns

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4392,8 +4392,11 @@ fn validate_bind_host(host: &str, allow_public_bind: bool) -> Result<()> {
     Ok(())
 }
 
+/// Inverse of [`rocm_engine_protocol::is_public_bind_host`], which owns the
+/// policy so `rocmd` classifies a recorded `host` identically when it respawns
+/// the service.
 fn is_loopback_host(host: &str) -> bool {
-    matches!(host, "127.0.0.1" | "localhost" | "::1")
+    !rocm_engine_protocol::is_public_bind_host(host)
 }
 
 /// Resolve the API key that will guard this endpoint, applying the
@@ -4469,6 +4472,37 @@ fn ensure_public_bind_engine_supported(
             "public binding with the lemonade engine is not supported on Windows: the endpoint \
              API key cannot be enforced there. Use `--engine vllm`, or bind a loopback host \
              (the default 127.0.0.1)."
+        );
+    }
+    Ok(())
+}
+
+/// Refuse to (re)spawn a managed service recorded on a public host when its
+/// endpoint API key is gone, so a respawn cannot reopen the endpoint anonymously.
+///
+/// `serve()` applies the loopback-vs-public policy once, via
+/// [`resolve_endpoint_auth`], and persists the resulting key. Every later spawn
+/// — `rocm services restart`, and `rocmd`'s recovery supervisor — reads that key
+/// file back and would otherwise treat "no key file" as "no auth wanted",
+/// silently downgrading a protected public endpoint to an open one. The real
+/// invariant is a property of the *host*, not of the file: a non-loopback bind
+/// must always be authenticated.
+///
+/// The gap is reachable through ordinary commands, because a stop deletes the
+/// key file and `rocm services restart` accepts a stopped service id (its help
+/// points at `rocm services list --all`).
+///
+/// `key_present` is a plain `bool` rather than a path so both branches are
+/// unit-testable without touching the filesystem, mirroring `is_windows` in
+/// [`ensure_public_bind_engine_supported`].
+fn ensure_public_service_has_endpoint_key(host: &str, key_present: bool) -> Result<()> {
+    if rocm_engine_protocol::is_public_bind_host(host) && !key_present {
+        bail!(
+            "managed service is bound to the public host `{host}` but has no endpoint API key, \
+             so restarting it would reopen it without authentication. The key is dropped when a \
+             service stops and cannot be recovered. Launch it again with \
+             `rocm serve --host {host} --allow-public-bind` (add `--api-key <key>`, or set \
+             ROCM_SERVE_API_KEY, to choose the key instead of generating one)."
         );
     }
     Ok(())
@@ -4687,6 +4721,11 @@ fn spawn_managed_engine_child(
     // primitives accept as an env override, and it keeps the key off both the argv
     // and the environment block. `serve()` wrote the file before spawning.
     let endpoint_key_file = endpoint_keys::endpoint_key_file_if_present(paths, service_id);
+    // `serve()` already resolved and stored the key for a public bind, so this
+    // cannot fire on the fresh-launch path today. It is the shared choke point
+    // for managed spawns, so enforce the invariant here too rather than relying
+    // on every future caller having done so.
+    ensure_public_service_has_endpoint_key(host, endpoint_key_file.is_some())?;
     #[cfg(windows)]
     let child_pid = {
         let env_values = app_path_env_var_values(paths, engine_envs_root.as_deref());
@@ -12817,7 +12856,14 @@ fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<s
     // Drop the endpoint key with the service by deleting its 0600 key file.
     // Best-effort — a stopped service must not fail to stop just because key
     // cleanup did.
-    endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
+    //
+    // Gated on `all_stopped` for the same reason the status is: an unconfirmed
+    // stop may have left the engine alive and still enforcing the key, and
+    // discarding our only copy would lock the CLI's own probes, chat, and
+    // service discovery out of a service that is otherwise fine.
+    if all_stopped {
+        endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
+    }
     let engine_stop = match engine_stop {
         Ok(response) => serde_json::json!({
             "attempted": true,
@@ -12866,6 +12912,9 @@ fn restart_internal_managed_service(
     // service back on the same public host with the same auth. Capture it first and
     // re-store it after the stop so the spawn below hands the child the same key.
     let preserved_endpoint_key = endpoint_keys::endpoint_api_key(paths, service_id);
+    // Checked before the stop, so a refused restart leaves a running service
+    // running instead of stopping it and then failing to bring it back.
+    ensure_public_service_has_endpoint_key(&record.host, preserved_endpoint_key.is_some())?;
     let _ = stop_internal_managed_service(paths, service_id);
     if let Some(key) = preserved_endpoint_key.as_deref() {
         endpoint_keys::store_endpoint_api_key(paths, service_id, key)?;
@@ -20720,6 +20769,68 @@ install therock";
         ensure_public_bind_engine_supported("vllm", true, true).unwrap(); // vLLM enforces auth on Windows
         ensure_public_bind_engine_supported("lemonade", true, false).unwrap(); // non-Windows
         ensure_public_bind_engine_supported("lemonade", false, true).unwrap(); // loopback needs no key
+    }
+
+    #[test]
+    fn respawn_fails_closed_for_a_public_service_whose_key_is_gone() {
+        // A stop deletes the key file, so a later restart of a public service
+        // would otherwise respawn it with no auth at all.
+        let error = ensure_public_service_has_endpoint_key("0.0.0.0", false).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("0.0.0.0"), "{error:#}");
+        assert!(message.contains("without authentication"), "{error:#}");
+        // Actionable: name the command that mints a fresh key.
+        assert!(message.contains("--allow-public-bind"), "{error:#}");
+
+        // A public service that still has its key restarts normally.
+        ensure_public_service_has_endpoint_key("0.0.0.0", true).unwrap();
+    }
+
+    #[test]
+    fn respawn_allows_loopback_services_without_an_endpoint_key() {
+        // Loopback stays credential-free, so every accepted spelling must pass
+        // the guard with no key present.
+        for host in ["127.0.0.1", "localhost", "::1"] {
+            ensure_public_service_has_endpoint_key(host, false)
+                .unwrap_or_else(|error| panic!("{host} must not require a key: {error:#}"));
+        }
+    }
+
+    #[test]
+    fn restart_refuses_a_public_service_without_a_key_before_stopping_it() {
+        // The guard runs before the stop, so a refused restart must leave the
+        // record exactly as it was rather than taking down a running service.
+        let (root, paths) = test_paths("restart-public-no-key");
+        let service_id = "svc-public-nokey";
+        let mut record = ManagedServiceRecord::new(
+            &paths,
+            service_id,
+            "vllm",
+            "model-ref",
+            "canonical/model",
+            "0.0.0.0",
+            11435,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            Some("gpu_required".to_owned()),
+        );
+        record.status = "running".to_owned();
+        record.write().unwrap();
+
+        let error = restart_internal_managed_service(&paths, service_id).unwrap_err();
+        assert!(
+            error.to_string().contains("without authentication"),
+            "{error:#}"
+        );
+
+        let after = load_managed_service(&paths, service_id).unwrap();
+        assert_ne!(
+            after.status, "stopped",
+            "a refused restart must not stop the service"
+        );
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4720,7 +4720,12 @@ fn spawn_managed_engine_child(
     // environment. A path — not the secret value — is what the detached-spawn
     // primitives accept as an env override, and it keeps the key off both the argv
     // and the environment block. `serve()` wrote the file before spawning.
-    let endpoint_key_file = endpoint_keys::endpoint_key_file_if_present(paths, service_id);
+    // Validity, not mere existence: the engine adapters resolve the key with
+    // `endpoint_api_key_from_file` and enforce nothing when it yields `None`, so
+    // an empty or malformed key file would otherwise satisfy the guard below and
+    // still produce an unauthenticated public listener.
+    let endpoint_key_file = endpoint_keys::endpoint_key_file_if_present(paths, service_id)
+        .filter(|path| rocm_engine_protocol::endpoint_api_key_from_file(path).is_some());
     // `serve()` already resolved and stored the key for a public bind, so this
     // cannot fire on the fresh-launch path today. It is the shared choke point
     // for managed spawns, so enforce the invariant here too rather than relying
@@ -13821,6 +13826,11 @@ fn refresh_managed_service_runtime_liveness(
     let has_tracked_pid = !tracked_pids.is_empty();
     let has_live_pid = tracked_pids.iter().any(|pid| process_is_running(*pid));
     if has_tracked_pid && !has_live_pid {
+        // Confirmed dead, so the endpoint key can finally go. `stop` only drops
+        // it when it could verify termination; this is where an unconfirmed stop
+        // (or a crash) gets its deferred cleanup, so a plaintext secret is not
+        // stranded on disk for a service that no longer exists.
+        endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
         if record.status != "stopped" {
             record.status = "stopped".to_owned();
             return true;
@@ -20825,6 +20835,11 @@ install therock";
             "{error:#}"
         );
 
+        // Proves the *ordering*, not just the refusal: had the guard run after
+        // `stop_internal_managed_service`, the stop would have written
+        // "stopped". It reaches that state here because the record's only pid is
+        // the test's own (`engine_pid` is None and `terminate_recorded_service_pids`
+        // skips the caller's pid), so the stop confirms termination trivially.
         let after = load_managed_service(&paths, service_id).unwrap();
         assert_ne!(
             after.status, "stopped",

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -12856,6 +12856,13 @@ fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<s
     // that did not happen.
     if all_stopped {
         record.status = "stopped".to_owned();
+        record.stop_requested_unix_ms = None;
+    } else {
+        // Record that a stop was *asked for* even though it could not be
+        // confirmed. `refresh_managed_service_runtime_liveness` needs this to
+        // tell a service the operator stopped from one that merely crashed: only
+        // the former should lose its endpoint key once its processes are gone.
+        record.stop_requested_unix_ms = Some(rocm_core::unix_time_millis());
     }
     record.write()?;
     // Drop the endpoint key with the service by deleting its 0600 key file.
@@ -12865,7 +12872,8 @@ fn stop_internal_managed_service(paths: &AppPaths, service_id: &str) -> Result<s
     // Gated on `all_stopped` for the same reason the status is: an unconfirmed
     // stop may have left the engine alive and still enforcing the key, and
     // discarding our only copy would lock the CLI's own probes, chat, and
-    // service discovery out of a service that is otherwise fine.
+    // service discovery out of a service that is otherwise fine. The marker
+    // written above hands that cleanup to the liveness refresh instead.
     if all_stopped {
         endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
     }
@@ -12924,6 +12932,12 @@ fn restart_internal_managed_service(
     if let Some(key) = preserved_endpoint_key.as_deref() {
         endpoint_keys::store_endpoint_api_key(paths, service_id, key)?;
     }
+    // The stop above may have recorded an unconfirmed-stop marker; a successful
+    // restart supersedes it. Leaving it set would let the next liveness refresh
+    // delete the key of the service we are bringing back up. Reaches disk with
+    // the record writes below; if the restart bails before one of those, the
+    // marker stays set on disk — correct, since then the stop is what stands.
+    record.stop_requested_unix_ms = None;
     let policy = parse_device_policy(record.device_policy.as_deref())?;
     fs::OpenOptions::new()
         .create(true)
@@ -13790,12 +13804,56 @@ fn managed_service_running_state(status: &str) -> &'static str {
 
 const SERVICE_LIVENESS_CHECK_TIMEOUT: Duration = Duration::from_millis(750);
 
+/// The real process ids a record tracks.
+///
+/// The launcher pid is always recorded; `engine_pid` is adopted once the engine
+/// state file reports one. A `0` pid is a placeholder, never a real process.
+fn recorded_service_pids(record: &ManagedServiceRecord) -> Vec<u32> {
+    [record.engine_pid, Some(record.supervisor_pid)]
+        .into_iter()
+        .flatten()
+        .filter(|pid| *pid != 0)
+        .collect()
+}
+
+/// Complete a stop that was requested but could not confirm termination, once
+/// the processes are actually observed gone: drop the endpoint key and clear the
+/// marker. Returns whether the record changed.
+///
+/// This is deliberately keyed on `stop_requested_unix_ms` rather than on "the
+/// tracked pids are dead". A *crashed* service also has dead pids, but its
+/// operator never asked for it to go away and will want it back: dropping the
+/// key there would make `rocm services restart` and daemon recovery refuse it
+/// permanently — fail-closed guards have no way to re-mint a key. The cost of
+/// this choice is that a crashed public service's 0600 key file outlives the
+/// process until the service is stopped or successfully restarted.
+///
+/// Called before the liveness gate in
+/// [`refresh_managed_service_runtime_liveness`], so a record that reached
+/// "stopped" by another route still gets its deferred cleanup rather than
+/// stranding the key.
+fn settle_pending_stop_key_cleanup(paths: &AppPaths, record: &mut ManagedServiceRecord) -> bool {
+    if record.stop_requested_unix_ms.is_none() {
+        return false;
+    }
+    if recorded_service_pids(record)
+        .iter()
+        .any(|pid| process_is_running(*pid))
+    {
+        return false;
+    }
+    endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
+    record.stop_requested_unix_ms = None;
+    true
+}
+
 fn refresh_managed_service_runtime_liveness(
     paths: &AppPaths,
     record: &mut ManagedServiceRecord,
 ) -> bool {
+    let settled_pending_stop = settle_pending_stop_key_cleanup(paths, record);
     if !managed_service_is_live(record) {
-        return false;
+        return settled_pending_stop;
     }
 
     // Probe with the service's key so a protected public service is not mistaken
@@ -13815,27 +13873,23 @@ fn refresh_managed_service_runtime_liveness(
             record.status = "ready".to_owned();
             return true;
         }
-        return false;
+        return settled_pending_stop;
     }
 
-    let tracked_pids = [record.engine_pid, Some(record.supervisor_pid)]
-        .into_iter()
-        .flatten()
-        .filter(|pid| *pid != 0)
-        .collect::<Vec<_>>();
+    let tracked_pids = recorded_service_pids(record);
     let has_tracked_pid = !tracked_pids.is_empty();
     let has_live_pid = tracked_pids.iter().any(|pid| process_is_running(*pid));
     if has_tracked_pid && !has_live_pid {
-        // Confirmed dead, so the endpoint key can finally go. `stop` only drops
-        // it when it could verify termination; this is where an unconfirmed stop
-        // (or a crash) gets its deferred cleanup, so a plaintext secret is not
-        // stranded on disk for a service that no longer exists.
-        endpoint_keys::clear_endpoint_api_key(paths, &record.service_id);
+        // Reconcile the status only. The endpoint key is *not* dropped here:
+        // dead pids alone do not distinguish a stopped service from a crashed
+        // one, and a crashed public service needs its key to be restartable.
+        // `settle_pending_stop_key_cleanup` above owns that cleanup, gated on a
+        // stop having actually been requested.
         if record.status != "stopped" {
             record.status = "stopped".to_owned();
             return true;
         }
-        return false;
+        return settled_pending_stop;
     }
 
     if matches!(record.status.as_str(), "ready" | "running") {
@@ -13846,7 +13900,7 @@ fn refresh_managed_service_runtime_liveness(
         }
     }
 
-    false
+    settled_pending_stop
 }
 
 fn local_server_sidebar_status(counts: &ManagedServiceSidebarCounts) -> String {
@@ -20845,6 +20899,112 @@ install therock";
             after.status, "stopped",
             "a refused restart must not stop the service"
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    /// A public record with a dead pid and a stored endpoint key, for the
+    /// liveness-refresh cases below. The port is one nothing listens on, so the
+    /// refresh's endpoint probe fails and it falls through to the pid check.
+    fn dead_public_service_with_key(
+        paths: &AppPaths,
+        service_id: &str,
+        port: u16,
+    ) -> ManagedServiceRecord {
+        paths.ensure().unwrap();
+        let mut record = ManagedServiceRecord::new(
+            paths,
+            service_id,
+            "vllm",
+            "model-ref",
+            "canonical/model",
+            "0.0.0.0",
+            port,
+            "managed",
+            // A pid far above any plausible live process, as in
+            // `dead_managed_service_allows_relaunch`.
+            999_999_999,
+            None,
+            None,
+            None,
+        );
+        record.status = "running".to_owned();
+        record.write().unwrap();
+        endpoint_keys::store_endpoint_api_key(paths, service_id, "secret-key").unwrap();
+        record
+    }
+
+    #[test]
+    fn crashed_public_service_keeps_its_endpoint_key() {
+        // A crash (OOM kill, host reboot, panic) leaves the record at "running"
+        // with dead pids and no stop marker. Dropping the key here would make
+        // the fail-closed respawn guards refuse every later `rocm services
+        // restart` and every daemon recovery attempt — permanently, because
+        // nothing can re-mint the key. The refresh happens on every read
+        // (`rocm services list`), so this must survive it.
+        let (root, paths) = test_paths("liveness-crash-keeps-key");
+        let service_id = "svc-crashed-public";
+        let mut record = dead_public_service_with_key(&paths, service_id, 11982);
+
+        let changed = refresh_managed_service_runtime_liveness(&paths, &mut record);
+
+        assert!(changed, "a dead service must be demoted to stopped");
+        assert_eq!(record.status, "stopped");
+        assert_eq!(
+            endpoint_keys::endpoint_api_key(&paths, service_id).as_deref(),
+            Some("secret-key"),
+            "a crashed public service must stay restartable"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn unconfirmed_stop_clears_the_endpoint_key_once_the_processes_are_gone() {
+        // The other half: a stop that could not confirm termination leaves the
+        // key in place (the engine may still be alive and enforcing it) and
+        // records the intent. Once the processes are observed gone, the deferred
+        // cleanup runs, so no plaintext secret is stranded for a service the
+        // operator did ask to stop.
+        let (root, paths) = test_paths("liveness-pending-stop-clears-key");
+        let service_id = "svc-pending-stop";
+        let mut record = dead_public_service_with_key(&paths, service_id, 11983);
+        record.stop_requested_unix_ms = Some(1);
+
+        let changed = refresh_managed_service_runtime_liveness(&paths, &mut record);
+
+        assert!(changed);
+        assert_eq!(record.status, "stopped");
+        assert_eq!(
+            endpoint_keys::endpoint_api_key(&paths, service_id),
+            None,
+            "a requested stop must still drop the key"
+        );
+        assert_eq!(
+            record.stop_requested_unix_ms, None,
+            "the marker is consumed, so the cleanup does not run again"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn pending_stop_cleanup_runs_even_once_the_record_reads_stopped() {
+        // Proves the cleanup sits *before* the `managed_service_is_live` gate:
+        // a record that reached "stopped" by another route (an engine state
+        // refresh, a concurrent writer) would otherwise early-return and strand
+        // the key of a service the operator stopped.
+        let (root, paths) = test_paths("liveness-pending-stop-when-stopped");
+        let service_id = "svc-pending-stop-stopped";
+        let mut record = dead_public_service_with_key(&paths, service_id, 11984);
+        record.status = "stopped".to_owned();
+        record.stop_requested_unix_ms = Some(1);
+
+        let changed = refresh_managed_service_runtime_liveness(&paths, &mut record);
+
+        assert!(
+            changed,
+            "consuming the marker is a record change worth writing"
+        );
+        assert_eq!(endpoint_keys::endpoint_api_key(&paths, service_id), None);
+        assert_eq!(record.stop_requested_unix_ms, None);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -2553,8 +2553,10 @@ fn build_watcher_enable_args(arguments: &serde_json::Map<String, Value>) -> Resu
     Ok(argv)
 }
 
+/// Inverse of [`rocm_engine_protocol::is_public_bind_host`], which owns the
+/// policy so `rocm` and `rocmd` never classify the same host differently.
 fn is_loopback_host(host: &str) -> bool {
-    matches!(host, "127.0.0.1" | "localhost" | "::1")
+    !rocm_engine_protocol::is_public_bind_host(host)
 }
 
 fn system_prefix_requires_ack(prefix: &std::path::Path) -> bool {
@@ -3081,6 +3083,16 @@ fn supervise_service(
     );
     record.gpu_indices = gpu_indices;
     record.engine_recipe_json = engine_recipe_json.clone();
+    // Refuse a keyless public respawn before the manifest write, so a refused
+    // attempt leaves the recorded restart_count and timestamps intact instead of
+    // clobbering them with a record no live process will ever back. The spawn
+    // site below re-checks against the key actually threaded onto the command.
+    ensure_public_service_has_endpoint_key(
+        &record.host,
+        rocm_engine_protocol::endpoint_key_file_if_present(paths, &record.service_id)
+            .and_then(|path| rocm_engine_protocol::endpoint_api_key_file_if_valid(&path))
+            .is_some(),
+    )?;
     record.write()?;
 
     let log_file = fs::File::create(&record.log_path)
@@ -4625,6 +4637,31 @@ fn handle_server_recover_event_with_record(
                 && now.saturating_sub(last_restart) < SERVER_RECOVER_BACKOFF_MS
             {
                 return Ok(());
+            }
+            // A public service whose endpoint key is gone can never be recovered:
+            // the respawn guard in `supervise_service` refuses it by design.
+            // Report it and stop, rather than letting a permanent failure
+            // propagate out of `evaluate_watchers` and take the whole daemon —
+            // and every other watcher — down on each 30s recovery tick.
+            if let Err(error) = ensure_public_service_has_endpoint_key(
+                &record.host,
+                rocm_engine_protocol::endpoint_key_file_if_present(paths, &record.service_id)
+                    .and_then(|path| rocm_engine_protocol::endpoint_api_key_file_if_valid(&path))
+                    .is_some(),
+            ) {
+                return record_event(
+                    paths,
+                    state,
+                    "server-recover",
+                    "error",
+                    "restart_managed_service_refused",
+                    &format!(
+                        "cannot recover managed service {} on {}:{} after \
+                         {recovery_reason_display}: {error}",
+                        record.service_id, record.host, record.port
+                    ),
+                    Some(record.service_id.clone()),
+                );
             }
             restart_managed_service(paths, &mut *record)?;
             record_event(
@@ -7046,6 +7083,19 @@ mod tests {
             })
             .expect("endpoint key env var must be set once the key file exists");
         assert_eq!(env_value, key_path.as_os_str());
+
+        // An empty (or otherwise unusable) key file is not a key: the engine
+        // adapters would enforce nothing, so reporting `true` here would let the
+        // respawn guard pass and still open an anonymous public listener.
+        fs::write(&key_path, "   \n").unwrap();
+        let mut command = ProcessCommand::new("true");
+        assert!(!apply_endpoint_key_env(&mut command, &paths, service_id));
+        assert!(
+            command
+                .get_envs()
+                .all(|(key, _)| key != rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV),
+            "an unusable key file must not be threaded onto the child"
+        );
     }
 
     #[test]
@@ -8954,13 +9004,20 @@ fn healthcheck_response_recoverable(response: &HealthcheckResponse) -> bool {
 /// check it against the service's host — a public bind with no key would come
 /// up anonymous (see [`ensure_public_service_has_endpoint_key`]). Callers that
 /// only make a stdio plugin call can ignore it.
+///
+/// The file must hold a *usable* key, not merely exist: the engine adapters
+/// resolve it with `endpoint_api_key_from_file` and enforce nothing when that
+/// yields `None`, so treating an empty or malformed file as "protected" would
+/// let the guard pass while the endpoint served anonymously.
 #[must_use]
 fn apply_endpoint_key_env(
     command: &mut ProcessCommand,
     paths: &AppPaths,
     service_id: &str,
 ) -> bool {
-    if let Some(key_file) = rocm_engine_protocol::endpoint_key_file_if_present(paths, service_id) {
+    if let Some(key_file) = rocm_engine_protocol::endpoint_key_file_if_present(paths, service_id)
+        .and_then(|path| rocm_engine_protocol::endpoint_api_key_file_if_valid(&path))
+    {
         command.env(rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file);
         return true;
     }

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -3114,7 +3114,11 @@ fn supervise_service(
     // recovery (`restart_managed_service` re-execs `rocmd supervise`), so
     // without this a previously-authenticated public service would come back
     // up anonymous after a crash/recover cycle.
-    apply_endpoint_key_env(&mut command, paths, &record.service_id);
+    // If the key is gone the child would listen on the recorded public host with
+    // no auth, so fail closed instead — an unreachable service is recoverable,
+    // an anonymous public one is not.
+    let endpoint_key_applied = apply_endpoint_key_env(&mut command, paths, &record.service_id);
+    ensure_public_service_has_endpoint_key(&record.host, endpoint_key_applied)?;
     let mut child = command
         .spawn()
         .with_context(|| format!("failed to spawn engine supervisor child for {engine}"))?;
@@ -7017,7 +7021,7 @@ mod tests {
         // Loopback service: no key file has ever been written, so the child's
         // environment must be left untouched.
         let mut command = ProcessCommand::new("true");
-        apply_endpoint_key_env(&mut command, &paths, service_id);
+        assert!(!apply_endpoint_key_env(&mut command, &paths, service_id));
         assert!(
             command
                 .get_envs()
@@ -7032,7 +7036,7 @@ mod tests {
         fs::create_dir_all(paths.services_dir()).unwrap();
         fs::write(&key_path, "secret-key").unwrap();
         let mut command = ProcessCommand::new("true");
-        apply_endpoint_key_env(&mut command, &paths, service_id);
+        assert!(apply_endpoint_key_env(&mut command, &paths, service_id));
         let env_value = command
             .get_envs()
             .find_map(|(key, value)| {
@@ -7042,6 +7046,24 @@ mod tests {
             })
             .expect("endpoint key env var must be set once the key file exists");
         assert_eq!(env_value, key_path.as_os_str());
+    }
+
+    #[test]
+    fn recovery_respawn_fails_closed_for_a_public_service_without_a_key() {
+        // Daemon recovery re-execs `rocmd supervise` for the recorded host. With
+        // the key gone the child would listen on that public host anonymously,
+        // so the spawn must be refused instead.
+        let error = ensure_public_service_has_endpoint_key("0.0.0.0", false).unwrap_err();
+        assert!(
+            error.to_string().contains("without authentication"),
+            "{error:#}"
+        );
+
+        ensure_public_service_has_endpoint_key("0.0.0.0", true).unwrap();
+        for host in ["127.0.0.1", "localhost", "::1"] {
+            ensure_public_service_has_endpoint_key(host, false)
+                .unwrap_or_else(|error| panic!("{host} must not require a key: {error:#}"));
+        }
     }
 
     #[test]
@@ -8924,13 +8946,42 @@ fn healthcheck_response_recoverable(response: &HealthcheckResponse) -> bool {
 }
 
 /// Re-thread the endpoint key file (public bind only) onto an engine child's
-/// environment, mirroring the initial `rocm serve` spawn. `None` for a
-/// loopback service with no stored key leaves the command's environment
-/// untouched, matching the unauthenticated default.
-fn apply_endpoint_key_env(command: &mut ProcessCommand, paths: &AppPaths, service_id: &str) {
+/// environment, mirroring the initial `rocm serve` spawn. A loopback service
+/// with no stored key leaves the command's environment untouched, matching the
+/// unauthenticated default.
+///
+/// Returns whether a key was applied. Callers that spawn a *listener* must
+/// check it against the service's host — a public bind with no key would come
+/// up anonymous (see [`ensure_public_service_has_endpoint_key`]). Callers that
+/// only make a stdio plugin call can ignore it.
+#[must_use]
+fn apply_endpoint_key_env(
+    command: &mut ProcessCommand,
+    paths: &AppPaths,
+    service_id: &str,
+) -> bool {
     if let Some(key_file) = rocm_engine_protocol::endpoint_key_file_if_present(paths, service_id) {
         command.env(rocm_engine_protocol::ENDPOINT_API_KEY_FILE_ENV, key_file);
+        return true;
     }
+    false
+}
+
+/// Refuse to respawn a recorded service on a public host without its endpoint
+/// API key, so daemon recovery cannot reopen a protected endpoint anonymously.
+///
+/// Mirrors the guard of the same name in `rocm`; the shared
+/// [`rocm_engine_protocol::is_public_bind_host`] keeps the two classifications
+/// identical for a given `ManagedServiceRecord::host`.
+fn ensure_public_service_has_endpoint_key(host: &str, key_present: bool) -> Result<()> {
+    if rocm_engine_protocol::is_public_bind_host(host) && !key_present {
+        bail!(
+            "refusing to respawn a service bound to the public host `{host}` without an endpoint \
+             API key: it would come back up without authentication. Relaunch it with \
+             `rocm serve --host {host} --allow-public-bind` to issue a new key."
+        );
+    }
+    Ok(())
 }
 
 fn engine_request<T, R>(
@@ -8962,7 +9013,10 @@ where
     // adapter's HTTP probe is unauthenticated and the endpoint looks
     // unreachable, which would misclassify a healthy protected service as
     // recoverable.
-    apply_endpoint_key_env(&mut command, paths, service_id);
+    //
+    // No host to check here: this is a stdio plugin call, not a listener, so a
+    // missing key only weakens this probe rather than opening a port.
+    let _ = apply_endpoint_key_env(&mut command, paths, service_id);
     let mut child = command.spawn().with_context(|| {
         format!(
             "failed to spawn engine stdio process {}",

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5804,6 +5804,15 @@ pub struct ManagedServiceRecord {
     pub restart_count: u32,
     #[serde(default)]
     pub last_restart_unix_ms: Option<u128>,
+    /// When a stop was requested but could not confirm that every recorded
+    /// process died. It records *intent*: the operator asked for this service to
+    /// go away, so once the processes are observed gone the endpoint key may be
+    /// dropped. A service that merely crashed carries no such intent and keeps
+    /// its key, so it stays restartable/recoverable. Cleared on a confirmed stop
+    /// and on a successful respawn. `None` on records written before this field
+    /// existed, which is the safe default (keep the key).
+    #[serde(default)]
+    pub stop_requested_unix_ms: Option<u128>,
     /// Coarse startup stage (`downloading`/`loading`/`warmup`) parsed from the
     /// serve process's own log output while it is coming up. Set to `None` once
     /// the service reaches `ready`, and absent on older on-disk records.
@@ -5858,6 +5867,7 @@ impl ManagedServiceRecord {
             engine_recipe_json: None,
             restart_count: 0,
             last_restart_unix_ms: None,
+            stop_requested_unix_ms: None,
             startup_phase: None,
             manifest_path,
             log_path,

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -30,6 +30,24 @@ pub const DEFAULT_LOG_TAIL_LINES: usize = 80;
 /// (e.g. a loopback bind).
 pub const ENDPOINT_API_KEY_FILE_ENV: &str = "ROCM_SERVE_API_KEY_FILE";
 
+/// Whether `host` names a public (non-loopback) bind, i.e. one that must be
+/// protected by an endpoint API key.
+///
+/// Shared so `rocm` (which decides at `serve` time whether to mint a key) and
+/// `rocmd` (which respawns recorded services during recovery) apply the same
+/// policy to the same `ManagedServiceRecord::host` value.
+///
+/// Deliberately an exact match against the three loopback spellings the CLI
+/// accepts, so anything unrecognized — an IPv6 loopback alias, a differently
+/// cased `localhost`, a hostname that happens to resolve locally — is treated
+/// as public and therefore *requires* a key. Misclassifying a loopback bind as
+/// public costs a key nobody needed; the reverse would open an unauthenticated
+/// network listener.
+#[must_use]
+pub fn is_public_bind_host(host: &str) -> bool {
+    !matches!(host, "127.0.0.1" | "localhost" | "::1")
+}
+
 /// Resolve the endpoint API key an engine adapter must enforce, if any.
 ///
 /// Reads the key file named by [`ENDPOINT_API_KEY_FILE_ENV`]. Returns `None` when
@@ -662,6 +680,27 @@ mod tests {
         std::fs::remove_file(&path).unwrap();
         assert_eq!(endpoint_key_file_if_present(&paths, service_id), None);
         std::fs::remove_dir_all(&paths.data_dir).ok();
+    }
+
+    #[test]
+    fn is_public_bind_host_recognizes_only_the_accepted_loopback_spellings() {
+        for host in ["127.0.0.1", "localhost", "::1"] {
+            assert!(!is_public_bind_host(host), "{host} must be loopback");
+        }
+        for host in [
+            "0.0.0.0",
+            "::",
+            "192.168.1.10",
+            "example.internal",
+            // Conservative on purpose: an unrecognized spelling of a loopback
+            // address is classified public, so it requires a key rather than
+            // opening an unauthenticated listener.
+            "LOCALHOST",
+            "127.0.0.2",
+            "[::1]",
+        ] {
+            assert!(is_public_bind_host(host), "{host} must be public");
+        }
     }
 
     #[test]

--- a/crates/rocm-engine-protocol/src/lib.rs
+++ b/crates/rocm-engine-protocol/src/lib.rs
@@ -691,7 +691,7 @@ mod tests {
             "0.0.0.0",
             "::",
             "192.168.1.10",
-            "example.internal",
+            "example.test",
             // Conservative on purpose: an unrecognized spelling of a loopback
             // address is classified public, so it requires a key rather than
             // opening an unauthenticated listener.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -426,8 +426,14 @@ cargo test -p rocm --bin rocm resolve_endpoint_auth
 cargo test -p rocm --bin rocm endpoint_client_config
 cargo test -p rocm --bin rocm api_key_client_config
 cargo test -p rocm --bin rocm public_bind_fails_closed
+cargo test -p rocm --bin rocm respawn_fails_closed
+cargo test -p rocm --bin rocm respawn_allows_loopback
+cargo test -p rocm --bin rocm restart_refuses_a_public_service
 cargo test -p rocm-core generate_endpoint_api_key
 cargo test -p rocm-engine-protocol endpoint_api_key
+cargo test -p rocm-engine-protocol is_public_bind_host
+cargo test -p rocmd recovery_respawn_fails_closed
+cargo test -p rocmd apply_endpoint_key_env
 ```
 
 A loopback bind (`rocm serve <model>`, default `127.0.0.1`) stays
@@ -441,7 +447,18 @@ audit log. Verifying that the running server actually *rejects* an
 unauthenticated request requires a live engine; that end-to-end assertion is a
 deferred follow-up and is **not yet** exercised by the GPU acceptance scripts
 (`scripts/vllm_therock_gpu_test.py`). The unit tests cover key policy,
-generation, the 0600 key file, key-file resolution, and cleanup on stop.
+generation, the 0600 key file, and key-file resolution.
+
+The same requirement holds across respawns, because the invariant belongs to the
+recorded *host*, not to the key file: a service recorded on a public host refuses
+to respawn once its key is gone, rather than coming back unauthenticated. That
+covers `rocm services restart` and `rocmd`'s recovery supervisor, and the refusal
+happens before anything is stopped, so it cannot take down a running service. A
+stop therefore drops the key only once it has confirmed the engine is gone —
+otherwise the CLI would lock itself out of a service that is still running and
+still enforcing the key — and the deferred cleanup lands on the liveness refresh
+that later observes the process dead. There is no e2e coverage of `services
+stop`/`restart` or endpoint auth; these paths are unit-tested only.
 
 Windows + Lemonade note: the Windows *managed* native-Lemonade server is launched
 via `spawn_hidden_console_with_log`, whose env-override API is path-valued only,


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No EAI-7409 rows exist; endpoint auth has never had e2e coverage.)

## Problem

Public-endpoint authentication (EAI-7409, added in #124) held for the *initial* `rocm serve`, but not for any path that **respawns** a recorded service. Those paths treated "a key file exists" as the source of truth. The real invariant is a property of the recorded **host**: a non-loopback bind must always be authenticated.

Reachable through first-class commands:

```
rocm serve --host 0.0.0.0 --allow-public-bind   # key minted, stored 0600, printed
rocm services stop <id>                         # key file deleted
rocm services restart <id>                      # comes back with NO key
```

`restart_internal_managed_service` captured `None` for the preserved key, stored nothing, and spawned the engine child with no `ROCM_SERVE_API_KEY_FILE`, so the service returned on `0.0.0.0` completely unauthenticated. `rocm services restart` documents its argument as an id from `rocm services list --all`, which includes stopped records, so this is the documented flow rather than an edge case. `rocmd`'s recovery supervisor had the same gap.

## Approach

Enforce the invariant at each spawn site and fail closed, following the existing `ensure_public_bind_engine_supported` precedent. Fail-closed rather than mint-and-print a replacement key: `restart_server` is also an automation/sandbox tool whose JSON result can land in agent transcripts, so regenerating would add a secret-disclosure surface.

- `rocm_engine_protocol::is_public_bind_host` is now the single classification, so `rocm` and `rocmd` cannot disagree about a recorded host. Both crates' `is_loopback_host` delegate to it.
- Refuse a keyless public respawn in `restart_internal_managed_service` (**before** the stop, so a refused restart leaves a running service running), in `spawn_managed_engine_child`, and in `rocmd`'s `supervise_service` (before the manifest write, so a refusal does not clobber restart_count/timestamps).
- The guards check key **validity**, not file existence — the engine adapters resolve the key with `endpoint_api_key_from_file` and enforce nothing when it yields `None`, so an empty file would otherwise pass the guard and still serve anonymously.
- A stop drops the key only once it has confirmed termination. An unconfirmed stop may have left the engine alive and still enforcing the key, and discarding the only copy locked the CLI's own probes, chat, and discovery out of a healthy service. The deferred cleanup lands on the liveness refresh that later observes the process dead, so no plaintext secret is stranded.
- Daemon recovery refuses at the recovery boundary with a recorded `restart_managed_service_refused` event, rather than letting a permanent failure propagate out of `evaluate_watchers` and take every watcher down on each 30s tick.

Loopback behavior is unchanged: it stays credential-free.

## Behavior change

A public-host service whose key is gone (including records predating #124) is no longer restartable in place; relaunch it with `rocm serve --host <host> --allow-public-bind` to issue a new key. The refusal message says so. This is the intended cost of fail-closed.

## Known gap

`rocmd`'s own `stop_managed_service` still clears the key unconditionally: its `terminate_process` reports only that a signal was accepted, so it has no confirmed-termination notion to gate on. Giving it one is a larger change than this fix.

## Testing

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo test --workspace --no-fail-fast` passes except two pre-existing `rocm-core` `proc_lifecycle::tests::tree_*` failures, which fail on WSL2 for process-tree signalling reasons unrelated to this change (untouched file).

**Not run locally:** GPU acceptance (`scripts/vllm_therock_gpu_test.py`) and the GPU e2e lanes — no GPU on this host. The end-to-end assertion that a restarted public server actually rejects an unauthenticated request needs a live engine; endpoint auth has no e2e coverage today, so these paths are unit-tested only. Filters are listed in `docs/testing.md`.

Closes EAI-7409.