### PR TITLE
test(e2e): tolerate intermittent EAI-7423 XPASS on the Strix Halo Ubuntu lane (EAI-7853)

### DIFF
--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -10,7 +10,9 @@
 #   1. A scenario whose @requires-gpu / @requires-engine can't be satisfied on
 #      this host is SKIPPED (not-applicable) — never listed here.
 #   2. Otherwise, the FIRST matching condition below marks it expected-fail
-#      (xfail); a scenario that then PASSES is an XPASS (stale entry — remove it).
+#      (xfail); a scenario that then PASSES is an XPASS — a stale entry to be
+#      removed, UNLESS the row is `flaky = true`, which tolerates either result
+#      while the bug stays open (see the grammar below).
 #   3. No matching condition → expected-pass.
 #
 # Condition predicate grammar (deliberately tiny):
@@ -20,6 +22,8 @@
 #   bug = "EAI-NNNN"                  ticket reference (shown in the report)
 #   reason = "..."                    human explanation (shown in the report)
 #   serve_timeout_secs = 90          optional: shorter serve wait for a known bug
+#   flaky = true                     optional: bug reproduces only intermittently,
+#                                    so an XPASS is tolerated (reported, not stale)
 #
 # An empty `when = {}` means "always xfail" (platform-independent bug).
 
@@ -45,14 +49,16 @@ reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completi
 serve_timeout_secs = 90
 flaky = true
 
-# EAI-7423 is INTERMITTENT on this host as of 2026-08-05, not fixed: which of its
-# scenarios pass varies run to run (run 30995473578: 2 XPASS; run 30993213188:
-# 3 XPASS; run 30939967076: all 6). A deterministic-XPASS row fails the lane on
-# unrelated PRs, so every EAI-7423 lemonade-linux row below is `flaky = true` —
-# either outcome is tolerated while the bug stays open. See EAI-7853; if the
-# lemonade 11.5.1 upgrade turns out to fix EAI-7423, drop these rows outright
-# rather than leaving them flaky.
-
+# EAI-7423 was INTERMITTENT on Strix Halo Ubuntu as of 2026-08-05, not fixed:
+# which of its scenarios pass varied run to run (run 30995473578: 2 XPASS; run
+# 30993213188: 3 XPASS; run 30939967076: all 6). A deterministic-XPASS row fails
+# that lane on unrelated PRs, so the EAI-7423 lemonade-linux rows below carry
+# `flaky = true` — either outcome is tolerated while the bug stays open. The flag
+# is per-row and is NOT derived from `bug`, so a new EAI-7423 row needs it added
+# explicitly. Revisit under EAI-7853 before deleting any of them: which lemonade
+# build a given run used cannot currently be read back from this lane, so an
+# XPASS streak here is not by itself evidence that the bug is fixed.
+#
 # On a lemonade-native LINUX host (Strix Halo Ubuntu) the lemonade managed serve
 # loads the model and reaches ready on :8001, then is shut down ~0.08s later, so
 # the endpoint never becomes reachable (EAI-7423, root-caused on the box

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -45,6 +45,14 @@ reason = "vLLM service reports ready (/v1/models 200) but POST /v1/chat/completi
 serve_timeout_secs = 90
 flaky = true
 
+# EAI-7423 is INTERMITTENT on this host as of 2026-08-05, not fixed: which of its
+# scenarios pass varies run to run (run 30995473578: 2 XPASS; run 30993213188:
+# 3 XPASS; run 30939967076: all 6). A deterministic-XPASS row fails the lane on
+# unrelated PRs, so every EAI-7423 lemonade-linux row below is `flaky = true` —
+# either outcome is tolerated while the bug stays open. See EAI-7853; if the
+# lemonade 11.5.1 upgrade turns out to fix EAI-7423, drop these rows outright
+# rather than leaving them flaky.
+
 # On a lemonade-native LINUX host (Strix Halo Ubuntu) the lemonade managed serve
 # loads the model and reaches ready on :8001, then is shut down ~0.08s later, so
 # the endpoint never becomes reachable (EAI-7423, root-caused on the box
@@ -56,6 +64,7 @@ when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the endpoint never becomes reachable."
 serve_timeout_secs = 90
+flaky = true
 
 # On a lemonade-native LINUX host the served model's endpoint drops before
 # inference: the lemonade managed serve reaches ready then is shut down ~0.08s
@@ -66,6 +75,7 @@ when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so inference never succeeds."
 serve_timeout_secs = 90
+flaky = true
 
 # EAI-7333 (CLI healthcheck reports ready off /v1/models before inference works)
 # on the vLLM path. This scenario is FLAKY, not fixed: it XPASS'd on MI300X once
@@ -89,6 +99,7 @@ when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the ready-to-serve contract fails."
 serve_timeout_secs = 90
