### PR TITLE
refactor(e2e-report): group the expectation grid by feature and fix scenario indexing

### DIFF
--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -622,6 +622,14 @@ impl PlatformVersions {
 #[derive(Deserialize, Clone)]
 struct ManifestExpectation {
     id: String,
+    /// The `Feature:` this scenario belongs to. Absent in artifacts predating
+    /// the grouped grid — see [`feature_of`] for the fallback.
+    #[serde(default)]
+    feature: String,
+    /// The scenario's own name (`<key>-<NN> - <description>`), carrying the
+    /// per-feature index rows are sorted by. Absent in older artifacts.
+    #[serde(default)]
+    scenario: String,
     #[serde(default)]
     effective_engine: String,
     /// "pass" | "xfail" | "skip".
@@ -739,19 +747,72 @@ struct GridColumn {
     details: std::collections::BTreeMap<String, ManifestExpectation>,
 }
 
-/// The reconciled grid: ordered scenario ids × platform columns. Built from each
-/// input's `platform.json` (expected) joined with its `report.json` (actual) by
-/// stable `@id`. Inputs without a `platform.json` (pre-expectation artifacts) are
-/// skipped here — they still appear in the legacy platform×tier matrix.
+/// One row of the grid: a scenario, with the identity used to place and order it.
+struct GridRow {
+    id: String,
+    /// The scenario's human name, or empty when unknown (an artifact predating
+    /// the `scenario` field whose scenario ran nowhere).
+    name: String,
+    /// Per-feature index parsed from the `<key>-<NN>` name prefix. `None` when
+    /// the name is absent or unindexed — those rows sort last, by id.
+    index: Option<u32>,
+}
+
+/// Scenarios of one `Feature:`, in display order.
+struct FeatureGroup {
+    feature: String,
+    rows: Vec<GridRow>,
+}
+
+/// The reconciled grid: scenario rows grouped by feature × platform columns.
+/// Built from each input's `platform.json` (expected) joined with its
+/// `report.json` (actual) by stable `@id`. Inputs without a `platform.json`
+/// (pre-expectation artifacts) are skipped here — they still appear in the legacy
+/// platform×tier matrix.
 struct Grid {
-    /// Scenario ids in first-seen order across all columns.
-    ids: Vec<String>,
+    /// Feature groups, alphabetical by feature name; rows within a group ordered
+    /// by their `<key>-<NN>` index (i.e. feature-file order).
+    groups: Vec<FeatureGroup>,
     columns: Vec<GridColumn>,
+}
+
+/// The per-feature index in a scenario name like `serve-07 - Something happens`.
+/// `None` for a name that doesn't carry one (older artifact, or a scenario
+/// renamed out of the convention).
+fn scenario_index(name: &str) -> Option<u32> {
+    let head = name.split(" - ").next()?;
+    let (_key, digits) = head.rsplit_once('-')?;
+    digits.parse().ok()
+}
+
+/// The feature a scenario belongs to, best-effort.
+///
+/// 1. `platform.json`'s own `feature` — the honest source, and the only one that
+///    covers a scenario skipped on every platform.
+/// 2. The feature name from a `report.json` that ran it.
+/// 3. Failing both, the id's leading segment (`serve-vllm-inference` → `serve`),
+///    so a pre-expectation artifact still groups sensibly instead of collapsing
+///    into one bucket.
+fn feature_of(exp: &ManifestExpectation, from_reports: Option<&str>) -> String {
+    if !exp.feature.is_empty() {
+        return exp.feature.clone();
+    }
+    if let Some(name) = from_reports.filter(|n| !n.is_empty()) {
+        return name.to_owned();
+    }
+    exp.id
+        .split_once('-')
+        .map_or_else(|| exp.id.clone(), |(key, _)| key.to_owned())
 }
 
 impl Grid {
     fn build(inputs: &[(String, PathBuf)]) -> Self {
-        let mut ids: Vec<String> = Vec::new();
+        // Feature names for ids that ran somewhere, as a fallback for artifacts
+        // whose platform.json predates the `feature` field.
+        let features_from_reports = id_features(inputs);
+        // id → (feature, scenario name), merged across inputs. A later input can
+        // fill in identity an earlier (older) artifact lacked.
+        let mut identity: BTreeMap<String, (String, String)> = BTreeMap::new();
         let mut columns: Vec<GridColumn> = Vec::new();
 
         for (_label, json_path) in inputs {
@@ -782,8 +843,15 @@ impl Grid {
                 });
 
             for exp in &manifest.expectations {
-                if !ids.contains(&exp.id) {
-                    ids.push(exp.id.clone());
+                let entry = identity
+                    .entry(exp.id.clone())
+                    .or_insert_with(|| (String::new(), String::new()));
+                if entry.0.is_empty() {
+                    entry.0 =
+                        feature_of(exp, features_from_reports.get(&exp.id).map(String::as_str));
+                }
+                if entry.1.is_empty() {
+                    entry.1.clone_from(&exp.scenario);
                 }
                 let outcome =
                     CellOutcome::reconcile(&exp.expected, exp.flaky, actual.get(&exp.id).copied());
@@ -801,8 +869,27 @@ impl Grid {
             }
         }
 
-        ids.sort();
-        Self { ids, columns }
+        // Group by feature, then order rows by their per-feature index so the
+        // grid reads in feature-file order rather than the alphabetical-by-id
+        // mash the flat table used to show. Unindexed rows sort last, by id.
+        let mut by_feature: BTreeMap<String, Vec<GridRow>> = BTreeMap::new();
+        for (id, (feature, name)) in identity {
+            let index = scenario_index(&name);
+            by_feature
+                .entry(feature)
+                .or_default()
+                .push(GridRow { id, name, index });
+        }
+        let groups = by_feature
+            .into_iter()
+            .map(|(feature, mut rows)| {
+                rows.sort_by(|a, b| {
+                    (a.index.is_none(), a.index, &a.id).cmp(&(b.index.is_none(), b.index, &b.id))
+                });
+                FeatureGroup { feature, rows }
+            })
+            .collect();
+        Self { groups, columns }
     }
 
     /// Every problem cell across the grid, as `(slug, id, outcome, detail)`.
@@ -823,9 +910,26 @@ impl Grid {
         out
     }
 
-    const fn is_empty(&self) -> bool {
-        self.columns.is_empty() || self.ids.is_empty()
+    fn is_empty(&self) -> bool {
+        self.columns.is_empty() || self.groups.is_empty()
     }
+}
+
+/// Map each scenario `@id` → the name of the feature that ran it, from every
+/// input's `report.json`. The fallback used when a `platform.json` predates the
+/// `feature` field.
+fn id_features(inputs: &[(String, PathBuf)]) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for (_label, json_path) in inputs {
+        for f in parse_features(json_path) {
+            for el in &f.elements {
+                if let Some(id) = scenario_id(el) {
+                    map.entry(id).or_insert_with(|| f.name.clone());
+                }
+            }
+        }
+    }
+    map
 }
 
 /// Map each scenario's stable `@id` → whether it passed, from a `report.json`.
@@ -1236,31 +1340,39 @@ fn expectation_grid_html(inputs: &[(String, PathBuf)]) -> Markup {
             span.status-fail { "❌FAIL" } " regression · "
             "⚠️XPASS bug fixed here (stale entry) · · no data."
         }
-        table.stats {
-            thead {
-                tr {
-                    th { "Scenario" }
-                    @for col in &grid.columns {
-                        @let versions = col.versions.summary();
-                        th {
-                            (col.slug)
-                            @if !col.engine.is_empty() { br; small { (col.engine) } }
-                            @if !versions.is_empty() { br; small.versions { (versions) } }
+        // One table per feature, so a reader can scan a single area of the CLI
+        // instead of one undivided 60-row block.
+        @for group in &grid.groups {
+            h3.feature-heading { (group.feature) }
+            table.stats {
+                thead {
+                    tr {
+                        th { "Scenario" }
+                        @for col in &grid.columns {
+                            @let versions = col.versions.summary();
+                            th {
+                                (col.slug)
+                                @if !col.engine.is_empty() { br; small { (col.engine) } }
+                                @if !versions.is_empty() { br; small.versions { (versions) } }
+                            }
                         }
                     }
                 }
-            }
-            tbody {
-                @for id in &grid.ids {
-                    tr {
-                        td { code { (id) } }
-                        @for col in &grid.columns {
-                            @let outcome = col.outcomes.get(id).copied().unwrap_or(CellOutcome::Missing);
-                            // One combined class attr — `td.num class=(..)` would emit
-                            // two `class` attributes, and the browser keeps only the
-                            // first ("num"), dropping the status colour.
-                            td class=(format!("num {}", outcome.grid_class())) {
-                                (outcome.glyph())
+                tbody {
+                    @for row in &group.rows {
+                        tr {
+                            td {
+                                @if !row.name.is_empty() { (row.name) br; }
+                                code { (row.id) }
+                            }
+                            @for col in &grid.columns {
+                                @let outcome = col.outcomes.get(&row.id).copied().unwrap_or(CellOutcome::Missing);
+                                // One combined class attr — `td.num class=(..)` would emit
+                                // two `class` attributes, and the browser keeps only the
+                                // first ("num"), dropping the status colour.
+                                td class=(format!("num {}", outcome.grid_class())) {
+                                    (outcome.glyph())
+                                }
                             }
                         }
                     }
@@ -1313,36 +1425,52 @@ fn expectation_grid_markdown(
          ❌FAIL regression · ⚠️XPASS bug fixed here (stale entry) · · no data._\n\n",
     );
 
-    // Header: one column per platform, with its effective engine. Component
-    // versions live in the summary matrix above, not here.
-    out.push_str("| Scenario |");
-    for col in &grid.columns {
-        let eng = if col.engine.is_empty() {
-            String::new()
-        } else {
-            format!("<br><sub>{}</sub>", col.engine)
-        };
-        let _ = write!(out, " {}{} |", col.slug, eng);
-    }
-    out.push('\n');
-    out.push_str("|---|");
-    for _ in &grid.columns {
-        out.push_str(":--:|");
-    }
-    out.push('\n');
+    // One table per feature, under its own heading — a single undivided table of
+    // every scenario in the suite is unreadable, and gives no clue where one area
+    // of the CLI ends and the next begins.
+    for group in &grid.groups {
+        let _ = writeln!(out, "#### {}\n", group.feature);
 
-    for id in &grid.ids {
-        // Scenario cell: human name on top, the @id below as a link to its entry
-        // in the Scenario reference section (GitHub anchors `#### <id>` to `#<id>`).
-        let name = scenarios.get(id).map_or("", |(n, _)| n.as_str());
-        let _ = write!(out, "| {name}<br>[`{id}`](#{id}) |");
+        // Header: one column per platform, with its effective engine. Component
+        // versions live in the summary matrix above, not here.
+        out.push_str("| Scenario |");
         for col in &grid.columns {
-            let g = col
-                .outcomes
-                .get(id)
-                .copied()
-                .unwrap_or(CellOutcome::Missing);
-            let _ = write!(out, " {} |", g.glyph());
+            let eng = if col.engine.is_empty() {
+                String::new()
+            } else {
+                format!("<br><sub>{}</sub>", col.engine)
+            };
+            let _ = write!(out, " {}{} |", col.slug, eng);
+        }
+        out.push('\n');
+        out.push_str("|---|");
+        for _ in &grid.columns {
+            out.push_str(":--:|");
+        }
+        out.push('\n');
+
+        for row in &group.rows {
+            // Scenario cell: human name on top, the @id below as a link to its
+            // entry in the Scenario reference section (GitHub anchors
+            // `#### <id>` to `#<id>`). Prefer the name recorded in platform.json
+            // — it covers a scenario that was skipped everywhere and so has no
+            // report.json entry to read a name from.
+            let name = if row.name.is_empty() {
+                scenarios.get(&row.id).map_or("", |(n, _)| n.as_str())
+            } else {
+                row.name.as_str()
+            };
+            let id = &row.id;
+            let _ = write!(out, "| {name}<br>[`{id}`](#{id}) |");
+            for col in &grid.columns {
+                let g = col
+                    .outcomes
+                    .get(id)
+                    .copied()
+                    .unwrap_or(CellOutcome::Missing);
+                let _ = write!(out, " {} |", g.glyph());
+            }
+            out.push('\n');
         }
         out.push('\n');
     }
@@ -1379,9 +1507,9 @@ fn expectation_grid_markdown(
 }
 
 /// Render the Scenario reference section: each scenario `@id` with its actual
-/// Gherkin scenario (name + steps), anchored by the id (`#### <id>` → GitHub
-/// anchor `#<id>`) so the grid's id links resolve. Ordered by id for stability.
-/// Empty when no scenarios are known.
+/// Gherkin scenario (name + steps), anchored by the id (`##### <id>` → GitHub
+/// anchor `#<id>`) so the grid's id links resolve. Grouped by feature and ordered
+/// like the grid. Empty when no scenarios are known.
 fn scenario_reference_markdown(
     inputs: &[(String, PathBuf)],
     scenarios: &std::collections::BTreeMap<String, (String, Vec<String>)>,
@@ -1390,18 +1518,36 @@ fn scenario_reference_markdown(
 
     // Only emit when there is a grid to reference (platform.json sidecars present),
     // matching where the id links are generated.
-    if scenarios.is_empty() || Grid::build(inputs).is_empty() {
+    let grid = Grid::build(inputs);
+    if scenarios.is_empty() || grid.is_empty() {
         return String::new();
     }
 
+    // Walk the grid's own order so the reference is laid out feature by feature,
+    // matching the tables that link into it. Every grid row gets an entry — a
+    // scenario skipped on every platform has no steps to show, but still needs
+    // its anchor or the grid's link to it dangles.
     let mut out = String::from("\n### Scenario reference\n\n");
-    for (id, (name, steps)) in scenarios {
-        let _ = writeln!(out, "#### {id}\n");
-        let _ = writeln!(out, "_{name}_\n");
-        for step in steps {
-            let _ = writeln!(out, "- {step}");
+    for group in &grid.groups {
+        let _ = writeln!(out, "#### {}\n", group.feature);
+        for row in &group.rows {
+            let entry = scenarios.get(&row.id);
+            let name = entry.map_or(row.name.as_str(), |(n, _)| n.as_str());
+            let _ = writeln!(out, "##### {}\n", row.id);
+            if !name.is_empty() {
+                let _ = writeln!(out, "_{name}_\n");
+            }
+            match entry {
+                Some((_, steps)) => {
+                    for step in steps {
+                        let _ = writeln!(out, "- {step}");
+                    }
+                }
+                // Ran nowhere (n/a on every platform), so no steps were recorded.
+                None => out.push_str("_Not run on any platform in this run._\n"),
+            }
+            out.push('\n');
         }
-        out.push('\n');
     }
     out
 }
@@ -1914,6 +2060,9 @@ const STYLE: &str = r#"
   /* xfail: a known bug that failed as expected — a muted grey ✗, sibling to the red ✗. */
   .status-xfail { color: #9e9e9e; font-weight: 600; }
   .grid-legend { font-size: 0.82rem; color: #555; margin: -0.5rem 0 0.75rem; }
+  /* Feature heading above each sub-table of the expectation grid. */
+  .feature-heading { margin: 1.25rem 0 0.4rem; padding-bottom: 0.2rem; border-bottom: 1px solid #e0e0e0;
+                     color: #1565c0; }
 
   table.stats { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.9rem; }
   table.stats th { background: #f5f5f5; padding: 6px 12px; text-align: left; border: 1px solid #ddd;

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -846,9 +846,18 @@ impl Grid {
                 let entry = identity
                     .entry(exp.id.clone())
                     .or_insert_with(|| (String::new(), String::new()));
-                if entry.0.is_empty() {
-                    entry.0 =
-                        feature_of(exp, features_from_reports.get(&exp.id).map(String::as_str));
+                // An artifact that names the feature itself is authoritative and
+                // OVERWRITES whatever a fallback guessed — `feature_of` always
+                // yields something (worst case the id's prefix), so a mere
+                // is-empty check would let the first input's guess stick and the
+                // later, better-informed artifact be ignored.
+                if exp.feature.is_empty() {
+                    if entry.0.is_empty() {
+                        entry.0 =
+                            feature_of(exp, features_from_reports.get(&exp.id).map(String::as_str));
+                    }
+                } else {
+                    entry.0.clone_from(&exp.feature);
                 }
                 if entry.1.is_empty() {
                     entry.1.clone_from(&exp.scenario);
@@ -1527,12 +1536,23 @@ fn scenario_reference_markdown(
     // matching the tables that link into it. Every grid row gets an entry — a
     // scenario skipped on every platform has no steps to show, but still needs
     // its anchor or the grid's link to it dangles.
+    //
+    // Scoped to grid rows deliberately: this section exists to back the grid's
+    // links, so it documents exactly what the grid shows. A scenario present only
+    // in an artifact with no `platform.json` sidecar has no grid row and so gets
+    // no entry — nothing links to it either.
     let mut out = String::from("\n### Scenario reference\n\n");
     for group in &grid.groups {
         let _ = writeln!(out, "#### {}\n", group.feature);
         for row in &group.rows {
             let entry = scenarios.get(&row.id);
-            let name = entry.map_or(row.name.as_str(), |(n, _)| n.as_str());
+            // Prefer the platform.json name, as the grid does — it is the only
+            // source that covers a scenario which ran nowhere.
+            let name = if row.name.is_empty() {
+                entry.map_or("", |(n, _)| n.as_str())
+            } else {
+                row.name.as_str()
+            };
             let _ = writeln!(out, "##### {}\n", row.id);
             if !name.is_empty() {
                 let _ = writeln!(out, "_{name}_\n");
@@ -2613,6 +2633,51 @@ mod tests {
                 ("dash".to_string(), "dash-y".to_string()),
             ],
             "an artifact with no feature field must still group, not vanish",
+        );
+    }
+
+    #[test]
+    fn a_named_feature_overrides_an_older_artifact_s_guess() {
+        // Mixing artifact vintages: the old one has no `feature` field, so the
+        // id prefix is all there is to go on; the new one names the feature.
+        // The named one must win regardless of input order, or the scenario
+        // splits across two groups sorted far apart.
+        let old = r#"{
+            "platform_slug": "mi300x",
+            "capability": {"effective_serve_engine": "vllm"},
+            "expectations": [{"id":"serve-x","expected":"skip"}]
+        }"#;
+        let new = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-x","feature":"Model serving","scenario":"serve-01 - a","expected":"skip"}
+            ]
+        }"#;
+        let report = feature_json(&[]);
+        let (_d1, old_path) = write_platform(&report, old);
+        let (_d2, new_path) = write_platform(&report, new);
+
+        // Old artifact first: its id-prefix guess must not stick.
+        let inputs = vec![
+            ("mi300x".to_string(), old_path.clone()),
+            ("mock".to_string(), new_path.clone()),
+        ];
+        assert_eq!(
+            grid_order(&inputs),
+            vec![("Model serving".to_string(), "serve-x".to_string())],
+            "a later artifact that names the feature must override the guess",
+        );
+
+        // And the reverse order must not regress it back to the guess.
+        let inputs = vec![
+            ("mock".to_string(), new_path),
+            ("mi300x".to_string(), old_path),
+        ];
+        assert_eq!(
+            grid_order(&inputs),
+            vec![("Model serving".to_string(), "serve-x".to_string())],
+            "an older artifact must not overwrite a named feature",
         );
     }
 

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -859,7 +859,15 @@ impl Grid {
                 } else {
                     entry.0.clone_from(&exp.feature);
                 }
-                if entry.1.is_empty() {
+                // The display name needs no fallback — unlike `feature` it is
+                // never synthesized, so an absent one is simply empty and the
+                // first artifact that HAS a name supplies it either way.
+                // The only case the two rules differ on is two artifacts naming
+                // the same id differently (mixing vintages across a rename):
+                // take the last, matching `feature` above. The name carries the
+                // sort index, so the rule should at least be stated rather than
+                // falling out of map iteration order.
+                if !exp.scenario.is_empty() {
                     entry.1.clone_from(&exp.scenario);
                 }
                 let outcome =
@@ -1461,7 +1469,7 @@ fn expectation_grid_markdown(
         for row in &group.rows {
             // Scenario cell: human name on top, the @id below as a link to its
             // entry in the Scenario reference section (GitHub anchors
-            // `#### <id>` to `#<id>`). Prefer the name recorded in platform.json
+            // `##### <id>` to `#<id>`). Prefer the name recorded in platform.json
             // — it covers a scenario that was skipped everywhere and so has no
             // report.json entry to read a name from.
             let name = if row.name.is_empty() {
@@ -2678,6 +2686,46 @@ mod tests {
             grid_order(&inputs),
             vec![("Model serving".to_string(), "serve-x".to_string())],
             "an older artifact must not overwrite a named feature",
+        );
+    }
+
+    #[test]
+    fn the_last_naming_artifact_sets_the_sort_position() {
+        // Two artifacts naming the same ids differently — a `Scenario:` renamed
+        // between vintages. The name carries the sort index, so which one wins
+        // decides row order; pin the documented rule (last wins) rather than
+        // leaving it to fall out of iteration order.
+        let older = r#"{
+            "platform_slug": "mi300x",
+            "capability": {"effective_serve_engine": "vllm"},
+            "expectations": [
+                {"id":"serve-a","feature":"Model serving","scenario":"serve-01 - a","expected":"skip"},
+                {"id":"serve-b","feature":"Model serving","scenario":"serve-02 - b","expected":"skip"}
+            ]
+        }"#;
+        let newer = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-a","feature":"Model serving","scenario":"serve-02 - a moved","expected":"skip"},
+                {"id":"serve-b","feature":"Model serving","scenario":"serve-01 - b moved","expected":"skip"}
+            ]
+        }"#;
+        let report = feature_json(&[]);
+        let (_d1, older_path) = write_platform(&report, older);
+        let (_d2, newer_path) = write_platform(&report, newer);
+
+        let inputs = vec![
+            ("mi300x".to_string(), older_path),
+            ("mock".to_string(), newer_path),
+        ];
+        assert_eq!(
+            grid_order(&inputs)
+                .into_iter()
+                .map(|(_, id)| id)
+                .collect::<Vec<_>>(),
+            vec!["serve-b".to_string(), "serve-a".to_string()],
+            "the last artifact to name a scenario sets its sort position",
         );
     }
 

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -910,7 +910,7 @@ impl Grid {
         out
     }
 
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.columns.is_empty() || self.groups.is_empty()
     }
 }
@@ -2516,6 +2516,130 @@ mod tests {
         std::fs::write(&report, report_json).expect("write report");
         std::fs::write(dir.path().join("platform.json"), platform_json).expect("write platform");
         (dir, report)
+    }
+
+    /// The order the grid renders rows in, flattened across feature groups.
+    fn grid_order(inputs: &[(String, PathBuf)]) -> Vec<(String, String)> {
+        Grid::build(inputs)
+            .groups
+            .iter()
+            .flat_map(|g| g.rows.iter().map(|r| (g.feature.clone(), r.id.clone())))
+            .collect()
+    }
+
+    #[test]
+    fn scenario_index_parses_the_per_feature_number() {
+        assert_eq!(scenario_index("serve-07 - A model responds"), Some(7));
+        assert_eq!(scenario_index("lifecycle-01 - Linux - a bundle"), Some(1));
+        // Unindexed names (older artifacts) have no number to sort by.
+        assert_eq!(scenario_index("A model responds"), None);
+        assert_eq!(scenario_index(""), None);
+    }
+
+    #[test]
+    fn grid_groups_by_feature_and_orders_by_index() {
+        // Declared deliberately out of order (and interleaved across features)
+        // so a passing assertion can only come from real grouping + sorting,
+        // not from the input order.
+        let report = feature_json(&[
+            (&["id:serve-b"], &["passed"]),
+            (&["id:examine-a"], &["passed"]),
+        ]);
+        let platform = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-b","feature":"Serving","scenario":"serve-02 - second","expected":"pass"},
+                {"id":"examine-a","feature":"Examine","scenario":"examine-09 - ninth","expected":"pass"},
+                {"id":"serve-a","feature":"Serving","scenario":"serve-01 - first","expected":"skip"},
+                {"id":"examine-b","feature":"Examine","scenario":"examine-10 - tenth","expected":"skip"}
+            ]
+        }"#;
+        let (_d, path) = write_platform(&report, platform);
+        let inputs = vec![("mock".to_string(), path)];
+
+        assert_eq!(
+            grid_order(&inputs),
+            vec![
+                ("Examine".to_string(), "examine-a".to_string()),
+                ("Examine".to_string(), "examine-b".to_string()),
+                ("Serving".to_string(), "serve-a".to_string()),
+                ("Serving".to_string(), "serve-b".to_string()),
+            ],
+            "rows must group by feature and sort by index (09 before 10, not \
+             lexically), regardless of declaration order",
+        );
+
+        // Each feature gets its own table under its own heading.
+        let md = consolidated_summary_markdown(&inputs);
+        assert!(
+            md.contains("#### Examine"),
+            "missing feature heading:\n{md}"
+        );
+        assert!(
+            md.contains("#### Serving"),
+            "missing feature heading:\n{md}"
+        );
+        // The human name is shown alongside the id, sourced from platform.json —
+        // serve-a was skipped everywhere, so report.json has no name for it.
+        assert!(
+            md.contains("serve-01 - first<br>[`serve-a`](#serve-a)"),
+            "skipped scenario should still show its name:\n{md}"
+        );
+    }
+
+    #[test]
+    fn grid_falls_back_to_report_feature_then_id_prefix() {
+        // A platform.json predating the `feature`/`scenario` fields. `serve-x`
+        // ran (so report.json knows its feature); `dash-y` was skipped
+        // everywhere, leaving only its id to group by.
+        let report = feature_json(&[(&["id:serve-x"], &["passed"])]);
+        let platform = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-x","effective_engine":"","expected":"pass"},
+                {"id":"dash-y","effective_engine":"","expected":"skip"}
+            ]
+        }"#;
+        let (_d, path) = write_platform(&report, platform);
+        let inputs = vec![("mock".to_string(), path)];
+
+        // `feature_json` names its feature "F"; the id prefix covers the rest.
+        assert_eq!(
+            grid_order(&inputs),
+            vec![
+                ("F".to_string(), "serve-x".to_string()),
+                ("dash".to_string(), "dash-y".to_string()),
+            ],
+            "an artifact with no feature field must still group, not vanish",
+        );
+    }
+
+    #[test]
+    fn scenario_reference_anchors_every_grid_row() {
+        // A scenario that is n/a everywhere has no report.json entry — it still
+        // needs an anchor, or the grid's link to it dangles.
+        let report = feature_json(&[(&["id:serve-x"], &["passed"])]);
+        let platform = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-x","feature":"Serving","scenario":"serve-01 - ran","expected":"pass"},
+                {"id":"serve-z","feature":"Serving","scenario":"serve-02 - skipped","expected":"skip"}
+            ]
+        }"#;
+        let (_d, path) = write_platform(&report, platform);
+        let md = consolidated_summary_markdown(&[("mock".to_string(), path)]);
+        assert!(md.contains("##### serve-x"), "missing anchor:\n{md}");
+        assert!(
+            md.contains("##### serve-z"),
+            "a never-run scenario still needs its anchor:\n{md}"
+        );
+        assert!(
+            md.contains("_Not run on any platform in this run._"),
+            "a never-run scenario should say so instead of showing no steps:\n{md}"
+        );
     }
 
     #[test]

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -1526,7 +1526,7 @@ fn expectation_grid_markdown(
 /// Render the Scenario reference section: each scenario `@id` with its actual
 /// Gherkin scenario (name + steps), anchored by the id (`##### <id>` → GitHub
 /// anchor `#<id>`) so the grid's id links resolve. Grouped by feature and ordered
-/// like the grid. Empty when no scenarios are known.
+/// like the grid. Empty when no expectation grid exists.
 fn scenario_reference_markdown(
     inputs: &[(String, PathBuf)],
     scenarios: &std::collections::BTreeMap<String, (String, Vec<String>)>,
@@ -1536,7 +1536,7 @@ fn scenario_reference_markdown(
     // Only emit when there is a grid to reference (platform.json sidecars present),
     // matching where the id links are generated.
     let grid = Grid::build(inputs);
-    if scenarios.is_empty() || grid.is_empty() {
+    if grid.is_empty() {
         return String::new();
     }
 
@@ -2752,6 +2752,40 @@ mod tests {
         assert!(
             md.contains("_Not run on any platform in this run._"),
             "a never-run scenario should say so instead of showing no steps:\n{md}"
+        );
+    }
+
+    #[test]
+    fn scenario_reference_anchors_grid_when_report_has_no_scenarios() {
+        let report = feature_json(&[]);
+        let platform = r#"{
+            "platform_slug": "mock",
+            "capability": {"effective_serve_engine": "none"},
+            "expectations": [
+                {"id":"serve-a","feature":"Serving","scenario":"serve-01 - first skipped","expected":"skip"},
+                {"id":"serve-b","feature":"Serving","scenario":"serve-02 - second skipped","expected":"skip"}
+            ]
+        }"#;
+        let (_d, path) = write_platform(&report, platform);
+        let md = consolidated_summary_markdown(&[("mock".to_string(), path)]);
+
+        for (id, name) in [
+            ("serve-a", "serve-01 - first skipped"),
+            ("serve-b", "serve-02 - second skipped"),
+        ] {
+            assert!(
+                md.contains(&format!("{name}<br>[`{id}`](#{id})")),
+                "grid link should use the manifest name for {id}:\n{md}"
+            );
+            assert!(
+                md.contains(&format!("##### {id}")),
+                "grid link for {id} should have a Scenario reference anchor:\n{md}"
+            );
+        }
+        assert_eq!(
+            md.matches("_Not run on any platform in this run._").count(),
+            2,
+            "each all-skipped reference entry should explain that it was not run:\n{md}"
         );
     }
 

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -108,9 +108,10 @@ matrix, then reconciles the actual result against that expectation.
 
 ### Naming
 
-Each feature file has a short **key** (`chat`, `dash`, `diagnose`, `examine`,
-`lifecycle`, `serve`, `networking`, `runtime`) that prefixes both its scenario
-names and its ids:
+Each feature file has a short **key** that prefixes both its scenario names and
+its ids. The key is usually the file's stem, but not always — `install_lifecycle`
+uses `lifecycle` and `model_serving` uses `serve` — so `FEATURE_KEYS` in
+`tests/feature_naming.rs` is the list, not this page:
 
 - **Scenario name** — `Scenario: <key>-<NN> - <description>`, numbered
   sequentially in declaration order. The report sorts the grid's rows by this

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -106,11 +106,28 @@ There is no tag-filter tiering. Each CI job runs the **whole** suite
 **pass / xfail / skip** at runtime from its capability tags plus the known-bug
 matrix, then reconciles the actual result against that expectation.
 
+### Naming
+
+Each feature file has a short **key** (`chat`, `dash`, `diagnose`, `examine`,
+`lifecycle`, `serve`, `networking`, `runtime`) that prefixes both its scenario
+names and its ids:
+
+- **Scenario name** — `Scenario: <key>-<NN> - <description>`, numbered
+  sequentially in declaration order. The report sorts the grid's rows by this
+  index, so it must match the order in the file. Without the key the index names
+  nothing: every file used to number from 1, so "1" meant eight different
+  scenarios.
+- **`@id:`** — `<key>-<slug>`, so an id alone says which feature it belongs to.
+
+`tests/feature_naming.rs` enforces all of this (sequential, unique suite-wide,
+feature-qualified ids) in the ordinary `cargo test` run. Adding a feature file
+means adding its key to `FEATURE_KEYS` there.
+
 Scenarios carry stable-id and capability tags:
 
 | Tag | Meaning |
 |---|---|
-| `@id:<slug>` | Stable scenario id. Keys the expectation matrix and the report grid; every scenario has one. |
+| `@id:<key>-<slug>` | Stable scenario id, prefixed with its feature's key. Keys the expectation matrix and the report grid; every scenario has one. |
 | `@requires-gpu` | Needs a usable AMD GPU. Resolves to **skip** (n/a) on a host with none — the mock job, or a WSL host whose ROCm passthrough is incomplete (`driver_status` other than `wsl_rocdxg_ready`), where the gfx target is reported but unreachable. |
 | `@requires-bare-metal` | Premise is a host running the in-tree amdgpu driver, so it does not hold under WSL2. Resolves to **skip** there. `@requires-os:linux` cannot express this: WSL2 reports an `os_family` of `linux`. |
 | `@requires-wsl` | The inverse: premise **is** a WSL2 host. Resolves to **skip** on native Linux, native Windows, and everything else. |

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -109,9 +109,14 @@ matrix, then reconciles the actual result against that expectation.
 ### Naming
 
 Each feature file has a short **key** that prefixes both its scenario names and
-its ids. The key is usually the file's stem, but not always — `install_lifecycle`
-uses `lifecycle` and `model_serving` uses `serve` — so `FEATURE_KEYS` in
-`tests/feature_naming.rs` is the list, not this page:
+its ids. The key is usually the file's stem in kebab-case, but not always —
+`install_lifecycle` uses `lifecycle`, `model_serving` uses `serve`, and
+`dependency_guard` uses `deps-guard` — so `FEATURE_KEYS` in
+`tests/feature_naming.rs` is the list, not this page.
+
+Keys must also be **distinct between files**: `runtime_setup` owns `runtime`, so
+`runtime_lifecycle` takes `runtime-lifecycle`. Two files sharing a key would emit
+the same `<key>-01` index twice, which is exactly what the key exists to prevent.
 
 - **Scenario name** — `Scenario: <key>-<NN> - <description>`, numbered
   sequentially in declaration order. The report sorts the grid's rows by this

--- a/tests/e2e-cucumber/features/artifact_prefetch.feature
+++ b/tests/e2e-cucumber/features/artifact_prefetch.feature
@@ -1,7 +1,7 @@
 Feature: Artifact prefetch cleanup
 
   @id:artifact-prefetch-failed-marker-leaves-no-temp
-  Scenario: A failed artifact cache write leaves no temporary marker
+  Scenario: artifact-prefetch-01 - A failed artifact cache write leaves no temporary marker
     Given a signed direct-download artifact fixture
     And its cache marker destination is occupied by a directory
     When the user approves the artifact prefetch

--- a/tests/e2e-cucumber/features/automations.feature
+++ b/tests/e2e-cucumber/features/automations.feature
@@ -7,7 +7,7 @@ Feature: Automation watchers
   # (no GPU, no network), so it runs on the mock lane every PR.
 
   @id:automations-enable-confirms-mode
-  Scenario: 1 - Enabling a watcher confirms its mode
+  Scenario: automations-01 - Enabling a watcher confirms its mode
     Given a fresh CLI configuration
     When the user enables an automation watcher in observe mode
     Then the CLI confirms the watcher is enabled in observe mode
@@ -15,13 +15,13 @@ Feature: Automation watchers
     Then the CLI confirms the watcher is enabled in propose mode
 
   @id:automations-disable-confirmed
-  Scenario: 2 - Disabling a watcher is confirmed
+  Scenario: automations-02 - Disabling a watcher is confirmed
     Given an enabled automation watcher
     When the user disables the watcher
     Then the CLI confirms the watcher is disabled
 
   @id:automations-enable-unknown-refused
-  Scenario: 3 - Enabling an unknown watcher is refused
+  Scenario: automations-03 - Enabling an unknown watcher is refused
     Given a fresh CLI configuration
     When the user tries to enable a watcher that does not exist
     Then the CLI refuses and names it as unknown

--- a/tests/e2e-cucumber/features/bench.feature
+++ b/tests/e2e-cucumber/features/bench.feature
@@ -6,29 +6,29 @@ Feature: Benchmarking a served endpoint
   # one of the two 404'd — and every request failure was swallowed, so the run
   # still exited 0 with a row of blanks.
   #
-  # Scenarios 1-3 run on every lane (MockServer-backed, no GPU needed) and are
-  # what pin the request path and the failure reporting. Scenario 4 is the
+  # bench-01 to bench-03 run on every lane (MockServer-backed, no GPU needed)
+  # and are what pin the request path and the failure reporting. bench-04 is the
   # hardware proof against a really served model.
 
   # The mock answers chat on BOTH the versioned and unversioned routes, so
   # "the benchmark succeeded" alone would pass even with the bug present. This
   # scenario therefore asserts which route the requests actually landed on.
   @id:bench-load-reports-throughput
-  Scenario: 1 - Benchmarking a running server reports measured throughput
+  Scenario: bench-01 - Benchmarking a running server reports measured throughput
     Given a model is being served
     When the user benchmarks the served endpoint
     Then the benchmark reports measured throughput
     And the benchmark requests reached the versioned chat route
 
   @id:bench-load-accepts-plain-address
-  Scenario: 2 - A plain host address is accepted and still reaches the server
+  Scenario: bench-02 - A plain host address is accepted and still reaches the server
     Given a model is being served
     When the user benchmarks the server using its plain host address
     Then the benchmark reports measured throughput
     And the benchmark requests reached the versioned chat route
 
   @id:bench-load-surfaces-failures
-  Scenario: 3 - A benchmark whose every request is rejected fails loudly
+  Scenario: bench-03 - A benchmark whose every request is rejected fails loudly
     Given an endpoint that rejects every request
     When the user benchmarks the served endpoint
     Then the benchmark reports that the requests failed
@@ -42,7 +42,7 @@ Feature: Benchmarking a served endpoint
   # without an active ROCm runtime. Lemonade hosts do not need it, so omitting it
   # fails on Instinct alone — mirror the sibling GPU serve scenarios and keep it.
   @id:bench-load-real-serve @requires-gpu
-  Scenario: 4 - Benchmarking a really served model reports throughput
+  Scenario: bench-04 - Benchmarking a really served model reports throughput
     Given a managed runtime is active
     And a model is being served on GPU
     When the user benchmarks the served endpoint

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -1,7 +1,7 @@
 Feature: Chat and endpoint detection
 
   @id:chat-served-model-discoverable
-  Scenario: 1 - A served model is discoverable through the services list
+  Scenario: chat-01 - A served model is discoverable through the services list
     Given a model is being served
     And the model is registered with the CLI
     When the user checks for running services
@@ -13,7 +13,7 @@ Feature: Chat and endpoint detection
   # offers it — the notice must precede any request. (Previously an
   # untestable-black-box gap.)
   @id:chat-privacy-notice-accurate @requires-os:linux
-  Scenario: 2 - The privacy notice is shown before using a local endpoint
+  Scenario: chat-02 - The privacy notice is shown before using a local endpoint
     Given a model is being served locally
     And the model is registered with the CLI
     When the user opens interactive chat
@@ -23,7 +23,7 @@ Feature: Chat and endpoint detection
     Then interactive chat exits successfully
 
   @id:chat-managed-model-interactive @requires-os:linux
-  Scenario: 3 - Interactive chat uses a running managed model
+  Scenario: chat-03 - Interactive chat uses a running managed model
     Given a running managed model is available locally
     When the user opens interactive chat
     Then the local endpoint is shown for confirmation
@@ -35,7 +35,7 @@ Feature: Chat and endpoint detection
     Then interactive chat exits successfully
 
   @id:chat-endpoint-shown-in-services
-  Scenario: 4 - A served model's endpoint is shown in the services list
+  Scenario: chat-04 - A served model's endpoint is shown in the services list
     Given a model is being served
     And the model is registered with the CLI
     When the user lists running services
@@ -46,18 +46,18 @@ Feature: Chat and endpoint detection
   # assertion (a tools-bearing request is accepted) is engine-agnostic, so no GPU
   # is required — dropping @requires-gpu gives this per-PR mock-lane coverage.
   @id:chat-tool-definitions-accepted
-  Scenario: 5 - Chat requests that include tool definitions are accepted
+  Scenario: chat-05 - Chat requests that include tool definitions are accepted
     Given a managed runtime is active
     And a model is served in the background
     When a chat request with tool definitions is sent
     Then the chat response is successful
 
-  # Runs on every lane (see scenario 5): real serve on a GPU host, MockServer on
+  # Runs on every lane (see chat-05): real serve on a GPU host, MockServer on
   # the no-GPU mock lane. Asserts only that a served model returns a non-empty
   # reply, which is engine-agnostic — real generation is covered by the
   # @requires-gpu serve-*-inference scenarios.
   @id:chat-end-to-end-local-model
-  Scenario: 6 - End-to-end chat through a locally served model
+  Scenario: chat-06 - End-to-end chat through a locally served model
     Given a managed runtime is active
     And a model is served in the background
     And the served model has been detected
@@ -70,7 +70,7 @@ Feature: Chat and endpoint detection
   # reports `rocm chat` as covered. Runs on mock (no GPU): the local provider
   # resolves the planted managed-service record and talks to the mock server.
   @id:chat-cli-oneshot-prompt
-  Scenario: 7 - The chat CLI answers a one-shot prompt against a local server
+  Scenario: chat-07 - The chat CLI answers a one-shot prompt against a local server
     Given a model is being served
     And the model is registered with the CLI
     When the user sends a one-shot chat prompt through the CLI

--- a/tests/e2e-cucumber/features/config.feature
+++ b/tests/e2e-cucumber/features/config.feature
@@ -7,7 +7,7 @@ Feature: Configuration mutations
   # PR, catching a regression in the config surface before the field does.
 
   @id:config-default-engine-set-and-cleared
-  Scenario: 1 - Setting and clearing the default engine is confirmed
+  Scenario: config-01 - Setting and clearing the default engine is confirmed
     Given a fresh CLI configuration
     When the user sets the default engine
     Then the CLI confirms the default engine was set
@@ -15,7 +15,7 @@ Feature: Configuration mutations
     Then the CLI confirms the default engine was cleared
 
   @id:config-default-runtime-set-and-cleared
-  Scenario: 2 - Setting and clearing the default runtime is confirmed
+  Scenario: config-02 - Setting and clearing the default runtime is confirmed
     Given a fresh CLI configuration
     When the user sets the default runtime
     Then the CLI confirms the default runtime was set
@@ -23,19 +23,19 @@ Feature: Configuration mutations
     Then the CLI confirms the default runtime was cleared
 
   @id:config-telemetry-mode-confirmed
-  Scenario: 3 - Choosing a telemetry mode is confirmed with its policy
+  Scenario: config-03 - Choosing a telemetry mode is confirmed with its policy
     Given a fresh CLI configuration
     When the user turns telemetry off
     Then the CLI confirms the telemetry mode and states the policy
 
   @id:config-permissions-mode-confirmed
-  Scenario: 4 - Choosing a permissions mode is confirmed
+  Scenario: config-04 - Choosing a permissions mode is confirmed
     Given a fresh CLI configuration
     When the user selects a permissions mode
     Then the CLI confirms the permissions mode
 
   @id:config-set-engine-requires-target
-  Scenario: 5 - Configuring an engine requires a target
+  Scenario: config-05 - Configuring an engine requires a target
     Given a fresh CLI configuration
     When the user configures an engine without saying what to change
     Then the CLI refuses and explains a target is required
@@ -43,7 +43,7 @@ Feature: Configuration mutations
     Then the CLI confirms the engine configuration was updated
 
   @id:config-provider-enable-disable
-  Scenario: 6 - Enabling and disabling a cloud provider is confirmed
+  Scenario: config-06 - Enabling and disabling a cloud provider is confirmed
     Given a fresh CLI configuration
     When the user enables a cloud provider
     Then the CLI confirms the provider is enabled for prompt sending
@@ -51,7 +51,7 @@ Feature: Configuration mutations
     Then the CLI confirms the provider is disabled
 
   @id:config-local-provider-not-toggleable
-  Scenario: 7 - The always-on local provider cannot be toggled as a cloud provider
+  Scenario: config-07 - The always-on local provider cannot be toggled as a cloud provider
     Given a fresh CLI configuration
     When the user tries to enable the local provider
     Then the CLI refuses and explains the local provider is always enabled
@@ -62,7 +62,7 @@ Feature: Configuration mutations
   # present and cannot be disabled the same way, so the failure premise only holds
   # on Linux. The no-echo property it verifies is the security-relevant contract.
   @id:config-provider-key-no-secret-storage @requires-os:linux
-  Scenario: 8 - Saving a provider key without secure storage fails without leaking the key
+  Scenario: config-08 - Saving a provider key without secure storage fails without leaking the key
     Given a machine with no secure secret storage
     When the user saves a provider API key
     Then the CLI reports it could not save the key securely

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -111,8 +111,8 @@ Feature: Interactive dashboard
     When the user quits the dashboard
     Then the dashboard exits successfully
 
-  @id:launcher-shows-live-serving-instance @requires-os:linux
-  Scenario: 10 - The launcher front door shows a live serving model rather than idle
+  @id:dash-launcher-shows-live-serving-instance @requires-os:linux
+  Scenario: dash-10 - The launcher front door shows a live serving model rather than idle
     # EAI-8190 regression: bare `rocm` opens the launcher front door, which
     # reads the managed-service registry (`launcher_serving_instances`) the same
     # way `rocm services` does. A model already serving must surface as

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -6,7 +6,7 @@ Feature: Interactive dashboard
   # not yet promoted to a blocking contract (tracked as a follow-up).
 
   @id:dash-opens-and-navigates @requires-os:linux
-  Scenario: 1 - A user opens the dashboard and navigates to ROCm setup
+  Scenario: dash-01 - A user opens the dashboard and navigates to ROCm setup
     When the user opens the dashboard with demo data
     Then the dashboard home view is displayed
     When the user opens the ROCm view
@@ -15,7 +15,7 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
   @id:dash-chat-offline-reply @requires-os:linux
-  Scenario: 2 - A user receives a response in interactive chat
+  Scenario: dash-02 - A user receives a response in interactive chat
     Given interactive chat uses an offline assistant
     When the user opens interactive chat
     And the user sends a message about GPU health
@@ -24,7 +24,7 @@ Feature: Interactive dashboard
     Then interactive chat exits successfully
 
   @id:dash-loading-service-status @requires-os:linux
-  Scenario: 3 - The dashboard reports a model that is still loading as loading
+  Scenario: dash-03 - The dashboard reports a model that is still loading as loading
     Given a managed model is still loading
     When the user opens the dashboard
     And the user opens the Observe view
@@ -33,7 +33,7 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
   @id:dash-managed-service-metrics @requires-os:linux
-  Scenario: 4 - Observe displays metrics from a managed model
+  Scenario: dash-04 - Observe displays metrics from a managed model
     Given a managed model exposes serving metrics
     When the user opens the dashboard
     And the user opens the Observe view
@@ -42,7 +42,7 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
   @id:dash-help-guidance @requires-os:linux
-  Scenario: 5 - A user can discover dashboard help and next-step guidance
+  Scenario: dash-05 - A user can discover dashboard help and next-step guidance
     When the user opens the dashboard with demo data
     And the user opens dashboard help
     Then navigation and next-step guidance are displayed
@@ -51,7 +51,7 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
   @id:dash-command-palette-navigation @requires-os:linux
-  Scenario: 6 - A user navigates to Serving through the command palette
+  Scenario: dash-06 - A user navigates to Serving through the command palette
     When the user opens the dashboard with demo data
     And the user opens the command palette
     Then dashboard destinations are displayed
@@ -61,7 +61,7 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
   @id:dash-managed-service-visible @requires-os:linux
-  Scenario: 7 - A managed model is visible in the dashboard
+  Scenario: dash-07 - A managed model is visible in the dashboard
     Given a running managed model is available locally
     When the user opens the dashboard
     And the user opens the Observe view
@@ -70,8 +70,8 @@ Feature: Interactive dashboard
     Then the dashboard exits successfully
 
 
-  @id:eai-7960-gen-tps-held-after-scrape-failure @requires-os:linux
-  Scenario: 8 - Gen throughput stays visible for the validity window after a scrape failure
+  @id:dash-gen-tps-held-after-scrape-failure @requires-os:linux
+  Scenario: dash-08 - Gen throughput stays visible for the validity window after a scrape failure
     # EAI-7960 principal regression: after establishing a positive gen_tps
     # baseline through the scripted mock, a single /metrics transport failure
     # must NOT immediately clear the displayed "tok/s" value.  The contract
@@ -88,8 +88,8 @@ Feature: Interactive dashboard
     When the user quits the dashboard
     Then the dashboard exits successfully
 
-  @id:eai-7960-gen-tps-expiry-boundary @requires-os:linux
-  Scenario: 9 - Gen throughput expires after the validity window following sustained failure
+  @id:dash-gen-tps-expiry-boundary @requires-os:linux
+  Scenario: dash-09 - Gen throughput expires after the validity window following sustained failure
     # EAI-7960 expiry-boundary scenario: two contract boundaries are pinned.
     #
     # BOUNDARY 1 (held assertion) — immediately after the first failed scrape,

--- a/tests/e2e-cucumber/features/dependency_guard.feature
+++ b/tests/e2e-cucumber/features/dependency_guard.feature
@@ -18,7 +18,7 @@ Feature: System dependency installs preserve ROCm
   # assert; move this behind a package-manager capability gate if such a lane
   # is ever added.
   @id:deps-guard-refuses-rocm-removal @requires-os:linux
-  Scenario: 1 - Installing a dependency never silently removes ROCm
+  Scenario: deps-guard-01 - Installing a dependency never silently removes ROCm
     Given a machine with a registered ROCm runtime
     And installing OpenMPI would remove the ROCm packages
     When the user installs the vLLM engine and approves system changes

--- a/tests/e2e-cucumber/features/diagnose.feature
+++ b/tests/e2e-cucumber/features/diagnose.feature
@@ -17,48 +17,48 @@ Feature: Diagnosing failures and listing fixes
   # designed behaviour with its own unit test, not a bug, so they are skipped
   # rather than xfail'd. `@requires-os:linux` would not do it: WSL2 is linux.
   @id:diagnose-matches-known-symptom @requires-bare-metal
-  Scenario: 1 - Diagnosing a recognised failure reports a likely cause and a fix
+  Scenario: diagnose-01 - Diagnosing a recognised failure reports a likely cause and a fix
     Given a user who hit a known ROCm failure
     When the user asks the CLI to diagnose that symptom
     Then the CLI reports a likely cause with a suggested fix
     And every reported cause comes with a command that applies it
 
   @id:diagnose-always-offers-a-way-forward
-  Scenario: 2 - Diagnosing any failure always gives the user a way to escalate
+  Scenario: diagnose-02 - Diagnosing any failure always gives the user a way to escalate
     Given a user who hit a failure the CLI does not recognise
     When the user asks the CLI to diagnose that symptom in machine-readable form
     Then the CLI always points to somewhere the problem can be reported
 
   @id:diagnose-json-has-match-flag @requires-bare-metal
-  Scenario: 3 - A diagnosis is available in machine-readable form for tooling
+  Scenario: diagnose-03 - A diagnosis is available in machine-readable form for tooling
     Given a user who hit a known ROCm failure
     When the user asks the CLI to diagnose that symptom in machine-readable form
     Then the result is machine-readable and identifies the matched cause
 
-  @id:fix-lists-known-recipes
-  Scenario: 4 - The user can see every fix the CLI knows how to apply
+  @id:diagnose-fix-lists-known-recipes
+  Scenario: diagnose-04 - The user can see every fix the CLI knows how to apply
     When the user asks the CLI which fixes it offers
     Then the CLI lists the fixes it can apply
     And each fix indicates whether the CLI can apply it automatically
     And the listing explains what those indicators mean
 
-  @id:fix-dry-run-changes-nothing
-  Scenario: 5 - Previewing a fix explains the change without making it
+  @id:diagnose-fix-dry-run-changes-nothing
+  Scenario: diagnose-05 - Previewing a fix explains the change without making it
     Given a user who has chosen a known fix
     When the user previews that fix without applying it
     Then the CLI describes what the fix would change
     And nothing on the machine is changed
 
-  @id:fix-unknown-id-rejected
-  Scenario: 6 - Asking for a fix the CLI does not know is refused clearly
+  @id:diagnose-fix-unknown-id-rejected
+  Scenario: diagnose-06 - Asking for a fix the CLI does not know is refused clearly
     Given a user who names a fix the CLI does not offer
     When the user asks the CLI to apply that fix
     Then the CLI refuses and explains that the fix is not recognised
 
   # A diagnosis ranks causes `#1`, `#2`; reaching for that number here is the
   # natural mistake, and it used to get the same bare "unknown id" as a typo.
-  @id:fix-position-argument-rejected
-  Scenario: 7 - Asking for a fix by its position in the diagnosis is corrected
+  @id:diagnose-fix-position-argument-rejected
+  Scenario: diagnose-07 - Asking for a fix by its position in the diagnosis is corrected
     Given a user who refers to a cause by its position in the diagnosis
     When the user asks the CLI to apply that fix
     Then the CLI refuses and explains that a position is not a fix-id
@@ -72,14 +72,14 @@ Feature: Diagnosing failures and listing fixes
   # same recipe persists through `setx` into the user environment, which the
   # suite cannot plant or read back safely. The gate itself is shared code, so
   # this still guards it — just not the Windows persistence step.
-  @id:fix-requires-agreement-before-changing-anything @requires-os:linux
-  Scenario: 8 - A fix that changes the machine is not applied without agreement
+  @id:diagnose-fix-requires-agreement-before-changing-anything @requires-os:linux
+  Scenario: diagnose-08 - A fix that changes the machine is not applied without agreement
     Given a user who has chosen a fix that would change the machine
     When the user asks the CLI to apply it without agreeing to the change
     Then the CLI refuses and explains that it needs agreement
     And the file the fix would have changed is untouched
 
-  # The other half of scenario 3, and the half every host can prove. A caller
+  # The other half of diagnose-03, and the half every host can prove. A caller
   # cannot read "did anything match?" off the size of the list: every checker
   # that fires at all is reported, including ones scoring too low to act on,
   # and several open with a nonzero score for a situation that is merely
@@ -88,7 +88,7 @@ Feature: Diagnosing failures and listing fixes
   # that are not wrong with it. A caller treating that as a diagnosis proposes
   # a fix for a machine with nothing wrong, and never routes the user onward.
   @id:diagnose-json-states-when-nothing-matched
-  Scenario: 9 - A tool is told plainly when no cause was established
+  Scenario: diagnose-09 - A tool is told plainly when no cause was established
     Given a user who hit a failure the CLI does not recognise
     When the user asks the CLI to diagnose that symptom in machine-readable form
     Then the result states that no cause was established
@@ -108,7 +108,7 @@ Feature: Diagnosing failures and listing fixes
   # to be worth writing. An earlier version of this scenario returned early on a
   # covered platform and asserted nothing at all on any lane CI runs.
   @id:diagnose-states-whether-the-platform-is-covered
-  Scenario: 10 - A platform the catalog does not cover says so and routes onward
+  Scenario: diagnose-10 - A platform the catalog does not cover says so and routes onward
     Given a user who hit a known ROCm failure
     When the user asks the CLI to diagnose that symptom in machine-readable form
     Then the result says whether this platform is covered
@@ -121,22 +121,22 @@ Feature: Diagnosing failures and listing fixes
   # broken machine when the truth is "wrong operating system". The scenario
   # picks whichever catalog entry belongs to the OTHER platform, so it carries
   # the same weight on the Linux and Windows lanes.
-  @id:fix-inapplicable-here-is-declined-not-attempted
-  Scenario: 11 - A fix meant for another operating system is declined, not attempted
+  @id:diagnose-fix-inapplicable-here-is-declined-not-attempted
+  Scenario: diagnose-11 - A fix meant for another operating system is declined, not attempted
     Given a user who has chosen a fix meant for a different operating system
     When the user asks the CLI to apply that fix
     Then the CLI declines because the fix does not apply to this machine
     And nothing on the machine is changed
 
-  # Scenario 4 proves the listing works; this proves it is COMPLETE. Which
+  # diagnose-04 proves the listing works; this proves it is COMPLETE. Which
   # failure modes exist, and which of them the CLI will carry out itself, are
   # part of the published contract rather than private detail — so a mode added
   # or removed is a change to what callers were promised, and it should not be
   # possible to make it quietly. This is deliberately the brittle test that
   # breaks when the catalog changes; that break is the notification. Do not
   # loosen it.
-  @id:fix-catalog-is-complete
-  Scenario: 12 - The CLI offers every fix its catalog documents
+  @id:diagnose-fix-catalog-is-complete
+  Scenario: diagnose-12 - The CLI offers every fix its catalog documents
     When the user asks the CLI which fixes it offers
     Then every fix the catalog documents is listed
     And only the fixes the CLI can carry out itself are marked as such

--- a/tests/e2e-cucumber/features/engine_shell.feature
+++ b/tests/e2e-cucumber/features/engine_shell.feature
@@ -15,7 +15,7 @@ Feature: Engine shell
   # Windows, and the runner's own $SHELL varies, which would otherwise decide
   # whether a marker appears at all.
   @id:engine-shell-marks-the-prompt @requires-os:linux
-  Scenario: 1 - Entering an engine shell is visibly different from the shell you left
+  Scenario: engine-shell-01 - Entering an engine shell is visibly different from the shell you left
     Given a machine with an installed engine environment
     When the user opens a shell for that engine
     Then the shell is visibly marked as that engine's shell

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -118,7 +118,7 @@ Feature: GPU detection and system inspection
   # would actually pull. The plan is rendered on every Linux host regardless of
   # GPU (the driver is not yet installed when you preview it), so the mock lane
   # pins this without hardware.
-  @id:install-driver-dry-run-resolves-repo-version @requires-os:linux
-  Scenario: 12 - The driver install dry-run shows the effective repo version
+  @id:examine-install-driver-dry-run-resolves-repo-version @requires-os:linux
+  Scenario: examine-12 - The driver install dry-run shows the effective repo version
     When the user previews the driver install plan
     Then the plan's repo version is a concrete version, not a shell placeholder

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -1,24 +1,24 @@
 Feature: GPU detection and system inspection
 
   @id:examine-version
-  Scenario: 1 - The CLI reports its version
+  Scenario: examine-01 - The CLI reports its version
     When the user asks for the version
     Then a version string is returned
 
   @id:examine-engines-list
-  Scenario: 2 - The CLI lists all supported engines
+  Scenario: examine-02 - The CLI lists all supported engines
     When the user lists available engines
     Then all supported engines are listed
 
   # EAI-7383: keep the top-level command list alphabetized so it remains easy to
   # scan as commands are added or reordered in the source declaration.
-  @id:help-lists-subcommands-alphabetically
-  Scenario: 5 - The help output lists subcommands in alphabetical order
+  @id:examine-help-lists-subcommands-alphabetically
+  Scenario: examine-03 - The help output lists subcommands in alphabetical order
     When the user asks for help
     Then the subcommands are listed in alphabetical order
 
   @id:examine-detects-gpu-and-driver @requires-gpu
-  Scenario: 3 - System inspection detects the GPU and driver
+  Scenario: examine-04 - System inspection detects the GPU and driver
     Given a machine with an AMD GPU
     When the user inspects the system
     Then the inspection reports which GPU is installed
@@ -32,7 +32,7 @@ Feature: GPU detection and system inspection
   # naming either. The harness derives its answer from the GPU probe rather than
   # from `examine`, so this is a cross-check and not a tautology.
   @id:examine-reports-host-default-engine
-  Scenario: 6 - System inspection names the engine this machine serves on
+  Scenario: examine-05 - System inspection names the engine this machine serves on
     When the user inspects the system
     Then the inspection names the engine this host serves on by default
 
@@ -42,7 +42,7 @@ Feature: GPU detection and system inspection
   # hardware. Dropping `@requires-gpu` gains per-PR mock-lane coverage for the
   # reporting this scenario exists to pin.
   @id:examine-distinguishes-unmanaged-rocm
-  Scenario: 4 - System inspection distinguishes CLI-managed from pre-existing ROCm
+  Scenario: examine-06 - System inspection distinguishes CLI-managed from pre-existing ROCm
     Given a machine with a ROCm install that was not set up by the CLI
     When the user inspects the system
     Then the inspection reports the install as pre-existing
@@ -59,7 +59,7 @@ Feature: GPU detection and system inspection
   # level: tooling reads this one, and it must not drift back into being the
   # weaker of the two.
   @id:examine-machine-readable-report
-  Scenario: 7 - What the inspection tells a tool matches what it tells a person
+  Scenario: examine-07 - What the inspection tells a tool matches what it tells a person
     When the user inspects the system both for reading and for scripting
     Then the machine-readable form states everything the readable one does
 
@@ -72,7 +72,7 @@ Feature: GPU detection and system inspection
   # expectation silently resolves against the wrong host. Since fixed; this is
   # the guard that keeps it fixed.
   @id:examine-both-forms-agree-on-gpu
-  Scenario: 8 - Both forms of the inspection agree about the GPU
+  Scenario: examine-08 - Both forms of the inspection agree about the GPU
     When the user inspects the system both for reading and for scripting
     Then both reports agree on whether this machine has an AMD GPU
     And both reports agree on whether this platform is in scope
@@ -81,7 +81,7 @@ Feature: GPU detection and system inspection
   # whether it liked what it saw. Finding no GPU is a finding, not a failure.
   # This is the mock lane's to prove — it is the one lane with nothing to find.
   @id:examine-reports-without-failing
-  Scenario: 9 - Inspecting a machine reports what it finds without failing
+  Scenario: examine-09 - Inspecting a machine reports what it finds without failing
     When the user inspects the system
     Then the inspection completes successfully
     And it states a verdict for this machine
@@ -97,7 +97,7 @@ Feature: GPU detection and system inspection
   # the choice is reachable, and it cannot answer that where no choice is acted
   # on at all.
   @id:examine-can-skip-framework-probing @requires-bare-metal
-  Scenario: 10 - The user can leave the frameworks out of the inspection
+  Scenario: examine-10 - The user can leave the frameworks out of the inspection
     When the user inspects the system without probing frameworks
     Then the inspection reports that it skipped the frameworks
     And it still states a verdict for this machine
@@ -106,7 +106,7 @@ Feature: GPU detection and system inspection
   # so `@requires-os:linux` cannot express "only where the host really is WSL".
   # Runs only on the WSL lane; everywhere else the premise does not exist.
   @id:examine-detects-wsl @requires-wsl
-  Scenario: 11 - System inspection recognizes a WSL host
+  Scenario: examine-11 - System inspection recognizes a WSL host
     Given the CLI is running in WSL
     When the user inspects the system
     Then the inspection reports Linux as the operating system

--- a/tests/e2e-cucumber/features/install_lifecycle.feature
+++ b/tests/e2e-cucumber/features/install_lifecycle.feature
@@ -19,7 +19,7 @@ Feature: Release install lifecycle
   # ── Packaging + signature-verified install (Linux) ────────────────────
 
   @id:lifecycle-linux-install-signed-keypath @lifecycle @requires-os:linux
-  Scenario: Linux - a bundle signed with a key file installs, verifies, and sets up the shell profile
+  Scenario: lifecycle-01 - Linux - a bundle signed with a key file installs, verifies, and sets up the shell profile
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -32,7 +32,7 @@ Feature: Release install lifecycle
     And the shell profile lists the install directory
 
   @id:lifecycle-linux-install-signed-pem @lifecycle @requires-os:linux
-  Scenario: Linux - a bundle signed with an inline PEM installs and verifies
+  Scenario: lifecycle-02 - Linux - a bundle signed with an inline PEM installs and verifies
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key PEM
@@ -44,7 +44,7 @@ Feature: Release install lifecycle
   # ── Trust rejection: untrusted key, bad checksum, bad/missing signature ─
 
   @id:lifecycle-linux-reject-untrusted-key @lifecycle @requires-os:linux
-  Scenario: Linux - an install with no public key falls back to the pinned trust root and rejects an untrusted signer
+  Scenario: lifecycle-03 - Linux - an install with no public key falls back to the pinned trust root and rejects an untrusted signer
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -53,7 +53,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-linux-reject-bad-checksum @lifecycle @requires-os:linux
-  Scenario: Linux - a tampered checksum is rejected before activation
+  Scenario: lifecycle-04 - Linux - a tampered checksum is rejected before activation
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -63,7 +63,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-linux-reject-bad-signature @lifecycle @requires-os:linux
-  Scenario: Linux - a tampered signature is rejected before activation
+  Scenario: lifecycle-05 - Linux - a tampered signature is rejected before activation
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -73,7 +73,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-linux-reject-missing-signature @lifecycle @requires-os:linux
-  Scenario: Linux - a missing signature is rejected when a signature is required
+  Scenario: lifecycle-06 - Linux - a missing signature is rejected when a signature is required
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -85,7 +85,7 @@ Feature: Release install lifecycle
   # ── Reinstall: stale-manifest purge, config preservation, PATH idempotency ─
 
   @id:lifecycle-linux-reinstall-purges-stale @lifecycle @requires-os:linux
-  Scenario: Linux - reinstalling purges a stale prior entry and preserves config
+  Scenario: lifecycle-07 - Linux - reinstalling purges a stale prior entry and preserves config
     Given a freshly built release tree
     And a generated signing keypair
     And a signed bundle installed with the shell profile updated
@@ -101,7 +101,7 @@ Feature: Release install lifecycle
   # ── Installed-binary PTY, shell-profile / XDG, and uninstall ────────────
 
   @id:lifecycle-linux-installed-binary-pty @lifecycle @requires-os:linux
-  Scenario: Linux - the installed binary opens and exits interactive chat through a pseudo-terminal
+  Scenario: lifecycle-08 - Linux - the installed binary opens and exits interactive chat through a pseudo-terminal
     Given a freshly built release tree
     And a generated signing keypair
     And a signed bundle installed with the public key file
@@ -113,7 +113,7 @@ Feature: Release install lifecycle
     And the installed config still selects the vllm default engine
 
   @id:lifecycle-linux-uninstall-full-purge @lifecycle @requires-os:linux
-  Scenario: Linux - uninstall removes binaries, manifest, and XDG state
+  Scenario: lifecycle-09 - Linux - uninstall removes binaries, manifest, and XDG state
     Given a freshly built release tree
     And a generated signing keypair
     And a signed bundle installed with the shell profile updated
@@ -126,7 +126,7 @@ Feature: Release install lifecycle
   # ── Windows user-PATH restoration, loopback HTTP install, isolated smoke ─
 
   @id:lifecycle-windows-install-signed @lifecycle @requires-os:windows
-  Scenario: Windows - a signed zip installs and verifies with native crypto
+  Scenario: lifecycle-10 - Windows - a signed zip installs and verifies with native crypto
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -136,7 +136,7 @@ Feature: Release install lifecycle
     And the install manifest is present
 
   @id:lifecycle-windows-key-rotation-fallback @lifecycle @requires-os:windows
-  Scenario: Windows - a malformed current trust root falls through to the valid next key
+  Scenario: lifecycle-11 - Windows - a malformed current trust root falls through to the valid next key
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -146,7 +146,7 @@ Feature: Release install lifecycle
     And the installed rocm binary is present
 
   @id:lifecycle-windows-all-pinned-keys-malformed @lifecycle @requires-os:windows
-  Scenario: Windows - all malformed pinned trust roots fail deterministically
+  Scenario: lifecycle-12 - Windows - all malformed pinned trust roots fail deterministically
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -156,7 +156,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-updates-user-path @lifecycle @requires-os:windows
-  Scenario: Windows - a default install updates the user PATH and restores it afterwards
+  Scenario: lifecycle-13 - Windows - a default install updates the user PATH and restores it afterwards
     Given a freshly built release tree
     And a generated signing keypair
     And the user PATH is captured for restoration
@@ -167,7 +167,7 @@ Feature: Release install lifecycle
     And the install directory is on the user PATH
 
   @id:lifecycle-windows-verifies-without-openssl @lifecycle @requires-os:windows
-  Scenario: Windows - the installer verifies with native crypto when openssl is absent from PATH
+  Scenario: lifecycle-14 - Windows - the installer verifies with native crypto when openssl is absent from PATH
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -177,7 +177,7 @@ Feature: Release install lifecycle
     And the install manifest is present
 
   @id:lifecycle-windows-rejects-bad-signature-without-openssl @lifecycle @requires-os:windows
-  Scenario: Windows - a bad signature is rejected with native crypto when openssl is absent from PATH
+  Scenario: lifecycle-15 - Windows - a bad signature is rejected with native crypto when openssl is absent from PATH
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -187,7 +187,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-reinstall-purges-stale @lifecycle @requires-os:windows
-  Scenario: Windows - reinstalling purges a stale prior entry
+  Scenario: lifecycle-16 - Windows - reinstalling purges a stale prior entry
     Given a freshly built release tree
     And a generated signing keypair
     And a signed bundle installed with the public key file
@@ -198,7 +198,7 @@ Feature: Release install lifecycle
     And the install manifest is present
 
   @id:lifecycle-windows-reject-untrusted-key @lifecycle @requires-os:windows
-  Scenario: Windows - an install with no public key rejects an untrusted signer
+  Scenario: lifecycle-17 - Windows - an install with no public key rejects an untrusted signer
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -207,7 +207,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-reject-bad-checksum @lifecycle @requires-os:windows
-  Scenario: Windows - a tampered checksum is rejected before activation
+  Scenario: lifecycle-18 - Windows - a tampered checksum is rejected before activation
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -217,7 +217,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-reject-bad-signature @lifecycle @requires-os:windows
-  Scenario: Windows - a tampered signature is rejected before activation
+  Scenario: lifecycle-19 - Windows - a tampered signature is rejected before activation
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -227,7 +227,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-reject-missing-signature @lifecycle @requires-os:windows
-  Scenario: Windows - a missing signature is rejected when a signature is required
+  Scenario: lifecycle-20 - Windows - a missing signature is rejected when a signature is required
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -237,7 +237,7 @@ Feature: Release install lifecycle
     And no binaries are activated in the target directory
 
   @id:lifecycle-windows-http-install @lifecycle @requires-os:windows
-  Scenario: Windows - a signed bundle installs over a loopback HTTP download
+  Scenario: lifecycle-21 - Windows - a signed bundle installs over a loopback HTTP download
     Given a freshly built release tree
     And a generated signing keypair
     When the release is packaged and signed with the private key file
@@ -247,7 +247,7 @@ Feature: Release install lifecycle
     And the install manifest is present
 
   @id:lifecycle-windows-installed-binary-smoke @lifecycle @requires-os:windows
-  Scenario: Windows - the installed binary honors isolated directories and keeps the running executable on uninstall
+  Scenario: lifecycle-22 - Windows - the installed binary honors isolated directories and keeps the running executable on uninstall
     Given a freshly built release tree
     And a generated signing keypair
     And a signed bundle installed with the public key file

--- a/tests/e2e-cucumber/features/logs.feature
+++ b/tests/e2e-cucumber/features/logs.feature
@@ -8,19 +8,19 @@ Feature: Log inspection
   # not the recent-line total, which also counts other log sources.
 
   @id:logs-search-reports-match-count
-  Scenario: 1 - Searching logs reports how many recent lines match
+  Scenario: logs-01 - Searching logs reports how many recent lines match
     Given recorded command logs containing several lines about a topic
     When the user searches the logs for that topic
     Then the CLI reports the matching recent lines
 
   @id:logs-search-absent-term-no-matches
-  Scenario: 2 - Searching logs for an absent term reports no matches
+  Scenario: logs-02 - Searching logs for an absent term reports no matches
     Given recorded command logs containing several lines about a topic
     When the user searches the logs for a term that appears nowhere
     Then the CLI reports no matching lines
 
   @id:logs-service-and-search-conflict
-  Scenario: 3 - Asking for a service and a search term at once is refused
+  Scenario: logs-03 - Asking for a service and a search term at once is refused
     Given recorded command logs containing several lines about a topic
     When the user asks for one service's logs and a search term together
     Then the CLI refuses and explains only one may be used

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -141,7 +141,7 @@ Feature: Model serving
   # check runs inside argument parsing, before engine selection or any GPU
   # pre-flight, so it needs no GPU and no engine and gates every PR (ungated).
   @id:serve-negative-temperature-rejected
-  Scenario: 15 - Serving with a temperature below zero is refused with a clear reason
+  Scenario: serve-14 - Serving with a temperature below zero is refused with a clear reason
     When the user serves a model with a negative sampling temperature
     Then serving is refused before any engine starts
     And the CLI explains that temperature cannot be negative
@@ -150,7 +150,7 @@ Feature: Model serving
   # GPU-required serve must treat it as "no GPU" and refuse, not fall back. Runs on
   # GPU hardware (Strix Halo / Instinct).
   @id:serve-masked-devices-fail @requires-gpu @requires-os:linux
-  Scenario: serve-14 - Serving is refused when every GPU is masked from view
+  Scenario: serve-15 - Serving is refused when every GPU is masked from view
     When the user serves a model with every GPU masked from view
     Then serving is refused before any engine starts
     And the user is told no AMD GPU was detected
@@ -161,7 +161,7 @@ Feature: Model serving
   # refuses ("no usable AMD GPU") before the index is ever validated, so the
   # index-specific rejection can only be observed where a real device is present.
   @id:serve-absent-gpu-index-rejected @requires-gpu @requires-os:linux
-  Scenario: serve-15 - Serving pinned to a GPU that does not exist is refused
+  Scenario: serve-16 - Serving pinned to a GPU that does not exist is refused
     When the user serves a model pinned to a GPU index that does not exist
     Then serving is refused before any engine starts
     And the user is told that GPU index is unavailable
@@ -171,7 +171,7 @@ Feature: Model serving
   # during argument parsing — before any engine or GPU work. No device needed, so
   # this runs on the mock lane every PR.
   @id:serve-runtime-and-env-selectors-conflict
-  Scenario: 15 - Selecting both a runtime and an environment at once is refused
+  Scenario: serve-17 - Selecting both a runtime and an environment at once is refused
     When the user serves a model selecting both a runtime and an environment
     Then serving is refused before any engine starts
     And the user is told the two selectors cannot be combined
@@ -182,7 +182,7 @@ Feature: Model serving
   # deterministic on the blocking no-GPU lane rather than relying on a real 3 GiB
   # transfer to fail at just the right moment.
   @id:serve-lemonade-preparation-recovery @requires-no-gpu
-  Scenario: 16 - Repeated Lemonade preparation failure gives the user a recovery path
+  Scenario: serve-18 - Repeated Lemonade preparation failure gives the user a recovery path
     Given Lemonade preparation cannot complete
     When the user serves a model with Lemonade
     Then serving stops after one automatic retry

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -33,8 +33,9 @@ Feature: Model serving
   # deliberate vLLM half of a per-engine pair with `serve-lemonade-inference`
   # below, so it stays pinned to vLLM (the slug names the engine). It is also the
   # vLLM per-PR canary: one real vLLM serve runs on every PR so a broken serve is
-  # caught before merge, while the heavier `@merge-queue` serves (6, 6b, 8) run
-  # only in the merge queue.
+  # caught before merge, while the heavier `@merge-queue` serves
+  # (`serve-default-engine-working-endpoint`, `serve-default-engine-inference`,
+  # and `serve-readiness-contract`) run only in the merge queue.
   @id:serve-vllm-inference @requires-gpu @requires-engine:vllm
   Scenario: serve-05 - A served model responds to inference requests on vLLM
     Given a managed runtime is active

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -6,24 +6,24 @@ Feature: Model serving
   # so the harness can skip a scenario whose engine can't start on this host.
 
   @id:serve-short-name-expansion
-  Scenario: 1 - Short model names are expanded to their full name
+  Scenario: serve-01 - Short model names are expanded to their full name
     When the user serves a model using its short name
     Then the output shows the full model name
 
   @id:serve-short-name-consistent-across-engines
-  Scenario: 2 - Short name expansion is consistent across engines
+  Scenario: serve-02 - Short name expansion is consistent across engines
     When the user serves the same short name with different engines
     Then all engines expand to the same full model name
 
   @id:serve-discoverable-by-name
-  Scenario: 3 - A running model server is discoverable by name
+  Scenario: serve-03 - A running model server is discoverable by name
     Given a model is being served on the default port
     And the model is registered with the CLI
     When the user lists running services
     Then the service appears with the correct model name and connection details
 
   @id:serve-connection-details
-  Scenario: 4 - Running services show the correct connection details
+  Scenario: serve-04 - Running services show the correct connection details
     Given a model is being served on a non-default port
     And the model is registered with the CLI
     When the user lists running services
@@ -36,7 +36,7 @@ Feature: Model serving
   # caught before merge, while the heavier `@merge-queue` serves (6, 6b, 8) run
   # only in the merge queue.
   @id:serve-vllm-inference @requires-gpu @requires-engine:vllm
-  Scenario: 5 - A served model responds to inference requests on vLLM
+  Scenario: serve-05 - A served model responds to inference requests on vLLM
     Given a managed runtime is active
     And a model is being served on GPU
     When the user sends a chat completion request
@@ -50,7 +50,7 @@ Feature: Model serving
   # loads stay off the ordinary per-PR path, and the longer readiness timeout also
   # gives the first inference request enough time to complete.
   @id:serve-large-model-inference @requires-gpu @serve-timeout:2400 @nightly
-  Scenario: 10 - A large platform-specific model serves and responds to inference
+  Scenario: serve-06 - A large platform-specific model serves and responds to inference
     Given a managed runtime is active
     And a large model is being served on GPU
     When the user sends a chat completion request
@@ -61,7 +61,7 @@ Feature: Model serving
   # lemonade per-PR canary: one real lemonade serve runs on every PR (the
   # counterpart to the vLLM canary above).
   @id:serve-lemonade-inference @requires-gpu @requires-engine:lemonade
-  Scenario: 7 - A model served on lemonade responds to inference requests
+  Scenario: serve-07 - A model served on lemonade responds to inference requests
     Given a managed runtime is active
     And a GGUF model is being served on lemonade
     When the user sends a chat completion request
@@ -77,7 +77,7 @@ Feature: Model serving
   # `serve-lemonade-inference` (cache-shared, no extra download) so this stays a
   # fast per-PR canary rather than needing the @nightly large-checkpoint path.
   @id:serve-hf-checkpoint-inference @requires-gpu @requires-engine:lemonade
-  Scenario: 14 - A canonical Hugging Face checkpoint serves and responds to inference
+  Scenario: serve-08 - A canonical Hugging Face checkpoint serves and responds to inference
     Given a managed runtime is active
     And a canonical Hugging Face GGUF checkpoint is being served on lemonade
     When the user sends a chat completion request
@@ -88,15 +88,15 @@ Feature: Model serving
   # default from the capability probe, so this covers whichever engine the host
   # would actually pick.
   @id:serve-default-engine-working-endpoint @requires-gpu @merge-queue
-  Scenario: 6 - Serving a model without specifying an engine produces a working endpoint
+  Scenario: serve-09 - Serving a model without specifying an engine produces a working endpoint
     Given a managed runtime is active
     When the user serves a model without specifying an engine
     Then an engine is selected automatically
     And the model is reachable
 
-  # The inference half of scenario 6.
+  # The inference half of serve-09.
   @id:serve-default-engine-inference @requires-gpu @merge-queue
-  Scenario: 6b - A default-engine served model responds to inference requests
+  Scenario: serve-10 - A default-engine served model responds to inference requests
     Given a managed runtime is active
     When the user serves a model without specifying an engine
     Then the model responds to inference requests
@@ -108,7 +108,7 @@ Feature: Model serving
   # skips it on lemonade-default hosts (Strix Halo), where asserting a vLLM
   # default would be a guaranteed false failure.
   @id:serve-vllm-default-on-instinct @requires-gpu @requires-engine:vllm
-  Scenario: 9 - vLLM is the default serving engine on Instinct
+  Scenario: serve-11 - vLLM is the default serving engine on Instinct
     Given a managed runtime is active
     When the user serves a vLLM-capable model without specifying an engine
     Then vLLM is selected as the default engine
@@ -119,7 +119,7 @@ Feature: Model serving
   # platform. Readiness is gated on a real inference probe, which is what makes
   # this contract hold rather than race the model load.
   @id:serve-readiness-contract @requires-gpu @merge-queue
-  Scenario: 8 - A service reported ready can immediately serve inference
+  Scenario: serve-12 - A service reported ready can immediately serve inference
     Given a managed runtime is active
     And a model is being served on GPU
     When the CLI reports the service as ready
@@ -130,7 +130,7 @@ Feature: Model serving
   # launched — with an actionable message, never a CPU or device-0 fallback. Runs
   # on the no-GPU mock host, so it gates every PR (@requires-no-gpu, no GPU needed).
   @id:serve-no-gpu-fails-fast @requires-no-gpu
-  Scenario: 11 - Serving is refused on a host with no AMD GPU
+  Scenario: serve-13 - Serving is refused on a host with no AMD GPU
     When the user serves a model under the GPU-required default
     Then serving is refused before any engine starts
     And the user is told no AMD GPU was detected
@@ -149,7 +149,7 @@ Feature: Model serving
   # GPU-required serve must treat it as "no GPU" and refuse, not fall back. Runs on
   # GPU hardware (Strix Halo / Instinct).
   @id:serve-masked-devices-fail @requires-gpu @requires-os:linux
-  Scenario: 12 - Serving is refused when every GPU is masked from view
+  Scenario: serve-14 - Serving is refused when every GPU is masked from view
     When the user serves a model with every GPU masked from view
     Then serving is refused before any engine starts
     And the user is told no AMD GPU was detected
@@ -160,7 +160,7 @@ Feature: Model serving
   # refuses ("no usable AMD GPU") before the index is ever validated, so the
   # index-specific rejection can only be observed where a real device is present.
   @id:serve-absent-gpu-index-rejected @requires-gpu @requires-os:linux
-  Scenario: 13 - Serving pinned to a GPU that does not exist is refused
+  Scenario: serve-15 - Serving pinned to a GPU that does not exist is refused
     When the user serves a model pinned to a GPU index that does not exist
     Then serving is refused before any engine starts
     And the user is told that GPU index is unavailable

--- a/tests/e2e-cucumber/features/networking.feature
+++ b/tests/e2e-cucumber/features/networking.feature
@@ -35,7 +35,7 @@ Feature: Native HTTP networking
   # first thing `serve` does, before any engine or model work — so it needs no GPU
   # and runs on the mock lane every PR.
   @id:networking-public-bind-requires-opt-in
-  Scenario: 3 - Binding to a public interface without opt-in is refused up front
+  Scenario: networking-03 - Binding to a public interface without opt-in is refused up front
     When the user serves a model bound to a public interface without allowing public binding
     Then serving is refused before any engine starts
     And the user is told to allow public binding first

--- a/tests/e2e-cucumber/features/networking.feature
+++ b/tests/e2e-cucumber/features/networking.feature
@@ -12,7 +12,7 @@ Feature: Native HTTP networking
   # native HTTP GET to `/v1/models` as its readiness probe (served by the mock).
   # Listing the model and its endpoint therefore exercises that native GET.
   @id:networking-native-http-endpoint-reachable
-  Scenario: 1 - The CLI reaches a served endpoint over the native HTTP stack
+  Scenario: networking-01 - The CLI reaches a served endpoint over the native HTTP stack
     Given a model is being served
     And the model is registered with the CLI
     When the user lists running services
@@ -23,7 +23,7 @@ Feature: Native HTTP networking
   # to GET `/v1/models` and POST `/v1/chat/completions` over the native stack, then
   # prints the reply — proving the native HTTP client works end-to-end via the CLI.
   @id:networking-native-http-chat-round-trip
-  Scenario: 2 - A chat round-trip over a local endpoint uses the native HTTP stack
+  Scenario: networking-02 - A chat round-trip over a local endpoint uses the native HTTP stack
     Given a model is being served
     And the model is registered with the CLI
     When the user sends a one-shot chat prompt through the CLI

--- a/tests/e2e-cucumber/features/runtime_lifecycle.feature
+++ b/tests/e2e-cucumber/features/runtime_lifecycle.feature
@@ -7,29 +7,29 @@ Feature: Runtime lifecycle state machine
   # runtimes in the isolated registry, so no SDK download or GPU is needed — they
   # run on the mock lane every PR. Related EAI-7404.
 
-  @id:runtime-activate-records-previous
-  Scenario: 1 - Activating a runtime records where it changed from
+  @id:runtime-lifecycle-activate-records-previous
+  Scenario: runtime-lifecycle-01 - Activating a runtime records where it changed from
     Given two registered runtimes and none active
     When the user activates the first runtime
     Then that runtime becomes active having changed from nothing
     When the user activates the second runtime
     Then that runtime becomes active having changed from the first
 
-  @id:runtime-rollback-returns-to-previous
-  Scenario: 2 - Rolling back returns to the previously active runtime
+  @id:runtime-lifecycle-rollback-returns-to-previous
+  Scenario: runtime-lifecycle-02 - Rolling back returns to the previously active runtime
     Given two registered runtimes with the second active after the first
     When the user rolls back
     Then the first runtime is active again
 
-  @id:runtime-uninstall-keeps-external-folder
-  Scenario: 3 - Uninstalling an externally-sourced runtime keeps its folder
+  @id:runtime-lifecycle-uninstall-keeps-external-folder
+  Scenario: runtime-lifecycle-03 - Uninstalling an externally-sourced runtime keeps its folder
     Given a registered read-only runtime
     When the user uninstalls that runtime
     Then its registry entry is removed
     And its external folder is left in place
 
-  @id:runtime-import-rejects-duplicate-unless-replacing
-  Scenario: 4 - Importing a runtime, then rejecting a duplicate unless replacing
+  @id:runtime-lifecycle-import-rejects-duplicate-unless-replacing
+  Scenario: runtime-lifecycle-04 - Importing a runtime, then rejecting a duplicate unless replacing
     Given a runtime manifest to import
     When the user imports the runtime
     Then the runtime is registered as read-only

--- a/tests/e2e-cucumber/features/runtime_setup.feature
+++ b/tests/e2e-cucumber/features/runtime_setup.feature
@@ -1,7 +1,7 @@
 Feature: Runtime configuration
 
   @id:runtime-install-sdk-active @requires-gpu @nightly
-  Scenario: 1 - Installing the SDK makes it the active runtime
+  Scenario: runtime-01 - Installing the SDK makes it the active runtime
     Given a machine with no CLI-managed runtimes
     When the user installs the SDK
     Then a runtime is registered
@@ -14,7 +14,7 @@ Feature: Runtime configuration
   # runtime's folder path has no such recursive segment. GPU-gated (needs a real
   # install so the folder path is populated).
   @id:runtime-path-not-nested @requires-gpu
-  Scenario: 3 - The managed runtime path is not nested inside another runtime
+  Scenario: runtime-02 - The managed runtime path is not nested inside another runtime
     Given a managed runtime is active
     When the user inspects the system
     Then the managed runtime folder path is not recursively nested
@@ -126,7 +126,7 @@ Feature: Runtime configuration
   # to a bogus `C:/usr/bin/python3` and errors on the missing path before it can
   # emit the install-type guidance), so the scenario's premise doesn't hold there.
   @id:runtime-adopt-preexisting-rejected @requires-os:linux
-  Scenario: 2 - Adopting a pre-existing ROCm install is rejected with guidance
+  Scenario: runtime-03 - Adopting a pre-existing ROCm install is rejected with guidance
     Given a machine with a standard ROCm install
     When the user tries to adopt the existing install
     Then the adoption is refused

--- a/tests/e2e-cucumber/features/runtime_setup.feature
+++ b/tests/e2e-cucumber/features/runtime_setup.feature
@@ -39,7 +39,7 @@ Feature: Runtime configuration
   # already run a GPU kernel with this SDK is kept instead of rewritten and reports
   # a `retained_*` verdict — settled, with nothing installed.
   @id:runtime-sdk-reinstall-keeps-engine-consistent @requires-gpu @requires-engine:vllm @nightly
-  Scenario: 4 - Reinstalling the SDK leaves the installed engine able to use the GPU
+  Scenario: runtime-03 - Reinstalling the SDK leaves the installed engine able to use the GPU
     Given a managed runtime with an inference engine already installed
     When the user installs the SDK again
     Then the runtime can still use the GPU
@@ -71,7 +71,7 @@ Feature: Runtime configuration
   # real engine, on the serialized nightly GPU runners. `@requires-engine:vllm`
   # because only vLLM shares the runtime environment the alignment writes into.
   @id:runtime-torch-alignment-opt-out @requires-gpu @requires-engine:vllm @nightly
-  Scenario: 9 - Opting out of the torch alignment keeps the torch the user installed
+  Scenario: runtime-04 - Opting out of the torch alignment keeps the torch the user installed
     Given a managed runtime with an inference engine already installed
     And the user has opted out of realigning torch
     When the user installs the SDK again
@@ -89,7 +89,7 @@ Feature: Runtime configuration
   # already-installed shared runtime. `status=error` is an ACCEPTED outcome, so an
   # offline runner reports honestly instead of flaking.
   @id:runtime-update-reports-freshness @requires-gpu
-  Scenario: 5 - The update check reports the active runtime's freshness
+  Scenario: runtime-05 - The update check reports the active runtime's freshness
     Given a managed runtime is active
     When the user checks for runtime updates
     Then the report states the runtime's freshness against the channel index
@@ -115,7 +115,7 @@ Feature: Runtime configuration
   # under load, which is their own problem to fix; until then this runs on the
   # nightly lanes, where a GPU is present and scenarios are serialized.
   @id:runtime-install-records-the-real-folder @nightly
-  Scenario: 8 - Previewing an install through a linked runtimes folder names the real folder
+  Scenario: runtime-06 - Previewing an install through a linked runtimes folder names the real folder
     Given a machine whose runtimes folder is a link to somewhere else
     When the user previews an SDK install
     Then the planned runtime folder is inside the folder the link points at
@@ -126,7 +126,7 @@ Feature: Runtime configuration
   # to a bogus `C:/usr/bin/python3` and errors on the missing path before it can
   # emit the install-type guidance), so the scenario's premise doesn't hold there.
   @id:runtime-adopt-preexisting-rejected @requires-os:linux
-  Scenario: runtime-03 - Adopting a pre-existing ROCm install is rejected with guidance
+  Scenario: runtime-07 - Adopting a pre-existing ROCm install is rejected with guidance
     Given a machine with a standard ROCm install
     When the user tries to adopt the existing install
     Then the adoption is refused

--- a/tests/e2e-cucumber/features/update.feature
+++ b/tests/e2e-cucumber/features/update.feature
@@ -7,7 +7,7 @@ Feature: Update report
   # managed runtimes so the report needs no network — mock lane, every PR.
 
   @id:update-report-distinguishes-feed-status
-  Scenario: 1 - The update report distinguishes configured from not-configured feeds
+  Scenario: update-01 - The update report distinguishes configured from not-configured feeds
     Given a machine with no managed runtimes
     When the user checks for updates
     Then the report shows there are no managed runtimes to update

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -877,7 +877,7 @@ reason = "unrelated open bug"
     #[test]
     fn vllm_pinned_scenario_skips_where_vllm_cannot_start() {
         let m = Expectations::default();
-        // Scenario 5-style: pins vLLM.
+        // The feature-qualified `serve-vllm-inference` scenario pins vLLM.
         let d = decl(&[
             "id:serve-vllm-inference",
             "requires-gpu",

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -317,6 +317,16 @@ impl Expectation {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ResolvedScenario {
     pub id: String,
+    /// The `Feature:` this scenario belongs to. Recorded here because a SKIPPED
+    /// scenario never reaches `report.json`, so the report has no other way to
+    /// place it under its feature in the grouped grid.
+    #[serde(default)]
+    pub feature: String,
+    /// The scenario's own name (`<key>-<NN> - <description>`). Carries the
+    /// per-feature index the report sorts rows by, and gives skipped scenarios a
+    /// human label they'd otherwise lack.
+    #[serde(default)]
+    pub scenario: String,
     pub effective_engine: String,
     /// "pass" | "xfail" | "skip".
     pub expected: String,
@@ -329,7 +339,13 @@ pub struct ResolvedScenario {
 }
 
 impl ResolvedScenario {
-    pub fn new(id: &str, effective_engine: &str, expectation: &Expectation) -> Self {
+    pub fn new(
+        id: &str,
+        feature: &str,
+        scenario: &str,
+        effective_engine: &str,
+        expectation: &Expectation,
+    ) -> Self {
         let (bug, reason, flaky) = match expectation {
             Expectation::ExpectXfail { bug, reason, flaky } => {
                 (Some(bug.clone()), Some(reason.clone()), *flaky)
@@ -339,6 +355,8 @@ impl ResolvedScenario {
         };
         Self {
             id: id.to_owned(),
+            feature: feature.to_owned(),
+            scenario: scenario.to_owned(),
             effective_engine: effective_engine.to_owned(),
             expected: expectation.label().to_owned(),
             bug,

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -320,12 +320,15 @@ pub struct ResolvedScenario {
     /// The `Feature:` this scenario belongs to. Recorded here because a SKIPPED
     /// scenario never reaches `report.json`, so the report has no other way to
     /// place it under its feature in the grouped grid.
-    #[serde(default)]
+    ///
+    /// No `#[serde(default)]` here: this struct only derives `Serialize`, so a
+    /// deserialization attribute would be dead. Backward compatibility for
+    /// artifacts written before these fields existed lives entirely on the
+    /// consuming side — `ManifestExpectation` in the `e2e-report` crate.
     pub feature: String,
     /// The scenario's own name (`<key>-<NN> - <description>`). Carries the
     /// per-feature index the report sorts rows by, and gives skipped scenarios a
     /// human label they'd otherwise lack.
-    #[serde(default)]
     pub scenario: String,
     pub effective_engine: String,
     /// "pass" | "xfail" | "skip".

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -102,7 +102,7 @@ pub struct E2eWorld {
 /// filters OUT. A filtered (skipped) scenario never reaches `report.json`, so
 /// this is the only place its feature and name survive to `platform.json`.
 struct Resolution {
-    expectation: Expectation,
+    expectation: e2e_cucumber::expectation::Expectation,
     /// Effective serve engine for this scenario on this host.
     engine: String,
     feature: String,

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -96,6 +96,19 @@ pub struct E2eWorld {
     pub lifecycle: Option<e2e::lifecycle_steps::LifecycleState>,
 }
 
+/// One scenario's resolved expectation plus the identity needed to report it.
+///
+/// Recorded by `filter_run`, which sees every scenario — including the ones it
+/// filters OUT. A filtered (skipped) scenario never reaches `report.json`, so
+/// this is the only place its feature and name survive to `platform.json`.
+struct Resolution {
+    expectation: Expectation,
+    /// Effective serve engine for this scenario on this host.
+    engine: String,
+    feature: String,
+    scenario: String,
+}
+
 /// Resolve a CI-provided shared-directory env var to a validated, existing path.
 ///
 /// The value is CI-controlled, but validate it before it reaches a filesystem
@@ -1095,8 +1108,11 @@ async fn main() {
     // Populated by `filter_run` (which sees every scenario, run or skipped) so
     // the post-run evaluation and platform.json can reconcile by id — including
     // skipped scenarios, which never appear in cucumber's report.json.
-    // id → (resolved expectation, effective engine for that scenario).
-    let resolutions: &'static Mutex<BTreeMap<String, (Expectation, String)>> =
+    // id → (resolved expectation, effective engine, feature name, scenario name).
+    // The feature/scenario names travel with the resolution so platform.json can
+    // place even a SKIPPED scenario under its feature in the report's grouped
+    // grid — a skip never reaches report.json, which is the only other source.
+    let resolutions: &'static Mutex<BTreeMap<String, Resolution>> =
         Box::leak(Box::new(Mutex::new(BTreeMap::new())));
 
     // `.run()` records failures into the writers but never sets a non-zero exit
@@ -1152,7 +1168,7 @@ async fn main() {
         // host — e.g. a required engine can't start) are filtered out and never
         // run; their resolution is still recorded so platform.json can show N/A.
         .filter_run(concat!(env!("CARGO_MANIFEST_DIR"), "/features/"), {
-            move |_feature, _rule, scenario| {
+            move |feature, _rule, scenario| {
                 let decl = ScenarioDecl::from_tags(&scenario.tags);
                 let expectation = resolve(
                     &decl,
@@ -1166,10 +1182,15 @@ async fn main() {
                     && !matches!(expectation, Expectation::Skip { .. });
                 if let Some(id) = &decl.id {
                     let engine = decl.effective_engine(cap).to_owned();
-                    let prev = resolutions
-                        .lock()
-                        .expect("resolutions poisoned")
-                        .insert(id.clone(), (expectation, engine));
+                    let prev = resolutions.lock().expect("resolutions poisoned").insert(
+                        id.clone(),
+                        Resolution {
+                            expectation,
+                            engine,
+                            feature: feature.name.clone(),
+                            scenario: scenario.name.clone(),
+                        },
+                    );
                     // Two scenarios sharing an `@id` would silently overwrite each
                     // other's resolution (e.g. a copy-paste with a forgotten id
                     // change) — the report grid keys on @id, so the collision would
@@ -1224,8 +1245,14 @@ async fn main() {
         versions,
         expectations: resolutions
             .iter()
-            .map(|(id, (exp, engine))| {
-                e2e_cucumber::expectation::ResolvedScenario::new(id, engine, exp)
+            .map(|(id, r)| {
+                e2e_cucumber::expectation::ResolvedScenario::new(
+                    id,
+                    &r.feature,
+                    &r.scenario,
+                    &r.engine,
+                    &r.expectation,
+                )
             })
             .collect(),
     };
@@ -1241,7 +1268,7 @@ async fn main() {
     let mut unexpected_fail = Vec::new();
     let mut xfail_count = 0u32;
     for (id, passed) in &actual {
-        match resolutions.get(id).map(|(exp, _)| exp) {
+        match resolutions.get(id).map(|r| &r.expectation) {
             Some(Expectation::ExpectXfail { bug, flaky, .. }) => {
                 if *passed {
                     let label = format!("{id} ({bug})");

--- a/tests/e2e-cucumber/tests/feature_naming.rs
+++ b/tests/e2e-cucumber/tests/feature_naming.rs
@@ -1,0 +1,139 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Drift guard for the `.feature` files' scenario naming and ids.
+//!
+//! The report groups its expectation grid by feature and orders rows by the
+//! `<feature-key>-<NN>` index in each scenario's name, so that convention is
+//! load-bearing, not cosmetic. It had already drifted once — indexes restarting
+//! at 1 in every file, `examine` numbered 1, 2, 5, 3, 4, a stray `6b` in
+//! `model_serving`, and no indexes at all in `install_lifecycle`.
+//!
+//! This runs in the ordinary `cargo test` set (unlike the `e2e` target, which
+//! needs a real `rocm` binary), so a mis-numbered scenario is caught without a
+//! full suite run.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// The short key each feature file's scenarios and ids are prefixed with.
+/// Adding a `.feature` file means adding its key here — deliberately explicit,
+/// so a new file can't quietly opt out of the convention.
+const FEATURE_KEYS: &[(&str, &str)] = &[
+    ("artifact_prefetch.feature", "artifact-prefetch"),
+    ("bench.feature", "bench"),
+    ("chat.feature", "chat"),
+    ("dash.feature", "dash"),
+    ("diagnose.feature", "diagnose"),
+    ("engine_shell.feature", "engine-shell"),
+    ("examine.feature", "examine"),
+    ("install_lifecycle.feature", "lifecycle"),
+    ("model_serving.feature", "serve"),
+    ("networking.feature", "networking"),
+    ("runtime_setup.feature", "runtime"),
+];
+
+fn features_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("features")
+}
+
+/// Every `.feature` file actually present, by file name.
+fn feature_files() -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(features_dir())
+        .expect("features dir")
+        .map(|e| e.expect("dir entry").file_name().to_string_lossy().into())
+        .filter(|n: &String| n.ends_with(".feature"))
+        .collect();
+    names.sort();
+    names
+}
+
+/// The `@id:` tags and `Scenario:` names in one feature file, paired in
+/// declaration order. Tags precede their scenario, so the most recent id seen
+/// belongs to the next scenario line.
+fn scenarios_of(file: &str) -> Vec<(Option<String>, String)> {
+    let text = std::fs::read_to_string(features_dir().join(file)).expect("read feature");
+    let mut pending_id = None;
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix('@') {
+            for tag in rest.split_whitespace() {
+                if let Some(id) = tag.strip_prefix("id:") {
+                    pending_id = Some(id.to_owned());
+                }
+            }
+        } else if let Some(name) = line.strip_prefix("Scenario: ") {
+            out.push((pending_id.take(), name.to_owned()));
+        }
+    }
+    out
+}
+
+#[test]
+fn every_feature_file_has_a_declared_key() {
+    let declared: Vec<&str> = FEATURE_KEYS.iter().map(|(f, _)| *f).collect();
+    for file in feature_files() {
+        assert!(
+            declared.contains(&file.as_str()),
+            "{file} has no key in FEATURE_KEYS — add one so its scenarios are \
+             indexed and its ids are qualified like every other feature",
+        );
+    }
+}
+
+#[test]
+fn scenario_names_are_indexed_sequentially_per_feature() {
+    for (file, key) in FEATURE_KEYS {
+        for (n, (_id, name)) in scenarios_of(file).iter().enumerate() {
+            let expected = format!("{key}-{:02} - ", n + 1);
+            assert!(
+                name.starts_with(&expected),
+                "{file}: scenario {} is named {name:?} but must start with \
+                 {expected:?} — indexes are per-feature, sequential, and in \
+                 declaration order (the report sorts grid rows by them)",
+                n + 1,
+            );
+        }
+    }
+}
+
+#[test]
+fn scenario_indexes_are_unique_across_the_suite() {
+    // The whole point of the feature key: an index must name exactly one
+    // scenario suite-wide. Before the key, "1" named eight different scenarios.
+    let mut seen: BTreeMap<String, String> = BTreeMap::new();
+    for (file, _key) in FEATURE_KEYS {
+        for (_id, name) in scenarios_of(file) {
+            let index = name
+                .split(" - ")
+                .next()
+                .expect("split always yields one part")
+                .to_owned();
+            if let Some(prev) = seen.insert(index.clone(), (*file).to_owned()) {
+                panic!("index {index:?} is used by both {prev} and {file}");
+            }
+        }
+    }
+}
+
+#[test]
+fn every_scenario_has_a_feature_qualified_id() {
+    let mut seen: BTreeMap<String, String> = BTreeMap::new();
+    for (file, key) in FEATURE_KEYS {
+        for (id, name) in scenarios_of(file) {
+            let id = id.unwrap_or_else(|| {
+                panic!("{file}: scenario {name:?} has no @id: tag — the report grid keys on it")
+            });
+            assert!(
+                id.starts_with(&format!("{key}-")),
+                "{file}: @id:{id} must start with {key:?} so the id alone says \
+                 which feature it belongs to",
+            );
+            if let Some(prev) = seen.insert(id.clone(), (*file).to_owned()) {
+                panic!("duplicate @id:{id} in both {prev} and {file}");
+            }
+        }
+    }
+}

--- a/tests/e2e-cucumber/tests/feature_naming.rs
+++ b/tests/e2e-cucumber/tests/feature_naming.rs
@@ -49,11 +49,16 @@ fn feature_files() -> Vec<String> {
     names
 }
 
-/// The `@id:` tags and `Scenario:` names in one feature file, paired in
-/// declaration order. Tags precede their scenario, so the most recent id seen
-/// belongs to the next scenario line.
+/// The `@id:` tags and scenario names in one feature file, paired in declaration
+/// order. Tags precede their scenario, so the most recent id seen belongs to the
+/// next scenario line.
+///
+/// `Scenario Outline:` counts too — the suite has none today, but an outline
+/// added later would otherwise slip past every check in this file silently.
 fn scenarios_of(file: &str) -> Vec<(Option<String>, String)> {
-    let text = std::fs::read_to_string(features_dir().join(file)).expect("read feature");
+    let path = features_dir().join(file);
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{}: {e} — stale FEATURE_KEYS entry?", path.display()));
     let mut pending_id = None;
     let mut out = Vec::new();
     for line in text.lines() {
@@ -64,7 +69,10 @@ fn scenarios_of(file: &str) -> Vec<(Option<String>, String)> {
                     pending_id = Some(id.to_owned());
                 }
             }
-        } else if let Some(name) = line.strip_prefix("Scenario: ") {
+        } else if let Some(name) = line
+            .strip_prefix("Scenario: ")
+            .or_else(|| line.strip_prefix("Scenario Outline: "))
+        {
             out.push((pending_id.take(), name.to_owned()));
         }
     }
@@ -72,13 +80,22 @@ fn scenarios_of(file: &str) -> Vec<(Option<String>, String)> {
 }
 
 #[test]
-fn every_feature_file_has_a_declared_key() {
+fn feature_files_and_declared_keys_agree() {
     let declared: Vec<&str> = FEATURE_KEYS.iter().map(|(f, _)| *f).collect();
-    for file in feature_files() {
+    let present = feature_files();
+    for file in &present {
         assert!(
             declared.contains(&file.as_str()),
             "{file} has no key in FEATURE_KEYS — add one so its scenarios are \
              indexed and its ids are qualified like every other feature",
+        );
+    }
+    // The reciprocal: a key left behind after its file was deleted or renamed
+    // would otherwise surface as an unexplained read error deep in another test.
+    for file in declared {
+        assert!(
+            present.iter().any(|p| p == file),
+            "FEATURE_KEYS lists {file}, which does not exist — drop the entry",
         );
     }
 }

--- a/tests/e2e-cucumber/tests/feature_naming.rs
+++ b/tests/e2e-cucumber/tests/feature_naming.rs
@@ -22,16 +22,24 @@ use std::path::{Path, PathBuf};
 /// so a new file can't quietly opt out of the convention.
 const FEATURE_KEYS: &[(&str, &str)] = &[
     ("artifact_prefetch.feature", "artifact-prefetch"),
+    ("automations.feature", "automations"),
     ("bench.feature", "bench"),
     ("chat.feature", "chat"),
+    ("config.feature", "config"),
     ("dash.feature", "dash"),
+    ("dependency_guard.feature", "deps-guard"),
     ("diagnose.feature", "diagnose"),
     ("engine_shell.feature", "engine-shell"),
     ("examine.feature", "examine"),
     ("install_lifecycle.feature", "lifecycle"),
+    ("logs.feature", "logs"),
     ("model_serving.feature", "serve"),
     ("networking.feature", "networking"),
+    // Not `runtime`: `runtime_setup.feature` owns that key, and two files
+    // sharing one key would collide on every index (`runtime-01` in both).
+    ("runtime_lifecycle.feature", "runtime-lifecycle"),
     ("runtime_setup.feature", "runtime"),
+    ("update.feature", "update"),
 ];
 
 fn features_dir() -> PathBuf {

--- a/tests/e2e-cucumber/tests/feature_naming.rs
+++ b/tests/e2e-cucumber/tests/feature_naming.rs
@@ -63,8 +63,15 @@ fn scenarios_of(file: &str) -> Vec<(Option<String>, String)> {
     let mut out = Vec::new();
     for line in text.lines() {
         let line = line.trim();
-        if let Some(rest) = line.strip_prefix('@') {
-            for tag in rest.split_whitespace() {
+        if line.starts_with('@') {
+            // Strip the `@` per TAG, not just off the head of the line: on a
+            // multi-tag line every token after the first keeps its own `@`, so
+            // `@requires-os:linux @id:x` would hide the id. This mirrors
+            // `ScenarioDecl::from_tags` in src/expectation.rs — the guard must
+            // read tags exactly as the harness does, or it rejects Gherkin the
+            // harness accepts.
+            for tag in line.split_whitespace() {
+                let tag = tag.strip_prefix('@').unwrap_or(tag);
                 if let Some(id) = tag.strip_prefix("id:") {
                     pending_id = Some(id.to_owned());
                 }
@@ -96,6 +103,18 @@ fn feature_files_and_declared_keys_agree() {
         assert!(
             present.iter().any(|p| p == file),
             "FEATURE_KEYS lists {file}, which does not exist — drop the entry",
+        );
+    }
+    // Every other check in this file is a `for … in scenarios_of(file)` loop, so
+    // a file the parser reads as having NO scenarios passes them all vacuously.
+    // A mangled `Scenario:` keyword — precisely what a bad bulk find-replace
+    // does — would then hide a whole feature from the guard while the report
+    // silently renders its rows unsorted.
+    for file in &present {
+        assert!(
+            !scenarios_of(file).is_empty(),
+            "{file}: no scenarios parsed — the naming checks would pass \
+             vacuously. Is a `Scenario:` keyword malformed?",
         );
     }
 }


### PR DESCRIPTION
## Summary

The consolidated E2E report's expectation grid rendered all 66 scenarios as one
undivided table, sorted alphabetically by scenario id. This splits it into one
sub-table per feature and gives every scenario an index that actually
identifies it.

- **Split by feature** — the grid (markdown + HTML) now renders one sub-table
  per `Feature:`, with rows in feature-file order. The Scenario reference
  section follows the same grouping, so the links from the grid land in a
  matching layout.
- **Fixed scenario indexing** — every feature file numbered its scenarios from
  1, so `1` named eight different scenarios. Some files had drifted further:
  `examine` ran 1, 2, **5**, 3, 4; `model_serving` had a stray `6b` and a `10`
  sitting in sixth place; `install_lifecycle` had no indexes at all. Scenarios
  are now `<feature-key>-<NN>`, sequential in declaration order.
- **Feature-qualified ids** — four `@id`s didn't carry their feature's key
  (`help-*` in `examine.feature`, `fix-*` in `diagnose.feature`), so the id
  alone didn't say where the scenario lived. Renamed, along with the matching
  `expectations.toml` key.
- **Drift guard** — `tests/feature_naming.rs` enforces the convention (indexes
  sequential per feature and unique suite-wide, ids feature-qualified) in the
  ordinary `cargo test` run.

Why: the grid is the main artifact for "where should each test pass", and at 66
undivided rows it was hard to scan a single area of the CLI or find a scenario
you cared about.

Risk: **low**. The report is a CI artifact — no product code is touched. The
scenario renames are internal to the suite; nothing outside it keys on scenario
names, and the four renamed ids were grepped repo-wide.

## Non-obvious decisions

- **Feature name comes from `platform.json`, not the id prefix.** A scenario
  skipped on every platform never reaches `report.json`, so the harness records
  each scenario's feature and name alongside its resolved expectation. Deriving
  the feature from the id prefix would re-encode structure in a string and break
  the moment a key is renamed, so it is kept only as the last fallback.
- **Fallback chain for older artifacts**: `platform.json`'s `feature` →
  `report.json`'s feature name → the id's leading segment. Both new fields are
  `#[serde(default)]` on the *consuming* side (`ManifestExpectation`), so
  pre-existing artifacts still render rather than dropping rows. (An earlier
  revision of this description said "on both sides" — that was wrong: the
  producer derives `Serialize` only, where a deserialization attribute is dead.
  The attributes have been removed there.) An artifact that names the feature is treated as
  authoritative and overrides a fallback guess — without that, the first input
  to mention an id fixed its feature permanently and one feature could split
  into two groups.
- **Every grid row now gets an anchor** in the Scenario reference. A scenario
  that was n/a on every platform previously had a dangling link.

## Test plan

- `cargo test -p e2e-report -p e2e-cucumber` — new unit tests cover grouping,
  numeric-not-lexical index ordering (`09` before `10`), the no-`feature`-field
  fallback, the authoritative-override case, and the anchor for a scenario that
  ran nowhere.
- The drift guard was verified to **fail** on each of the drift shapes that
  existed before this change (restarted numbering, out-of-order index,
  unqualified id) before passing on the fixed files.
- `cargo fmt --check` and both CI clippy invocations clean.
- End-to-end on real artifacts: ran the mock lane, then
  `cargo xtask e2e-report` over its output — 66 rows across 8 feature groups in
  the right order, and 66 resolving anchors. Re-ran with the new fields stripped
  from `platform.json`: all 66 rows still render via the fallback.

Two `diagnose-*` scenarios fail on my local WSL2 box (`rocm diagnose` reports
itself out of scope on WSL2, which uses `/dev/dxg` rather than `/dev/kfd`);
they are unrelated to this change and pass on the Linux runners.

- [ ] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows.
