### PR TITLE
test(e2e): retry a cold-start chat request and report why it failed

### DIFF
--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -661,43 +661,112 @@ fn inference_timeout_for(world: &E2eWorld) -> u64 {
     inference_timeout_secs().max(world.serve_timeout_override.unwrap_or(0))
 }
 
-pub async fn send_chat(world: &mut E2eWorld) {
-    let endpoint = world.endpoint.as_ref().expect("no endpoint configured");
+/// A transport failure spelled out well enough to triage from a CI log alone.
+///
+/// `reqwest::Error`'s `Display` prints only its KIND — a client timeout and a
+/// refused/reset connection both read as "error sending request for url (…)",
+/// with the real cause reachable only through `source()`. That ambiguity cost a
+/// full log archaeology once (a 10s client timeout that read as a dead server),
+/// so classify the error and unwind the source chain into the panic message.
+fn describe_request_error(error: &reqwest::Error) -> String {
+    use std::error::Error as _;
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(inference_timeout_for(world)))
-        .build()
-        .expect("failed to build HTTP client");
+    let kind = if error.is_timeout() {
+        " [client timeout — the harness gave up, the server may still be working]"
+    } else if error.is_connect() {
+        " [connect failure — nothing accepted the connection]"
+    } else {
+        ""
+    };
+    let mut detail = format!("{error}{kind}");
+    let mut source = error.source();
+    while let Some(cause) = source {
+        detail.push_str(&format!("\n  caused by: {cause}"));
+        source = cause.source();
+    }
+    detail
+}
 
