### PR TITLE
test(e2e): gate heavy GPU serves to the merge queue

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -130,6 +130,12 @@ jobs:
       # workflow sets this unconditionally; here it lets a scoped dispatch confirm
       # a single nightly scenario (e.g. the 27B serve) without the full nightly run.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
+      # Opt-in @merge-queue serves: the heavy real serves (default-engine +
+      # readiness) run only in the merge queue, where a cheaper per-engine canary
+      # (scenarios 5 vLLM / 7 lemonade) has already guarded the PR. This keeps the
+      # per-PR GPU run short while still exercising the full serve matrix before a
+      # change lands. Only set on the `merge_group` event.
+      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -327,6 +333,8 @@ jobs:
       # Match the MI300X dispatch path: opt into the platform-adaptive large-model
       # scenario only when the manual include_nightly input is enabled.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
+      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu.
+      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -469,6 +477,8 @@ jobs:
       # Match the Linux Strix dispatch path: opt into the platform-adaptive
       # large-model scenario only when the manual input is enabled.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
+      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu.
+      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -31,7 +31,10 @@ Feature: Model serving
 
   # vLLM serve + inference (safetensors model). Engine coverage: vLLM. This is the
   # deliberate vLLM half of a per-engine pair with `serve-lemonade-inference`
-  # below, so it stays pinned to vLLM (the slug names the engine).
+  # below, so it stays pinned to vLLM (the slug names the engine). It is also the
+  # vLLM per-PR canary: one real vLLM serve runs on every PR so a broken serve is
+  # caught before merge, while the heavier `@merge-queue` serves (6, 6b, 8) run
+  # only in the merge queue.
   @id:serve-vllm-inference @requires-gpu @requires-engine:vllm
   Scenario: 5 - A served model responds to inference requests on vLLM
     Given a managed runtime is active
@@ -54,7 +57,9 @@ Feature: Model serving
     Then the response contains a model reply
     And the response identifies the correct model
 
-  # Lemonade serve + inference (GGUF model). Engine coverage: Lemonade.
+  # Lemonade serve + inference (GGUF model). Engine coverage: Lemonade. The
+  # lemonade per-PR canary: one real lemonade serve runs on every PR (the
+  # counterpart to the vLLM canary above).
   @id:serve-lemonade-inference @requires-gpu @requires-engine:lemonade
   Scenario: 7 - A model served on lemonade responds to inference requests
     Given a managed runtime is active
@@ -66,7 +71,7 @@ Feature: Model serving
   # Default-engine serve (no --engine): the effective engine is the platform
   # default from the capability probe, so this covers whichever engine the host
   # would actually pick.
-  @id:serve-default-engine-working-endpoint @requires-gpu
+  @id:serve-default-engine-working-endpoint @requires-gpu @merge-queue
   Scenario: 6 - Serving a model without specifying an engine produces a working endpoint
     Given a managed runtime is active
     When the user serves a model without specifying an engine
@@ -74,7 +79,7 @@ Feature: Model serving
     And the model is reachable
 
   # The inference half of scenario 6.
-  @id:serve-default-engine-inference @requires-gpu
+  @id:serve-default-engine-inference @requires-gpu @merge-queue
   Scenario: 6b - A default-engine served model responds to inference requests
     Given a managed runtime is active
     When the user serves a model without specifying an engine
@@ -97,7 +102,7 @@ Feature: Model serving
   # `a model is being served on GPU`), so this holds the contract on every GPU
   # platform. Readiness is gated on a real inference probe, which is what makes
   # this contract hold rather than race the model load.
-  @id:serve-readiness-contract @requires-gpu
+  @id:serve-readiness-contract @requires-gpu @merge-queue
   Scenario: 8 - A service reported ready can immediately serve inference
     Given a managed runtime is active
     And a model is being served on GPU

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -29,6 +29,7 @@ const REQUIRES_NO_GPU_TAG: &str = "requires-no-gpu";
 const SERVE_TIMEOUT_PREFIX: &str = "serve-timeout:";
 const NIGHTLY_TAG: &str = "nightly";
 const LIFECYCLE_TAG: &str = "lifecycle";
+const MERGE_QUEUE_TAG: &str = "merge-queue";
 
 /// The resolved expectation for one scenario on one host.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +79,12 @@ pub struct ScenarioDecl {
     /// so the fast E2E suite stays fast, and only runs when the caller opts in via
     /// `E2E_INCLUDE_LIFECYCLE`. Runs explicitly in heavy CI and on demand.
     pub lifecycle: bool,
