### PR TITLE
build(deps): bump vLLM to 0.26.0 and make the pin real

### DIFF
--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -44,7 +44,17 @@ const STOP_SCOPE: rocm_core::KillScope = rocm_core::KillScope::Tree;
 /// This pins both the vLLM release and the ROCm ABI tag, so it can drift from
 /// the resolved runtime. Override it with `ROCM_CLI_VLLM_ROCM_INDEX_URL` to
 /// match a different vLLM/ROCm combination without rebuilding.
-const VLLM_ROCM_EXTRA_INDEX_URL: &str = "https://wheels.vllm.ai/rocm/0.23.0/rocm723";
+///
+/// Keep the release and ABI tag here in sync with [`VLLM_PINNED_SPEC`] below.
+const VLLM_ROCM_EXTRA_INDEX_URL: &str = "https://wheels.vllm.ai/rocm/0.26.0/rocm723";
+/// Exact requirement handed to `uv pip install`.
+///
+/// The index URL alone is not a pin: it only constrains where wheels are
+/// fetched from, so a bare `vllm` requirement would install whatever version
+/// that path happens to serve (or fall back to PyPI when no wheel on the index
+/// matches the interpreter). Spelling the version and local ABI tag out here
+/// makes the pin real.
+const VLLM_PINNED_SPEC: &str = "vllm==0.26.0+rocm723";
 /// Default time to wait for vLLM to report readiness before giving up.
 const DEFAULT_VLLM_READY_TIMEOUT: Duration = Duration::from_mins(5);
 