+/// Discover the served model id over `/models` and POST one chat completion to
+/// it, returning the decoded response. `tools` is merged into the request body
+/// for the tool-definitions scenario.
+///
+/// Retries once on a transport failure, but only for a scenario expected to
+/// PASS — the same rule the serve relaunch uses. The FIRST inference after a
+/// serve pays a cold start (weights paged in on demand), and on a busy runner
+/// that has exceeded the flat inference timeout even though the steady-state
+/// request on the very same host takes ~1s: run 30614673685 (Strix-Windows)
+/// failed this at exactly 10.000s while the next scenario's chat answered in
+/// 1.4s. The aborted attempt still leaves the model resident, so the retry runs
+/// warm. A known-bug scenario keeps its single attempt so hang detection stays
+/// as prompt as `inference_timeout_secs` documents.
+pub async fn request_chat_completion(
+    world: &mut E2eWorld,
+    prompt: &str,
+    tools: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let endpoint = world.endpoint.clone().expect("no endpoint configured");
+    let timeout_secs = inference_timeout_for(world);
+    let attempts = if world.expect_xfail { 1 } else { 2 };
     let models_url = format!("{endpoint}/models");
-    let resp: serde_json::Value = client
-        .get(&models_url)
-        .send()
-        .await
-        .unwrap_or_else(|e| panic!("GET {models_url} failed: {e}"))
-        .json()
-        .await
-        .unwrap_or_else(|e| panic!("GET {models_url} returned non-JSON: {e}"));
-    let model = resp["data"][0]["id"]
-        .as_str()
-        .unwrap_or_else(|| panic!("no model id in response: {resp}"))
-        .to_string();
-    world.discovered_model = Some(model.clone());
-
     let chat_url = format!("{endpoint}/chat/completions");
-    let chat_resp: serde_json::Value = client
-        .post(&chat_url)
-        .json(&serde_json::json!({
+    let mut diagnostics = Vec::new();
+
+    for attempt in 1..=attempts {
+        // A fresh client per attempt: the pooled connection of a timed-out
+        // attempt is not worth reusing.
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_secs))
+            .build()
+            .expect("failed to build HTTP client");
+
+        let models: serde_json::Value = client
+            .get(&models_url)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("GET {models_url} failed: {}", describe_request_error(&e)))
+            .json()
+            .await
+            .unwrap_or_else(|e| panic!("GET {models_url} returned non-JSON: {e}"));
+        let model = models["data"][0]["id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("no model id in response: {models}"))
+            .to_string();
+        world.discovered_model = Some(model.clone());
+
+        let mut body = serde_json::json!({
             "model": model,
-            "messages": [{"role": "user", "content": "Hello"}]
-        }))
-        .send()
-        .await
-        .unwrap_or_else(|e| panic!("POST {chat_url} failed: {e}"))
-        .json()
-        .await
-        .unwrap_or_else(|e| panic!("POST {chat_url} returned non-JSON: {e}"));
-    world.chat_response = Some(chat_resp);
+            "messages": [{"role": "user", "content": prompt}]
+        });
+        if let Some(tools) = tools.clone() {
+            body["tools"] = tools;
+        }
+
+        let started = std::time::Instant::now();
+        match client.post(&chat_url).json(&body).send().await {
+            Ok(response) => {
+                return response
+                    .json()
+                    .await
+                    .unwrap_or_else(|e| panic!("POST {chat_url} returned non-JSON: {e}"));
+            }
+            Err(error) => diagnostics.push(format!(
+                "attempt {attempt} failed after {:.1}s: {}",
+                started.elapsed().as_secs_f64(),
+                describe_request_error(&error)
+            )),
+        }
+    }
+
+    panic!(
+        "POST {chat_url} failed after {attempts} attempt(s) of {timeout_secs}s each:\n{}",
+        diagnostics.join("\n")
+    );
+}
+
+pub async fn send_chat(world: &mut E2eWorld) {
+    let response = request_chat_completion(world, "Hello", None).await;
+    world.chat_response = Some(response);
 }
 
 // ── Runner ─────────────────────────────────────────────────────────

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -667,7 +667,7 @@ fn inference_timeout_for(world: &E2eWorld) -> u64 {
 /// full log archaeology once (a 10s client timeout that read as a dead server),
 /// so classify the error and unwind the source chain into the panic message.
 fn describe_request_error(error: &reqwest::Error) -> String {
-    use std::error::Error as _;
+    use std::{error::Error as _, fmt::Write as _};
 
     let kind = if error.is_timeout() {
         " [client timeout — the harness gave up, the server may still be working]"
@@ -679,7 +679,8 @@ fn describe_request_error(error: &reqwest::Error) -> String {
     let mut detail = format!("{error}{kind}");
     let mut source = error.source();
     while let Some(cause) = source {
-        detail.push_str(&format!("\n  caused by: {cause}"));
+        // Infallible: writing into a String never errors.
+        let _ = write!(detail, "\n  caused by: {cause}");
         source = cause.source();
     }
     detail

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -32,7 +32,6 @@ pub struct E2eWorld {
     pub mock: Option<MockServer>,
     pub endpoint: Option<String>,
     pub model_name: Option<String>,
-    pub discovered_model: Option<String>,
     pub chat_response: Option<serde_json::Value>,
     pub cli_output: Option<String>,
     pub cli_outputs: Option<Vec<String>>,
@@ -166,7 +165,6 @@ impl Default for E2eWorld {
             mock: None,
             endpoint: None,
             model_name: None,
-            discovered_model: None,
             chat_response: None,
             cli_output: None,
             cli_outputs: None,
@@ -691,28 +689,44 @@ fn describe_request_error(error: &reqwest::Error) -> String {
 /// it, returning the decoded response. `tools` is merged into the request body
 /// for the tool-definitions scenario.
 ///
-/// Retries once on a transport failure, but only for a scenario expected to
-/// PASS — the same rule the serve relaunch uses. The FIRST inference after a
-/// serve pays a cold start (weights paged in on demand), and on a busy runner
-/// that has exceeded the flat inference timeout even though the steady-state
-/// request on the very same host takes ~1s: run 30614673685 (Strix-Windows)
-/// failed this at exactly 10.000s while the next scenario's chat answered in
-/// 1.4s. The aborted attempt still leaves the model resident, so the retry runs
-/// warm. A known-bug scenario keeps its single attempt so hang detection stays
-/// as prompt as `inference_timeout_secs` documents.
+/// Retries once on a TRANSPORT failure of either request (the `send`, not the
+/// decode), and only for a scenario expected to PASS — the same rule the serve
+/// relaunch uses. A malformed reply is a server-contract violation rather than
+/// a flake, so it still fails on the spot. The FIRST inference after a serve
+/// pays a cold start (weights paged in on demand), and on a busy runner that
+/// has exceeded the flat inference timeout even though the steady-state request
+/// on the very same host takes ~1s: run 30614673685 (Strix-Windows) failed this
+/// at exactly 10.000s while the next scenario's chat answered in 1.4s. The
+/// aborted attempt still leaves the model resident, so the retry runs warm. A
+/// known-bug scenario keeps its single attempt so hang detection stays as
+/// prompt as `inference_timeout_secs` documents.
 pub async fn request_chat_completion(
     world: &mut E2eWorld,
     prompt: &str,
     tools: Option<serde_json::Value>,
 ) -> serde_json::Value {
     let endpoint = world.endpoint.clone().expect("no endpoint configured");
-    let timeout_secs = inference_timeout_for(world);
+    // Only the FIRST attempt gets this scenario's full (possibly `@serve-timeout`
+    // -inflated) budget; the retry is capped at the flat default. The retry's
+    // whole premise is that it runs WARM, so it has no use for headroom that
+    // exists solely to cover a cold first token — and granting it would let one
+    // step spend 2x2400s on the large-model nightly scenario and blow the job's
+    // 90-minute limit, losing the results of every scenario behind it. This is
+    // the same job-level protection the serve relaunch gets from its run-wide
+    // `relaunch_budget`, expressed as a per-attempt cap instead of a shared one.
+    let first_timeout_secs = inference_timeout_for(world);
+    let retry_timeout_secs = inference_timeout_secs();
     let attempts = if world.expect_xfail { 1 } else { 2 };
     let models_url = format!("{endpoint}/models");
     let chat_url = format!("{endpoint}/chat/completions");
     let mut diagnostics = Vec::new();
 
     for attempt in 1..=attempts {
+        let timeout_secs = if attempt == 1 {
+            first_timeout_secs
+        } else {
+            retry_timeout_secs
+        };
         // A fresh client per attempt: the pooled connection of a timed-out
         // attempt is not worth reusing.
         let client = reqwest::Client::builder()
@@ -720,11 +734,23 @@ pub async fn request_chat_completion(
             .build()
             .expect("failed to build HTTP client");
 
-        let models: serde_json::Value = client
-            .get(&models_url)
-            .send()
-            .await
-            .unwrap_or_else(|e| panic!("GET {models_url} failed: {}", describe_request_error(&e)))
+        let started = std::time::Instant::now();
+        let models = match client.get(&models_url).send().await {
+            Ok(response) => response,
+            // Fall through to the next attempt rather than panicking here: a
+            // panic would also throw away the diagnostics of the attempts
+            // already recorded, which is the whole point of collecting them.
+            Err(error) => {
+                diagnostics.push(format!(
+                    "attempt {attempt} (budget {timeout_secs}s): GET {models_url} failed after \
+                     {:.1}s: {}",
+                    started.elapsed().as_secs_f64(),
+                    describe_request_error(&error)
+                ));
+                continue;
+            }
+        };
+        let models: serde_json::Value = models
             .json()
             .await
             .unwrap_or_else(|e| panic!("GET {models_url} returned non-JSON: {e}"));
@@ -732,7 +758,6 @@ pub async fn request_chat_completion(
             .as_str()
             .unwrap_or_else(|| panic!("no model id in response: {models}"))
             .to_string();
-        world.discovered_model = Some(model.clone());
 
         let mut body = serde_json::json!({
             "model": model,
@@ -742,16 +767,31 @@ pub async fn request_chat_completion(
             body["tools"] = tools;
         }
 
+        // Time the POST on its own: the discovery round trip ahead of it is
+        // cheap and constant, and mixing it in would blur the number that
+        // actually gets compared against the timeout.
         let started = std::time::Instant::now();
         match client.post(&chat_url).json(&body).send().await {
             Ok(response) => {
+                // Say so when an earlier attempt failed. A rescued flake is
+                // otherwise invisible — the scenario just goes green — and then
+                // nobody can tell from the logs whether cold starts are getting
+                // slower until the retry stops being enough.
+                if !diagnostics.is_empty() {
+                    eprintln!(
+                        "chat request succeeded on attempt {attempt} of {attempts} after an \
+                         earlier failure:\n{}",
+                        diagnostics.join("\n")
+                    );
+                }
                 return response
                     .json()
                     .await
                     .unwrap_or_else(|e| panic!("POST {chat_url} returned non-JSON: {e}"));
             }
             Err(error) => diagnostics.push(format!(
-                "attempt {attempt} failed after {:.1}s: {}",
+                "attempt {attempt} (budget {timeout_secs}s): POST {chat_url} failed after {:.1}s: \
+                 {}",
                 started.elapsed().as_secs_f64(),
                 describe_request_error(&error)
             )),
@@ -759,7 +799,7 @@ pub async fn request_chat_completion(
     }
 
     panic!(
-        "POST {chat_url} failed after {attempts} attempt(s) of {timeout_secs}s each:\n{}",
+        "chat request failed after {attempts} attempt(s):\n{}",
         diagnostics.join("\n")
     );
 }

--- a/tests/e2e-cucumber/tests/e2e/chat_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/chat_steps.rs
@@ -37,51 +37,19 @@ async fn user_checks_services(world: &mut E2eWorld) {
 
 #[when("a chat request with tool definitions is sent")]
 async fn send_chat_with_tools(world: &mut E2eWorld) {
-    let endpoint = world.endpoint.as_ref().expect("no endpoint configured");
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(
-            crate::inference_timeout_for(world),
-        ))
-        .build()
-        .expect("failed to build HTTP client");
-
-    let models_url = format!("{endpoint}/models");
-    let resp: serde_json::Value = client
-        .get(&models_url)
-        .send()
-        .await
-        .unwrap_or_else(|e| panic!("GET {models_url} failed: {e}"))
-        .json()
-        .await
-        .unwrap_or_else(|e| panic!("GET {models_url} returned non-JSON: {e}"));
-    let model = resp["data"][0]["id"]
-        .as_str()
-        .unwrap_or_else(|| panic!("no model id in response: {resp}"))
-        .to_string();
-
-    let chat_url = format!("{endpoint}/chat/completions");
-    let chat_resp: serde_json::Value = client
-        .post(&chat_url)
-        .json(&serde_json::json!({
-            "model": model,
-            "messages": [{"role": "user", "content": "What GPUs are available?"}],
-            "tools": [{
-                "type": "function",
-                "function": {
-                    "name": "gpu_status",
-                    "description": "Get GPU status",
-                    "parameters": {"type": "object", "properties": {}}
-                }
-            }]
-        }))
-        .send()
-        .await
-        .unwrap_or_else(|e| panic!("POST {chat_url} failed: {e}"))
-        .json()
-        .await
-        .unwrap_or_else(|e| panic!("POST {chat_url} returned non-JSON: {e}"));
-    world.chat_response = Some(chat_resp);
+    // Same discover-then-POST path as a plain chat (including its cold-start
+    // retry and transport diagnostics), with a tool definition attached.
+    let tools = serde_json::json!([{
+        "type": "function",
+        "function": {
+            "name": "gpu_status",
+            "description": "Get GPU status",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    }]);
+    let response =
+        crate::request_chat_completion(world, "What GPUs are available?", Some(tools)).await;
+    world.chat_response = Some(response);
 }
 
 #[when("the user sends a chat message")]


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No xfail change: this is a harness flake, not a product bug — `chat-tool-definitions-accepted` is expected to pass on this host and should stay that way.)

## Summary

- Give a chat inference request one retry, for expect-pass scenarios only, so the first (cold) inference after a serve doesn't fail the run on a busy runner.
- Report *why* an inference request failed: classify timeout vs. connect failure, print elapsed time per attempt and the full error source chain.
- Route both chat steps (plain and tool-definitions) through one shared helper instead of two near-identical copies.

**Why:** the Strix-Windows lane failed `chat-tool-definitions-accepted` on run 30614673685. Root cause is a harness flake, not a product regression: the first inference after a serve pays a cold start (weights paged in on demand), and it overran the flat 10s inference cap. Evidence — the step failed at exactly 10.000s, the very next scenario's chat on the same host answered in 1.4s, and the same scenario took 1.0–3.1s in the four preceding Windows runs.

The retry is scoped the same way the existing serve relaunch is: `attempts = if world.expect_xfail { 1 } else { 2 }`. A known-bug scenario keeps its single fail-fast attempt, so the hang detection that `inference_timeout_secs` documents stays as prompt as before. The aborted attempt leaves the model resident, so the retry runs warm.

The diagnostics change is what made this failure expensive to triage: `reqwest::Error`'s `Display` prints only the error *kind*, so a client timeout and a refused connection both read as `error sending request for url (...)`, with the real cause reachable only through `source()`. The panic now says which one it was.

**Risk:** low — test harness only, no product code. Worst case for a genuinely failing expect-pass scenario is one extra bounded attempt (10s).

## Test plan

- `cargo xtask e2e` (mock lane): chat scenarios 5/6/7 pass. Two `diagnose-*` failures on my box are pre-existing — verified identical with the change stashed; they're a local host-capability quirk, not related to this diff.
- Retry and diagnostics exercised directly by temporarily pointing the POST at a dead port (reverted before commit): both attempts logged with `[connect failure — nothing accepted the connection]` and the full `Connection refused (os error 111)` chain.
- `cargo fmt --check` and `cargo clippy --tests` clean.

Not verified here: that the retry actually rescues a real GPU cold start — that needs the Strix-Windows runner. The failure reproduces roughly 1 run in 5, so confirmation comes from the lane staying green.