+flaky = true
 
 # --- EAI-7423: on a lemonade LINUX host the managed serve reaches ready then is
 # shut down immediately, so inference never happens (root-caused on the box
@@ -100,6 +111,7 @@ when = { effective_engine = "lemonade", os = "linux" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so inference never succeeds."
 serve_timeout_secs = 90
+flaky = true
 
 # --- EAI-7223: chat requests with tool definitions rejected (vLLM path) ---
 [["chat-tool-definitions-accepted"]]
@@ -119,6 +131,7 @@ when = { effective_engine = "lemonade", os = "linux", therock_family = "gfx*" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the chat request never reaches a live model."
 serve_timeout_secs = 90
+flaky = true
 
 # EAI-7221 (TUI chat sends hardcoded 'local-model' instead of querying /v1/models)
 # was previously mapped here as a vLLM-path xfail, but that bug is TUI-only and this
@@ -135,6 +148,7 @@ when = { effective_engine = "lemonade", os = "linux", therock_family = "gfx*" }
 bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the chat request never reaches a live model."
 serve_timeout_secs = 90
+flaky = true
 
 # --- EAI-7383: `rocm help` lists subcommands in declaration order, not
 # alphabetically. Platform-independent (pure CLI help output). ---


### PR DESCRIPTION
## Summary

The `E2E tests (Strix Halo, Ubuntu)` lane currently fails on PRs that touch
neither serve nor chat — including #174 and #181 — with `0 unexpected
failure(s)`. Nothing regressed: the reconciler is failing on **stale XPASS**.
That lane is `continue-on-error: true` like the other two GPU lanes, so this is
a signal-quality fix, not an unblocking one — a red X on unrelated PRs trains
reviewers to ignore the lane.

Six scenarios are marked expected-to-fail against **EAI-7423** (lemonade managed
serve reaches ready, then shuts down ~0.08s later on gfx1151). That bug no
longer reproduces reliably on the runner, and — importantly — not consistently
either. Which scenarios pass varies run to run:

| Run | XPASS |
| --- | --- |
| 30995473578 (#174) | 2 — serve-default-engine-working-endpoint, serve-readiness-contract |
| 30993213188 (#181) | 3 — the above plus chat-end-to-end-local-model |
| 30939967076 (#177) | 6 — all EAI-7423 lemonade-linux rows |

## Change

Mark the six EAI-7423 lemonade-linux rows `flaky = true`. That flag exists for
exactly this state — "tolerates either result while the intermittent bug remains
open" — and the EAI-7333 rows already use it for the same reason on the vLLM
path.

**This does not claim EAI-7423 is fixed.** The inference scenarios still fail on
some runs, so the bug stays open and the rows stay in place; only the
deterministic-XPASS failure mode goes away. Removing the rows instead would
convert those runs into unexpected failures the next time the bug bites.

## Tradeoff: this removes the obsolescence detector

Stale XPASS is the only automated signal that a row has outlived its bug. Once a
row is flaky its XPASS is counted as a pass and rendered `✅XPASS (flaky)`;
nothing tracks "this row hasn't failed in N runs". Run 30939967076 turning the
lane red is precisely how anyone noticed these six had started passing — after
this PR the same run passes silently.

That is an accepted trade for the signal-quality win, but it makes the revisit a
scheduled action rather than an event: tracked in EAI-7853, owned by me, to be
re-examined by **2026-09-30**.

## Scope boundary

The right long-term answer may be to delete the rows outright, but only once
something establishes EAI-7423 is genuinely fixed — and that is not currently
answerable from this lane. The lemonade install gate is a file-existence check
with no comparison against the stored manifest version, and the install root
persists across jobs, so a run can reuse an older `lemond` than the compiled
pin. An XPASS streak here therefore does not attribute to any particular
lemonade build. The version-aware gate is tracked separately; this PR only drops
the untestable attribution from the TOML note.

## Test plan

- `cargo test -p e2e-cucumber --lib expectation` (17 passed) and the file parses
  as TOML. Note these are pre-existing resolver tests — none exercise `flaky`;
  the `flaky` reconciliation tests live in `crates/e2e-report`.
- Real verification is the Strix Halo Ubuntu lane on this PR: it reports the
  XPASS scenarios as `flaky` rather than `stale`, and passes. The run also shows
  `7 xfail, 3 XPASS (3 flaky, 0 stale)` — three of the six still failed in the
  same run, which is the evidence the bug is intermittent rather than fixed.

## Risk

Low. Data-only change to expected-failure metadata; no product or test code. The
worst case is that a genuine EAI-7423 failure is tolerated on that lane rather
than reported — which is already true of the xfail rows themselves, since they
expect failure.