@@ -940,7 +950,7 @@ fn install_vllm_with_uv(python: &Path, reinstall: bool) -> Result<()> {
     if reinstall {
         args.push("--reinstall".to_owned());
     }
-    args.push("vllm".to_owned());
+    args.push(VLLM_PINNED_SPEC.to_owned());
     args.push("--extra-index-url".to_owned());
     args.push(index_url.clone());
     let output = ProcessCommand::new(&uv)

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, Subcommand};
 use rocm_core::{
     AppPaths, DEFAULT_LOCAL_PORT, ensure_uv_binary, format_http_base_url,
@@ -43,11 +43,13 @@ const STOP_SCOPE: rocm_core::KillScope = rocm_core::KillScope::Tree;
 ///
 /// This pins both the vLLM release and the ROCm ABI tag, so it can drift from
 /// the resolved runtime. Override it with `ROCM_CLI_VLLM_ROCM_INDEX_URL` to
-/// match a different vLLM/ROCm combination without rebuilding.
+/// match a different vLLM/ROCm combination without rebuilding; see
+/// [`resolve_vllm_install_target`] for how the requirement follows the URL.
 ///
-/// Keep the release and ABI tag here in sync with [`VLLM_PINNED_SPEC`] below.
+/// Keep the release and ABI tag here in sync with [`VLLM_PINNED_SPEC`] below;
+/// `vllm_pinned_spec_matches_extra_index_url` fails if the two drift apart.
 const VLLM_ROCM_EXTRA_INDEX_URL: &str = "https://wheels.vllm.ai/rocm/0.26.0/rocm723";
-/// Exact requirement handed to `uv pip install`.
+/// Exact requirement handed to `uv pip install` for [`VLLM_ROCM_EXTRA_INDEX_URL`].
 ///
 /// The index URL alone is not a pin: it only constrains where wheels are
 /// fetched from, so a bare `vllm` requirement would install whatever version
@@ -55,6 +57,12 @@ const VLLM_ROCM_EXTRA_INDEX_URL: &str = "https://wheels.vllm.ai/rocm/0.26.0/rocm
 /// matches the interpreter). Spelling the version and local ABI tag out here
 /// makes the pin real.
 const VLLM_PINNED_SPEC: &str = "vllm==0.26.0+rocm723";
+/// Prefix shared by every published vLLM ROCm wheel index.
+///
+/// Release indexes are `{VLLM_ROCM_INDEX_PREFIX}/<version>/<abi>`, which is
+/// what lets [`vllm_rocm_build_from_index_url`] recover the build a custom
+/// index serves and keep the requirement pinned to it.
+const VLLM_ROCM_INDEX_PREFIX: &str = "https://wheels.vllm.ai/rocm";
 /// Default time to wait for vLLM to report readiness before giving up.
 const DEFAULT_VLLM_READY_TIMEOUT: Duration = Duration::from_mins(5);
 
@@ -942,7 +950,10 @@ fn runtime_from_python(
 fn install_vllm_with_uv(python: &Path, reinstall: bool) -> Result<()> {
     let paths = AppPaths::discover()?;
     let uv = ensure_uv_binary(&paths).context("failed to acquire uv binary for vLLM install")?;
-    let index_url = vllm_rocm_extra_index_url();
+    let VllmInstallTarget {
+        index_url,
+        requirement,
+    } = vllm_install_target()?;
     let mut args = uv_pip_install_base(python);
     // Without `--reinstall`, `uv pip install vllm` is a no-op when the wheel is
     // already present, which would silently turn a requested reinstall into a
@@ -950,7 +961,7 @@ fn install_vllm_with_uv(python: &Path, reinstall: bool) -> Result<()> {
     if reinstall {
         args.push("--reinstall".to_owned());
     }
-    args.push(VLLM_PINNED_SPEC.to_owned());
+    args.push(requirement.clone());
     args.push("--extra-index-url".to_owned());
     args.push(index_url.clone());
     let output = ProcessCommand::new(&uv)
@@ -971,7 +982,8 @@ fn install_vllm_with_uv(python: &Path, reinstall: bool) -> Result<()> {
         "no output".to_owned()
     };
     bail!(
-        "`uv pip install vllm --extra-index-url {}` failed for {}: {}",
+        "`uv pip install {} --extra-index-url {}` failed for {}: {}",
+        requirement,
         index_url,
         python.display(),
         detail
@@ -1329,20 +1341,91 @@ fn vllm_enforce_eager_enabled() -> bool {
         })
 }
 
+/// Wheel index and exact requirement for one `uv pip install vllm`.
+///
+/// The two are always derived from the same `<version>+<abi>` build, so the
+/// install can never be pinned to something the index does not serve — and can
+/// never be left unpinned, which would let the resolver fall through to PyPI's
+/// non-ROCm build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VllmInstallTarget {
+    index_url: String,
+    requirement: String,
+}
+
 /// ROCm wheel index passed to `uv pip install vllm`.
 ///
 /// Defaults to [`VLLM_ROCM_EXTRA_INDEX_URL`]; override with
 /// `ROCM_CLI_VLLM_ROCM_INDEX_URL` (non-empty) to target a different
 /// vLLM/ROCm combination.
-fn vllm_rocm_extra_index_url() -> String {
-    resolve_vllm_rocm_extra_index_url(std::env::var("ROCM_CLI_VLLM_ROCM_INDEX_URL").ok())
-}
-
 fn resolve_vllm_rocm_extra_index_url(override_value: Option<String>) -> String {
     override_value
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| VLLM_ROCM_EXTRA_INDEX_URL.to_owned())
+}
+
+/// Index URL and requirement for the current environment.
+fn vllm_install_target() -> Result<VllmInstallTarget> {
+    resolve_vllm_install_target(std::env::var("ROCM_CLI_VLLM_ROCM_INDEX_URL").ok())
+}
+
+/// Resolve the wheel index and the exact requirement to install from it.
+///
+/// Without an override, the built-in [`VLLM_ROCM_EXTRA_INDEX_URL`] and
+/// [`VLLM_PINNED_SPEC`] are used. With `ROCM_CLI_VLLM_ROCM_INDEX_URL` set, the
+/// build is recovered from the URL when it has the published
+/// `{VLLM_ROCM_INDEX_PREFIX}/<version>/<abi>` shape — so pointing at another
+/// release of the same index works *and* stays pinned, with no extra
+/// configuration.
+///
+/// A URL of any other shape cannot be pinned automatically, and dropping the
+/// pin is not an option: the install passes `--extra-index-url`, so PyPI stays
+/// in play and a bare `vllm` can silently resolve to the non-ROCm build. Such a
+/// URL is therefore rejected rather than installed unpinned.
+fn resolve_vllm_install_target(index_override: Option<String>) -> Result<VllmInstallTarget> {
+    let index_url = resolve_vllm_rocm_extra_index_url(index_override);
+    if index_url == VLLM_ROCM_EXTRA_INDEX_URL {
+        return Ok(VllmInstallTarget {
+            index_url,
+            requirement: VLLM_PINNED_SPEC.to_owned(),
+        });
+    }
+
+    let (version, abi) = vllm_rocm_build_from_index_url(&index_url).ok_or_else(|| {
+        anyhow!(
+            "cannot determine which vLLM build `{index_url}` serves: it is not a published \
+             release index of the form `{VLLM_ROCM_INDEX_PREFIX}/<version>/<abi>`. Installing an \
+             unpinned `vllm` instead would let the resolver fall back to PyPI's non-ROCm build, \
+             so point ROCM_CLI_VLLM_ROCM_INDEX_URL at a release index, or unset it to use the \
+             built-in one."
+        )
+    })?;
+
+    Ok(VllmInstallTarget {
+        index_url,
+        requirement: format!("vllm=={version}+{abi}"),
+    })
+}
+
+/// Recover the `<version>+<abi>` build a published release index serves.
+///
+/// Returns `None` for anything that is not
+/// `{VLLM_ROCM_INDEX_PREFIX}/<version>/<abi>`, including the rolling top-level
+/// index, which is latest-only and therefore not a pin.
+fn vllm_rocm_build_from_index_url(index_url: &str) -> Option<(String, String)> {
+    let valid = |segment: &str| {
+        !segment.is_empty()
+            && segment
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+    };
+    let rest = index_url
+        .trim_end_matches('/')
+        .strip_prefix(VLLM_ROCM_INDEX_PREFIX)?
+        .strip_prefix('/')?;
+    let (version, abi) = rest.split_once('/')?;
+    (valid(version) && valid(abi)).then(|| (version.to_owned(), abi.to_owned()))
 }
 
 /// Time to wait for vLLM to become ready before terminating the process tree.
@@ -2251,6 +2334,10 @@ mod tests {
         );
     }
 