+    /// `@merge-queue`: a heavy real-GPU serve that is redundant with a cheaper
+    /// per-engine canary on the fast path, so it is skipped on ordinary per-PR /
+    /// on-demand runs and only runs in the merge queue, which opts in via
+    /// `E2E_MERGE_QUEUE`. Keeps the PR feedback loop short while still exercising
+    /// the full serve matrix before a change lands.
+    pub merge_queue: bool,
 }
 
 impl ScenarioDecl {
@@ -92,6 +99,7 @@ impl ScenarioDecl {
         let mut serve_timeout_secs = None;
         let mut nightly = false;
         let mut lifecycle = false;
+        let mut merge_queue = false;
         for tag in tags {
             let tag = tag
                 .as_ref()
@@ -113,6 +121,8 @@ impl ScenarioDecl {
                 nightly = true;
             } else if tag == LIFECYCLE_TAG {
                 lifecycle = true;
+            } else if tag == MERGE_QUEUE_TAG {
+                merge_queue = true;
             }
         }
         Self {
@@ -124,6 +134,7 @@ impl ScenarioDecl {
             serve_timeout_secs,
             nightly,
             lifecycle,
+            merge_queue,
         }
     }
 
@@ -311,8 +322,9 @@ pub struct PlatformManifest<'a> {
 /// Resolve a scenario's expectation on this host.
 ///
 /// 1. Not-applicable → `Skip`: a `@nightly` scenario when nightly isn't included,
-///    a `@requires-gpu` scenario on a host with no AMD GPU, a `@requires-os:<os>`
-///    scenario on a different OS, or a scenario whose effective engine can't start.
+///    a `@merge-queue` scenario outside the merge queue, a `@requires-gpu`
+///    scenario on a host with no AMD GPU, a `@requires-os:<os>` scenario on a
+///    different OS, or a scenario whose effective engine can't start.
 /// 2. First matching `expectations.toml` condition → `ExpectXfail`.
 /// 3. Otherwise → `ExpectPass`.
 ///
@@ -321,12 +333,16 @@ pub struct PlatformManifest<'a> {
 /// scenarios stay out of the fast path. `include_lifecycle` is set (via
 /// `E2E_INCLUDE_LIFECYCLE`) only when the caller opts into the expensive,
 /// OS-mutating release-lifecycle scenarios; the default fast suite keeps them out.
+/// `include_merge_queue` is set only in the merge queue (via `E2E_MERGE_QUEUE`);
+/// per-PR runs pass `false` so heavy `@merge-queue` serves stay off the PR path (a
+/// cheaper per-engine canary covers them) and run once before the change lands.
 pub fn resolve(
     decl: &ScenarioDecl,
     cap: &HostCapability,
     matrix: &Expectations,
     include_nightly: bool,
     include_lifecycle: bool,
+    include_merge_queue: bool,
 ) -> Expectation {
     // (1) Applicability / skip.
     if decl.nightly && !include_nightly {
@@ -337,6 +353,11 @@ pub fn resolve(
     if decl.lifecycle && !include_lifecycle {
         return Expectation::Skip {
             reason: "lifecycle-only scenario; set E2E_INCLUDE_LIFECYCLE=1 to run".to_owned(),
+        };
+    }
+    if decl.merge_queue && !include_merge_queue {
+        return Expectation::Skip {
+            reason: "merge-queue-only scenario; set E2E_MERGE_QUEUE to run".to_owned(),
         };
     }
     if decl.requires_gpu && !cap.has_amd_gpu {
@@ -524,17 +545,17 @@ serve_timeout_secs = 90
         let d = decl(&["id:big", "requires-gpu", "nightly"]);
         assert!(d.nightly);
         assert!(matches!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
         assert_eq!(
-            resolve(&d, &cap("mi300x"), &m, true, false),
+            resolve(&d, &cap("mi300x"), &m, true, false, false),
             Expectation::ExpectPass
         );
         // The nightly gate is cheapest-first: a @nightly scenario that ALSO can't
         // run here (no GPU) still skips regardless of the include flag.
         assert!(matches!(
-            resolve(&d, &cap("mock"), &m, true, false),
+            resolve(&d, &cap("mock"), &m, true, false, false),
             Expectation::Skip { .. }
         ));
     }
@@ -543,7 +564,7 @@ serve_timeout_secs = 90
     fn lifecycle_scenario_skips_unless_included() {
         let m = Expectations::default();
         // A @lifecycle scenario is skipped on the default fast path and runs only
-        // when the caller opts in via E2E_INCLUDE_LIFECYCLE (the last arg).
+        // when the caller opts in via E2E_INCLUDE_LIFECYCLE.
         let d = decl(&[
             "id:lifecycle-linux-install",
             "requires-os:linux",
@@ -551,16 +572,48 @@ serve_timeout_secs = 90
         ]);
         assert!(d.lifecycle);
         assert!(matches!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, false),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
         assert_eq!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, true),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, true, false),
             Expectation::ExpectPass
         );
         // Even when included, an inapplicable OS still skips (os gate is checked).
         assert!(matches!(
-            resolve(&d, &cap("strix-windows"), &m, false, true),
+            resolve(&d, &cap("strix-windows"), &m, false, true, false),
+            Expectation::Skip { .. }
+        ));
+    }
+
+    #[test]
+    fn merge_queue_scenario_skips_unless_included() {
+        let m = Expectations::default();
+        // A @merge-queue GPU serve on an applicable host: skipped on the per-PR
+        // fast path (a cheaper canary covers it), runs in the merge queue.
+        let d = decl(&[
+            "id:serve-default-engine-inference",
+            "requires-gpu",
+            "merge-queue",
+        ]);
+        assert!(d.merge_queue);
+        assert!(matches!(
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
+            Expectation::Skip { .. }
+        ));
+        assert_eq!(
+            resolve(&d, &cap("mi300x"), &m, false, false, true),
+            Expectation::ExpectPass
+        );
+        // Independent of the nightly axis: a merge-queue scenario is not opted in
+        // by E2E_INCLUDE_NIGHTLY.
+        assert!(matches!(
+            resolve(&d, &cap("mi300x"), &m, true, false, false),
+            Expectation::Skip { .. }
+        ));
+        // Cheapest-first: still skips where it can't run at all (no GPU).
+        assert!(matches!(
+            resolve(&d, &cap("mock"), &m, false, false, true),
             Expectation::Skip { .. }
         ));
     }
@@ -585,17 +638,17 @@ serve_timeout_secs = 90
 
         // MI300X: default engine vLLM → xfail.
         assert!(matches!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::ExpectXfail { .. }
         ));
         // Strix Ubuntu: gfx1151 → lemonade default → NOT vLLM → expect-pass.
         assert_eq!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, false),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, false, false),
             Expectation::ExpectPass
         );
         // Strix Windows: lemonade default → expect-pass (this is the XPASS fix).
         assert_eq!(
-            resolve(&d, &cap("strix-windows"), &m, false, false),
+            resolve(&d, &cap("strix-windows"), &m, false, false, false),
             Expectation::ExpectPass
         );
     }
