### PR TITLE
fix(serve): stop hardcoding vLLM GPU memory utilization (EAI-7353)

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -21986,10 +21986,25 @@ install therock";
 
     #[test]
     fn gpu_memory_utilization_override_leaves_non_vllm_engines_untouched() {
+        // The override is vLLM-specific: other engines are never rewritten, with
+        // or without a recipe of their own.
         assert!(
             engine_recipe_with_gpu_memory_utilization_override("lemonade", None, Some(0.5))
                 .is_none()
         );
+        let existing = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "lemonade".to_owned(),
+            required_flags: vec!["--some-flag".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        let hint = engine_recipe_with_gpu_memory_utilization_override(
+            "lemonade",
+            Some(existing.clone()),
+            Some(0.5),
+        )
+        .unwrap();
+        assert_eq!(hint.required_flags, existing.required_flags);
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4240,7 +4240,7 @@ fn parse_gpu_memory_utilization(value: Option<&str>) -> Result<Option<f64>> {
     if !parsed.is_finite() || parsed <= 0.0 || parsed > 1.0 {
         bail!(
             "--gpu-memory-utilization must be greater than 0 and at most 1 (a fraction of \
-             the GPU's TOTAL VRAM); got `{trimmed}`"
+             the GPU's TOTAL VRAM, e.g. 0.5); got `{trimmed}`"
         );
     }
     Ok(Some(parsed))

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -336,6 +336,12 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         /// and implies `--enable-auto-tool-choice`. Applies to vLLM only.
         #[arg(long, value_name = "NAME")]
         tool_call_parser: Option<String>,
+        /// Fraction of each GPU's TOTAL VRAM that vLLM may claim for weights and
+        /// KV cache (`0.0 < value <= 1.0`). Omitted by default, so vLLM applies
+        /// its own default. Lower it when a small model should not reserve most
+        /// of a large card. Applies to vLLM only.
+        #[arg(long, value_name = "FRACTION", allow_hyphen_values = true)]
+        gpu_memory_utilization: Option<String>,
         /// API key that clients must present to a public (non-loopback) endpoint.
         /// When binding a public interface and this is omitted, a strong key is
         /// generated automatically. Prefer the `ROCM_SERVE_API_KEY` environment
@@ -1623,6 +1629,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             no_smoke_test,
             allow_public_bind,
             tool_call_parser,
+            gpu_memory_utilization,
             api_key,
         }) => serve(ServeArgs {
             model,
@@ -1639,6 +1646,7 @@ fn dispatch(cli: Cli) -> Result<()> {
             no_smoke_test,
             allow_public_bind,
             tool_call_parser,
+            gpu_memory_utilization,
             api_key,
         }),
         Some(Command::Comfyui { command }) => comfyui(command),
@@ -4162,6 +4170,82 @@ fn set_vllm_tool_call_parser(flags: &mut Vec<String>, parser: &str) {
     *flags = rewritten;
 }
 
+/// Applies an explicit `--gpu-memory-utilization` to the vLLM engine recipe.
+///
+/// rocm-cli intentionally ships no default for this: vLLM sizes its KV cache as
+/// a fraction of the device's TOTAL VRAM, and any number rocm-cli picked would
+/// silently override upstream's and drift from it. So the flag is passed through
+/// only when the user asked for one, via `required_flags` (the same channel the
+/// `--tool-call-parser` override uses — no protocol change needed).
+///
+/// Only vLLM is affected. An explicit value wins over any recipe-authored one,
+/// and a minimal hint is synthesized when none exists.
+fn engine_recipe_with_gpu_memory_utilization_override(
+    engine: &str,
+    hint: Option<EngineRecipeHint>,
+    gpu_memory_utilization: Option<f64>,
+) -> Option<EngineRecipeHint> {
+    if !engine.eq_ignore_ascii_case("vllm") {
+        return hint;
+    }
+    let Some(value) = gpu_memory_utilization else {
+        return hint;
+    };
+    let mut hint = hint.unwrap_or_else(|| EngineRecipeHint {
+        contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+        engine: engine.to_owned(),
+        ..EngineRecipeHint::default()
+    });
+    set_vllm_gpu_memory_utilization(&mut hint.required_flags, value);
+    Some(hint)
+}
+
+/// Rewrites `flags` so vLLM receives exactly one `--gpu-memory-utilization
+/// <value>` pair: drops any existing pair, then appends the new one.
+fn set_vllm_gpu_memory_utilization(flags: &mut Vec<String>, value: f64) {
+    let existing = std::mem::take(flags);
+    let mut rewritten: Vec<String> = Vec::with_capacity(existing.len() + 2);
+    let mut skip_value = false;
+    for flag in existing {
+        if skip_value {
+            // Drop the value that followed the removed flag.
+            skip_value = false;
+            continue;
+        }
+        if flag == "--gpu-memory-utilization" {
+            skip_value = true;
+            continue;
+        }
+        rewritten.push(flag);
+    }
+    rewritten.push("--gpu-memory-utilization".to_owned());
+    rewritten.push(format!("{value}"));
+    *flags = rewritten;
+}
+
+/// Parse `rocm serve --gpu-memory-utilization`. Unlike the env-var overrides
+/// elsewhere in this file, an explicit CLI value is never silently ignored: a
+/// user who types a bad fraction is told so.
+fn parse_gpu_memory_utilization(value: Option<&str>) -> Result<Option<f64>> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    let parsed: f64 = trimmed.parse().map_err(|_| {
+        anyhow::anyhow!(
+            "--gpu-memory-utilization expects a fraction greater than 0 and at most 1 \
+             (e.g. 0.5); got `{trimmed}`"
+        )
+    })?;
+    if !parsed.is_finite() || parsed <= 0.0 || parsed > 1.0 {
+        bail!(
+            "--gpu-memory-utilization must be greater than 0 and at most 1 (a fraction of \
+             the GPU's TOTAL VRAM); got `{trimmed}`"
+        );
+    }
+    Ok(Some(parsed))
+}
+
 /// Whether the resolved engine recipe launches vLLM with tool calling enabled.
 fn engine_recipe_enables_tool_choice(hint: Option<&EngineRecipeHint>) -> bool {
     hint.is_some_and(|hint| {
@@ -4188,6 +4272,7 @@ struct ServeArgs {
     no_smoke_test: bool,
     allow_public_bind: bool,
     tool_call_parser: Option<String>,
+    gpu_memory_utilization: Option<String>,
     api_key: Option<String>,
 }
 
@@ -4207,6 +4292,7 @@ fn serve(args: ServeArgs) -> Result<()> {
         no_smoke_test,
         allow_public_bind,
         tool_call_parser,
+        gpu_memory_utilization,
         api_key,
     } = args;
     let _ = managed; // background is now the default; --managed is accepted as an explicit synonym.
@@ -4268,6 +4354,20 @@ fn serve(args: ServeArgs) -> Result<()> {
         recipe_hint,
         tool_call_parser.as_deref(),
     );
+    // Validated before anything is launched so a typo fails immediately rather
+    // than surfacing as a vLLM argparse error deep in the engine log.
+    let gpu_memory_utilization = parse_gpu_memory_utilization(gpu_memory_utilization.as_deref())?;
+    let engine_recipe = engine_recipe_with_gpu_memory_utilization_override(
+        &selected_engine,
+        engine_recipe,
+        gpu_memory_utilization,
+    );
+    let gpu_memory_utilization_note = (gpu_memory_utilization.is_some() && !engine_serves_vllm)
+        .then(|| {
+            format!(
+                "note: --gpu-memory-utilization applies only to vLLM; ignored for engine '{selected_engine}'"
+            )
+        });
     let tool_call_note = if tool_call_parser.is_some() && !engine_serves_vllm {
         Some(format!(
             "note: --tool-call-parser applies only to vLLM; ignored for engine '{selected_engine}'"
@@ -4412,6 +4512,9 @@ fn serve(args: ServeArgs) -> Result<()> {
             print!("{}", render_serve_engine_recipe_lines(engine_recipe));
         }
         if let Some(note) = &tool_call_note {
+            println!("  {note}");
+        }
+        if let Some(note) = &gpu_memory_utilization_note {
             println!("  {note}");
         }
     }
@@ -21810,6 +21913,104 @@ install therock";
         )
         .unwrap();
         assert_eq!(hint.required_flags, existing.required_flags);
+    }
+
+    #[test]
+    fn gpu_memory_utilization_absent_without_explicit_flag() {
+        // rocm-cli ships no default: with nothing supplied the recipe is left
+        // alone, so vLLM applies its own default rather than one rocm-cli owns.
+        assert_eq!(parse_gpu_memory_utilization(None).unwrap(), None);
+        assert!(engine_recipe_with_gpu_memory_utilization_override("vllm", None, None).is_none());
+        let authored = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec!["--enable-auto-tool-choice".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        let hint = engine_recipe_with_gpu_memory_utilization_override("vllm", Some(authored), None)
+            .unwrap();
+        assert!(
+            !hint
+                .required_flags
+                .iter()
+                .any(|flag| flag == "--gpu-memory-utilization"),
+            "no default may be injected: {:?}",
+            hint.required_flags
+        );
+    }
+
+    #[test]
+    fn gpu_memory_utilization_override_reaches_required_flags() {
+        let value = parse_gpu_memory_utilization(Some("0.35")).unwrap();
+        let hint = engine_recipe_with_gpu_memory_utilization_override("vllm", None, value)
+            .expect("an explicit value should synthesize a vllm hint");
+        assert_eq!(hint.engine, "vllm");
+        assert_eq!(hint.contract_version, ENGINE_RECIPE_CONTRACT_VERSION);
+        assert_eq!(
+            hint.required_flags,
+            vec!["--gpu-memory-utilization".to_owned(), "0.35".to_owned()]
+        );
+    }
+
+    #[test]
+    fn gpu_memory_utilization_override_replaces_authored_value_and_keeps_others() {
+        let existing = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--gpu-memory-utilization".to_owned(),
+                "0.8".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+            ],
+            ..EngineRecipeHint::default()
+        };
+        let hint = engine_recipe_with_gpu_memory_utilization_override(
+            "vllm",
+            Some(existing),
+            parse_gpu_memory_utilization(Some("1.0")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            hint.required_flags,
+            vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--tool-call-parser".to_owned(),
+                "hermes".to_owned(),
+                "--gpu-memory-utilization".to_owned(),
+                "1".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn gpu_memory_utilization_override_leaves_non_vllm_engines_untouched() {
+        assert!(
+            engine_recipe_with_gpu_memory_utilization_override("lemonade", None, Some(0.5))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn gpu_memory_utilization_rejects_out_of_range_and_unparsable_values() {
+        // An explicit CLI value is never silently ignored (unlike the env-var
+        // overrides elsewhere): each bad value must produce an actionable error.
+        for bad in ["0", "0.0", "1.5", "-0.2", "abc", "", "NaN", "inf"] {
+            let Err(error) = parse_gpu_memory_utilization(Some(bad)) else {
+                panic!("`{bad}` must be rejected, not silently ignored");
+            };
+            let message = error.to_string();
+            assert!(
+                message.contains("--gpu-memory-utilization"),
+                "error for `{bad}` should name the flag: {message}"
+            );
+        }
+        assert_eq!(
+            parse_gpu_memory_utilization(Some(" 0.5 ")).unwrap(),
+            Some(0.5)
+        );
+        assert_eq!(parse_gpu_memory_utilization(Some("1")).unwrap(), Some(1.0));
     }
 
     #[test]

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -340,6 +340,11 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         /// KV cache (`0.0 < value <= 1.0`). Omitted by default, so vLLM applies
         /// its own default. Lower it when a small model should not reserve most
         /// of a large card. Applies to vLLM only.
+        // Taken as a string with `allow_hyphen_values` rather than a clap `f64` so a
+        // negative fraction reaches `parse_gpu_memory_utilization` and gets the domain
+        // error naming the valid range, instead of clap rejecting `-0.2` as an unknown
+        // flag. The cost is that a missing value swallows the next argument
+        // (`--gpu-memory-utilization --verbose`), which then fails loudly on parse.
         #[arg(long, value_name = "FRACTION", allow_hyphen_values = true)]
         gpu_memory_utilization: Option<String>,
         /// API key that clients must present to a public (non-loopback) endpoint.
@@ -4362,10 +4367,12 @@ fn serve(args: ServeArgs) -> Result<()> {
         engine_recipe,
         gpu_memory_utilization,
     );
+    // Stored without a `note:` prefix so it can feed both output paths: the plan
+    // path adds the prefix inline, the interactive summary adds it when rendering.
     let gpu_memory_utilization_note = (gpu_memory_utilization.is_some() && !engine_serves_vllm)
         .then(|| {
             format!(
-                "note: --gpu-memory-utilization applies only to vLLM; ignored for engine '{selected_engine}'"
+                "--gpu-memory-utilization applies only to vLLM; ignored for engine '{selected_engine}'"
             )
         });
     let tool_call_note = if tool_call_parser.is_some() && !engine_serves_vllm {
@@ -4515,7 +4522,7 @@ fn serve(args: ServeArgs) -> Result<()> {
             println!("  {note}");
         }
         if let Some(note) = &gpu_memory_utilization_note {
-            println!("  {note}");
+            println!("  note: {note}");
         }
     }
 
@@ -4590,6 +4597,7 @@ fn serve(args: ServeArgs) -> Result<()> {
                 rocr_visible_devices_set,
                 &gpu_indices,
                 gpu_vram.as_deref(),
+                gpu_memory_utilization_note.as_deref(),
             );
             let summary = serve_summary::DeploymentSummary {
                 engine: selected_engine.clone(),
@@ -4633,8 +4641,15 @@ fn collect_serve_notes(
     rocr_visible_devices_set: bool,
     gpu_indices: &[u32],
     gpu_vram: Option<&[GpuVramUsage]>,
+    engine_flag_note: Option<&str>,
 ) -> Vec<String> {
     let mut notes = Vec::new();
+    // An engine-scoped flag the selected engine cannot honor must be reported here
+    // too: the summary path is what an interactive `rocm serve` actually prints, so
+    // a note only emitted on the plan path would never reach that user.
+    if let Some(note) = engine_flag_note {
+        notes.push(note.to_owned());
+    }
     if cpu_only {
         if matches!(gpu_selection, GpuSelection::Index(_)) {
             notes.push(
@@ -22026,6 +22041,27 @@ install therock";
             Some(0.5)
         );
         assert_eq!(parse_gpu_memory_utilization(Some("1")).unwrap(), Some(1.0));
+    }
+
+    #[test]
+    fn serve_notes_surface_the_ignored_engine_flag_in_summary_mode() {
+        // The interactive summary is what a default `rocm serve` prints, so a flag
+        // the selected engine cannot honor has to be reported through this path —
+        // not only on the plan path that an interactive run never takes.
+        let note = "--gpu-memory-utilization applies only to vLLM; ignored for engine 'lemonade'";
+        let notes = collect_serve_notes(false, &GpuSelection::Auto, false, &[0], None, Some(note));
+        assert!(
+            notes.iter().any(|entry| entry == note),
+            "the ignored-flag note must reach the summary: {notes:?}"
+        );
+
+        let quiet = collect_serve_notes(false, &GpuSelection::Auto, false, &[0], None, None);
+        assert!(
+            !quiet
+                .iter()
+                .any(|entry| entry.contains("--gpu-memory-utilization")),
+            "nothing to report when the flag was honored: {quiet:?}"
+        );
     }
 
     #[test]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -896,7 +896,7 @@ vLLM TheRock GPU acceptance:
 ```bash
 cargo test -p rocm-engine-vllm running_state_records_managed_therock_env_for_gpu_verification
 cargo test -p rocm-engine-vllm managed_env_reflects_managed_runtime_manifest_source
-cargo test -p rocm-engine-vllm resolve_model_surfaces_conservative_vram_default
+cargo test -p rocm-engine-vllm resolve_model_omits_gpu_memory_utilization_default
 python -m py_compile scripts/vllm_therock_gpu_test.py
 python scripts/vllm_therock_gpu_test.py --self-test
 

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -97,8 +97,9 @@ vLLM claims a fixed fraction of each GPU's **total** VRAM — not of the free
 VRAM, and not scaled to the model — for weights plus KV cache. On a large card
 a small model therefore still reserves a large slice.
 
-rocm-cli passes no `--gpu-memory-utilization` of its own, so vLLM's own default
-applies. Override it when you want a different share:
+rocm-cli sets no `--gpu-memory-utilization` of its own, so vLLM's own default
+applies unless a value comes from somewhere else — either a model's catalog
+recipe or, taking precedence over it, the flag below:
 
 ```bash
 rocm serve <model> --engine vllm --gpu-memory-utilization 0.3 --managed

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -107,9 +107,13 @@ rocm serve <model> --engine vllm --gpu-memory-utilization 0.3 --managed
 
 The value is a fraction in `(0, 1]` of total device VRAM. Lower it to leave room
 for a display, another workload, or a second server; raise it to give a large
-model more KV cache. Applies to vLLM only — it is ignored (with a note) for
-other engines. An out-of-range or unparsable value fails the command rather than
-falling back silently.
+model more KV cache. Applies to vLLM only — it is ignored, with a note in the
+serve output, for other engines. An out-of-range or unparsable value fails the
+command rather than falling back silently.
+
+Earlier releases pinned this to `0.80` to leave display/WSL headroom. That pin is
+gone, so an unchanged command now reserves vLLM's own (higher) default. Pass
+`--gpu-memory-utilization 0.8` to restore the previous reservation.
 
 ### Tool calling
 

--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -53,9 +53,7 @@ runtime key or an unambiguous runtime id.
 
 On WSL, the tested source build needed vLLM ROCm platform detection to use
 TheRock PyTorch device data when `amdsmi` is unavailable, and needed vLLM's
-ROCm GPTQ half-atomic compatibility path enabled for TheRock 7.13 headers. The
-adapter passes `--gpu-memory-utilization 0.80` by default so display/WSL VRAM
-use does not prevent a small GPU model from starting.
+ROCm GPTQ half-atomic compatibility path enabled for TheRock 7.13 headers.
 
 On the MI300X/gfx942 TheRock 7.13 runtime, current vLLM source required the
 GPTQ compatibility guard in
@@ -92,6 +90,25 @@ rocm serve Qwen/Qwen3.5-4B --engine vllm --gpu 1 --managed
 
 rocm-cli pins the device via `HIP_VISIBLE_DEVICES`. Serving one model across
 multiple GPUs is not supported.
+
+### GPU memory
+
+vLLM claims a fixed fraction of each GPU's **total** VRAM — not of the free
+VRAM, and not scaled to the model — for weights plus KV cache. On a large card
+a small model therefore still reserves a large slice.
+
+rocm-cli passes no `--gpu-memory-utilization` of its own, so vLLM's own default
+applies. Override it when you want a different share:
+
+```bash
+rocm serve <model> --engine vllm --gpu-memory-utilization 0.3 --managed
+```
+
+The value is a fraction in `(0, 1]` of total device VRAM. Lower it to leave room
+for a display, another workload, or a second server; raise it to give a large
+model more KV cache. Applies to vLLM only — it is ignored (with a note) for
+other engines. An out-of-range or unparsable value fails the command rather than
+falling back silently.
 
 ### Tool calling
 

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -31,7 +31,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const ENGINE_NAME: &str = "vllm";
 const DEFAULT_HOST: &str = "127.0.0.1";
 const HEALTHCHECK_TIMEOUT_MS: u64 = 700;
-const DEFAULT_GPU_MEMORY_UTILIZATION: &str = "0.80";
 const STARTUP_FAILURE_LOG_TAIL_LINES: usize = 80;
 const MAX_TAIL_READ: u64 = 4 * 1024 * 1024;
 /// How long a stop waits for the server to actually exit after each signal
@@ -496,8 +495,7 @@ fn resolve_model_response(request: ResolveModelRequest) -> Result<ResolveModelRe
         launch_defaults: json!({
             "endpoint_mode": "openai",
             "host": DEFAULT_HOST,
-            "port": DEFAULT_LOCAL_PORT,
-            "gpu_memory_utilization": DEFAULT_GPU_MEMORY_UTILIZATION
+            "port": DEFAULT_LOCAL_PORT
         }),
         engine_recipe,
         warnings: vec![
@@ -698,23 +696,13 @@ the ROCm SDK's bundled numa uses renamed symbol versions and cannot satisfy it, 
 
     let mut command = ProcessCommand::new(&runtime.command);
     command
-        .arg("serve")
-        .arg(&request.model_ref)
-        .arg("--host")
-        .arg(&request.host)
-        .arg("--port")
-        .arg(request.port.to_string())
-        .arg("--gpu-memory-utilization")
-        .arg(DEFAULT_GPU_MEMORY_UTILIZATION);
-    // vLLM's FULL CUDA-graph replay hangs ROCm gfx94x GPUs on the first decode
-    // (surfaces as `HW Exception ... reason :GPU Hang`, which kills the engine and
-    // drops every inference request). Eager mode disables CUDA graphs and keeps
-    // inference stable. Allow opting back in via env once a runtime ships a fix.
-    if vllm_enforce_eager_enabled() {
-        command.arg("--enforce-eager");
-    }
-    command
-        .args(engine_recipe_launch_args(request.engine_recipe.as_ref()))
+        .args(vllm_serve_args(
+            &request.model_ref,
+            &request.host,
+            request.port,
+            vllm_enforce_eager_enabled(),
+            request.engine_recipe.as_ref(),
+        ))
         .stdin(Stdio::null());
     // When `rocm serve` protects a public endpoint, the key arrives via the
     // environment / key file (never argv). Hand it to vLLM as `VLLM_API_KEY` so
@@ -1295,6 +1283,42 @@ fn apply_therock_env(command: &mut ProcessCommand, runtime: &VllmRuntime) -> Res
         );
     }
     Ok(())
+}
+
+/// Full argument vector for `vllm serve`, as spawned by [`spawn_vllm_server`].
+///
+/// Kept as a pure function so the exact argv can be asserted in tests: memory
+/// and graph-mode flags materially change how much VRAM vLLM claims, and a
+/// wiring mistake there is invisible until a live GPU launch.
+///
+/// Notably absent: `--gpu-memory-utilization`. rocm-cli deliberately does not
+/// supply a default — vLLM's own default applies unless the user asks for a
+/// specific fraction via `rocm serve --gpu-memory-utilization`, which arrives
+/// here through the engine recipe's `required_flags`.
+fn vllm_serve_args(
+    model_ref: &str,
+    host: &str,
+    port: u16,
+    enforce_eager: bool,
+    engine_recipe: Option<&EngineRecipeHint>,
+) -> Vec<String> {
+    let mut args = vec![
+        "serve".to_owned(),
+        model_ref.to_owned(),
+        "--host".to_owned(),
+        host.to_owned(),
+        "--port".to_owned(),
+        port.to_string(),
+    ];
+    // vLLM's FULL CUDA-graph replay hangs ROCm gfx94x GPUs on the first decode
+    // (surfaces as `HW Exception ... reason :GPU Hang`, which kills the engine and
+    // drops every inference request). Eager mode disables CUDA graphs and keeps
+    // inference stable. Allow opting back in via env once a runtime ships a fix.
+    if enforce_eager {
+        args.push("--enforce-eager".to_owned());
+    }
+    args.extend(engine_recipe_launch_args(engine_recipe));
+    args
 }
 
 fn engine_recipe_launch_args(engine_recipe: Option<&EngineRecipeHint>) -> Vec<String> {
@@ -2070,7 +2094,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_surfaces_conservative_vram_default() -> Result<()> {
+    fn resolve_model_omits_gpu_memory_utilization_default() -> Result<()> {
         let response = resolve_model_response(ResolveModelRequest {
             model_ref: "facebook/opt-125m".to_owned(),
             runtime_id: None,
@@ -2079,14 +2103,55 @@ mod tests {
             engine_recipe: None,
         })?;
 
-        assert_eq!(
+        assert!(
             response
                 .launch_defaults
                 .get("gpu_memory_utilization")
-                .and_then(Value::as_str),
-            Some(DEFAULT_GPU_MEMORY_UTILIZATION)
+                .is_none(),
+            "rocm-cli defers to vLLM's own default, so it must not advertise one: {}",
+            response.launch_defaults
         );
         Ok(())
+    }
+
+    #[test]
+    fn vllm_serve_args_omit_gpu_memory_utilization_without_override() {
+        let args = vllm_serve_args("facebook/opt-125m", "127.0.0.1", 8000, false, None);
+
+        assert_eq!(
+            args,
+            vec![
+                "serve",
+                "facebook/opt-125m",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000"
+            ]
+        );
+        assert!(
+            !args.iter().any(|arg| arg == "--gpu-memory-utilization"),
+            "vLLM must apply its own default when the user asked for nothing: {args:?}"
+        );
+    }
+
+    #[test]
+    fn vllm_serve_args_forward_recipe_gpu_memory_utilization() {
+        let hint = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: ENGINE_NAME.to_owned(),
+            required_flags: vec!["--gpu-memory-utilization".to_owned(), "0.35".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+
+        let args = vllm_serve_args("facebook/opt-125m", "127.0.0.1", 8000, true, Some(&hint));
+
+        let position = args
+            .iter()
+            .position(|arg| arg == "--gpu-memory-utilization")
+            .expect("explicit utilization must reach the spawned argv");
+        assert_eq!(args.get(position + 1).map(String::as_str), Some("0.35"));
+        assert!(args.contains(&"--enforce-eager".to_owned()));
     }
 
     #[test]

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -105,8 +105,9 @@ async fn ensure_serve_port_free() -> String {
     // Always kill any listener on the shared port — NOT just one that already
     // answers /v1/models. A prior scenario's vLLM that is still LOADING holds the
     // port and GPU memory without yet serving /v1/models; if we only checked HTTP
-    // readiness we'd start a second server, overcommit GPU memory (each asks for
-    // 0.80), and the collision crashes a server → the next chat POST fails with
+    // readiness we'd start a second server, overcommit GPU memory (each claims
+    // vLLM's default fraction of the device), and the collision crashes a server
+    // → the next chat POST fails with
     // "error sending request". Killing by port (fuser/lsof) catches the starting
     // server too. Best-effort; then wait for the socket to actually close.
     // Also kill the CLI's auto-started lemonade assistant — it hogs a GPU core on
@@ -458,7 +459,7 @@ async fn setup_gpu_model(world: &mut E2eWorld) {
         // Stop THIS attempt's stalled service before doing anything else. A vLLM
         // still in engine init has not bound the serve port yet, so the port kill
         // in `ensure_serve_port_free` cannot see it — it would survive into the
-        // next attempt, hold its ~0.8-of-device memory reservation, and guarantee
+        // next attempt, hold its fraction-of-device memory reservation, and guarantee
         // the relaunch dies on vLLM's free-memory check. Going through `rocm
         // services stop` is what actually clears it: that path signals the whole
         // process tree (the EngineCore worker pins the allocation, not the parent)

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -144,8 +144,12 @@ async fn ensure_serve_port_free() -> String {
 /// reservation needs the MI300X mostly clear. Only a data-center GPU has this
 /// much, so on smaller cards (e.g. Strix Halo's smaller unified-memory pool) the
 /// floor is capped to 90% of the device total (see [`required_free_vram_mib`]) —
-/// otherwise the check could never pass. That cap is deliberately at vLLM's own
-/// default utilization, so a drained device still just satisfies the request.
+/// otherwise the check could never pass. Note the cap no longer sits above what
+/// vLLM asks for: rocm-cli used to pin utilization below it, and now defers to
+/// vLLM's own (higher) default, so the wait has little headroom left and can
+/// time out on a device that is merely holding display memory. The wait is
+/// best-effort and the serve proceeds regardless, so this costs time rather
+/// than correctness; sizing a deliberate margin is follow-up work.
 const MAX_FREE_VRAM_FLOOR_MIB: u64 = 150_000;
 
 /// The free-VRAM floor to wait for on this host: the model-sized ceiling, but

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -129,8 +129,9 @@ async fn ensure_serve_port_free() -> String {
     // The port closing does NOT mean the prior serve's VRAM is back: a killed
     // vLLM releases ~tens of GiB of device memory only as the process fully
     // exits, which lags the socket close. The next `rocm serve` reads free VRAM
-    // at startup and demands `gpu-memory-utilization` of the TOTAL — after a large
-    // model (e.g. 27B ~54 GiB) the residue can drop free memory below that
+    // at startup and demands vLLM's `gpu-memory-utilization` fraction of the
+    // TOTAL (rocm-cli passes no value, so vLLM's own default applies) — after a
+    // large model (e.g. 27B ~54 GiB) the residue can drop free memory below that
     // request, so the next serve dies with "Free memory ... less than desired GPU
     // memory utilization" (engine core init failed). Wait for the device to
     // actually drain before returning.
@@ -139,11 +140,12 @@ async fn ensure_serve_port_free() -> String {
 
 /// Upper bound on the free-VRAM floor (MiB). Sized so the largest single
 /// scenario model can allocate its engine's memory share without tripping its
-/// startup check: Qwen3.6-27B plus vLLM's ~0.8-of-total KV reservation needs the
-/// MI300X mostly clear. Only a data-center GPU has this much, so on smaller
-/// cards (e.g. Strix Halo's smaller unified-memory pool) the floor is capped to
-/// 90% of the device total (see [`required_free_vram_mib`]) — otherwise the
-/// check could never pass.
+/// startup check: Qwen3.6-27B plus vLLM's default fraction-of-total KV
+/// reservation needs the MI300X mostly clear. Only a data-center GPU has this
+/// much, so on smaller cards (e.g. Strix Halo's smaller unified-memory pool) the
+/// floor is capped to 90% of the device total (see [`required_free_vram_mib`]) —
+/// otherwise the check could never pass. That cap is deliberately at vLLM's own
+/// default utilization, so a drained device still just satisfies the request.
 const MAX_FREE_VRAM_FLOOR_MIB: u64 = 150_000;
 
 /// The free-VRAM floor to wait for on this host: the model-sized ceiling, but


### PR DESCRIPTION
## Problem

Serving a 0.5B model on a large-VRAM machine reserved roughly 200 GB of VRAM.

The vLLM adapter always passed `--gpu-memory-utilization 0.80`, and vLLM reserves that fraction of **total** device VRAM for its KV cache regardless of how small the model is. There was no way for a user to override it.

## Changes

- **Stop overriding vLLM's default.** When the user does not ask for a value, no `--gpu-memory-utilization` argument is passed at all, so vLLM's own default applies. Chosen over hardcoding vLLM's current 0.9 so the value cannot drift out of sync with upstream.
- **Add `rocm serve --gpu-memory-utilization <FRACTION>`** so the value can be set explicitly. The flag is vLLM-scoped and follows the existing `--tool-call-parser` precedent: same warn-and-ignore behavior on other engines, routed through `EngineRecipeHint.required_flags`, so the engine protocol is unchanged.
- **Validate `0 < value <= 1`** with an error that names the flag.
- **Extract a pure `vllm_serve_args` helper** so the launch argv is unit-testable.
- **Update `docs/vllm.md`**: drop the now-stale "0.80 by default for display/WSL headroom" rationale, document the flag, and state that it is a fraction of total — not free — VRAM.
- **Update `docs/testing.md`**: point the vLLM TheRock acceptance runbook at the renamed test so the documented command runs.

## Why an engine-scoped flag

An engine-agnostic knob was considered and rejected: llama.cpp/lemonade has no fractional-VRAM-reservation concept, and multi-engine wrappers in the wider ecosystem (Xinference, LocalAI, RamaLama, KubeAI, Jan, llama-swap) all decline to unify this for the same reason. `gpu-memory-utilization` is also the near-universal spelling (vLLM, TGI's equivalent, Ray Serve, KServe, KubeAI, NIM).

## Behavior change

On machines where the old 0.80 was providing display or WSL headroom, the effective reservation now rises to vLLM's default. Passing `--gpu-memory-utilization 0.8` restores the previous behavior.

Related: the e2e free-VRAM floor in `tests/e2e-cucumber/tests/e2e/serving_steps.rs` caps at 90% of total, which now sits exactly at vLLM's default instead of having slack. That is a tight tolerance on small cards and may deserve a deliberate margin in a follow-up.

## Test plan

- 7 new unit tests plus one rewritten (`resolve_model_surfaces_conservative_vram_default` → `resolve_model_omits_gpu_memory_utilization_default`) across `engines/vllm` and `apps/rocm`: flag absent (no argument emitted), flag present (value reaches argv), and invalid input (`0`, `1.5`, `-0.2`, `abc`, `NaN`, `inf`, empty).
- Fails-before verified by temporarily restoring the hardcoded flag/value pair.
- No `expectations.toml` rows reference this ticket, so none needed narrowing.

Risk: low for the code path; medium for users who relied on the implicit 0.80 headroom, which the docs now cover.
