### PR TITLE
fix(install): stop leaking temp files when an atomic write fails

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -275,11 +275,12 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # Build the rocm binary ONCE and reuse it for both the pre-warm and the
-          # suite (via ROCM_CLI_BINARY) so xtask does not rebuild. Honors
+          # Build the rocm and rocmd binaries ONCE and reuse them for both the
+          # pre-warm and suite so xtask does not rebuild. Honors
           # CARGO_TARGET_DIR set above.
-          cargo build --release -p rocm
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
           # Pre-warm the shared runtime ONCE, SERIALLY, before the suite — never
           # lazily inside a concurrent scenario (two multi-GiB installs racing the
@@ -442,10 +443,10 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # Build the rocm binary once; reuse for pre-warm + suite so xtask doesn't
-          # rebuild.
-          cargo build --release -p rocm
+          # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
           # Pre-warm once, serially, in place (no mv/symlink). Skipped once the tree
           # is populated (persists across runs on RUNNER_WORKSPACE).
@@ -593,13 +594,14 @@ jobs:
           $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm"
           $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
 
-          # Build the rocm binary once; reuse for pre-warm + suite so xtask doesn't
-          # rebuild. This job does not set CARGO_TARGET_DIR, so the binary lands in
+          # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
+          # This job does not set CARGO_TARGET_DIR, so the binaries land in
           # the default target\release (fall back to it when the env var is unset).
-          cargo build --release -p rocm
+          cargo build --release -p rocm -p rocmd
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
+          $env:ROCM_CLI_ROCMD_BINARY = "$targetDir\release\rocmd.exe"
 
           # Pre-warm once, in place (no move/symlink). Skipped once the tree is
           # populated (persists across runs on RUNNER_WORKSPACE).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -384,9 +384,10 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # Build once; reuse for pre-warm + suite so xtask doesn't rebuild.
-          cargo build --release -p rocm
+          # Build both binaries once; reuse them for pre-warm + suite.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
           # Pre-warm the shared runtime once/serially before the suite; skipped
           # once populated (persists across runs). Install in place (no mv) so the
@@ -490,8 +491,9 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          cargo build --release -p rocm
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
           if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
             echo "pre-warming shared runtime (first run on this runner)…"
@@ -594,10 +596,11 @@ jobs:
           $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm"
           $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
 