+    fn install_target(index: Option<&str>) -> Result<VllmInstallTarget> {
+        resolve_vllm_install_target(index.map(ToOwned::to_owned))
+    }
+
     #[test]
     fn vllm_extra_index_url_defaults_to_const() {
         assert_eq!(
@@ -2270,6 +2357,82 @@ mod tests {
                 "  https://example.test/rocm/wheels  ".to_owned()
             )),
             "https://example.test/rocm/wheels"
+        );
+    }
+
+    #[test]
+    fn vllm_install_target_defaults_to_the_built_in_pin() {
+        let target = install_target(None).expect("built-in target resolves");
+        assert_eq!(target.index_url, VLLM_ROCM_EXTRA_INDEX_URL);
+        assert_eq!(target.requirement, VLLM_PINNED_SPEC);
+
+        let blank = install_target(Some("  ")).expect("a blank override is ignored");
+        assert_eq!(blank, target);
+    }
+
+    #[test]
+    fn vllm_install_target_stays_pinned_for_a_same_shape_index_override() {
+        for (index, expected_url) in [
+            (
+                " https://wheels.vllm.ai/rocm/0.27.0/rocm730 ",
+                "https://wheels.vllm.ai/rocm/0.27.0/rocm730",
+            ),
+            (
+                "https://wheels.vllm.ai/rocm/0.27.0/rocm730/",
+                "https://wheels.vllm.ai/rocm/0.27.0/rocm730/",
+            ),
+        ] {
+            let target = install_target(Some(index)).expect("published index shape resolves");
+            assert_eq!(target.index_url, expected_url);
+            assert_eq!(target.requirement, "vllm==0.27.0+rocm730");
+        }
+    }
+
+    #[test]
+    fn vllm_install_target_fails_rather_than_unpinning_an_unknown_index() {
+        for index in [
+            "https://example.test/rocm/wheels",
+            // Rolling latest-only index: no version/ABI to pin to.
+            "https://wheels.vllm.ai/rocm/",
+            "https://wheels.vllm.ai/rocm/0.27.0",
+            "https://wheels.vllm.ai/rocm//rocm730",
+            "https://wheels.vllm.ai/rocm/0.27.0/rocm 730",
+        ] {
+            let error = install_target(Some(index))
+                .expect_err("an unpinnable index must fail")
+                .to_string();
+            assert!(
+                error.contains(index.trim()),
+                "error for {index} should quote the index URL: {error}"
+            );
+            assert!(
+                error.contains(VLLM_ROCM_INDEX_PREFIX),
+                "error for {index} should show the expected index shape: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn vllm_pinned_spec_matches_extra_index_url() {
+        let (version, abi) = VLLM_PINNED_SPEC
+            .strip_prefix("vllm==")
+            .and_then(|rest| rest.split_once('+'))
+            .expect("pinned spec is spelled `vllm==<version>+<abi>`");
+        let expected_suffix = format!("/{version}/{abi}");
+        assert!(
+            VLLM_ROCM_EXTRA_INDEX_URL.ends_with(&expected_suffix),
+            "pinned spec {VLLM_PINNED_SPEC} does not match index {VLLM_ROCM_EXTRA_INDEX_URL}: \
+             expected the index to end with {expected_suffix}"
+        );
+    }
+
+    #[test]
+    fn vllm_default_index_has_the_published_release_shape() {
+        assert_eq!(
+            vllm_rocm_build_from_index_url(VLLM_ROCM_EXTRA_INDEX_URL),
+            Some(("0.26.0".to_owned(), "rocm723".to_owned())),
+            "the built-in index must parse back to its build, or overrides of the same shape \
+             cannot be pinned"
         );
     }
 

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1353,11 +1353,11 @@ struct VllmInstallTarget {
     requirement: String,
 }
 
-/// ROCm wheel index passed to `uv pip install vllm`.
+/// Pure resolution of the ROCm wheel index from an optional override value.
 ///
-/// Defaults to [`VLLM_ROCM_EXTRA_INDEX_URL`]; override with
-/// `ROCM_CLI_VLLM_ROCM_INDEX_URL` (non-empty) to target a different
-/// vLLM/ROCm combination.
+/// Falls back to [`VLLM_ROCM_EXTRA_INDEX_URL`] when the override is absent or
+/// blank; a usable one is trimmed. The caller supplies the value (see
+/// [`vllm_install_target`] for the environment read) so this stays testable.
 fn resolve_vllm_rocm_extra_index_url(override_value: Option<String>) -> String {
     override_value
         .map(|value| value.trim().to_owned())


### PR DESCRIPTION
## Summary

Two changes to the vLLM install path in `engines/vllm`:

- Bump the pinned vLLM release from `0.23.0` to `0.26.0` (published 2026-07-27). 0.26.0 brings support for additional model architectures over 0.23.0.
- Pass an exact requirement to `uv pip install` instead of a bare package name, on **every** path including the index override. This is the more important half of the change.

### The install was not actually pinned

The install pushed a bare `vllm` argument into the `uv pip install` invocation. The only thing constraining the release was the version segment of the ROCm wheel index URL (`https://wheels.vllm.ai/rocm/<version>/<abi>`). That is not a pin:

- if the index ever serves more than one version under that path, the resolver is free to pick any of them;
- if no wheel under that path matches the interpreter, the resolver falls back to PyPI (`--extra-index-url` keeps PyPI in play by design, because vLLM's dependencies need it) and installs a generic build.

The second case is not hypothetical — resolving bare `vllm` against the ROCm index on a CPython 3.13 host (the ROCm wheels are `cp312`) yields plain `vllm==0.26.0` from PyPI rather than the ROCm build.

The install now requests `vllm==0.26.0+rocm723` explicitly, so a mismatch fails loudly instead of installing something else.

### ABI tag

The ROCm ABI tag stays `rocm723`. The variant has shifted between releases in the past, so this was the main risk in the bump. Resolving against the live index confirms `rocm723` is published for 0.26.0, while neighbouring variants such as `rocm724` and `rocm730` are not:

```
$ uv pip compile r724.txt --python-version 3.12 \
    --extra-index-url https://wheels.vllm.ai/rocm/0.26.0/rocm724 \
    --index-strategy unsafe-best-match --no-deps
  x No solution found when resolving dependencies:
  `-> Because there is no version of vllm==0.26.0+rocm724 [...]
```

### The override stays pinned

`ROCM_CLI_VLLM_ROCM_INDEX_URL` selects a different vLLM/ROCm combination without rebuilding, and a hardcoded `vllm==0.26.0+rocm723` cannot resolve against an index serving some other release. The fix is to keep the requirement in lockstep with the index rather than dropping it — an unpinned override is exactly the PyPI-fallback hazard this PR exists to remove.

Version and ABI are treated as the single source of truth from which both the URL and the requirement derive:

- **Not set** — the built-in index and `vllm==0.26.0+rocm723`.
- **Set to a published release index** (`https://wheels.vllm.ai/rocm/<version>/<abi>`) — the version and ABI are parsed back out of the URL and the requirement becomes `vllm==<version>+<abi>`. Pointing at a different release of the same index therefore works *and* stays pinned, with no extra configuration.
- **Set to anything else** — the build cannot be determined, so the install fails with an error quoting the URL and the expected shape, rather than silently unpinning. A clear failure beats quietly installing the wrong artifact.

### Non-goals

- Deriving the ABI tag from the detected ROCm runtime rather than hardcoding it is a separate change that rewrites the same line; it is deliberately not folded in here.
- An explicit version/build override variable, for indexes that do not follow the published path shape, is deliberately left out: a repo-wide change is moving every engine version pin into one config file with a generated override variable per dependency, and vLLM will adopt that convention rather than introduce a one-off variable now.
- Opting into the rolling top-level index (`https://wheels.vllm.ai/rocm/`, which is latest-only) is out of scope — it is rejected here precisely because it is not a pin.

## Test plan

Verified against the live index with `uv`:

```
$ uv pip compile req.txt --python-version 3.12 \
    --extra-index-url https://wheels.vllm.ai/rocm/0.26.0/rocm723 \
    --index-strategy unsafe-best-match --no-deps
Resolved 1 package in 12ms
vllm==0.26.0+rocm723
```

Both the bare `vllm` requirement and the exact `vllm==0.26.0+rocm723` spec resolve to the same wheel, confirming the new index path and ABI tag exist and are self-consistent.

Unit tests cover the resolution rules as pure functions taking the environment value as a parameter (nothing touches process env): nothing set, empty/whitespace values, an override of the published shape (with and without a trailing slash), and overrides that must error rather than unpin — a foreign host, the rolling top-level index, a missing ABI segment, an empty version segment, and a malformed segment.

Local checks: `cargo test --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings`, and `cargo fmt --all --check` all pass. (Two `rocm-core` `proc_lifecycle` tests fail on my machine both with and without this change — a local process-group sandboxing artifact, unrelated to this diff.)

### Verification gap — please read

This change is weakly covered by automated testing, and honesty about that is more useful than a green checkmark:

- No test asserts that either literal is *correct* — the tests compare against the constants, so they stay green regardless of what the constants say. `vllm_pinned_spec_matches_extra_index_url` does assert the two literals agree with each other (it parses the version and ABI tag back out of the spec and requires the index path to end with them), so a half-finished bump fails in CI; it cannot tell whether the pair is published upstream.
- Nothing in default CI fetches the index.

A typo in either string therefore stays green all the way through CI and only surfaces on a real install against a GPU runner. The `uv pip compile` runs above are the actual verification for this PR.

## Risk

Low for the pin itself (a bad string now fails the install loudly rather than installing the wrong build). The override path can now fail where it previously proceeded — that is intentional: it only fails for a URL whose build cannot be determined, where the alternative was installing an unpinned, possibly non-ROCm build. Medium for the version bump, in the ordinary sense that a new vLLM release can change runtime behavior — that surface is not exercised by this repo's default CI.
