### PR TITLE
fix: retry HTTP download in install.ps1 on transient failure

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -163,11 +163,22 @@ function Save-File {
     if ($PSVersionTable.PSVersion.Major -lt 6) {
         $parameters.UseBasicParsing = $true
     }
-    try {
-        Invoke-WebRequest @parameters
-    } catch {
-        Remove-Item -LiteralPath $OutputPath -Force -ErrorAction SilentlyContinue
-        Fail "${FailureMessage}: $($_.Exception.Message)"
+
+    # An HTTP transfer can fail transiently (a momentary connection reset, or
+    # the server-side listener still finishing setup) even though a retry a
+    # moment later succeeds; give it a couple of chances before giving up.
+    $maxAttempts = 3
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        try {
+            Invoke-WebRequest @parameters
+            return
+        } catch {
+            Remove-Item -LiteralPath $OutputPath -Force -ErrorAction SilentlyContinue
+            if ($attempt -eq $maxAttempts) {
+                Fail "${FailureMessage}: $($_.Exception.Message)"
+            }
+            Start-Sleep -Milliseconds (250 * $attempt)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `Save-File`'s `Invoke-WebRequest` call had no retry logic: a single transient connection failure (e.g. a connection reset, or the loopback/server-side listener not yet fully ready) aborted the install outright.
- This is the failure signature behind the intermittent `lifecycle-windows-http-install` E2E flake seen on `main` and on PR #182's merge queue attempt (`"An error occurred while sending the request"`), and it also affects real-world production HTTP downloads, not just the test's loopback server.
- `Save-File` now retries the `Invoke-WebRequest` call up to 3 times with a short increasing backoff (250ms/500ms) before failing. The local `file://` (`Copy-Item`) branch is untouched since it isn't networked and isn't implicated in the flake.

## Why not use `expectations.toml`'s `flaky` mechanism instead?

I looked into marking the scenario as flaky via the existing xfail matrix, but it doesn't fit this failure shape: `flaky` only tolerates an *unexpected pass* of a scenario that's expected to fail as a known bug (an XPASS). `lifecycle-windows-http-install` is an ordinary `ExpectPass` scenario that intermittently *fails* outright — the opposite case, which the reconciliation logic in `tests/e2e-cucumber/tests/e2e.rs` always treats as a fatal `unexpected_fail`, with no existing tolerance path.

Reusing/extending that mechanism to also cover unexpected-fail-of-expect-pass was flagged in PR #182's review discussion as a bigger design decision (a quarantine marker with an expiry was suggested as the better long-term shape) that shouldn't be decided ad hoc here. A genuine reliability fix at the actual failure site is more proportionate, and improves the real installer besides.

## Test plan

- [ ] CI: Windows E2E lifecycle suite, specifically `lifecycle-windows-http-install`, should pass reliably (or at minimum no longer show this exact failure signature if it's hit again transiently, since it'll now retry).
- [ ] PSScriptAnalyzer lint check on `install.ps1` stays clean.
- Not locally testable: no `pwsh` available in this (Linux/WSL) dev environment, and there's no Pester/unit suite for `install.ps1` — it's only exercised via the Windows E2E cucumber scenarios in CI.