-          cargo build --release -p rocm
+          cargo build --release -p rocm -p rocmd
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
+          $env:ROCM_CLI_ROCMD_BINARY = "$targetDir\release\rocmd.exe"
 
           if (-not (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry")) {
             Write-Host "pre-warming shared runtime (first run on this runner)..."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,6 +3618,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "windows-native-keyring-store",
+ "windows-sys 0.61.2",
  "zbus-secret-service-keyring-store",
 ]
 
@@ -3782,6 +3783,7 @@ dependencies = [
  "sha2",
  "tokio",
  "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -42,8 +42,9 @@ ureq = { version = "2.12", features = ["native-certs"] }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-native-keyring-store = "1.1"
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1.0", features = ["keychain"] }

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -19,9 +19,10 @@ use rocm_core::{
 };
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::ffi::{OsStr, OsString};
 use std::fmt::Write as _;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -2281,47 +2282,158 @@ fn windows_child_path(path: &Path) -> String {
 /// A unique temp path next to `path`, preserving the full file name so a
 /// multi-extension artifact keeps its extensions (`sdk.tar.gz` becomes
 /// `sdk.tar.gz.tmp-<id>`, where `with_extension` would drop `.gz`).
-fn temp_sibling_path(path: &Path) -> Result<PathBuf> {
+const ATOMIC_WRITE_TEMP_ATTEMPTS: u32 = 128;
+
+fn temp_sibling_path(path: &Path, suffix: &OsStr) -> Result<PathBuf> {
     let parent = path.parent().context("file path has no parent directory")?;
-    let file_name = path
+    let mut file_name = path
         .file_name()
         .context("file path has no file name")?
-        .to_string_lossy()
-        .into_owned();
-    Ok(parent.join(format!(
-        "{file_name}.tmp-{}-{}",
-        std::process::id(),
-        unix_time_millis()
-    )))
+        .to_os_string();
+    file_name.push(".tmp-");
+    file_name.push(suffix);
+    Ok(parent.join(file_name))
 }
 
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    let temp_id = format!("{}-{}", std::process::id(), unix_time_millis());
+    write_file_atomically_with(
+        path,
+        bytes,
+        |attempt| OsString::from(format!("{temp_id}-{attempt}")),
+        || {},
+    )
+}
+
+fn write_file_atomically_with<S, P>(
+    path: &Path,
+    bytes: &[u8],
+    suffix_for_attempt: S,
+    before_publish: P,
+) -> Result<()>
+where
+    S: FnMut(u32) -> OsString,
+    P: FnOnce(),
+{
+    write_file_atomically_with_publish(
+        path,
+        bytes,
+        suffix_for_attempt,
+        before_publish,
+        publish_temp_file,
+    )
+}
+
+fn write_file_atomically_with_publish<S, P, F>(
+    path: &Path,
+    bytes: &[u8],
+    mut suffix_for_attempt: S,
+    before_publish: P,
+    publish: F,
+) -> Result<()>
+where
+    S: FnMut(u32) -> OsString,
+    P: FnOnce(),
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
     let parent = path.parent().context("file path has no parent directory")?;
     fs::create_dir_all(parent)?;
-    let tmp = temp_sibling_path(path)?;
-    // Clean up the temp file on every failure path. It carries a unique
-    // name, so leaving it behind would accumulate a fresh orphan per attempt —
-    // and when the failure is a full disk, those orphans are what keep it full.
-    let write_result = (|| -> Result<()> {
-        let mut file = fs::File::create(&tmp)
-            .with_context(|| format!("failed to create {}", tmp.display()))?;
-        file.write_all(bytes)
-            .map_err(|error| disk_space::map_write_error(error, &tmp))?;
-        Ok(())
-    })();
-    if let Err(error) = write_result {
-        let _ = fs::remove_file(&tmp);
-        return Err(error);
+
+    let mut reserved = None;
+    for attempt in 0..ATOMIC_WRITE_TEMP_ATTEMPTS {
+        let suffix = suffix_for_attempt(attempt);
+        let tmp = temp_sibling_path(path, &suffix)?;
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(file) => {
+                reserved = Some((tmp, file));
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to create {}", tmp.display()));
+            }
+        }
     }
-    fs::rename(&tmp, path)
-        .or_else(|_| {
-            let _ = fs::remove_file(path);
-            fs::rename(&tmp, path)
-        })
-        .inspect_err(|_| {
-            let _ = fs::remove_file(&tmp);
-        })?;
+    let Some((tmp, mut file)) = reserved else {
+        bail!(
+            "failed to reserve a temporary file next to {} after {} attempts",
+            path.display(),
+            ATOMIC_WRITE_TEMP_ATTEMPTS
+        );
+    };
+
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
+        let _ = fs::remove_file(&tmp);
+        return Err(disk_space::map_write_error(error, &tmp));
+    }
+    drop(file);
+    before_publish();
+
+    publish(&tmp, path).inspect_err(|_| {
+        let _ = fs::remove_file(&tmp);
+    })?;
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn publish_temp_file(tmp: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(tmp, path)
+}
+
+#[cfg(windows)]
+fn publish_temp_file(tmp: &Path, path: &Path) -> io::Result<()> {
+    if path.try_exists()? {
+        return replace_file_windows(path, tmp);
+    }
+
+    match fs::rename(tmp, path) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            if path.try_exists()? {
+                replace_file_windows(path, tmp)
+            } else {
+                Err(rename_error)
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn replace_file_windows(path: &Path, replacement: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
+
+    let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let replacement_wide: Vec<u16> = replacement
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    // SAFETY: both path buffers are valid, NUL-terminated UTF-16 strings and
+    // remain alive for the duration of the synchronous Windows API call. The
+    // optional backup, exclude, and reserved pointers are intentionally null.
+    let replaced = unsafe {
+        ReplaceFileW(
+            path_wide.as_ptr(),
+            replacement_wide.as_ptr(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn extract_tarball(archive_path: &Path, target_dir: &Path) -> Result<()> {
@@ -3392,13 +3504,110 @@ mod tests {
     /// directory can still tell what a leftover was going to be.
     #[test]
     fn temp_sibling_path_preserves_multi_dot_file_names() {
-        let temp = temp_sibling_path(Path::new("/tmp/cache/sdk.tar.gz")).unwrap();
+        let temp = temp_sibling_path(
+            Path::new("/tmp/cache/sdk.tar.gz"),
+            std::ffi::OsStr::new("test"),
+        )
+        .unwrap();
         let name = temp.file_name().unwrap().to_string_lossy().into_owned();
-        assert!(
-            name.starts_with("sdk.tar.gz.tmp-"),
-            "expected the full name to be preserved, got {name}"
-        );
+        assert_eq!(name, "sdk.tar.gz.tmp-test");
         assert_eq!(temp.parent().unwrap(), Path::new("/tmp/cache"));
+    }
+
+    #[test]
+    fn concurrent_atomic_writes_do_not_remove_a_published_destination() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-atomic-collision-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("sdk.tar.gz");
+        let before_publish = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let writers: Vec<_> = [b"first".as_slice(), b"second".as_slice()]
+            .into_iter()
+            .enumerate()
+            .map(|(writer, bytes)| {
+                let destination = destination.clone();
+                let before_publish = std::sync::Arc::clone(&before_publish);
+                std::thread::spawn(move || {
+                    write_file_atomically_with(
+                        &destination,
+                        bytes,
+                        |attempt| {
+                            if attempt == 0 {
+                                std::ffi::OsString::from("same-millisecond")
+                            } else {
+                                std::ffi::OsString::from(format!(
+                                    "same-millisecond-{writer}-{attempt}"
+                                ))
+                            }
+                        },
+                        || {
+                            before_publish.wait();
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+        let published = fs::read(&destination).expect("a writer must remain published");
+        let _ = fs::remove_dir_all(&root);
+        assert!(published == b"first" || published == b"second");
+    }
+
+    #[test]
+    fn failed_atomic_replace_preserves_destination_and_cleans_temp() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-atomic-replace-failure-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("sdk.tar.gz");
+        fs::write(&destination, b"published").unwrap();
+
+        write_file_atomically_with_publish(
+            &destination,
+            b"replacement",
+            |attempt| OsString::from(format!("replace-failure-{attempt}")),
+            || {},
+            |tmp, path| {
+                assert_eq!(fs::read(tmp).unwrap(), b"replacement");
+                assert_eq!(path, destination);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "simulated atomic replacement failure",
+                ))
+            },
+        )
+        .expect_err("simulated replacement failure must be returned");
+
+        assert_eq!(fs::read(&destination).unwrap(), b"published");
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(leftovers, vec![OsString::from("sdk.tar.gz")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_temp_name_preserves_non_unicode_file_name_bytes() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let file_name = std::ffi::OsString::from_vec(b"sdk-\xff.tar.gz".to_vec());
+        let destination = Path::new("/tmp").join(&file_name);
+        let temp = temp_sibling_path(&destination, std::ffi::OsStr::new("collision")).unwrap();
+
+        let mut expected = file_name.into_vec();
+        expected.extend_from_slice(b".tmp-collision");
+        assert_eq!(temp.file_name().unwrap().as_bytes(), expected);
     }
 
     /// Regression: a failed write must not leave a `.tmp-*` scratch file

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -164,7 +164,7 @@ struct CachedHttpText {
     text: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 struct CachedHttpMetadata {
     url: String,
     #[serde(default)]
@@ -176,11 +176,19 @@ struct CachedHttpMetadata {
     fetched_at_unix_ms: u128,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 struct CachedHttpSignatureMetadata {
     url: String,
     verified_at_unix_ms: u128,
     public_key_source: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct CachedHttpCacheEntry {
+    metadata: CachedHttpMetadata,
+    body: String,
+    #[serde(default)]
+    signature_bytes: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1865,39 +1873,39 @@ fn metadata_signature_path(body_path: &Path) -> PathBuf {
 fn fetch_and_verify_metadata_signature(
     policy: &MetadataSignaturePolicy,
     url: &str,
-    payload_path: &Path,
-    signature_path: &Path,
+    payload: &[u8],
     temp_key_path: &Path,
     max_time_secs: Option<u64>,
-) -> Result<Option<(CachedHttpSignatureMetadata, PathBuf)>> {
+) -> Result<Option<(CachedHttpSignatureMetadata, Vec<u8>)>> {
     if !policy.active() {
         return Ok(None);
     }
     let signature_url = metadata_signature_url(url);
-    let staged_signature = download_signature_file(&signature_url, signature_path, max_time_secs)?;
-    let verification = with_metadata_public_key(policy, temp_key_path, |public_key, source| {
-        verify_metadata_signature(payload_path, &staged_signature, public_key)?;
-        Ok(source.to_owned())
-    });
-    let public_key_source = match verification.and_then(|source| {
-        source.context("metadata signature policy was active but no public key was resolved")
-    }) {
-        Ok(source) => source,
-        Err(error) => {
-            let _ = fs::remove_file(&staged_signature);
-            return Err(error);
-        }
-    };
+    let response = http_get(&signature_url, &[], max_time_secs)?;
+    if response.status != 200 {
+        bail!(
+            "HTTP {} while fetching metadata signature {signature_url}",
+            response.status
+        );
+    }
+    let signature = response.body;
+    let public_key_source =
+        with_metadata_public_key(policy, temp_key_path, |public_key, source| {
+            verify_metadata_signature_bytes(payload, &signature, public_key)?;
+            Ok(source.to_owned())
+        })?
+        .context("metadata signature policy was active but no public key was resolved")?;
     Ok(Some((
         CachedHttpSignatureMetadata {
             url: signature_url,
             verified_at_unix_ms: unix_time_millis(),
             public_key_source,
         },
-        staged_signature,
+        signature,
     )))
 }
 
+#[cfg(test)]
 fn verify_cached_metadata_signature(
     policy: &MetadataSignaturePolicy,
     payload_path: &Path,
@@ -1919,25 +1927,7 @@ fn verify_cached_metadata_signature(
     Ok(())
 }
 
-fn download_signature_file(
-    url: &str,
-    destination: &Path,
-    max_time_secs: Option<u64>,
-) -> Result<PathBuf> {
-    let parent = destination
-        .parent()
-        .context("metadata signature destination has no parent directory")?;
-    fs::create_dir_all(parent)?;
-    let response = http_get(url, &[], max_time_secs)?;
-    if response.status != 200 {
-        bail!(
-            "HTTP {} while fetching metadata signature {url}",
-            response.status
-        );
-    }
-    stage_file_for_atomic_publish(destination, &response.body)
-}
-
+#[cfg(test)]
 fn verify_metadata_signature(
     payload_path: &Path,
     signature_path: &Path,
@@ -1964,12 +1954,105 @@ fn verify_metadata_signature(
     verify_rsa_pkcs1_sha256_signature(&public_key_pem, &payload, &signature, "metadata")
 }
 
+fn verify_metadata_signature_bytes(
+    payload: &[u8],
+    signature: &[u8],
+    public_key_path: &Path,
+) -> Result<()> {
+    let public_key_pem = fs::read_to_string(public_key_path).with_context(|| {
+        format!(
+            "failed to read metadata public key: {}",
+            public_key_path.display()
+        )
+    })?;
+    verify_rsa_pkcs1_sha256_signature(&public_key_pem, payload, signature, "metadata")
+}
+
+#[cfg(test)]
 fn metadata_cache_can_revalidate(
     metadata: &CachedHttpMetadata,
     policy: &MetadataSignaturePolicy,
     signature_path: &Path,
 ) -> bool {
     !policy.active() || (metadata.signature.is_some() && signature_path.is_file())
+}
+
+fn load_cached_http_entry(
+    metadata_path: &Path,
+    legacy_body_path: &Path,
+    legacy_signature_path: &Path,
+) -> Option<CachedHttpCacheEntry> {
+    let bytes = fs::read(metadata_path).ok()?;
+    if let Ok(entry) = serde_json::from_slice(&bytes) {
+        return Some(entry);
+    }
+
+    let metadata: CachedHttpMetadata = serde_json::from_slice(&bytes).ok()?;
+    let body = fs::read_to_string(legacy_body_path).ok()?;
+    let signature_bytes = metadata
+        .signature
+        .as_ref()
+        .map(|_| fs::read(legacy_signature_path))
+        .transpose()
+        .ok()?;
+    Some(CachedHttpCacheEntry {
+        metadata,
+        body,
+        signature_bytes,
+    })
+}
+
+const fn cached_http_entry_can_revalidate(
+    entry: &CachedHttpCacheEntry,
+    policy: &MetadataSignaturePolicy,
+) -> bool {
+    !policy.active() || (entry.metadata.signature.is_some() && entry.signature_bytes.is_some())
+}
+
+fn verify_cached_http_entry_signature(
+    policy: &MetadataSignaturePolicy,
+    entry: &CachedHttpCacheEntry,
+    temp_key_path: &Path,
+) -> Result<()> {
+    if !policy.active() {
+        return Ok(());
+    }
+    let signature = entry.signature_bytes.as_deref().context(
+        "metadata signature verification requested but cached signature bytes are missing",
+    )?;
+    with_metadata_public_key(policy, temp_key_path, |public_key, _source| {
+        verify_metadata_signature_bytes(entry.body.as_bytes(), signature, public_key)
+    })?;
+    Ok(())
+}
+
+fn write_cached_http_entry(path: &Path, entry: &CachedHttpCacheEntry) -> Result<()> {
+    write_file_atomically(
+        path,
+        &serde_json::to_vec_pretty(entry).context("failed to serialize metadata cache entry")?,
+    )
+}
+
+#[cfg(test)]
+fn write_cached_http_entry_with<S, P, F>(
+    path: &Path,
+    entry: &CachedHttpCacheEntry,
+    suffix_for_attempt: S,
+    before_publish: P,
+    publish: F,
+) -> Result<()>
+where
+    S: FnMut(u32) -> OsString,
+    P: FnOnce(),
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    write_file_atomically_with_publish(
+        path,
+        &serde_json::to_vec_pretty(entry).context("failed to serialize metadata cache entry")?,
+        suffix_for_attempt,
+        before_publish,
+        publish,
+    )
 }
 
 fn download_text_cached(
@@ -1982,10 +2065,8 @@ fn download_text_cached(
     let signature_path = metadata_signature_path(&body_path);
     let signature_policy = MetadataSignaturePolicy::from_env();
     signature_policy.validate_configuration()?;
-    let previous_metadata = fs::read(&metadata_path)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice::<CachedHttpMetadata>(&bytes).ok())
-        .filter(|metadata| metadata.url == url);
+    let previous_entry = load_cached_http_entry(&metadata_path, &body_path, &signature_path)
+        .filter(|entry| entry.metadata.url == url);
     let cache_dir = body_path
         .parent()
         .context("metadata cache path has no parent directory")?;
@@ -1993,51 +2074,35 @@ fn download_text_cached(
 
     let tmp_public_key = body_path.with_extension("public-key.pem");
     let mut headers = Vec::new();
-    if let Some(etag) = previous_metadata
+    if let Some(etag) = previous_entry
         .as_ref()
-        .filter(|metadata| {
-            metadata_cache_can_revalidate(metadata, &signature_policy, &signature_path)
-        })
-        .and_then(|metadata| metadata.etag.as_deref())
+        .filter(|entry| cached_http_entry_can_revalidate(entry, &signature_policy))
+        .and_then(|entry| entry.metadata.etag.as_deref())
     {
         headers.push(("If-None-Match", etag));
     }
 
     let response = http_get(url, &headers, max_time_secs)?;
     if response.status == 304 {
-        verify_cached_metadata_signature(
-            &signature_policy,
-            &body_path,
-            &signature_path,
-            &tmp_public_key,
+        let entry = previous_entry.context(
+            "metadata cache returned 304 but no complete cached generation is available",
         )?;
-        let text = fs::read_to_string(&body_path).with_context(|| {
-            format!(
-                "metadata cache returned 304 but cached body is missing: {}",
-                body_path.display()
-            )
-        })?;
-        return Ok(CachedHttpText { text });
+        verify_cached_http_entry_signature(&signature_policy, &entry, &tmp_public_key)?;
+        return Ok(CachedHttpText { text: entry.body });
     }
     if response.status != 200 {
         bail!("HTTP {} while fetching {url}", response.status);
     }
 
-    let tmp_body = stage_file_for_atomic_publish(&body_path, &response.body)?;
-    let fetched_signature = match fetch_and_verify_metadata_signature(
+    let body =
+        String::from_utf8(response.body).context("metadata response body was not valid UTF-8")?;
+    let fetched_signature = fetch_and_verify_metadata_signature(
         &signature_policy,
         url,
-        &tmp_body,
-        &signature_path,
+        body.as_bytes(),
         &tmp_public_key,
         max_time_secs,
-    ) {
-        Ok(signature) => signature,
-        Err(error) => {
-            let _ = fs::remove_file(&tmp_body);
-            return Err(error);
-        }
-    };
+    )?;
     let signature_metadata = fetched_signature
         .as_ref()
         .map(|(metadata, _)| metadata.clone());
@@ -2048,25 +2113,15 @@ fn download_text_cached(
         signature: signature_metadata,
         fetched_at_unix_ms: unix_time_millis(),
     };
-    if let Err(error) = publish_staged_file(&tmp_body, &body_path) {
-        if let Some((_, staged_signature)) = &fetched_signature {
-            let _ = fs::remove_file(staged_signature);
-        }
-        return Err(error);
-    }
-    if let Some((_, staged_signature)) = fetched_signature {
-        publish_staged_file(&staged_signature, &signature_path)?;
-    } else {
-        let _ = fs::remove_file(&signature_path);
-    }
-    write_file_atomically(
-        &metadata_path,
-        &serde_json::to_vec_pretty(&metadata)
-            .context("failed to serialize metadata cache record")?,
-    )?;
-    let text = fs::read_to_string(&body_path)
-        .with_context(|| format!("failed to read cached metadata {}", body_path.display()))?;
-    Ok(CachedHttpText { text })
+    let entry = CachedHttpCacheEntry {
+        metadata,
+        body,
+        signature_bytes: fetched_signature.map(|(_, signature)| signature),
+    };
+    write_cached_http_entry(&metadata_path, &entry)?;
+    let _ = fs::remove_file(&body_path);
+    let _ = fs::remove_file(&signature_path);
+    Ok(CachedHttpText { text: entry.body })
 }
 
 fn metadata_cache_paths(paths: &AppPaths, cache_key: &str) -> (PathBuf, PathBuf) {
@@ -2393,6 +2448,7 @@ where
     Ok(tmp)
 }
 
+#[cfg(test)]
 fn publish_staged_file(tmp: &Path, path: &Path) -> Result<()> {
     publish_staged_file_with(tmp, path, publish_temp_file)
 }
@@ -3683,6 +3739,123 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 
+    fn cached_http_entry(generation: &str) -> CachedHttpCacheEntry {
+        CachedHttpCacheEntry {
+            metadata: CachedHttpMetadata {
+                url: format!("https://example.invalid/{generation}"),
+                etag: Some(format!("etag-{generation}")),
+                last_modified: None,
+                signature: Some(CachedHttpSignatureMetadata {
+                    url: format!("https://example.invalid/{generation}.sig"),
+                    verified_at_unix_ms: 1,
+                    public_key_source: generation.to_owned(),
+                }),
+                fetched_at_unix_ms: 2,
+            },
+            body: format!("body-{generation}"),
+            signature_bytes: Some(generation.as_bytes().to_vec()),
+        }
+    }
+
+    #[test]
+    fn concurrent_cached_http_commits_publish_one_complete_generation() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-cache-generation-collision-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("index.json");
+        let before_publish = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let writers: Vec<_> = ["first", "second"]
+            .into_iter()
+            .enumerate()
+            .map(|(writer, generation)| {
+                let destination = destination.clone();
+                let before_publish = std::sync::Arc::clone(&before_publish);
+                std::thread::spawn(move || {
+                    let entry = cached_http_entry(generation);
+                    write_cached_http_entry_with(
+                        &destination,
+                        &entry,
+                        |attempt| {
+                            if attempt == 0 {
+                                OsString::from("same-millisecond")
+                            } else {
+                                OsString::from(format!("same-millisecond-{writer}-{attempt}"))
+                            }
+                        },
+                        || {
+                            before_publish.wait();
+                        },
+                        publish_temp_file,
+                    )
+                })
+            })
+            .collect();
+
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+        let published: CachedHttpCacheEntry =
+            serde_json::from_slice(&fs::read(&destination).unwrap()).unwrap();
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().contains(".tmp-"))
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(
+            published == cached_http_entry("first") || published == cached_http_entry("second"),
+            "published cache mixed generations: {published:?}"
+        );
+        assert!(leftovers.is_empty(), "cache commit leaked: {leftovers:?}");
+    }
+
+    #[test]
+    fn failed_cached_http_commit_preserves_previous_complete_generation() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-cache-generation-failure-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("index.json");
+        let previous = cached_http_entry("previous");
+        write_cached_http_entry(&destination, &previous).unwrap();
+
+        write_cached_http_entry_with(
+            &destination,
+            &cached_http_entry("replacement"),
+            |attempt| OsString::from(format!("commit-failure-{attempt}")),
+            || {},
+            |tmp, path| {
+                let staged: CachedHttpCacheEntry =
+                    serde_json::from_slice(&fs::read(tmp).unwrap()).unwrap();
+                assert_eq!(staged, cached_http_entry("replacement"));
+                assert_eq!(path, destination);
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "simulated cache generation commit failure",
+                ))
+            },
+        )
+        .expect_err("simulated commit failure must be returned");
+
+        let preserved: CachedHttpCacheEntry =
+            serde_json::from_slice(&fs::read(&destination).unwrap()).unwrap();
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(preserved, previous);
+        assert_eq!(leftovers, vec![OsString::from("index.json")]);
+    }
+
     #[test]
     fn failed_atomic_replace_preserves_destination_and_cleans_temp() {
         let root = std::env::temp_dir().join(format!(
@@ -4421,7 +4594,15 @@ echo Python 3.12.10
         })?
         .expect("inline key should be active");
 
-        assert_eq!(observed, temp_key);
+        assert_eq!(observed.parent(), temp_key.parent());
+        assert!(
+            observed
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("metadata-key.pem.tmp-")),
+            "inline key must use a reserved sibling path: {}",
+            observed.display()
+        );
+        assert!(!observed.exists());
         assert!(!temp_key.exists());
         let _ = fs::remove_dir_all(root);
         Ok(())

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -1844,14 +1844,9 @@ fn with_metadata_public_key<T>(
         return verify(public_key_path, "path").map(Some);
     }
     if let Some(public_key_pem) = &policy.public_key_pem {
-        let parent = temp_key_path
-            .parent()
-            .context("metadata public key temp path has no parent directory")?;
-        fs::create_dir_all(parent)?;
-        fs::write(temp_key_path, public_key_pem)
-            .with_context(|| format!("failed to write {}", temp_key_path.display()))?;
-        let result = verify(temp_key_path, "env-pem");
-        let _ = fs::remove_file(temp_key_path);
+        let staged_key = stage_file_for_atomic_publish(temp_key_path, public_key_pem.as_bytes())?;
+        let result = verify(&staged_key, "env-pem");
+        let _ = fs::remove_file(staged_key);
         return result.map(Some);
     }
     bail!(
@@ -1874,23 +1869,33 @@ fn fetch_and_verify_metadata_signature(
     signature_path: &Path,
     temp_key_path: &Path,
     max_time_secs: Option<u64>,
-) -> Result<Option<CachedHttpSignatureMetadata>> {
+) -> Result<Option<(CachedHttpSignatureMetadata, PathBuf)>> {
     if !policy.active() {
         return Ok(None);
     }
     let signature_url = metadata_signature_url(url);
-    download_signature_file(&signature_url, signature_path, max_time_secs)?;
-    let public_key_source =
-        with_metadata_public_key(policy, temp_key_path, |public_key, source| {
-            verify_metadata_signature(payload_path, signature_path, public_key)?;
-            Ok(source.to_owned())
-        })?
-        .context("metadata signature policy was active but no public key was resolved")?;
-    Ok(Some(CachedHttpSignatureMetadata {
-        url: signature_url,
-        verified_at_unix_ms: unix_time_millis(),
-        public_key_source,
-    }))
+    let staged_signature = download_signature_file(&signature_url, signature_path, max_time_secs)?;
+    let verification = with_metadata_public_key(policy, temp_key_path, |public_key, source| {
+        verify_metadata_signature(payload_path, &staged_signature, public_key)?;
+        Ok(source.to_owned())
+    });
+    let public_key_source = match verification.and_then(|source| {
+        source.context("metadata signature policy was active but no public key was resolved")
+    }) {
+        Ok(source) => source,
+        Err(error) => {
+            let _ = fs::remove_file(&staged_signature);
+            return Err(error);
+        }
+    };
+    Ok(Some((
+        CachedHttpSignatureMetadata {
+            url: signature_url,
+            verified_at_unix_ms: unix_time_millis(),
+            public_key_source,
+        },
+        staged_signature,
+    )))
 }
 
 fn verify_cached_metadata_signature(
@@ -1918,21 +1923,19 @@ fn download_signature_file(
     url: &str,
     destination: &Path,
     max_time_secs: Option<u64>,
-) -> Result<()> {
+) -> Result<PathBuf> {
     let parent = destination
         .parent()
         .context("metadata signature destination has no parent directory")?;
     fs::create_dir_all(parent)?;
     let response = http_get(url, &[], max_time_secs)?;
     if response.status != 200 {
-        let _ = fs::remove_file(destination);
         bail!(
             "HTTP {} while fetching metadata signature {url}",
             response.status
         );
     }
-    write_file_atomically(destination, &response.body)?;
-    Ok(())
+    stage_file_for_atomic_publish(destination, &response.body)
 }
 
 fn verify_metadata_signature(
@@ -1988,10 +1991,7 @@ fn download_text_cached(
         .context("metadata cache path has no parent directory")?;
     fs::create_dir_all(cache_dir)?;
 
-    let unique = unix_time_millis();
-    let tmp_body = body_path.with_extension(format!("body.tmp-{unique}"));
-    let tmp_signature = body_path.with_extension(format!("sig.tmp-{unique}"));
-    let tmp_public_key = body_path.with_extension(format!("public-key.tmp-{unique}.pem"));
+    let tmp_public_key = body_path.with_extension("public-key.pem");
     let mut headers = Vec::new();
     if let Some(etag) = previous_metadata
         .as_ref()
@@ -2005,7 +2005,6 @@ fn download_text_cached(
 
     let response = http_get(url, &headers, max_time_secs)?;
     if response.status == 304 {
-        let _ = fs::remove_file(&tmp_body);
         verify_cached_metadata_signature(
             &signature_policy,
             &body_path,
@@ -2021,49 +2020,48 @@ fn download_text_cached(
         return Ok(CachedHttpText { text });
     }
     if response.status != 200 {
-        let _ = fs::remove_file(&tmp_body);
         bail!("HTTP {} while fetching {url}", response.status);
     }
 
-    write_file_atomically(&tmp_body, &response.body)?;
-    let signature_metadata = match fetch_and_verify_metadata_signature(
+    let tmp_body = stage_file_for_atomic_publish(&body_path, &response.body)?;
+    let fetched_signature = match fetch_and_verify_metadata_signature(
         &signature_policy,
         url,
         &tmp_body,
-        &tmp_signature,
+        &signature_path,
         &tmp_public_key,
         max_time_secs,
     ) {
-        Ok(signature_metadata) => signature_metadata,
+        Ok(signature) => signature,
         Err(error) => {
             let _ = fs::remove_file(&tmp_body);
-            let _ = fs::remove_file(&tmp_signature);
-            let _ = fs::remove_file(&tmp_public_key);
             return Err(error);
         }
     };
+    let signature_metadata = fetched_signature
+        .as_ref()
+        .map(|(metadata, _)| metadata.clone());
     let metadata = CachedHttpMetadata {
         url: url.to_owned(),
         etag: http_header_value(&response.headers, "etag"),
         last_modified: http_header_value(&response.headers, "last-modified"),
-        signature: signature_metadata.clone(),
+        signature: signature_metadata,
         fetched_at_unix_ms: unix_time_millis(),
     };
-    fs::rename(&tmp_body, &body_path).or_else(|_| {
-        let _ = fs::remove_file(&body_path);
-        fs::rename(&tmp_body, &body_path)
-    })?;
-    if signature_metadata.is_some() {
-        fs::rename(&tmp_signature, &signature_path).or_else(|_| {
-            let _ = fs::remove_file(&signature_path);
-            fs::rename(&tmp_signature, &signature_path)
-        })?;
+    if let Err(error) = publish_staged_file(&tmp_body, &body_path) {
+        if let Some((_, staged_signature)) = &fetched_signature {
+            let _ = fs::remove_file(staged_signature);
+        }
+        return Err(error);
+    }
+    if let Some((_, staged_signature)) = fetched_signature {
+        publish_staged_file(&staged_signature, &signature_path)?;
     } else {
         let _ = fs::remove_file(&signature_path);
     }
-    fs::write(
+    write_file_atomically(
         &metadata_path,
-        serde_json::to_vec_pretty(&metadata)
+        &serde_json::to_vec_pretty(&metadata)
             .context("failed to serialize metadata cache record")?,
     )?;
     let text = fs::read_to_string(&body_path)
@@ -2327,7 +2325,7 @@ where
 fn write_file_atomically_with_publish<S, P, F>(
     path: &Path,
     bytes: &[u8],
-    mut suffix_for_attempt: S,
+    suffix_for_attempt: S,
     before_publish: P,
     publish: F,
 ) -> Result<()>
@@ -2335,6 +2333,26 @@ where
     S: FnMut(u32) -> OsString,
     P: FnOnce(),
     F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    let tmp = stage_file_for_atomic_publish_with(path, bytes, suffix_for_attempt)?;
+    before_publish();
+    publish_staged_file_with(&tmp, path, publish)
+}
+
+fn stage_file_for_atomic_publish(path: &Path, bytes: &[u8]) -> Result<PathBuf> {
+    let temp_id = format!("{}-{}", std::process::id(), unix_time_millis());
+    stage_file_for_atomic_publish_with(path, bytes, |attempt| {
+        OsString::from(format!("{temp_id}-{attempt}"))
+    })
+}
+
+fn stage_file_for_atomic_publish_with<S>(
+    path: &Path,
+    bytes: &[u8],
+    mut suffix_for_attempt: S,
+) -> Result<PathBuf>
+where
+    S: FnMut(u32) -> OsString,
 {
     let parent = path.parent().context("file path has no parent directory")?;
     fs::create_dir_all(parent)?;
@@ -2372,12 +2390,22 @@ where
         return Err(disk_space::map_write_error(error, &tmp));
     }
     drop(file);
-    before_publish();
+    Ok(tmp)
+}
 
-    publish(&tmp, path).inspect_err(|_| {
-        let _ = fs::remove_file(&tmp);
-    })?;
-    Ok(())
+fn publish_staged_file(tmp: &Path, path: &Path) -> Result<()> {
+    publish_staged_file_with(tmp, path, publish_temp_file)
+}
+
+fn publish_staged_file_with<F>(tmp: &Path, path: &Path, publish: F) -> Result<()>
+where
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    publish(tmp, path)
+        .inspect_err(|_| {
+            let _ = fs::remove_file(tmp);
+        })
+        .with_context(|| format!("failed to publish {}", path.display()))
 }
 
 #[cfg(not(windows))]
@@ -3584,6 +3612,75 @@ mod tests {
         let published = fs::read(&destination).expect("a writer must remain published");
         let _ = fs::remove_dir_all(&root);
         assert!(published == b"first" || published == b"second");
+    }
+
+    #[test]
+    fn concurrent_cached_publications_use_distinct_staging_files() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-cache-publish-collision-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("index.body");
+        let before_publish = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let writers: Vec<_> = [b"first".as_slice(), b"second".as_slice()]
+            .into_iter()
+            .map(|bytes| {
+                let destination = destination.clone();
+                let before_publish = std::sync::Arc::clone(&before_publish);
+                std::thread::spawn(move || {
+                    let staged = stage_file_for_atomic_publish(&destination, bytes)?;
+                    before_publish.wait();
+                    publish_staged_file(&staged, &destination)
+                })
+            })
+            .collect();
+
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+        let published = fs::read(&destination).expect("a cache writer must remain published");
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().contains(".tmp-"))
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert!(published == b"first" || published == b"second");
+        assert!(
+            leftovers.is_empty(),
+            "staged cache files leaked: {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn failed_cached_publication_preserves_destination_and_cleans_staging_file() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-cache-publish-failure-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("index.body");
+        fs::write(&destination, b"published").unwrap();
+        let staged = stage_file_for_atomic_publish(&destination, b"replacement").unwrap();
+
+        publish_staged_file_with(&staged, &destination, |_, _| {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "simulated cache publication failure",
+            ))
+        })
+        .expect_err("simulated cache publication failure must be returned");
+
+        assert_eq!(fs::read(&destination).unwrap(), b"published");
+        assert!(
+            !staged.exists(),
+            "failed publication leaked its staging file"
+        );
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -2278,20 +2278,49 @@ fn windows_child_path(path: &Path) -> String {
     runtime_path_for_windows_child(path)
 }
 
+/// A unique temp path next to `path`, preserving the full file name so a
+/// multi-extension artifact keeps its extensions (`sdk.tar.gz` becomes
+/// `sdk.tar.gz.tmp-<id>`, where `with_extension` would drop `.gz`).
+fn temp_sibling_path(path: &Path) -> Result<PathBuf> {
+    let parent = path.parent().context("file path has no parent directory")?;
+    let file_name = path
+        .file_name()
+        .context("file path has no file name")?
+        .to_string_lossy()
+        .into_owned();
+    Ok(parent.join(format!(
+        "{file_name}.tmp-{}-{}",
+        std::process::id(),
+        unix_time_millis()
+    )))
+}
+
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
     let parent = path.parent().context("file path has no parent directory")?;
     fs::create_dir_all(parent)?;
-    let tmp = path.with_extension(format!("tmp-{}", unix_time_millis()));
-    {
+    let tmp = temp_sibling_path(path)?;
+    // Clean up the temp file on every failure path. It carries a unique
+    // name, so leaving it behind would accumulate a fresh orphan per attempt —
+    // and when the failure is a full disk, those orphans are what keep it full.
+    let write_result = (|| -> Result<()> {
         let mut file = fs::File::create(&tmp)
             .with_context(|| format!("failed to create {}", tmp.display()))?;
         file.write_all(bytes)
             .map_err(|error| disk_space::map_write_error(error, &tmp))?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&tmp);
+        return Err(error);
     }
-    fs::rename(&tmp, path).or_else(|_| {
-        let _ = fs::remove_file(path);
-        fs::rename(&tmp, path)
-    })?;
+    fs::rename(&tmp, path)
+        .or_else(|_| {
+            let _ = fs::remove_file(path);
+            fs::rename(&tmp, path)
+        })
+        .inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        })?;
     Ok(())
 }
 
@@ -3357,6 +3386,100 @@ mod tests {
         );
         let text = format!("{error:#}");
         assert!(text.contains("ran out of disk space"), "{text}");
+    }
+
+    /// The temp name keeps every extension, so a cleanup sweep over a cache
+    /// directory can still tell what a leftover was going to be.
+    #[test]
+    fn temp_sibling_path_preserves_multi_dot_file_names() {
+        let temp = temp_sibling_path(Path::new("/tmp/cache/sdk.tar.gz")).unwrap();
+        let name = temp.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(
+            name.starts_with("sdk.tar.gz.tmp-"),
+            "expected the full name to be preserved, got {name}"
+        );
+        assert_eq!(temp.parent().unwrap(), Path::new("/tmp/cache"));
+    }
+
+    /// Regression: a failed write must not leave a `.tmp-*` scratch file
+    /// behind. The name is unique per attempt, so before this an orphan
+    /// accumulated per retry — and when the failure is a full disk, those
+    /// orphans are exactly what keeps it full.
+    ///
+    /// Provokes the failure by pointing the destination at a non-empty
+    /// directory: the temp file is written, then neither the rename nor the
+    /// replace fallback can succeed. Portable, unlike an out-of-space test.
+    #[test]
+    fn write_file_atomically_cleans_up_temp_when_the_rename_fails() {
+        let root = std::env::temp_dir().join(format!(
+            "rocm-atomic-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        let occupied = root.join("sdk.tar.gz");
+        fs::create_dir_all(occupied.join("nested")).unwrap();
+        fs::write(occupied.join("nested").join("keep"), b"x").unwrap();
+
+        write_file_atomically(&occupied, b"payload")
+            .expect_err("renaming onto a non-empty directory should fail");
+
+        let leftovers: Vec<String> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert!(
+            leftovers.is_empty(),
+            "failed write left temp files behind: {leftovers:?}"
+        );
+    }
+
+    /// Mirrors the `/dev/shm` reproduction from the original report: a genuine
+    /// ENOSPC, not a rename failure standing in for one.
+    ///
+    /// Ignored by default because it fills `/dev/shm`, which is shared with
+    /// anything else on the host, so it is not safe to run concurrently. Run
+    /// with `cargo test -p rocm -- --ignored write_file_atomically_cleans_up`.
+    #[test]
+    #[ignore = "fills /dev/shm to provoke ENOSPC; not safe to run concurrently"]
+    fn write_file_atomically_cleans_up_temp_on_write_failure() {
+        let shm = Path::new("/dev/shm");
+        if !shm.is_dir() {
+            eprintln!("skipping: /dev/shm unavailable");
+            return;
+        }
+        let dir = shm.join(format!("rocm-enospc-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join("artifact.tar.gz");
+        // Larger than the tmpfs, so the write is guaranteed to hit ENOSPC.
+        let payload = vec![0u8; 256 * 1024 * 1024];
+
+        let mut failures = Vec::new();
+        for _ in 0..2 {
+            write_file_atomically(&dest, &payload)
+                .expect_err("writing past the end of the filesystem should fail");
+            failures.push(
+                fs::read_dir(&dir)
+                    .unwrap()
+                    .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>(),
+            );
+        }
+        let destination_exists = dest.exists();
+        let _ = fs::remove_dir_all(&dir);
+
+        for leftovers in &failures {
+            assert!(
+                leftovers.is_empty(),
+                "failed write left files behind: {leftovers:?}"
+            );
+        }
+        assert!(
+            !destination_exists,
+            "destination must not exist after failure"
+        );
     }
 
     #[test]

--- a/apps/rocmd/Cargo.toml
+++ b/apps/rocmd/Cargo.toml
@@ -21,3 +21,6 @@ serde_json.workspace = true
 sha2 = "0.10"
 tokio.workspace = true
 ureq = { version = "2.12", features = ["native-certs"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -36,7 +36,7 @@ use serde_json::json;
 #[cfg(test)]
 use sha2::{Digest, Sha256};
 use std::collections::{HashSet, VecDeque};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use std::net::{SocketAddr, TcpStream};
@@ -1037,35 +1037,158 @@ fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+const ATOMIC_WRITE_TEMP_ATTEMPTS: u32 = 128;
+
+fn temp_sibling_path(path: &Path, suffix: &OsStr) -> Result<PathBuf> {
     let parent = path.parent().context("file path has no parent directory")?;
-    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
-    // Preserve the full file name so multi-extension paths keep their
-    // extensions, and remove the temp file on every failure path so repeated
-    // attempts cannot accumulate orphans.
-    let file_name = path
+    let mut file_name = path
         .file_name()
         .context("file path has no file name")?
-        .to_string_lossy()
-        .into_owned();
-    let tmp = parent.join(format!(
-        "{file_name}.tmp-{}-{}",
-        std::process::id(),
-        unix_time_millis()
-    ));
-    if let Err(error) = fs::write(&tmp, bytes) {
+        .to_os_string();
+    file_name.push(".tmp-");
+    file_name.push(suffix);
+    Ok(parent.join(file_name))
+}
+
+fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    let temp_id = format!("{}-{}", std::process::id(), unix_time_millis());
+    write_file_atomically_with(
+        path,
+        bytes,
+        |attempt| OsString::from(format!("{temp_id}-{attempt}")),
+        || {},
+    )
+}
+
+fn write_file_atomically_with<S, P>(
+    path: &Path,
+    bytes: &[u8],
+    suffix_for_attempt: S,
+    before_publish: P,
+) -> Result<()>
+where
+    S: FnMut(u32) -> OsString,
+    P: FnOnce(),
+{
+    write_file_atomically_with_publish(
+        path,
+        bytes,
+        suffix_for_attempt,
+        before_publish,
+        publish_temp_file,
+    )
+}
+
+fn write_file_atomically_with_publish<S, P, F>(
+    path: &Path,
+    bytes: &[u8],
+    mut suffix_for_attempt: S,
+    before_publish: P,
+    publish: F,
+) -> Result<()>
+where
+    S: FnMut(u32) -> OsString,
+    P: FnOnce(),
+    F: FnOnce(&Path, &Path) -> io::Result<()>,
+{
+    let parent = path.parent().context("file path has no parent directory")?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+
+    let mut reserved = None;
+    for attempt in 0..ATOMIC_WRITE_TEMP_ATTEMPTS {
+        let suffix = suffix_for_attempt(attempt);
+        let tmp = temp_sibling_path(path, &suffix)?;
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(file) => {
+                reserved = Some((tmp, file));
+                break;
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to create {}", tmp.display()));
+            }
+        }
+    }
+    let Some((tmp, mut file)) = reserved else {
+        bail!(
+            "failed to reserve a temporary file next to {} after {} attempts",
+            path.display(),
+            ATOMIC_WRITE_TEMP_ATTEMPTS
+        );
+    };
+
+    if let Err(error) = file.write_all(bytes) {
+        drop(file);
         let _ = fs::remove_file(&tmp);
         return Err(error).with_context(|| format!("failed to write {}", tmp.display()));
     }
-    fs::rename(&tmp, path)
-        .or_else(|_| {
-            let _ = fs::remove_file(path);
-            fs::rename(&tmp, path)
-        })
-        .inspect_err(|_| {
-            let _ = fs::remove_file(&tmp);
-        })?;
+    drop(file);
+    before_publish();
+
+    publish(&tmp, path).inspect_err(|_| {
+        let _ = fs::remove_file(&tmp);
+    })?;
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn publish_temp_file(tmp: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(tmp, path)
+}
+
+#[cfg(windows)]
+fn publish_temp_file(tmp: &Path, path: &Path) -> io::Result<()> {
+    if path.try_exists()? {
+        return replace_file_windows(path, tmp);
+    }
+
+    match fs::rename(tmp, path) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            if path.try_exists()? {
+                replace_file_windows(path, tmp)
+            } else {
+                Err(rename_error)
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn replace_file_windows(path: &Path, replacement: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
+
+    let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let replacement_wide: Vec<u16> = replacement
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    // SAFETY: both path buffers are valid, NUL-terminated UTF-16 strings and
+    // remain alive for the duration of the synchronous Windows API call. The
+    // optional backup, exclude, and reserved pointers are intentionally null.
+    let replaced = unsafe {
+        ReplaceFileW(
+            path_wide.as_ptr(),
+            replacement_wide.as_ptr(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 fn sandbox_check_updates_value(output: CommandCapture) -> Value {
@@ -5110,6 +5233,100 @@ mod tests {
             vec!["artifact.tar.gz".to_owned()],
             "only the occupied destination should remain"
         );
+    }
+
+    #[test]
+    fn concurrent_atomic_writes_do_not_remove_a_published_destination() {
+        let root = std::env::temp_dir().join(format!(
+            "rocmd-atomic-collision-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("manifest.json");
+        let before_publish = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+        let writers: Vec<_> = [b"first".as_slice(), b"second".as_slice()]
+            .into_iter()
+            .enumerate()
+            .map(|(writer, bytes)| {
+                let destination = destination.clone();
+                let before_publish = std::sync::Arc::clone(&before_publish);
+                std::thread::spawn(move || {
+                    write_file_atomically_with(
+                        &destination,
+                        bytes,
+                        |attempt| {
+                            if attempt == 0 {
+                                OsString::from("same-millisecond")
+                            } else {
+                                OsString::from(format!("same-millisecond-{writer}-{attempt}"))
+                            }
+                        },
+                        || {
+                            before_publish.wait();
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        for writer in writers {
+            writer.join().unwrap().unwrap();
+        }
+        let published = fs::read(&destination).expect("a writer must remain published");
+        let _ = fs::remove_dir_all(&root);
+        assert!(published == b"first" || published == b"second");
+    }
+
+    #[test]
+    fn failed_atomic_replace_preserves_destination_and_cleans_temp() {
+        let root = std::env::temp_dir().join(format!(
+            "rocmd-atomic-replace-failure-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("manifest.json");
+        fs::write(&destination, b"published").unwrap();
+
+        write_file_atomically_with_publish(
+            &destination,
+            b"replacement",
+            |attempt| OsString::from(format!("replace-failure-{attempt}")),
+            || {},
+            |tmp, path| {
+                assert_eq!(fs::read(tmp).unwrap(), b"replacement");
+                assert_eq!(path, destination);
+                Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "simulated atomic replacement failure",
+                ))
+            },
+        )
+        .expect_err("simulated replacement failure must be returned");
+
+        assert_eq!(fs::read(&destination).unwrap(), b"published");
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(leftovers, vec![OsString::from("manifest.json")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_temp_name_preserves_non_unicode_file_name_bytes() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let file_name = OsString::from_vec(b"manifest-\xff.json".to_vec());
+        let destination = Path::new("/tmp").join(&file_name);
+        let temp = temp_sibling_path(&destination, std::ffi::OsStr::new("collision")).unwrap();
+
+        let mut expected = file_name.into_vec();
+        expected.extend_from_slice(b".tmp-collision");
+        assert_eq!(temp.file_name().unwrap().as_bytes(), expected);
     }
 
     /// Mirrors the `/dev/shm` reproduction from the original report: a genuine

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -1040,12 +1040,31 @@ fn sha256_hex(bytes: &[u8]) -> String {
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
     let parent = path.parent().context("file path has no parent directory")?;
     fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
-    let tmp = path.with_extension(format!("tmp-{}", unix_time_millis()));
-    fs::write(&tmp, bytes).with_context(|| format!("failed to write {}", tmp.display()))?;
-    fs::rename(&tmp, path).or_else(|_| {
-        let _ = fs::remove_file(path);
-        fs::rename(&tmp, path)
-    })?;
+    // Preserve the full file name so multi-extension paths keep their
+    // extensions, and remove the temp file on every failure path so repeated
+    // attempts cannot accumulate orphans.
+    let file_name = path
+        .file_name()
+        .context("file path has no file name")?
+        .to_string_lossy()
+        .into_owned();
+    let tmp = parent.join(format!(
+        "{file_name}.tmp-{}-{}",
+        std::process::id(),
+        unix_time_millis()
+    ));
+    if let Err(error) = fs::write(&tmp, bytes) {
+        let _ = fs::remove_file(&tmp);
+        return Err(error).with_context(|| format!("failed to write {}", tmp.display()));
+    }
+    fs::rename(&tmp, path)
+        .or_else(|_| {
+            let _ = fs::remove_file(path);
+            fs::rename(&tmp, path)
+        })
+        .inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        })?;
     Ok(())
 }
 
@@ -5030,6 +5049,104 @@ mod tests {
     use clap::CommandFactory;
     use rocm_core::ModelRecipeArtifactSourcePolicyRecord;
     use std::path::PathBuf;
+
+    /// Regression: a failed write must not leave a `.tmp-*` scratch file
+    /// behind. The name is unique per attempt, so before this an orphan
+    /// accumulated per retry — and when the failure is a full disk, those
+    /// orphans are exactly what keeps it full.
+    ///
+    /// Provokes the failure by pointing the destination at a non-empty
+    /// directory: the temp file is written, then neither the rename nor the
+    /// replace fallback can succeed. Portable, unlike an out-of-space test.
+    #[test]
+    fn write_file_atomically_cleans_up_temp_when_the_rename_fails() {
+        let root = std::env::temp_dir().join(format!(
+            "rocmd-atomic-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        let occupied = root.join("manifest.json");
+        fs::create_dir_all(occupied.join("nested")).unwrap();
+        fs::write(occupied.join("nested").join("keep"), b"x").unwrap();
+
+        write_file_atomically(&occupied, b"payload")
+            .expect_err("renaming onto a non-empty directory should fail");
+
+        let leftovers: Vec<String> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert!(
+            leftovers.is_empty(),
+            "failed write left temp files behind: {leftovers:?}"
+        );
+    }
+
+    /// The temp name keeps every extension, so a cleanup sweep over a cache
+    /// directory can still tell what a leftover was going to be.
+    #[test]
+    fn write_file_atomically_temp_name_preserves_multi_dot_file_names() {
+        let root = std::env::temp_dir().join(format!(
+            "rocmd-atomic-name-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        let occupied = root.join("artifact.tar.gz");
+        fs::create_dir_all(occupied.join("nested")).unwrap();
+        fs::write(occupied.join("nested").join("keep"), b"x").unwrap();
+
+        // Fails after the temp file exists, so the observed name is the real one.
+        write_file_atomically(&occupied, b"payload").expect_err("rename should fail");
+
+        let names: Vec<String> = fs::read_dir(&root)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(
+            names,
+            vec!["artifact.tar.gz".to_owned()],
+            "only the occupied destination should remain"
+        );
+    }
+
+    /// Mirrors the `/dev/shm` reproduction from the original report: a genuine
+    /// ENOSPC, not a rename failure standing in for one.
+    ///
+    /// Ignored by default because it fills `/dev/shm`, which is shared with
+    /// anything else on the host, so it is not safe to run concurrently.
+    #[test]
+    #[ignore = "fills /dev/shm to provoke ENOSPC; not safe to run concurrently"]
+    fn write_file_atomically_cleans_up_temp_on_write_failure() {
+        let shm = Path::new("/dev/shm");
+        if !shm.is_dir() {
+            eprintln!("skipping: /dev/shm unavailable");
+            return;
+        }
+        let dir = shm.join(format!("rocmd-enospc-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let dest = dir.join("manifest.json");
+        // Larger than the tmpfs, so the write is guaranteed to hit ENOSPC.
+        let payload = vec![b'x'; 256 * 1024 * 1024];
+
+        write_file_atomically(&dest, &payload)
+            .expect_err("writing past the end of the filesystem should fail");
+        let leftovers: Vec<String> = fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        let destination_exists = dest.exists();
+        let _ = fs::remove_dir_all(&dir);
+
+        assert!(
+            leftovers.is_empty(),
+            "failed write left files behind: {leftovers:?}"
+        );
+        assert!(!destination_exists);
+    }
 
     #[test]
     fn last_cr_segment_keeps_final_progress_redraw() {

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -76,7 +76,10 @@ cargo xtask e2e
 Prebuilt mode requires only `ROCM_CLI_BINARY` for scenarios that invoke
 `rocm`. Scenarios backed by `rocmd`, such as artifact prefetch, additionally
 require an explicit matching `ROCM_CLI_ROCMD_BINARY`; the harness does not
-infer a sibling executable.
+infer a sibling executable. Lifecycle packaging requires both prebuilt binaries
+to be in the same directory because `xtask package` consumes one `ROCM_BIN_DIR`;
+the harness rejects separate directories instead of silently packaging a
+different `rocmd`.
 
 The default run is fast: it excludes the expensive, OS-mutating `@lifecycle`
 release-install scenarios (packaging + the real installer + install/uninstall).
@@ -200,7 +203,7 @@ The `.feature` file is both the spec and the test input — cucumber reads it at
 
 ## Design principles
 
-- **Black-box only.** Step functions interact with `rocm` through its CLI and HTTP endpoints. No imports from the rocm-cli codebase. Where a scenario needs the CLI to know about a running server, it plants a managed-service record as plain JSON matching the on-disk schema (see `register_mock_service`) — the same file `rocm serve --managed` would write — rather than importing the record type.
+- **Black-box only.** Step functions interact with `rocm` and explicitly configured `rocmd` through their CLIs and HTTP endpoints. No imports from the rocm-cli codebase. Where a scenario needs the CLI to know about a running server, it plants a managed-service record as plain JSON matching the on-disk schema (see `register_mock_service`) — the same file `rocm serve --managed` would write — rather than importing the record type.
 - **Isolated state.** Each scenario uses isolated config, data, and cache directories. Tests never touch `~/.rocm`.
 - **Behavioral language.** Feature files describe what users care about, not implementation details. How steps are implemented (mock vs real, which port, which API) stays in the step functions.
 - **OS-assigned ports.** The mock server binds to `127.0.0.1:0` to avoid port conflicts between tests.

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -11,10 +11,12 @@ Behavioral end-to-end tests using [cucumber-rs](https://github.com/cucumber-rs/c
 ## Architecture
 
 ```
-.feature files (Gherkin)  →  step functions (Rust)  →  rocm binary / mock server
+.feature files (Gherkin)  →  step functions (Rust)  →  rocm / configured rocmd / mock server
 ```
 
-Tests exercise the `rocm` binary as a black box — no imports from the rocm-cli codebase. Mock-tier tests use an in-process axum server; GPU-tier tests run real model serving.
+Scenarios exercise `rocm` and, where required, an explicitly configured
+`rocmd` as black boxes — no imports from the rocm-cli codebase. Mock-tier tests
+use an in-process axum server; GPU-tier tests run real model serving.
 
 ## Prerequisites
 
@@ -52,8 +54,8 @@ tests/e2e-cucumber/
 
 ## Running tests
 
-The `cargo xtask e2e` task builds the release `rocm` binary and runs the suite.
-Extra arguments after `--` are forwarded to the cucumber CLI.
+The `cargo xtask e2e` task builds the release `rocm` and `rocmd` binaries and
+runs the suite. Extra arguments after `--` are forwarded to the cucumber CLI.
 
 ```bash
 # All features:
@@ -65,9 +67,16 @@ cargo xtask e2e -- -n "model name"
 # Stop on first failure:
 cargo xtask e2e -- --fail-fast
 
-# With a pre-built binary (skips the build step):
-ROCM_CLI_BINARY=./target/release/rocm cargo xtask e2e
+# With pre-built binaries (skips the build step):
+ROCM_CLI_BINARY=./target/release/rocm \
+ROCM_CLI_ROCMD_BINARY=./target/release/rocmd \
+cargo xtask e2e
 ```
+
+Prebuilt mode requires only `ROCM_CLI_BINARY` for scenarios that invoke
+`rocm`. Scenarios backed by `rocmd`, such as artifact prefetch, additionally
+require an explicit matching `ROCM_CLI_ROCMD_BINARY`; the harness does not
+infer a sibling executable.
 
 The default run is fast: it excludes the expensive, OS-mutating `@lifecycle`
 release-install scenarios (packaging + the real installer + install/uninstall).
@@ -82,6 +91,7 @@ E2E_INCLUDE_LIFECYCLE=1 E2E_ONLY_LIFECYCLE=1 cargo xtask e2e
 | Variable | Default | Description |
 |---|---|---|
 | `ROCM_CLI_BINARY` | `rocm` (on PATH) | Path to the rocm binary under test |
+| `ROCM_CLI_ROCMD_BINARY` | set by `cargo xtask e2e` after its release build | Path to the rocmd binary required by rocmd-backed scenarios; explicit in prebuilt mode |
 | `ROCM_CLI_CONFIG_DIR` | (temp dir) | Isolated config directory per scenario |
 | `ROCM_CLI_DATA_DIR` | (temp dir) | Isolated data directory per scenario |
 | `ROCM_CLI_CACHE_DIR` | (temp dir) | Isolated cache directory per scenario |

--- a/tests/e2e-cucumber/features/artifact_prefetch.feature
+++ b/tests/e2e-cucumber/features/artifact_prefetch.feature
@@ -1,0 +1,10 @@
+Feature: Artifact prefetch cleanup
+
+  @id:artifact-prefetch-failed-marker-leaves-no-temp
+  Scenario: A failed artifact cache write leaves no temporary marker
+    Given a signed direct-download artifact fixture
+    And its cache marker destination is occupied by a directory
+    When the user approves the artifact prefetch
+    Then the artifact download completes before marker publication fails
+    And no temporary cache marker is left behind
+    And the occupied cache marker destination remains unchanged

--- a/tests/e2e-cucumber/src/lib.rs
+++ b/tests/e2e-cucumber/src/lib.rs
@@ -12,6 +12,39 @@ pub mod model_id;
 pub mod panic_capture;
 pub mod serve_log;
 
+use std::path::{Path, PathBuf};
+
+/// Select the single binary directory consumed by lifecycle packaging.
+///
+/// `xtask package` accepts one `ROCM_BIN_DIR`, so prebuilt `rocm` and `rocmd`
+/// paths must name siblings. Reject a split layout instead of silently taking
+/// whichever `rocmd` happens to sit next to `rocm`.
+pub fn lifecycle_binary_dir(
+    rocm: &Path,
+    rocmd: Option<&Path>,
+    fallback: &Path,
+) -> Result<PathBuf, String> {
+    let parent_or_fallback = |path: &Path| {
+        path.parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map_or_else(|| fallback.to_path_buf(), Path::to_path_buf)
+    };
+    let rocm_dir = parent_or_fallback(rocm);
+    let rocmd = rocmd.ok_or_else(|| {
+        "ROCM_CLI_ROCMD_BINARY must be set for lifecycle packaging so the packaged rocmd is explicit"
+            .to_owned()
+    })?;
+    let rocmd_dir = parent_or_fallback(rocmd);
+    if rocm_dir != rocmd_dir {
+        return Err(format!(
+            "lifecycle packaging requires ROCM_CLI_BINARY and ROCM_CLI_ROCMD_BINARY in the same directory; rocm uses {}, rocmd uses {}",
+            rocm_dir.display(),
+            rocmd_dir.display()
+        ));
+    }
+    Ok(rocm_dir)
+}
+
 /// Render everything known about a failed `rocm` invocation.
 ///
 /// Both streams are always shown, each labelled and each with an explicit
@@ -55,7 +88,39 @@ pub use e2e_report as report;
 
 #[cfg(test)]
 mod tests {
-    use super::{chat_response_is_successful, cli_failure_report};
+    use super::{chat_response_is_successful, cli_failure_report, lifecycle_binary_dir};
+    use std::path::Path;
+
+    #[test]
+    fn lifecycle_packaging_rejects_rocm_and_rocmd_from_different_directories() {
+        let error = lifecycle_binary_dir(
+            Path::new("/prebuilt/cli/rocm"),
+            Some(Path::new("/prebuilt/daemon/rocmd")),
+            Path::new("/workspace/target/release"),
+        )
+        .expect_err("packaging cannot consume binaries from separate directories");
+
+        assert!(
+            error.contains("/prebuilt/cli"),
+            "missing rocm directory: {error}"
+        );
+        assert!(
+            error.contains("/prebuilt/daemon"),
+            "missing rocmd directory: {error}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_packaging_uses_the_directory_containing_both_configured_binaries() {
+        let selected = lifecycle_binary_dir(
+            Path::new("/prebuilt/bin/rocm"),
+            Some(Path::new("/prebuilt/bin/rocmd")),
+            Path::new("/workspace/target/release"),
+        )
+        .expect("sibling binaries must be accepted");
+
+        assert_eq!(selected, Path::new("/prebuilt/bin"));
+    }
 
     /// The regression this whole helper exists for: a serve that dies with
     /// nothing on stdout must still show the reason, which is on stderr.

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -11,10 +11,12 @@
 use std::path::PathBuf;
 
 use cucumber::{World as _, WriterExt as _};
+use e2e_cucumber::loopback_http::LoopbackServer;
 use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions, write_service_record_with};
 use tempfile::TempDir;
 
 mod e2e {
+    pub mod artifact_steps;
     pub mod bench_steps;
     pub mod chat_steps;
     pub mod dash_steps;
@@ -32,6 +34,11 @@ mod e2e {
 #[derive(Debug, cucumber::World)]
 pub struct E2eWorld {
     pub mock: Option<MockServer>,
+    /// Loopback file server used by artifact-prefetch scenarios. Kept on the
+    /// World so it remains alive while the real `rocmd` subprocess downloads.
+    pub artifact_server: Option<LoopbackServer>,
+    /// Cache-marker destination discovered from `rocmd`'s own JSON report.
+    pub artifact_marker_path: Option<PathBuf>,
     pub endpoint: Option<String>,
     pub model_name: Option<String>,
     pub chat_response: Option<serde_json::Value>,
@@ -165,6 +172,8 @@ impl Default for E2eWorld {
 
         Self {
             mock: None,
+            artifact_server: None,
+            artifact_marker_path: None,
             endpoint: None,
             model_name: None,
             chat_response: None,
@@ -370,6 +379,7 @@ impl Drop for E2eWorld {
         if let Some(mock) = self.mock.take() {
             mock.stop();
         }
+        self.artifact_server.take();
         // A scenario that ran `rocm serve --managed` left a DETACHED supervisor +
         // engine process (vLLM / llama-server) that outlives this harness — the
         // TempDir drop below removes the on-disk record but never kills those

--- a/tests/e2e-cucumber/tests/e2e/artifact_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/artifact_steps.rs
@@ -1,0 +1,283 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use cucumber::{given, then, when};
+use e2e_cucumber::loopback_http::LoopbackServer;
+
+use crate::E2eWorld;
+
+const ARTIFACT_REF: &str = "E2E/Atomic#direct-bin";
+const ARTIFACT_BYTES: &[u8] = b"atomic-download-fixture";
+const ARTIFACT_SHA256: &str = "12bc9c098e689d7eac74bf6ff8b0fdacddae2e9eba48c2eede0c46eeeb008500";
+
+fn root(world: &E2eWorld) -> &Path {
+    world
+        .isolated_root
+        .as_ref()
+        .expect("no isolated root")
+        .path()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("e2e-cucumber must live under <workspace>/tests")
+        .to_path_buf()
+}
+
+fn xtask_command() -> Command {
+    if let Some(binary) = std::env::var_os("ROCM_XTASK_BINARY") {
+        Command::new(binary)
+    } else {
+        let mut command = Command::new(
+            std::env::var_os("CARGO").unwrap_or_else(|| std::ffi::OsString::from("cargo")),
+        );
+        command.arg("xtask");
+        command
+    }
+}
+
+fn rocmd_binary() -> PathBuf {
+    let configured = std::env::var_os("ROCM_CLI_ROCMD_BINARY").unwrap_or_else(|| {
+        panic!(
+            "this rocmd-backed scenario requires ROCM_CLI_ROCMD_BINARY; when using a prebuilt \
+             ROCM_CLI_BINARY, provide the matching prebuilt rocmd path explicitly"
+        )
+    });
+    let configured = PathBuf::from(configured);
+    configured.canonicalize().unwrap_or_else(|error| {
+        panic!(
+            "failed to resolve ROCM_CLI_ROCMD_BINARY {}: {error}",
+            configured.display()
+        )
+    })
+}
+
+fn signed_index_paths(world: &E2eWorld) -> (PathBuf, PathBuf, PathBuf) {
+    let root = root(world);
+    (
+        root.join("recipes.json"),
+        root.join("recipes.json.sig"),
+        root.join("recipe-public.pem"),
+    )
+}
+
+fn run_rocmd(world: &E2eWorld, args: &[&str]) -> (String, String, i32) {
+    let (index, signature, public_key) = signed_index_paths(world);
+    let empty_path = root(world).join("empty-path");
+    std::fs::create_dir_all(&empty_path).expect("failed to create isolated PATH directory");
+    let mut command = Command::new(rocmd_binary());
+    command.args(args);
+    world.isolate_cmd(&mut command);
+    // Force the documented restricted-native fallback so this scenario has the
+    // same writable data/cache view on hosts that happen to provide bubblewrap.
+    command.env("PATH", empty_path);
+    command.env("ROCM_CLI_MODEL_RECIPE_INDEX_PATH", index);
+    command.env("ROCM_CLI_MODEL_RECIPE_INDEX_SIGNATURE_PATH", signature);
+    command.env("ROCM_CLI_MODEL_RECIPE_INDEX_PUBLIC_KEY_PATH", public_key);
+    let output = command.output().expect("failed to run rocmd");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[given("a signed direct-download artifact fixture")]
+async fn signed_direct_download_fixture(world: &mut E2eWorld) {
+    // Fail before fixture setup when a prebuilt-mode caller selected this
+    // rocmd-backed scenario without supplying its explicit harness contract.
+    let _ = rocmd_binary();
+    let served = root(world).join("served-artifacts");
+    std::fs::create_dir_all(&served).expect("failed to create served artifact directory");
+    std::fs::write(served.join("artifact.bin"), ARTIFACT_BYTES)
+        .expect("failed to write artifact fixture");
+    let server = LoopbackServer::start(&served);
+    let artifact_url = format!("{}/artifact.bin", server.base_url());
+
+    let (index, signature, public_key) = signed_index_paths(world);
+    let private_key = root(world).join("recipe-private.pem");
+    let document = serde_json::json!({
+        "schema_version": 1,
+        "source": "e2e-atomic-download",
+        "recipes": [{
+            "canonical_model_id": "E2E/Atomic",
+            "aliases": [],
+            "task": "chat",
+            "source": "signed_recipe_index",
+            "revision": "main",
+            "loader": "transformers",
+            "trust_remote_code": false,
+            "dtype": "float16",
+            "device_policy": "gpu_required",
+            "artifacts": [{
+                "artifact_id": "direct-bin",
+                "kind": "url",
+                "uri": artifact_url,
+                "revision": null,
+                "sha256": ARTIFACT_SHA256,
+                "size_bytes": ARTIFACT_BYTES.len(),
+                "license": "test-only",
+                "gated": false,
+                "quantization": null,
+                "engines": ["vllm"]
+            }],
+            "engine_recipes": [],
+            "manual_alternatives": [],
+            "featured": false,
+            "chat_template_mode": "auto",
+            "preferred_engines": ["vllm"],
+            "warnings": []
+        }]
+    });
+    std::fs::write(
+        &index,
+        serde_json::to_vec_pretty(&document).expect("failed to serialize recipe fixture"),
+    )
+    .expect("failed to write recipe fixture");
+
+    let keygen = xtask_command()
+        .args(["keygen", "--private-out"])
+        .arg(&private_key)
+        .arg("--public-out")
+        .arg(&public_key)
+        .current_dir(workspace_root())
+        .status()
+        .expect("failed to run xtask keygen");
+    assert!(keygen.success(), "xtask keygen failed");
+    let sign = xtask_command()
+        .args(["sign", "--private-key"])
+        .arg(&private_key)
+        .arg("--in")
+        .arg(&index)
+        .arg("--out")
+        .arg(&signature)
+        .current_dir(workspace_root())
+        .status()
+        .expect("failed to run xtask sign");
+    assert!(sign.success(), "xtask sign failed");
+    world.artifact_server = Some(server);
+}
+
+#[given("its cache marker destination is occupied by a directory")]
+async fn occupy_cache_marker(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = run_rocmd(
+        world,
+        &[
+            "sandbox-run",
+            "prefetch_artifact",
+            "--artifact-ref",
+            ARTIFACT_REF,
+            "--allow-native-fallback",
+        ],
+    );
+    assert_eq!(rc, 0, "marker discovery failed: {stderr}");
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).expect("rocmd did not print a JSON prefetch report");
+    let marker = report
+        .get("output")
+        .and_then(|output| output.get("cache"))
+        .and_then(|cache| cache.get("marker_path"))
+        .and_then(serde_json::Value::as_str)
+        .map(PathBuf::from)
+        .expect("prefetch report did not include cache.marker_path");
+    std::fs::create_dir_all(marker.join("occupied"))
+        .expect("failed to occupy cache marker destination");
+    std::fs::write(marker.join("occupied").join("keep"), b"keep")
+        .expect("failed to seed occupied cache marker destination");
+    world.artifact_marker_path = Some(marker);
+}
+
+#[when("the user approves the artifact prefetch")]
+async fn approve_artifact_prefetch(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = run_rocmd(
+        world,
+        &[
+            "sandbox-run",
+            "prefetch_artifact",
+            "--artifact-ref",
+            ARTIFACT_REF,
+            "--allow-artifact-download",
+            "--artifact-max-bytes",
+            "1024",
+            "--allow-native-fallback",
+        ],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[then("the artifact download completes before marker publication fails")]
+async fn artifact_download_completes_before_marker_publication_fails(world: &mut E2eWorld) {
+    assert_ne!(
+        world.cli_rc,
+        Some(0),
+        "prefetch unexpectedly succeeded: {}",
+        world.cli_output.as_deref().unwrap_or("")
+    );
+    let marker = world
+        .artifact_marker_path
+        .as_ref()
+        .expect("no marker path recorded");
+    let artifact = marker.with_extension("bin");
+    assert_eq!(
+        std::fs::read(&artifact).expect("artifact download did not complete"),
+        ARTIFACT_BYTES,
+        "downloaded artifact did not match the fixture"
+    );
+    let stderr = world.cli_stderr.as_deref().unwrap_or("");
+    assert!(
+        stderr.contains("os error"),
+        "prefetch did not report the expected marker-publication filesystem error: {stderr}"
+    );
+}
+
+#[then("no temporary cache marker is left behind")]
+async fn no_temporary_marker_remains(world: &mut E2eWorld) {
+    let marker = world
+        .artifact_marker_path
+        .as_ref()
+        .expect("no marker path recorded");
+    let marker_name = marker
+        .file_name()
+        .expect("marker has no file name")
+        .to_string_lossy();
+    let legacy_stem = marker
+        .file_stem()
+        .expect("marker has no file stem")
+        .to_string_lossy();
+    let temp_prefixes = [format!("{marker_name}.tmp-"), format!("{legacy_stem}.tmp-")];
+    let leftovers = std::fs::read_dir(marker.parent().expect("marker has no parent"))
+        .expect("failed to inspect marker directory")
+        .map(|entry| entry.expect("failed to read marker entry").file_name())
+        .filter(|name| {
+            let name = name.to_string_lossy();
+            temp_prefixes.iter().any(|prefix| name.starts_with(prefix))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        leftovers.is_empty(),
+        "failed prefetch left temporary cache markers: {leftovers:?}"
+    );
+}
+
+#[then("the occupied cache marker destination remains unchanged")]
+async fn occupied_marker_remains_unchanged(world: &mut E2eWorld) {
+    let marker = world
+        .artifact_marker_path
+        .as_ref()
+        .expect("no marker path recorded");
+    assert!(marker.is_dir(), "occupied marker destination was removed");
+    assert_eq!(
+        std::fs::read(marker.join("occupied").join("keep"))
+            .expect("occupied marker sentinel was removed"),
+        b"keep",
+        "occupied marker sentinel bytes changed"
+    );
+}

--- a/tests/e2e-cucumber/tests/e2e/lifecycle_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/lifecycle_steps.rs
@@ -164,11 +164,13 @@ fn run_package(world: &E2eWorld, sign_env: &[(&str, String)]) -> (String, bool) 
 /// packaging bundles exactly the binaries under test.
 fn release_bin_dir() -> PathBuf {
     let binary = crate::rocm_binary();
-    let path = PathBuf::from(&binary);
-    path.parent().map_or_else(
-        || workspace_root().join("target/release"),
-        Path::to_path_buf,
+    let rocmd = std::env::var_os("ROCM_CLI_ROCMD_BINARY").map(PathBuf::from);
+    e2e_cucumber::lifecycle_binary_dir(
+        Path::new(&binary),
+        rocmd.as_deref(),
+        &workspace_root().join("target/release"),
     )
+    .expect("lifecycle packaging requires matching rocm and rocmd binaries")
 }
 
 /// Run the platform installer (`install.sh` / `install.ps1`) with the given

--- a/xtask/src/e2e.rs
+++ b/xtask/src/e2e.rs
@@ -10,17 +10,64 @@
 //! `--fail-fast`). Used by both CI and local dev so the build+run recipe lives
 //! in one cross-platform place instead of a bash wrapper.
 
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::paths::{target_dir, workspace_root};
+use crate::paths::{binary_name, target_dir, workspace_root};
+
+#[derive(Debug, PartialEq, Eq)]
+struct E2eBinaries {
+    rocm: PathBuf,
+    rocmd: Option<PathBuf>,
+    build_release: bool,
+}
+
+fn resolve_caller_path(invocation_dir: &Path, path: OsString) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        invocation_dir.join(path)
+    }
+}
+
+fn e2e_binaries_from(
+    release_dir: &Path,
+    invocation_dir: &Path,
+    rocm_override: Option<OsString>,
+    rocmd_override: Option<OsString>,
+) -> E2eBinaries {
+    if let Some(rocm) = rocm_override {
+        E2eBinaries {
+            rocm: resolve_caller_path(invocation_dir, rocm),
+            rocmd: rocmd_override.map(|path| resolve_caller_path(invocation_dir, path)),
+            build_release: false,
+        }
+    } else {
+        E2eBinaries {
+            rocm: release_dir.join(binary_name("rocm")),
+            rocmd: Some(release_dir.join(binary_name("rocmd"))),
+            build_release: true,
+        }
+    }
+}
+
+fn configure_harness_env(command: &mut Command, binaries: &E2eBinaries) {
+    command.env("ROCM_CLI_BINARY", &binaries.rocm);
+    if let Some(rocmd) = &binaries.rocmd {
+        command.env("ROCM_CLI_ROCMD_BINARY", rocmd);
+    } else {
+        command.env_remove("ROCM_CLI_ROCMD_BINARY");
+    }
+}
 
 /// Build the release binaries and run the E2E suite, forwarding `args` to the
 /// cucumber CLI. If `ROCM_CLI_BINARY` is already set in the environment, the
-/// build step is skipped and that binary is used as-is; callers opting into
-/// lifecycle scenarios must then provide a sibling `rocmd` for packaging.
+/// build step is skipped and that binary is used as-is. A caller selecting a
+/// rocmd-backed scenario must also set `ROCM_CLI_ROCMD_BINARY` explicitly.
 ///
 /// The harness resolves each scenario to pass / xfail / skip per host (see the
 /// e2e-cucumber `expectation` module), so there is no tier flag: one invocation
@@ -28,40 +75,29 @@ use crate::paths::{target_dir, workspace_root};
 pub fn run(args: &[String]) -> Result<()> {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let root = workspace_root()?;
+    let invocation_dir = std::env::current_dir().context("failed to read the current directory")?;
+    let binaries = e2e_binaries_from(
+        &target_dir(&root).join("release"),
+        &invocation_dir,
+        std::env::var_os("ROCM_CLI_BINARY"),
+        std::env::var_os("ROCM_CLI_ROCMD_BINARY"),
+    );
 
-    let binary = if let Some(path) = std::env::var_os("ROCM_CLI_BINARY") {
-        // The cucumber steps spawn the binary from a working directory that may
-        // differ from where `cargo xtask` was invoked, so a relative path would
-        // fail to resolve. Make any caller-supplied path absolute.
-        let path = PathBuf::from(path);
-        if path.is_absolute() {
-            path
-        } else {
-            std::env::current_dir()
-                .context("failed to read the current directory")?
-                .join(path)
-        }
-    } else {
+    if binaries.build_release {
         let status = Command::new(&cargo)
             .args(["build", "--release", "-p", "rocm", "-p", "rocmd"])
             .current_dir(&root)
             .status()
-            .context("failed to run `cargo build --release -p rocm`")?;
+            .context("failed to run `cargo build --release -p rocm -p rocmd`")?;
         if !status.success() {
             bail!("building the rocm and rocmd binaries failed");
         }
-        // Honor CARGO_TARGET_DIR — the built binary is under the active target
-        // dir, which is not always `<root>/target` (e.g. a cross-platform
-        // container build points it elsewhere). Using a hardcoded `target/`
-        // here can pick up a stale binary built for a different OS/arch and
-        // fail with an exec-format error.
-        target_dir(&root).join("release/rocm")
-    };
+    }
 
     let mut cmd = Command::new(&cargo);
     cmd.args(["test", "-p", "e2e-cucumber", "--test", "e2e"])
-        .current_dir(&root)
-        .env("ROCM_CLI_BINARY", &binary);
+        .current_dir(&root);
+    configure_harness_env(&mut cmd, &binaries);
     // Hand the lifecycle E2E steps the path to this already-built `xtask`
     // executable (the running process). Those steps drive `xtask package` and
     // `xtask keygen` as subprocesses; they must run this prebuilt binary
@@ -82,4 +118,86 @@ pub fn run(args: &[String]) -> Result<()> {
         bail!("E2E suite failed");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::{OsStr, OsString};
+    use std::path::Path;
+
+    fn command_env(command: &Command, key: &str) -> Option<OsString> {
+        command
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new(key))
+            .and_then(|(_, value)| value.map(OsStr::to_os_string))
+    }
+
+    #[test]
+    fn release_build_resolves_and_exports_both_cli_binaries() {
+        let binaries = e2e_binaries_from(
+            Path::new("/ws/out/release"),
+            Path::new("/invoked"),
+            None,
+            None,
+        );
+        assert!(binaries.build_release);
+        assert_eq!(
+            binaries.rocm,
+            PathBuf::from("/ws/out/release").join(crate::paths::binary_name("rocm"))
+        );
+        assert_eq!(
+            binaries.rocmd,
+            Some(PathBuf::from("/ws/out/release").join(crate::paths::binary_name("rocmd")))
+        );
+
+        let mut command = Command::new("cargo");
+        configure_harness_env(&mut command, &binaries);
+        assert_eq!(
+            command_env(&command, "ROCM_CLI_BINARY"),
+            Some(binaries.rocm.into_os_string())
+        );
+        assert_eq!(
+            command_env(&command, "ROCM_CLI_ROCMD_BINARY"),
+            binaries.rocmd.map(PathBuf::into_os_string)
+        );
+    }
+
+    #[test]
+    fn prebuilt_cli_paths_resolve_from_the_invocation_directory_and_propagate() {
+        let binaries = e2e_binaries_from(
+            Path::new("/ws/out/release"),
+            Path::new("/invoked"),
+            Some(OsString::from("bin/rocm")),
+            Some(OsString::from("daemons/rocmd")),
+        );
+        assert!(!binaries.build_release);
+        assert_eq!(binaries.rocm, PathBuf::from("/invoked/bin/rocm"));
+        assert_eq!(
+            binaries.rocmd,
+            Some(PathBuf::from("/invoked/daemons/rocmd"))
+        );
+
+        let mut command = Command::new("cargo");
+        configure_harness_env(&mut command, &binaries);
+        assert_eq!(
+            command_env(&command, "ROCM_CLI_ROCMD_BINARY"),
+            Some(OsString::from("/invoked/daemons/rocmd"))
+        );
+    }
+
+    #[test]
+    fn prebuilt_rocm_without_explicit_rocmd_does_not_invent_or_export_one() {
+        let binaries = e2e_binaries_from(
+            Path::new("/ws/out/release"),
+            Path::new("/invoked"),
+            Some(OsString::from("/prebuilt/rocm")),
+            None,
+        );
+        assert_eq!(binaries.rocmd, None);
+
+        let mut command = Command::new("cargo");
+        configure_harness_env(&mut command, &binaries);
+        assert_eq!(command_env(&command, "ROCM_CLI_ROCMD_BINARY"), None);
+    }
 }

--- a/xtask/src/e2e.rs
+++ b/xtask/src/e2e.rs
@@ -182,7 +182,7 @@ mod tests {
         configure_harness_env(&mut command, &binaries);
         assert_eq!(
             command_env(&command, "ROCM_CLI_ROCMD_BINARY"),
-            Some(OsString::from("/invoked/daemons/rocmd"))
+            binaries.rocmd.map(PathBuf::into_os_string)
         );
     }
 

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -127,6 +127,87 @@ mod tests {
             .expect("workflow declares a top-level name:")
     }
 
+    fn multiline_run_blocks(text: &str) -> Vec<String> {
+        let lines: Vec<&str> = text.lines().collect();
+        let mut blocks = Vec::new();
+        for (i, line) in lines.iter().enumerate() {
+            if line.trim_start() != "run: |" {
+                continue;
+            }
+            let run_indent = indent_of(line);
+            let mut block = String::new();
+            for body_line in &lines[i + 1..] {
+                if !body_line.trim().is_empty() && indent_of(body_line) <= run_indent {
+                    break;
+                }
+                block.push_str(body_line.trim());
+                block.push('\n');
+            }
+            blocks.push(block);
+        }
+        blocks
+    }
+
+    fn invokes_e2e(block: &str) -> bool {
+        block.lines().any(|line| {
+            let line = line.trim();
+            line == "cargo xtask e2e" || line.starts_with("cargo xtask e2e --")
+        })
+    }
+
+    fn assert_prebuilt_e2e_lanes_export_rocmd(workflow: &str, text: &str) {
+        let blocks: Vec<_> = multiline_run_blocks(text)
+            .into_iter()
+            .filter(|block| block.contains("ROCM_CLI_BINARY") && invokes_e2e(block))
+            .collect();
+        assert!(
+            !blocks.is_empty(),
+            "{workflow} must contain prebuilt E2E run blocks"
+        );
+
+        let mut unix_lanes = 0;
+        let mut powershell_lanes = 0;
+        for block in blocks {
+            assert!(
+                block.contains("cargo build --release -p rocm -p rocmd"),
+                "{workflow} prebuilt E2E lane must build rocm and rocmd together:\n{block}"
+            );
+            assert!(
+                block.contains("ROCM_CLI_ROCMD_BINARY"),
+                "{workflow} prebuilt E2E lane exports ROCM_CLI_BINARY but not \
+                 ROCM_CLI_ROCMD_BINARY:\n{block}"
+            );
+
+            if block.contains("export ROCM_CLI_BINARY=") {
+                unix_lanes += 1;
+                assert!(
+                    block.contains(
+                        "export ROCM_CLI_ROCMD_BINARY=\"$CARGO_TARGET_DIR/release/rocmd\""
+                    ),
+                    "{workflow} Unix E2E lane must export the release rocmd path:\n{block}"
+                );
+            } else if block.contains("$env:ROCM_CLI_BINARY") {
+                powershell_lanes += 1;
+                assert!(
+                    block.contains(
+                        "$env:ROCM_CLI_ROCMD_BINARY = \"$targetDir\\release\\rocmd.exe\""
+                    ),
+                    "{workflow} PowerShell E2E lane must export the release rocmd.exe path:\n{block}"
+                );
+            } else {
+                panic!("{workflow} prebuilt E2E lane uses an unknown shell contract:\n{block}");
+            }
+        }
+        assert!(
+            unix_lanes > 0,
+            "{workflow} must cover at least one Unix E2E lane"
+        );
+        assert!(
+            powershell_lanes > 0,
+            "{workflow} must cover at least one PowerShell E2E lane"
+        );
+    }
+
     #[test]
     fn ci_yml_schedules_no_self_hosted_job() {
         let ci = read_workflow("ci.yml");
@@ -202,6 +283,18 @@ mod tests {
             "the two workflows must have different `name:` values so their \
              github.workflow-keyed concurrency groups are distinct (EAI-7548)"
         );
+    }
+
+    #[test]
+    fn self_hosted_prebuilt_e2e_lanes_export_rocmd() {
+        let workflow = read_workflow("e2e-selfhosted.yml");
+        assert_prebuilt_e2e_lanes_export_rocmd("e2e-selfhosted.yml", &workflow);
+    }
+
+    #[test]
+    fn nightly_prebuilt_e2e_lanes_export_rocmd() {
+        let workflow = read_workflow("nightly.yml");
+        assert_prebuilt_e2e_lanes_export_rocmd("nightly.yml", &workflow);
     }
 
     // Extractor guards: prove the helpers actually parse multiline forms, so the


### PR DESCRIPTION
## Summary

`write_file_atomically` leaves its scratch file behind when a write or rename
fails. The name embeds a millisecond timestamp, so each retry leaks a *distinct*
orphan instead of reusing one — on a full disk, retrying makes things worse.

- Remove the temp file on every failure path, in both copies of the helper
  (`apps/rocm/src/therock.rs`, `apps/rocmd/src/lib.rs`).
- Build the temp name from the whole file name, so a multi-extension artifact
  keeps its extensions: `sdk.tar.gz` yields `sdk.tar.gz.tmp-<id>` where
  `with_extension` dropped the `.gz`.

## Root cause

Reproduced by filling a small filesystem and calling the helper twice:

```
attempt 0: ... No space left on device (os error 28)
  leftovers: [("artifact.tar.tmp-1785755921807", 67108864)]
attempt 1: ... No space left on device (os error 28)
  leftovers: [("artifact.tar.tmp-1785755921807", 67108864),
              ("artifact.tar.tmp-1785755921875", 0)]
```

Two attempts, two orphans, the first holding all the space that was left.

## Scope

This PR originally also rewrote the download path. #198 has since landed
`download_file_streaming`, which covers that ground more thoroughly (sibling
`.part` file, resume, length and digest cross-checks), so those changes are
dropped in favour of it. What remains is the one defect #198 did not touch.

Note this does **not** close #158. Both in-call cleanup gaps are now fixed, but
a `.part` file orphaned by a hard crash or Ctrl-C still survives: the name is
keyed on the process id, so a later run never removes it, and nothing sweeps
for them. Leaving #158 open for that.

## Test plan

- `write_file_atomically_cleans_up_temp_when_the_rename_fails` (both crates) —
  portable, runs in CI. Fails before, passes after.
- `write_file_atomically_temp_name_preserves_multi_dot_file_names`,
  `temp_sibling_path_preserves_multi_dot_file_names`.
- `write_file_atomically_cleans_up_temp_on_write_failure` (both crates) —
  the original `/dev/shm` ENOSPC reproduction, `#[ignore]`d because it fills a
  shared tmpfs. Run with `cargo test -- --ignored`.

Risk: low. Two self-contained helpers; behaviour on the success path is
unchanged apart from the temp file's name.

Refs #158
