### PR TITLE
ci: give Dependabot Actions bumps a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Wait out the window in which a compromised release is typically found and
+    # yanked before adopting it. Bumping a pinned SHA is the one moment the pin
+    # stops protecting us: the bump PR itself runs the new action's code on CI —
+    # including the self-hosted GPU lanes, which every Dependabot PR reaches
+    # because each path filter in ci.yml folds in `.github/workflows/**` — before
+    # a human has read the diff. Those runners keep state across jobs, so the
+    # blast radius outlives the run. GitHub already applies 3 days by default;
+    # published Actions compromises have gone unnoticed for longer than that, so
+    # widen it. Cooldown delays only version updates, never security updates.
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

- Adds `cooldown: default-days: 7` to the `github-actions` Dependabot ecosystem.

**Why.** Pinning actions to SHAs prevents a tag being moved under us, but it does not cover the one moment the pin stops protecting us: adopting a *new* SHA. Dependabot's bump PR triggers `ci.yml`, which executes the new action's code before any human has read the diff. So the window between "a release is published" and "we run it" is the exposure, and today it is only GitHub's implicit 3-day default.

**Why it matters more here than in a typical repo.** Every path filter in `ci.yml` folds in `.github/workflows/**`. An Actions bump edits exactly those files, so such a PR trips the `heavy` filter and reaches the self-hosted GPU lanes (`e2e-gpu`, `e2e-gpu-strix-*`) — not just ephemeral `ubuntu-latest` containers. Those runners deliberately persist state across jobs (the uv cache, the prewarm data dir, the target dir kept via `cache: false`), so anything that executes there outlives the run and is reused by later jobs, including jobs on `main`.

**Why 7 days.** Long enough to cover the interval in which published action compromises have typically been found and yanked; GitHub's implicit default of 3 days has been shorter than that interval in practice. Cooldown applies to version updates only — security updates are explicitly exempt and still land immediately.

- Risk: low. Config-only; the sole behavioral effect is that routine SHA bumps arrive later than they would today. The eligibility gate widens by 4 days (3 → 7), but because `schedule: interval: weekly` quantizes PR creation to the weekly run, the wall-clock delta is 0 or a full week depending on where the release falls relative to that run — not a uniform 4 days.

## Scope / non-goals

Deliberately not included, to keep this to one change — happy to follow up on either if maintainers want them:

- Guarding the self-hosted GPU lanes with `github.actor != 'dependabot[bot]'`. This would remove the persistent-runner exposure outright rather than just delaying it; the tradeoff is that an Actions bump then gets GPU-lane validation only after merge (those jobs are `continue-on-error: true`, so they gate nothing today).
- Splitting first-party `actions/*` from third-party actions into separate groups, so a third-party bump can't ride along in a batch of routine ones.

## Test plan

- `.github/dependabot.yml` parses and yields the intended structure (`cooldown.default-days: 7` alongside the existing `schedule` and `groups`); `prek run --all-files --no-group local-tools` passes, including `check-yaml`.
- `default-days` is documented as supported for every listed package manager, GitHub Actions included. Only `default-days` is used — the `semver-*-days` variants are documented as applying "only to package managers supporting SemVer", and I did not confirm GitHub Actions is one of them.
- No local verification of Dependabot's runtime behavior is possible; that is observable only on the next scheduled run.

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — n/a, no bug fix.
