### PR TITLE
build(deps): track Cargo dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Let a bad release be found and yanked before we adopt it. A crate bump is
+    # not inert data waiting for review: `cargo build` runs the new version's
+    # `build.rs` and expands its proc macros on the CI runner, so the bump PR
+    # executes third-party code the moment it opens — before a human reads the
+    # lockfile diff. A week is long enough for the common case of a malicious or
+    # backdoored release being yanked from crates.io to play out off our
+    # runners. Cooldown delays only version updates, never security updates.
+    cooldown:
+      default-days: 7
     # Above the default of 5 so a backlog of separate major bumps cannot starve
     # the grouped minor/patch PR, but still bounded so the queue stays readable.
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,27 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Cargo dependencies were previously untracked, so the workspace could drift
+  # onto crate versions carrying published advisories with nothing to surface
+  # them. `directory: /` is the workspace root: Dependabot resolves the whole
+  # member graph from the root manifest and `Cargo.lock`, so one entry covers
+  # every crate. Minor and patch bumps are grouped into a single weekly PR --
+  # they are almost always drop-in for a workspace this wide, and one PR per
+  # crate would bury real review signal. Major bumps stay ungrouped so each
+  # breaking change is reviewed, and eventually merged, on its own.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    # Above the default of 5 so a backlog of separate major bumps cannot starve
+    # the grouped minor/patch PR, but still bounded so the queue stays readable.
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Add a `cargo` ecosystem entry to `.github/dependabot.yml`, with a 7-day cooldown.

Until now the Dependabot config covered only the `github-actions` ecosystem. Every Rust dependency in the workspace was therefore untracked: no PR ever opened for a new crate release, and nothing surfaced a published advisory for a crate we depend on. That is an odd gap in a repo that deliberately SHA-pins every third-party Action for supply-chain safety.

`directory: /` is the workspace root — Dependabot resolves the full member graph from the root manifest and `Cargo.lock`, so a single entry covers all workspace crates.

**Grouping.** Minor and patch bumps are collected into one weekly grouped PR (`cargo-minor-patch`, scoped with `applies-to: version-updates`). For a workspace this wide, one PR per crate per week would be pure noise and would bury genuine review signal; minor/patch bumps are near-always drop-in and are best reviewed as a single lockfile delta with one CI run. Major bumps are deliberately left out of the group so each breaking change arrives as its own PR and can be reviewed, adapted to, and merged independently.

**Cooldown.** `default-days: 7`. A crate bump is not inert data waiting for review — `cargo build` runs the new version's `build.rs` and expands its proc macros on the CI runner, so the bump PR executes third-party code the moment it opens, before a human reads the lockfile diff. A week is long enough for the common case of a malicious or backdoored release being yanked from crates.io to play out off our runners. Cooldown delays only version updates; security updates are never held back.

**PR volume.** `open-pull-requests-limit: 10` (default is 5). Expect a burst on the first run: one grouped minor/patch PR plus up to nine individual major-bump PRs, since the workspace has never been swept. Steady state after that first catch-up should be roughly one grouped PR per week plus the occasional major. The limit is a cap on concurrently open version-update PRs, so it keeps the queue readable while leaving enough headroom that a backlog of majors cannot starve the grouped PR.

## Relationship to #154

#154 adds the same `cooldown: default-days: 7` to the existing `github-actions` entry. The two PRs are complementary, not competing: #154 edits inside the `github-actions` block, this one appends a new `cargo` block. They touch the same file but disjoint regions and should merge cleanly in either order. The rationale differs by ecosystem — #154's is about a bumped SHA running the new action's code on CI, this one's is about `build.rs` and proc macros running at compile time — so the comments are written separately rather than shared.

## Test plan

- `prek run --all-files` — all hooks pass (`check yaml` included).
- Config keys verified against the current [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference): `package-ecosystem: cargo`, `open-pull-requests-limit`, `cooldown.default-days`, and group-level `applies-to` / `patterns` / `update-types` are all current.
- No Rust code is touched, so the workspace build and test suite are unaffected.

Risk: low — configuration only, and reversible by dropping the entry.