### PR TITLE
test(proc-lifecycle): stop counting a zombie as a running process

### DIFF
--- a/crates/rocm-core/src/proc_lifecycle.rs
+++ b/crates/rocm-core/src/proc_lifecycle.rs
@@ -526,6 +526,41 @@ mod tests {
         reap(child);
     }
 
+    /// A terminated child that has not been reaped yet is a zombie: it still has
+    /// a PID, so `kill(pid, 0)` succeeds and `process_is_running` reports `true`.
+    /// Termination checks must therefore go through `identity_state`, which
+    /// treats `Z` as gone. Asserting on `process_is_running` instead makes a test
+    /// depend on how quickly the host reaps, which varies between environments.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn zombie_is_gone_to_identity_state_but_still_running_to_a_bare_pid_check() {
+        let (mut child, _) = spawn_ready("echo ready");
+        let id = ProcessIdentity::capture(child.id());
+
+        // Wait for exit without reaping, so the process is parked as a zombie.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && !process_has_exited(id.pid) {
+            std::thread::sleep(POLL_INTERVAL);
+        }
+
+        assert!(
+            process_has_exited(id.pid),
+            "child should be an unreaped zombie by now"
+        );
+        assert!(
+            crate::process_is_running(id.pid),
+            "a bare PID check cannot tell a zombie from a live process"
+        );
+        assert_eq!(
+            identity_state(&id),
+            IdentityState::Gone,
+            "a zombie has exited and must not count as running"
+        );
+        assert!(is_exited(identity_state(&id)));
+
+        let _ = child.wait();
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn tree_stop_waits_for_descendants() {
@@ -533,9 +568,10 @@ mod tests {
         // test) must be terminated too — a graceful Tree stop that only confirmed
         // the root would leave it alive.
         let (child, gpid_line) = spawn_ready("sleep 300 & echo $!; wait");
-        let grandchild: u32 = gpid_line.parse().expect("grandchild pid");
-        assert!(
-            crate::process_is_running(grandchild),
+        let grandchild = ProcessIdentity::capture(gpid_line.parse().expect("grandchild pid"));
+        assert_eq!(
+            identity_state(&grandchild),
+            IdentityState::Matches,
             "grandchild should be running before stop"
         );
         let id = ProcessIdentity::capture(child.id());
@@ -544,7 +580,7 @@ mod tests {
         assert_eq!(outcome, TerminationOutcome::Graceful);
         assert_eq!(identity_state(&id), IdentityState::Gone);
         assert!(
-            !crate::process_is_running(grandchild),
+            is_exited(identity_state(&grandchild)),
             "Tree stop must terminate the descendant, not just the root"
         );
         reap(child);
@@ -558,14 +594,14 @@ mod tests {
         // stop must SIGKILL that reparented descendant after the root exits.
         let (child, gpid_line) =
             spawn_ready(r#"sh -c "trap '' TERM; echo \$\$; exec sleep 300" & wait"#);
-        let grandchild: u32 = gpid_line.parse().expect("grandchild pid");
-        assert!(crate::process_is_running(grandchild));
+        let grandchild = ProcessIdentity::capture(gpid_line.parse().expect("grandchild pid"));
+        assert_eq!(identity_state(&grandchild), IdentityState::Matches);
         let id = ProcessIdentity::capture(child.id());
 
         let outcome = terminate_verified(&id, KillScope::Tree, Duration::from_millis(300), true);
         assert_eq!(outcome, TerminationOutcome::Forced);
         assert!(
-            !crate::process_is_running(grandchild),
+            is_exited(identity_state(&grandchild)),
             "forced Tree stop must SIGKILL the SIGTERM-ignoring descendant"
         );
         reap(child);


### PR DESCRIPTION
## Summary

Two tree-termination tests checked whether a descendant was still alive with `crate::process_is_running`, which is `kill(pid, 0)`. That succeeds for a terminated-but-unreaped process, so a descendant that had been killed correctly still read as running until the host reaped it. The tests therefore depended on reaping latency: they pass on the CI runners and fail every time under WSL2.

## Root cause

The product code was right all along. `identity_state` deliberately treats a zombie as gone via `process_has_exited` (matching state `Z`), and `terminate_verified` uses that logic throughout. The tests bypassed it and used the weaker check.

Instrumenting the failing scenario showed termination working exactly as intended:

```
PROBE root=67962 grandchild=67963 tree=[67962, 67963]
PROBE after_term grandchild_running=true
PROBE grandchild_proc_state=Z
PROBE grandchild_identity_state=Gone
```

The tree was enumerated correctly, both processes were signalled, the descendant was a zombie, and `identity_state` reported `Gone`. Only the bare PID check disagreed.

## Changes

- Both tests now capture a `ProcessIdentity` for the descendant before the stop and assert `is_exited(identity_state(&grandchild))` afterwards — the same semantics the production path uses.
- New `zombie_is_gone_to_identity_state_but_still_running_to_a_bare_pid_check` pins the distinction: for an unreaped child, `process_is_running` is `true` while `identity_state` is `Gone`. It documents the trap and stops the weaker check creeping back.

## Why this matters beyond the two tests

The `pre-push` hook runs the test suite, so on an affected host every push needs `--force`-style escapes — concretely `--no-verify`, which also skips the commit-signing and sign-off checks that same hook enforces. With this change `cargo test --workspace` is fully green locally and the hook works unaided.

## Verification

`cargo test --workspace` passes with zero failures (previously two). `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

Fixes #168