@@ -605,7 +658,7 @@ serve_timeout_secs = 90
         let m = eai7333_matrix();
         let d = decl(&["id:serve-default-engine-inference", "requires-gpu"]);
         assert!(matches!(
-            resolve(&d, &cap("mock"), &m, false, false),
+            resolve(&d, &cap("mock"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
     }
@@ -616,16 +669,16 @@ serve_timeout_secs = 90
         let d = decl(&["id:serve-no-gpu-fails-fast", "requires-no-gpu"]);
         // The mock host has no AMD GPU → the no-GPU premise applies → runs.
         assert_eq!(
-            resolve(&d, &cap("mock"), &m, false, false),
+            resolve(&d, &cap("mock"), &m, false, false, false),
             Expectation::ExpectPass
         );
         // Every GPU host skips it — the premise can't hold there.
         assert!(matches!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
         assert!(matches!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, false),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
     }
@@ -641,12 +694,12 @@ serve_timeout_secs = 90
         ]);
         // MI300X: vLLM available → not skipped (expect-pass here, no matrix entry).
         assert_eq!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::ExpectPass
         );
         // Strix Windows: vLLM can't start → skip (N/A).
         assert!(matches!(
-            resolve(&d, &cap("strix-windows"), &m, false, false),
+            resolve(&d, &cap("strix-windows"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
     }
@@ -660,15 +713,15 @@ serve_timeout_secs = 90
         // Runs on a Linux GPU host; skips where os_family != linux (windows, and
         // the "other" fixture host).
         assert_eq!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, false),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, false, false),
             Expectation::ExpectPass
         );
         assert!(matches!(
-            resolve(&d, &cap("strix-windows"), &m, false, false),
+            resolve(&d, &cap("strix-windows"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
         assert!(matches!(
-            resolve(&d, &cap("mock"), &m, false, false),
+            resolve(&d, &cap("mock"), &m, false, false, false),
             Expectation::Skip { .. }
         ));
     }
@@ -678,11 +731,11 @@ serve_timeout_secs = 90
         let m = Expectations::default();
         let d = decl(&["id:examine-version"]);
         assert_eq!(
-            resolve(&d, &cap("mock"), &m, false, false),
+            resolve(&d, &cap("mock"), &m, false, false, false),
             Expectation::ExpectPass
         );
         assert_eq!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::ExpectPass
         );
     }
@@ -701,11 +754,11 @@ reason = "short-name not surfaced"
         let d = decl(&["id:serve-short-name-expansion"]);
         // No requires-gpu → runs everywhere, always xfail.
         assert!(matches!(
-            resolve(&d, &cap("mock"), &m, false, false),
+            resolve(&d, &cap("mock"), &m, false, false, false),
             Expectation::ExpectXfail { .. }
         ));
         assert!(matches!(
-            resolve(&d, &cap("mi300x"), &m, false, false),
+            resolve(&d, &cap("mi300x"), &m, false, false, false),
             Expectation::ExpectXfail { .. }
         ));
     }
