### PR TITLE
fix(uv): colocate the uv cache with the ROCm CLI data dir

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -672,6 +672,15 @@ official uv GitHub releases at `https://github.com/astral-sh/uv/releases/`.
 The binary is cached in the rocm-cli managed data directory and reused for
 subsequent operations. The version may be pinned via `ROCM_CLI_UV_VERSION`.
 
+`uv`'s own content-addressed package cache is also kept in the managed data
+directory (at `<data-dir>/uv-cache`), so that it shares a filesystem with the
+environments `uv` populates and packages can be hardlinked into them instead of
+copied. This cache holds every wheel `uv` downloads — the ROCm SDK and the
+torch stack included — so it is typically the largest directory rocm-cli
+manages, on the order of several GB per SDK version installed. It is removed by
+`rocm uninstall` unless `--keep-data` is passed, and its location can be
+overridden with `ROCM_CLI_UV_CACHE_DIR`.
+
 ### Lemonade Embeddable Runtime
 
 When `rocm engines install lemonade` is run, the CLI downloads a prebuilt

--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -348,6 +348,7 @@ pub(crate) fn install(
         let uv = ensure_uv_binary(paths)
             .context("failed to acquire uv binary for ComfyUI dependency install")?;
         run_uv_logged_command(
+            paths,
             &uv,
             uv_install_args(&runtime.python, &packages),
             Some(&runtime_env),
@@ -1400,6 +1401,7 @@ fn uv_install_args(venv_python: &Path, packages: &[String]) -> Vec<String> {
 }
 
 fn run_uv_logged_command(
+    paths: &AppPaths,
     uv: &Path,
     args: Vec<String>,
     runtime_env: Option<&ComfyUiRuntimeEnvironment>,
@@ -1421,7 +1423,7 @@ fn run_uv_logged_command(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    for (key, value) in uv_command_env() {
+    for (key, value) in uv_command_env(paths) {
         command.env(key, value);
     }
     if let Some(runtime_env) = runtime_env {

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -42,7 +42,7 @@ use rocm_core::{
     read_tcp_stream_to_string, resolve_builtin_model_recipe, resolve_model_recipe,
     runtime_install_root_is_protected, runtime_path_is_same_or_inside,
     runtime_python_activation_hint, runtime_python_env_bin_dir, runtime_python_executable_in_env,
-    shell_command_for_host, write_all_tcp_stream,
+    shell_command_for_host, uv_cache_source, write_all_tcp_stream,
 };
 use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
@@ -435,10 +435,12 @@ rocm logs --search error timeout")]
         /// Keep saved settings.
         #[arg(long)]
         keep_config: bool,
-        /// Keep app data such as logs, services, and engines.
+        /// Keep app data such as logs, services, engines, and the uv package cache
+        /// (often the largest directory rocm-cli manages).
         #[arg(long)]
         keep_data: bool,
-        /// Keep caches.
+        /// Keep caches under the cache directory. Does not cover the uv package cache,
+        /// which lives under the data directory; use --keep-data for that.
         #[arg(long)]
         keep_cache: bool,
         /// Allow removing development binaries inside the current build tree.
@@ -938,6 +940,7 @@ fn main() -> Result<()> {
         .and_then(|paths| logging::init(&paths));
 
     maybe_migrate_legacy_dashboard_config();
+    maybe_notice_legacy_uv_cache();
 
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
     if raw_args.is_empty() {
@@ -966,6 +969,54 @@ fn main() -> Result<()> {
     }
 
     dispatch(Cli::parse())
+}
+
+/// Legacy `uv` cache location, used before the cache was colocated with the managed
+/// data directory. Kept relative so the check works on every platform's home dir.
+const LEGACY_UV_CACHE_RELATIVE: [&str; 2] = [".cache", "uv"];
+
+/// One-shot notice that a pre-colocation `uv` cache is still occupying space at the
+/// default `uv` location. Nothing is migrated or deleted: the cache is
+/// content-addressed and may be shared with unrelated `uv` projects on the machine, so
+/// removing it is the user's call. Silent when the managed cache does not exist yet
+/// (nothing has moved) or when an override is in effect.
+fn maybe_notice_legacy_uv_cache() {
+    let Ok(paths) = AppPaths::discover() else {
+        return;
+    };
+    let cache = uv_cache_source(&paths);
+    if cache.is_override() {
+        return;
+    }
+    // Only worth mentioning once the managed cache is actually in use; otherwise the
+    // legacy directory is simply the cache still being used by other tools.
+    if !cache.path().is_dir() {
+        return;
+    }
+    let Some(home) = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+    else {
+        return;
+    };
+    let legacy = LEGACY_UV_CACHE_RELATIVE
+        .iter()
+        .fold(home, |dir, part| dir.join(part));
+    if !legacy.is_dir() {
+        return;
+    }
+    // One-shot: a standing reminder on every invocation would be noise, and the user may
+    // reasonably decide to keep the legacy cache for other uv projects.
+    let marker = paths.data_dir.join(".legacy-uv-cache-notice");
+    if marker.exists() {
+        return;
+    }
+    eprintln!(
+        "rocm: the uv cache now lives at {}; the previous cache at {} is no longer used by rocm-cli and can be removed if no other uv project needs it",
+        cache.path().display(),
+        legacy.display()
+    );
+    let _ = fs::write(&marker, b"");
 }
 
 /// One-shot, best-effort migration of a legacy rocm-dash `config.toml` into the

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -14,7 +14,9 @@ use rocm_core::{
     uv_venv_args, verify_rsa_pkcs1_sha256_signature,
 };
 #[cfg(test)]
-use rocm_core::{generate_rsa_signing_keypair, sign_rsa_pkcs1_sha256_signature};
+use rocm_core::{
+    generate_rsa_signing_keypair, managed_uv_cache_dir, sign_rsa_pkcs1_sha256_signature,
+};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Write as _;
@@ -3606,12 +3608,32 @@ mod tests {
     }
 
     #[test]
-    fn managed_uv_cache_defaults_inside_generated_runtime_folder() {
+    fn managed_uv_cache_sits_under_the_data_dir_for_generated_runtime_folders() {
         let (_root, paths) = test_paths("managed-uv-cache");
         let runtime_key = "release-wheel-gfx120x-all-7-14-0";
         let install_root = managed_runtime_root(&paths, "wheel", runtime_key);
-        // uv caches live beside the venv; verify the wheel root path structure
         assert!(install_root.starts_with(&paths.data_dir));
+        // Without --prefix the generated runtime folder is itself under the data dir, so
+        // the uv cache shares a filesystem with the environment it populates.
+        assert!(managed_uv_cache_dir(&paths.data_dir).starts_with(&paths.data_dir));
+    }
+
+    #[test]
+    fn uv_cache_does_not_follow_a_prefix_install_root() {
+        // Documents a known gap rather than an intended behavior: `--prefix` relocates
+        // install_root only, while the uv cache stays keyed off the data dir. When the two
+        // land on different filesystems uv falls back to copying. Tracked separately; see
+        // the `--prefix` non-goal on the PR that introduced the colocation.
+        let (_root, paths) = test_paths("prefix-uv-cache");
+        let prefix_root = PathBuf::from("/mnt/elsewhere/envs/my-env");
+        let cache = managed_uv_cache_dir(&paths.data_dir);
+
+        assert!(
+            !cache.starts_with(&prefix_root),
+            "cache {} unexpectedly followed the --prefix root",
+            cache.display()
+        );
+        assert!(cache.starts_with(&paths.data_dir));
     }
 
     #[test]

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -913,7 +913,7 @@ fn install_wheel_runtime(
         "Creating Python environment at {}.",
         install_root.display()
     ));
-    ensure_uv_venv(&uv, &python_launcher.executable, &install_root)?;
+    ensure_uv_venv(paths, &uv, &python_launcher.executable, &install_root)?;
     let env_python = venv_python_path(&install_root);
 
     progress_line(format!(
@@ -928,6 +928,7 @@ fn install_wheel_runtime(
     }
     install_args.extend(therock_pip_package_specs(&resolution.package_versions));
     run_uv_progress_command(
+        paths,
         &uv,
         install_args
             .iter()
@@ -2326,7 +2327,12 @@ fn extract_tarball_and_discard_archive(archive_path: &Path, target_dir: &Path) -
     Ok(())
 }
 
-fn ensure_uv_venv(uv: &Path, python_launcher: &Path, install_root: &Path) -> Result<()> {
+fn ensure_uv_venv(
+    paths: &AppPaths,
+    uv: &Path,
+    python_launcher: &Path,
+    install_root: &Path,
+) -> Result<()> {
     let env_python = venv_python_path(install_root);
     if env_python.is_file() {
         if run_command(
@@ -2353,7 +2359,7 @@ fn ensure_uv_venv(uv: &Path, python_launcher: &Path, install_root: &Path) -> Res
             .map(String::as_str)
             .collect::<Vec<_>>()
             .as_slice(),
-        &uv_command_env(),
+        &uv_command_env(paths),
         "create managed TheRock runtime virtual environment",
     )?;
     if !env_python.is_file() {
@@ -2738,10 +2744,15 @@ fn run_command_with_env(
     bail!("{context_text}: {detail}")
 }
 
-fn run_uv_progress_command(uv: &Path, args: &[&str], context_text: &str) -> Result<()> {
+fn run_uv_progress_command(
+    paths: &AppPaths,
+    uv: &Path,
+    args: &[&str],
+    context_text: &str,
+) -> Result<()> {
     let mut command = Command::new(uv);
     command.args(args);
-    for (key, value) in &uv_command_env() {
+    for (key, value) in &uv_command_env(paths) {
         command.env(key, value);
     }
     let status = command
@@ -2845,7 +2856,7 @@ fn ensure_managed_python(paths: &AppPaths) -> Result<PythonLauncher> {
     progress_line(format!("Installing Python {version} via uv..."));
     let status = Command::new(&uv)
         .args(["python", "install", &version])
-        .envs(uv_command_env())
+        .envs(uv_command_env(paths))
         .stdin(Stdio::null())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -2858,7 +2869,7 @@ fn ensure_managed_python(paths: &AppPaths) -> Result<PythonLauncher> {
     progress_line(format!("Finding Python {version}..."));
     let output = Command::new(&uv)
         .args(["python", "find", &version])
-        .envs(uv_command_env())
+        .envs(uv_command_env(paths))
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -70,8 +70,9 @@ pub use runtime::{
     runtime_rocm_library_filename, shell_command_for_host,
 };
 pub use uv::{
-    DEFAULT_UV_TIMEOUT_SECS, UV_CACHE_DIR_ENV, ensure_uv_binary, uv_binary_name, uv_command_env,
-    uv_http_timeout_secs, uv_pip_freeze_args, uv_pip_install_base, uv_venv_args,
+    DEFAULT_UV_TIMEOUT_SECS, UV_CACHE_DIR_ENV, UV_CACHE_DIR_OVERRIDE_ENV, UvCacheSource,
+    ensure_uv_binary, uv_binary_name, uv_cache_source, uv_command_env, uv_http_timeout_secs,
+    uv_pip_freeze_args, uv_pip_install_base, uv_venv_args,
 };
 
 pub const DEFAULT_LOCAL_PORT: u16 = 11_435;

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -55,7 +55,7 @@ use runtime::home_rocm_dir;
 pub use runtime::{
     RuntimeHost, RuntimePlatform, current_executable_path, default_cache_dir, default_config_dir,
     default_data_dir, default_interactive_shell_program, managed_logs_dir, managed_pip_cache_dir,
-    managed_runtime_cache_dir, managed_runtime_data_root, managed_tools_dir,
+    managed_runtime_cache_dir, managed_runtime_data_root, managed_tools_dir, managed_uv_cache_dir,
     normalize_runtime_path_for_host, normalize_runtime_path_for_storage,
     normalize_runtime_path_text_for_host, normalize_runtime_path_text_for_platform,
     normalize_runtime_path_text_for_storage, platform_binary_name, prepend_runtime_path,
@@ -70,7 +70,7 @@ pub use runtime::{
     runtime_rocm_library_filename, shell_command_for_host,
 };
 pub use uv::{
-    DEFAULT_UV_TIMEOUT_SECS, ensure_uv_binary, uv_binary_name, uv_command_env,
+    DEFAULT_UV_TIMEOUT_SECS, UV_CACHE_DIR_ENV, ensure_uv_binary, uv_binary_name, uv_command_env,
     uv_http_timeout_secs, uv_pip_freeze_args, uv_pip_install_base, uv_venv_args,
 };
 

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -226,6 +226,12 @@ pub fn managed_pip_cache_dir(root: &Path) -> PathBuf {
     normalize_runtime_path_for_host(root).join("pip-cache")
 }
 
+/// `uv`'s content-addressed cache, kept under the managed root so it shares a filesystem
+/// with the environments `uv` populates and hardlinking keeps working (see issue #160).
+pub fn managed_uv_cache_dir(root: &Path) -> PathBuf {
+    normalize_runtime_path_for_host(root).join("uv-cache")
+}
+
 pub fn managed_logs_dir(root: &Path) -> PathBuf {
     normalize_runtime_path_for_host(root).join("logs")
 }

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -13,11 +13,14 @@
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use crate::runtime::{managed_tools_dir, runtime_is_windows, runtime_os_name};
+use crate::runtime::{
+    managed_tools_dir, managed_uv_cache_dir, runtime_is_windows, runtime_os_name,
+};
 use crate::{AppPaths, download_file_to_path, unix_time_millis};
 
 /// Default network timeout, in seconds, applied to `uv` HTTP operations.
@@ -58,13 +61,42 @@ pub fn uv_http_timeout_secs() -> u64 {
         .unwrap_or(DEFAULT_UV_TIMEOUT_SECS)
 }
 
-/// Environment pairs to apply when spawning `uv` so network behavior is configured
-/// consistently (uv reads `UV_HTTP_TIMEOUT` rather than accepting a `--timeout` flag).
-pub fn uv_command_env() -> Vec<(String, String)> {
-    vec![(
+/// Environment variable `uv` reads to locate its content-addressed cache.
+pub const UV_CACHE_DIR_ENV: &str = "UV_CACHE_DIR";
+
+/// Environment pairs to apply when spawning `uv`.
+///
+/// Network behavior is configured consistently (uv reads `UV_HTTP_TIMEOUT` rather than
+/// accepting a `--timeout` flag) and the cache lives beside the managed environments it
+/// populates.
+///
+/// Without a cache inside the managed root, `uv` caches under `$HOME/.cache/uv`; when
+/// that is on a different filesystem from the data directory, `uv` cannot hardlink and
+/// silently copies every file, so each environment carries a full duplicate of the SDK
+/// and torch stack. An `UV_CACHE_DIR` already present in the environment is a deliberate
+/// choice (the e2e harness shares one cache across scenarios) and is left alone.
+pub fn uv_command_env(paths: &AppPaths) -> Vec<(String, String)> {
+    let inherited = std::env::var_os(UV_CACHE_DIR_ENV).filter(|value| !value.is_empty());
+    uv_command_env_with_inherited_cache(paths, inherited.as_deref())
+}
+
+fn uv_command_env_with_inherited_cache(
+    paths: &AppPaths,
+    inherited_cache_dir: Option<&OsStr>,
+) -> Vec<(String, String)> {
+    let mut env = vec![(
         "UV_HTTP_TIMEOUT".to_owned(),
         uv_http_timeout_secs().to_string(),
-    )]
+    )];
+    if inherited_cache_dir.is_none() {
+        env.push((
+            UV_CACHE_DIR_ENV.to_owned(),
+            managed_uv_cache_dir(&paths.data_dir)
+                .to_string_lossy()
+                .into_owned(),
+        ));
+    }
+    env
 }
 
 /// Arguments for `uv venv`, creating an environment at `env_root` using `python`.
@@ -364,6 +396,54 @@ mod tests {
         assert_eq!(
             args,
             vec!["pip", "install", "--python", "/envs/run/bin/python"]
+        );
+    }
+
+    fn test_paths(root: &str) -> AppPaths {
+        AppPaths {
+            config_dir: PathBuf::from(root).join("config"),
+            data_dir: PathBuf::from(root),
+            cache_dir: PathBuf::from(root).join("cache"),
+        }
+    }
+
+    fn cache_dir_in(env: &[(String, String)]) -> Option<String> {
+        env.iter()
+            .find(|(key, _)| key == UV_CACHE_DIR_ENV)
+            .map(|(_, value)| value.clone())
+    }
+
+    #[test]
+    fn command_env_cache_dir_is_derived_from_data_dir() {
+        let paths = test_paths("/managed/root");
+        let env = uv_command_env_with_inherited_cache(&paths, None);
+        assert_eq!(
+            cache_dir_in(&env),
+            Some(
+                managed_uv_cache_dir(&paths.data_dir)
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+        assert!(env.iter().any(|(key, _)| key == "UV_HTTP_TIMEOUT"));
+    }
+
+    #[test]
+    fn command_env_keeps_an_explicit_cache_dir() {
+        // The e2e harness sets UV_CACHE_DIR to share one cache across scenarios; a user can
+        // do the same. Such a choice must be inherited, not overridden.
+        let paths = test_paths("/managed/root");
+        let env = uv_command_env_with_inherited_cache(&paths, Some(OsStr::new("/shared/uv-cache")));
+        assert_eq!(cache_dir_in(&env), None);
+    }
+
+    #[test]
+    fn command_env_cache_dir_follows_a_relocated_data_dir() {
+        let default_root = test_paths("/home/user/.rocm");
+        let moved_root = test_paths("/mnt/big/rocm");
+        assert_ne!(
+            cache_dir_in(&uv_command_env_with_inherited_cache(&default_root, None)),
+            cache_dir_in(&uv_command_env_with_inherited_cache(&moved_root, None))
         );
     }
 

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -64,6 +64,82 @@ pub fn uv_http_timeout_secs() -> u64 {
 /// Environment variable `uv` reads to locate its content-addressed cache.
 pub const UV_CACHE_DIR_ENV: &str = "UV_CACHE_DIR";
 
+/// Environment variable used to place the `uv` cache explicitly.
+///
+/// Namespaced like the other rocm-cli knobs in this module so that a `UV_CACHE_DIR` a
+/// developer exported for unrelated Python work is distinguishable from a deliberate
+/// choice about rocm-cli.
+pub const UV_CACHE_DIR_OVERRIDE_ENV: &str = "ROCM_CLI_UV_CACHE_DIR";
+
+/// Where the `uv` cache for a spawned command comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UvCacheSource {
+    /// Derived from the managed data directory.
+    Managed(PathBuf),
+    /// Set explicitly via [`UV_CACHE_DIR_OVERRIDE_ENV`].
+    Override(PathBuf),
+    /// Inherited from an ambient [`UV_CACHE_DIR_ENV`] in the environment.
+    Inherited(PathBuf),
+}
+
+impl UvCacheSource {
+    /// The cache directory this source resolves to.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Managed(path) | Self::Override(path) | Self::Inherited(path) => path,
+        }
+    }
+
+    /// Whether the managed colocation was bypassed, so callers can report it.
+    pub const fn is_override(&self) -> bool {
+        !matches!(self, Self::Managed(_))
+    }
+}
+
+/// Resolve the `uv` cache directory from the managed paths and the two override
+/// variables.
+///
+/// Precedence: [`UV_CACHE_DIR_OVERRIDE_ENV`] (a deliberate rocm-cli choice), then an
+/// ambient [`UV_CACHE_DIR_ENV`] (kept so the e2e harness can share one cache across
+/// scenarios), then the managed location beside the environments `uv` populates.
+///
+/// Blank and whitespace-only values are ignored in both cases, matching `uv_version` and
+/// `env_secs` in this module — `UV_CACHE_DIR="   "` is a leftover, not a choice.
+pub fn uv_cache_source(paths: &AppPaths) -> UvCacheSource {
+    resolve_uv_cache_source(
+        paths,
+        std::env::var_os(UV_CACHE_DIR_OVERRIDE_ENV).as_deref(),
+        std::env::var_os(UV_CACHE_DIR_ENV).as_deref(),
+    )
+}
+
+fn resolve_uv_cache_source(
+    paths: &AppPaths,
+    override_dir: Option<&OsStr>,
+    inherited_dir: Option<&OsStr>,
+) -> UvCacheSource {
+    if let Some(value) = meaningful_cache_dir(override_dir) {
+        return UvCacheSource::Override(value);
+    }
+    if let Some(value) = meaningful_cache_dir(inherited_dir) {
+        return UvCacheSource::Inherited(value);
+    }
+    UvCacheSource::Managed(managed_uv_cache_dir(&paths.data_dir))
+}
+
+/// A cache path is meaningful only when it is present and not blank. `OsStr` has no
+/// `trim`, so trimming is done on the lossy view and the original value is kept when it
+/// survives — a path is never silently rewritten.
+fn meaningful_cache_dir(value: Option<&OsStr>) -> Option<PathBuf> {
+    let value = value?;
+    let trimmed = value.to_string_lossy();
+    let trimmed = trimmed.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
+}
+
 /// Environment pairs to apply when spawning `uv`.
 ///
 /// Network behavior is configured consistently (uv reads `UV_HTTP_TIMEOUT` rather than
@@ -73,30 +149,25 @@ pub const UV_CACHE_DIR_ENV: &str = "UV_CACHE_DIR";
 /// Without a cache inside the managed root, `uv` caches under `$HOME/.cache/uv`; when
 /// that is on a different filesystem from the data directory, `uv` cannot hardlink and
 /// silently copies every file, so each environment carries a full duplicate of the SDK
-/// and torch stack. An `UV_CACHE_DIR` already present in the environment is a deliberate
-/// choice (the e2e harness shares one cache across scenarios) and is left alone.
+/// and torch stack.
+///
+/// Note this colocates with the *data directory*, not with a `--prefix` install root; see
+/// the `--prefix` caveat in `docs/manual-testing.md`.
 pub fn uv_command_env(paths: &AppPaths) -> Vec<(String, String)> {
-    let inherited = std::env::var_os(UV_CACHE_DIR_ENV).filter(|value| !value.is_empty());
-    uv_command_env_with_inherited_cache(paths, inherited.as_deref())
+    uv_command_env_for_cache(uv_cache_source(paths))
 }
 
-fn uv_command_env_with_inherited_cache(
-    paths: &AppPaths,
-    inherited_cache_dir: Option<&OsStr>,
-) -> Vec<(String, String)> {
-    let mut env = vec![(
-        "UV_HTTP_TIMEOUT".to_owned(),
-        uv_http_timeout_secs().to_string(),
-    )];
-    if inherited_cache_dir.is_none() {
-        env.push((
+fn uv_command_env_for_cache(cache: UvCacheSource) -> Vec<(String, String)> {
+    vec![
+        (
+            "UV_HTTP_TIMEOUT".to_owned(),
+            uv_http_timeout_secs().to_string(),
+        ),
+        (
             UV_CACHE_DIR_ENV.to_owned(),
-            managed_uv_cache_dir(&paths.data_dir)
-                .to_string_lossy()
-                .into_owned(),
-        ));
-    }
-    env
+            cache.path().to_string_lossy().into_owned(),
+        ),
+    ]
 }
 
 /// Arguments for `uv venv`, creating an environment at `env_root` using `python`.
@@ -416,7 +487,7 @@ mod tests {
     #[test]
     fn command_env_cache_dir_is_derived_from_data_dir() {
         let paths = test_paths("/managed/root");
-        let env = uv_command_env_with_inherited_cache(&paths, None);
+        let env = uv_command_env_for_cache(resolve_uv_cache_source(&paths, None, None));
         assert_eq!(
             cache_dir_in(&env),
             Some(
@@ -429,21 +500,82 @@ mod tests {
     }
 
     #[test]
-    fn command_env_keeps_an_explicit_cache_dir() {
+    fn command_env_keeps_an_inherited_cache_dir() {
         // The e2e harness sets UV_CACHE_DIR to share one cache across scenarios; a user can
         // do the same. Such a choice must be inherited, not overridden.
         let paths = test_paths("/managed/root");
-        let env = uv_command_env_with_inherited_cache(&paths, Some(OsStr::new("/shared/uv-cache")));
-        assert_eq!(cache_dir_in(&env), None);
+        let source = resolve_uv_cache_source(&paths, None, Some(OsStr::new("/shared/uv-cache")));
+        assert_eq!(
+            source,
+            UvCacheSource::Inherited(PathBuf::from("/shared/uv-cache"))
+        );
+        assert_eq!(
+            cache_dir_in(&uv_command_env_for_cache(source)),
+            Some("/shared/uv-cache".to_owned())
+        );
     }
 
     #[test]
-    fn command_env_cache_dir_follows_a_relocated_data_dir() {
-        let default_root = test_paths("/home/user/.rocm");
-        let moved_root = test_paths("/mnt/big/rocm");
-        assert_ne!(
-            cache_dir_in(&uv_command_env_with_inherited_cache(&default_root, None)),
-            cache_dir_in(&uv_command_env_with_inherited_cache(&moved_root, None))
+    fn namespaced_override_wins_over_an_ambient_uv_cache_dir() {
+        // ROCM_CLI_UV_CACHE_DIR is the rocm-cli knob; a bare UV_CACHE_DIR may just be
+        // exported for unrelated Python work, so the namespaced one takes precedence.
+        let paths = test_paths("/managed/root");
+        let source = resolve_uv_cache_source(
+            &paths,
+            Some(OsStr::new("/chosen/uv-cache")),
+            Some(OsStr::new("/ambient/uv-cache")),
+        );
+        assert_eq!(
+            source,
+            UvCacheSource::Override(PathBuf::from("/chosen/uv-cache"))
+        );
+        assert!(source.is_override());
+    }
+
+    #[test]
+    fn blank_cache_overrides_fall_back_to_the_managed_location() {
+        // The boundary the env read actually has to survive: unset, empty, and
+        // whitespace-only all mean "no choice was made".
+        let paths = test_paths("/managed/root");
+        let managed = UvCacheSource::Managed(managed_uv_cache_dir(&paths.data_dir));
+        for blank in ["", "   ", "\t\n"] {
+            assert_eq!(
+                resolve_uv_cache_source(&paths, Some(OsStr::new(blank)), None),
+                managed,
+                "blank ROCM_CLI_UV_CACHE_DIR {blank:?} should not count as an override"
+            );
+            assert_eq!(
+                resolve_uv_cache_source(&paths, None, Some(OsStr::new(blank))),
+                managed,
+                "blank UV_CACHE_DIR {blank:?} should not count as an override"
+            );
+        }
+        assert!(!managed.is_override());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed_from_a_cache_override() {
+        let paths = test_paths("/managed/root");
+        assert_eq!(
+            resolve_uv_cache_source(&paths, Some(OsStr::new("  /chosen/uv-cache \n")), None),
+            UvCacheSource::Override(PathBuf::from("/chosen/uv-cache"))
+        );
+    }
+
+    #[test]
+    fn managed_cache_dir_tracks_rocm_cli_data_dir() {
+        // AppPaths::with_managed_root is how ROCM_CLI_DATA_DIR reaches the cache, so
+        // exercise that path rather than two hand-built AppPaths.
+        let moved = test_paths("/home/user/.rocm").with_managed_root("/mnt/big/rocm", false);
+        let source = resolve_uv_cache_source(&moved, None, None);
+        assert_eq!(
+            source,
+            UvCacheSource::Managed(managed_uv_cache_dir(&moved.data_dir))
+        );
+        assert!(
+            source.path().starts_with("/mnt/big/rocm"),
+            "cache {} should sit under the relocated data dir",
+            source.path().display()
         );
     }
 

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -45,6 +45,14 @@ pip create it when downloads start. If you omit `--prefix`, rocm-cli should
 choose a managed runtime folder and still place the pip cache inside that
 runtime folder at `<managed-runtime-folder>\pip-cache`.
 
+The `uv` package cache is separate from that pip cache and does **not** follow
+`--prefix`. It lives at `<data-dir>\uv-cache` so it shares a filesystem with the
+managed environments and `uv` can hardlink into them. With `--prefix` pointing at
+a different filesystem from `ROCM_CLI_DATA_DIR`, `uv` falls back to copying
+packages; set `ROCM_CLI_UV_CACHE_DIR` to a folder on the prefix filesystem to
+restore hardlinking. Making `--prefix` do this automatically is tracked
+separately.
+
 ## 1. First-Time Setup
 
 Start rocm-cli:

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -945,7 +945,7 @@ fn install_vllm_with_uv(python: &Path, reinstall: bool) -> Result<()> {
     args.push(index_url.clone());
     let output = ProcessCommand::new(&uv)
         .args(args)
-        .envs(uv_command_env())
+        .envs(uv_command_env(&paths))
         .output()
         .context("failed to launch uv pip install for vLLM")?;
     if output.status.success() {


### PR DESCRIPTION
## Summary

Point `uv` at a cache inside the ROCm CLI data directory, so the cache sits on the same filesystem as the environments it populates and hardlinking keeps working.

## Root cause

`uv_command_env()` set only `UV_HTTP_TIMEOUT`, never `UV_CACHE_DIR`, so the cache stayed at `$HOME/.cache/uv` while managed environments were created under the data directory. When those are on different filesystems, `uv` cannot hardlink and falls back to copying every file — each environment then carries its own full copy of the ROCm SDK and the torch stack.

This is not an exotic setup. It happens with a split `/home`, a container overlay, or a user who moved the data directory to a larger disk with `ROCM_CLI_DATA_DIR` — so the workaround for running out of space *multiplied* the space used.

Measured with uv 0.9.30 on a host where `$HOME/.cache` is a separate mount, installing a small package and comparing inodes:

```
same filesystem  -> inode=1740514 links=2 dev=830   (hardlink into the cache)
different fs     -> inode=1740556 links=1 dev=66    (full copy)
```

A distinct inode with link count 1 — a copy, not a reflink or symlink. Setting `UV_LINK_MODE=hardlink` explicitly does not help: the request is downgraded and the command still exits 0.

`uv` does print a fallback warning, but two of the three install paths discard it — ComfyUI pipes stderr to a log file, and the vLLM install captures output with `.output()` and drops stderr on success.

## Technical decisions

**Keyed off `data_dir`, not `cache_dir`.** A cache would naturally live in the cache directory, but `ROCM_CLI_CACHE_DIR` can point at a *different* filesystem from the environments, which would reintroduce the exact bug. Colocation with the environments is the property that matters here.

**The escape hatch is `ROCM_CLI_UV_CACHE_DIR`**, matching the sibling knobs in the same module (`ROCM_CLI_UV_BINARY`, `ROCM_CLI_UV_VERSION`, `ROCM_CLI_UV_TIMEOUT_SECS`). A bare `UV_CACHE_DIR` exported for unrelated Python work would otherwise silently opt a user out of the fix with no signal. An ambient `UV_CACHE_DIR` is still honored — the e2e harness sets one to share a cache across scenarios — but it ranks below the namespaced variable, and `UvCacheSource` lets callers tell managed / override / inherited apart.

**A one-shot notice, not a migration.** When a pre-colocation `$HOME/.cache/uv` is still on disk, the CLI prints one notice and records that it did, following `maybe_migrate_legacy_dashboard_config`. Nothing is migrated or deleted: the cache is content-addressed and may be shared with unrelated `uv` projects, so removing it is the user's call.

Threading `&AppPaths` through `uv_command_env` touched the call sites in `therock.rs`, `comfyui.rs`, and the vLLM engine; all of them already had `paths` in scope, so no new `AppPaths::discover()` calls were introduced.

## Non-goal: `--prefix` installs — #187

**This colocates with the data directory only.** `--prefix` relocates `install_root` for a single SDK install and leaves `paths.data_dir` — and therefore the uv cache — untouched. A `--prefix` on a different filesystem from the data directory still copies rather than hardlinks, and that case is *not* fixed here.

It is deliberately out of scope because the obvious fix does not work. Threading the target root through and using `<install_root>/uv-cache` breaks every wheel install: `uv` materializes `UV_CACHE_DIR` on *every* invocation including `uv venv`, and `uv venv` refuses to create an environment in a directory that already exists. Verified:

```
$ UV_CACHE_DIR=$P/fresh/uv-cache uv venv --python 3.12 $P/fresh
Creating virtual environment at: /tmp/.../fresh
error: Failed to create virtual environment
  Caused by: A directory already exists at: /tmp/.../fresh

$ ls $P/fresh
uv-cache          <-- uv created its cache there, which then blocked venv creation
```

Since `install_root` *is* the venv directory, the cache cannot live inside it. (This is also why the existing `<install-root>/pip-cache` convention in `docs/testing.md` works for pip but not for uv: pip creates its cache during downloads, after the venv exists.) Choosing a different scheme is a design decision for maintainers, so it is tracked in **#187** with the evidence and four options.

In the meantime the gap is documented in `docs/manual-testing.md`, pinned by `uv_cache_does_not_follow_a_prefix_install_root`, and `ROCM_CLI_UV_CACHE_DIR` is a manual workaround.

The related pre-existing `Downloads/cache:` message — which reports `<install_root>/pip-cache` although nothing sets `PIP_CACHE_DIR` — is folded into #187, since whatever scheme resolves `--prefix` decides what that message should say.

## Consequences worth noting

- `rocm uninstall` now covers the uv cache as a side effect, since it removes the data directory. That reclaims more space but makes uninstall slower. The `--keep-data` / `--keep-cache` help text has been corrected to say so: `--keep-cache` does *not* cover the uv cache.
- `MANIFEST.md` now discloses the wheel cache and its size, not just the uv binary.
- The cache is no longer shared with other `uv` projects on the machine. Users who want the old sharing can set `ROCM_CLI_UV_CACHE_DIR`.
- Existing installs re-download once.

## Tests

Cache resolution is a pure function over the two override variables, exercised for unset, empty, whitespace-only, trimmed, inherited, and namespaced-override inputs, plus precedence between the two. The relocated-data-dir test goes through `AppPaths::with_managed_root` rather than two hand-built `AppPaths`. `uv_cache_does_not_follow_a_prefix_install_root` pins the #187 gap so it cannot regress silently in either direction.

They exercise the pure helper rather than mutating the process environment, because the crate denies `unsafe_code` and `std::env::set_var` is `unsafe` in this edition. That also keeps them parallel-safe.

## CI note

`cargo test --workspace --all-targets --no-fail-fast` on this branch shows two failures in `proc_lifecycle` that are unrelated to it — see #168, fixed by #169. That file is not touched by this PR, and those are the only two failures in the workspace. `cargo fmt --all --check` and `cargo clippy --locked --workspace --all-targets -- -D warnings` are clean.

Fixes #160