@@ -728,12 +781,12 @@ reason = "lemonade vulkan fallback"
         ]);
         // Strix Ubuntu (linux, lemonade) → xfail.
         assert!(matches!(
-            resolve(&d, &cap("strix-ubuntu"), &m, false, false),
+            resolve(&d, &cap("strix-ubuntu"), &m, false, false, false),
             Expectation::ExpectXfail { .. }
         ));
         // Strix Windows (windows, lemonade) → os mismatch → expect-pass.
         assert_eq!(
-            resolve(&d, &cap("strix-windows"), &m, false, false),
+            resolve(&d, &cap("strix-windows"), &m, false, false, false),
             Expectation::ExpectPass
         );
     }

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -863,6 +863,10 @@ async fn main() {
     // either its CLI filter OR this closure, so CLI selection would bypass OS,
     // nightly/lifecycle, ID, and expectation resolution entirely.
     let only_lifecycle = std::env::var_os("E2E_ONLY_LIFECYCLE").is_some_and(|v| v == "1");
+    // Heavy `@merge-queue` serves run only in the merge queue (a cheaper
+    // per-engine canary covers them on the PR fast path); set by ci.yml on the
+    // `merge_group` event.
+    let include_merge_queue = std::env::var_os("E2E_MERGE_QUEUE").is_some_and(|v| v == "1");
     eprintln!(
         "Host capability: platform={} os={} gpu={} effective_engine={}",
         cap.platform_slug, cap.os_family, cap.has_amd_gpu, cap.effective_serve_engine,
@@ -931,7 +935,14 @@ async fn main() {
         .filter_run(concat!(env!("CARGO_MANIFEST_DIR"), "/features/"), {
             move |_feature, _rule, scenario| {
                 let decl = ScenarioDecl::from_tags(&scenario.tags);
-                let expectation = resolve(&decl, cap, matrix, include_nightly, include_lifecycle);
+                let expectation = resolve(
+                    &decl,
+                    cap,
+                    matrix,
+                    include_nightly,
+                    include_lifecycle,
+                    include_merge_queue,
+                );
                 let run = (!only_lifecycle || decl.lifecycle)
                     && !matches!(expectation, Expectation::Skip { .. });
                 if let Some(id) = &decl.id {


### PR DESCRIPTION
## Summary

The full real-GPU serve matrix ran on every PR, making the per-PR GPU lanes slow. This gates the redundant heavy serves to the merge queue while keeping one real serve per engine on the PR path as a pre-merge canary, so a broken serve is still caught before a change enters the queue.

## Changes

- Add a `@merge-queue` scenario axis, mirroring the existing `@nightly` one: a new `merge_queue` field on `ScenarioDecl`, an `include_merge_queue` arg to `resolve()` with a skip branch, and an `E2E_MERGE_QUEUE` env read in the harness.
- Tag the redundant default-engine and readiness serves (`serve-default-engine-working-endpoint`, `serve-default-engine-inference`, `serve-readiness-contract`) `@merge-queue` so they run only in the merge queue.
- Keep `serve-vllm-inference` (vLLM) and `serve-lemonade-inference` (lemonade) untagged as per-engine PR canaries.
- `ci.yml` sets `E2E_MERGE_QUEUE` on the `merge_group` event for all three GPU jobs. The jobs still run on `pull_request` and produce their required checks; only the work is trimmed.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets --exclude e2e-cucumber -- -D warnings` clean (Linux container).
- [x] `cargo test --workspace` + `cargo test -p e2e-cucumber --lib` green (64/64, incl. a new `merge_queue_scenario_skips_unless_included` unit test).
- [x] E2E mock lane reconciliation: 3 xfail / 0 XPASS / 0 unexpected.
- [x] Scoped MI300X dispatch verified the grid on hardware: scenarios 6/6b/8 resolve to skip on the PR path, canaries 5/7 run and serve; 0 unexpected failures.