### PR TITLE
fix(examine): detect versioned ROCm installs

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -11294,10 +11294,27 @@ fn render_examine_plain_header(summary: &ExamineSummary) -> String {
     } else {
         "AMD GPU not detected yet"
     };
-    let runtime = match summary.managed_runtime_count {
-        0 => "No ROCm installs saved yet".to_owned(),
-        1 => "1 ROCm install saved".to_owned(),
-        count => format!("{count} ROCm installs saved"),
+    // This line counted only CLI-managed runtimes, so a machine with ROCm
+    // already installed was greeted with "No ROCm installs saved yet" -- read,
+    // reasonably, as "nothing is installed". Now that the resolver finds those
+    // installs and their versions, say what is actually on the machine, and that
+    // a pre-existing install is left alone on purpose rather than missed.
+    let managed = match summary.managed_runtime_count {
+        0 => None,
+        1 => Some("1 ROCm install saved".to_owned()),
+        count => Some(format!("{count} ROCm installs saved")),
+    };
+    let existing = (summary.legacy_rocm.status != "not_detected").then(|| {
+        summary.legacy_rocm.version.as_deref().map_or_else(
+            || "existing ROCm install found, left unmanaged by design".to_owned(),
+            |version| format!("existing ROCm {version} found, left unmanaged by design"),
+        )
+    });
+    let runtime = match (managed, existing) {
+        (Some(managed), Some(existing)) => format!("{managed}; {existing}"),
+        (Some(managed), None) => managed,
+        (None, Some(existing)) => format!("No ROCm installs saved yet; {existing}"),
+        (None, None) => "No ROCm installs saved yet".to_owned(),
     };
     format!(
         "ROCm setup check\n  {gpu}\n  {runtime}\n  Driver: {}\n\nDetails\n",
@@ -16808,6 +16825,112 @@ mod tests {
         }
     }
 
+    /// An `ExamineSummary` with the install-reporting fields under test and
+    /// everything else inert.
+    fn summary_with_legacy(
+        managed_runtime_count: usize,
+        legacy_status: &str,
+        legacy_version: Option<&str>,
+    ) -> ExamineSummary {
+        ExamineSummary {
+            os: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
+            kernel: None,
+            distro: None,
+            cpu: None,
+            system_ram_gib: None,
+            interactive_terminal: false,
+            default_engine: "lemonade".to_owned(),
+            detected_gfx_target: None,
+            compatible_therock_family: None,
+            detected_therock_family: None,
+            driver: rocm_core::DriverSummary {
+                policy: "linux_official_amd_dkms_wrapper".to_owned(),
+                status: "amdgpu_available".to_owned(),
+                detail: None,
+            },
+            legacy_rocm: rocm_core::LegacyRocmSummary {
+                status: legacy_status.to_owned(),
+                paths: Vec::new(),
+                detail: None,
+                version: legacy_version.map(str::to_owned),
+            },
+            wsl: None,
+            managed_runtime_count,
+            managed_service_count: 0,
+            model_cache_entries: 0,
+            config_dir: PathBuf::from("config"),
+            data_dir: PathBuf::from("data"),
+            cache_dir: PathBuf::from("cache"),
+        }
+    }
+
+    #[test]
+    fn header_does_not_claim_nothing_is_installed_when_rocm_is_present() {
+        // The reported case: ROCm on the machine, none of it CLI-managed. The
+        // header counted only managed runtimes, so it said "No ROCm installs
+        // saved yet" — read as "nothing is installed".
+        let header = render_examine_plain_header(&summary_with_legacy(
+            0,
+            "detected_unmanaged",
+            Some("7.14.0"),
+        ));
+        assert!(
+            header.contains("existing ROCm 7.14.0 found"),
+            "the detected install and its version must appear:\n{header}"
+        );
+        assert!(
+            header.contains("left unmanaged by design"),
+            "it must read as a deliberate choice, not an oversight:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_reports_a_detected_install_whose_version_is_unknown() {
+        // Degrades to naming the install without inventing a version.
+        let header =
+            render_examine_plain_header(&summary_with_legacy(0, "detected_unmanaged", None));
+        assert!(
+            header.contains("existing ROCm install found"),
+            "the install must still be reported:\n{header}"
+        );
+        assert!(
+            !header.contains("<unknown>"),
+            "an unknown version must not leak a placeholder into the summary:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_accounts_for_managed_and_existing_installs_together() {
+        let header = render_examine_plain_header(&summary_with_legacy(
+            2,
+            "detected_unmanaged",
+            Some("6.4.1"),
+        ));
+        assert!(
+            header.contains("2 ROCm installs saved"),
+            "the managed count must survive:\n{header}"
+        );
+        assert!(
+            header.contains("existing ROCm 6.4.1 found"),
+            "the unmanaged install must be reported alongside it:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_still_says_nothing_is_installed_when_nothing_is() {
+        // The wording only changes when there is something to report.
+        let header = render_examine_plain_header(&summary_with_legacy(0, "not_detected", None));
+        assert!(
+            header.contains("No ROCm installs saved yet"),
+            "an empty machine must keep the original wording:\n{header}"
+        );
+        assert!(
+            !header.contains("existing ROCm"),
+            "nothing should be claimed on an empty machine:\n{header}"
+        );
+    }
+
     /// Regression test for the engine child-stdin write under the process-wide
     /// `SIG_DFL` that `main` installs via [`reset_sigpipe`]. If an engine child
     /// exits before reading its stdin, the parent's write to that pipe must
@@ -17741,6 +17864,7 @@ mod tests {
                 status: "not_detected".to_owned(),
                 paths: Vec::new(),
                 detail: None,
+                version: None,
             },
             wsl: wsl.then_some(rocm_core::WslSummary {
                 is_wsl: true,

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1594,6 +1594,55 @@ mod tests {
     }
 
     #[test]
+    fn path_missing_names_the_versioned_rocm_root() {
+        // A box whose only ROCm is a versioned root used to report an empty
+        // rocm_path, so both structural signals here scored zero and the fix
+        // could only fire on symptom keywords -- and then named /opt/rocm/bin,
+        // which does not exist on that machine.
+        //
+        // Drive the real resolver rather than hand-setting rocm_path, so this
+        // fails if versioned discovery regresses and not just if the check does.
+        let root = std::env::temp_dir().join(format!(
+            "rocm-core-diagnose-versioned-{}-{}",
+            std::process::id(),
+            crate::unix_time_millis()
+        ));
+        let opt = root.join("opt");
+        let install = opt.join("rocm-6.4.1");
+        std::fs::create_dir_all(install.join("bin")).expect("plant a fake versioned install");
+        std::fs::write(install.join("bin").join("rocminfo"), "").expect("plant the install marker");
+
+        let discovered = crate::discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+        let found = discovered
+            .first()
+            .expect("the resolver must find a versioned-only install");
+
+        let mut e = linux_base();
+        e.rocm_path = found.path.to_string_lossy().into_owned();
+        e.rocminfo_present = false;
+        e.env.insert("PATH".to_owned(), "/usr/bin:/bin".to_owned());
+
+        let report = diagnose(&e, "");
+        let top = &report.matched[0];
+
+        assert_eq!(top.id, "fix-6-path");
+        assert_eq!(top.score, 70, "50 (rocminfo absent) + 20 (bin not on PATH)");
+        let fix = top.fix.as_ref().expect("fix-6 carries a fix");
+        assert!(
+            fix.summary.contains("rocm-6.4.1/bin"),
+            "guidance must name the versioned root the resolver found: {}",
+            fix.summary
+        );
+        assert!(
+            !fix.summary.contains("/opt/rocm/bin"),
+            "guidance must not name the conventional root that is absent here: {}",
+            fix.summary
+        );
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
     fn igpu_dgpu_collision_fires_for_rdna3_apu_plus_discrete() {
         // End-to-end guard for EAI-7412: a gfx1103 (Phoenix APU) + gfx1100
         // (Navi 31 dGPU) box must now trigger the iGPU+dGPU collision fix,

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -891,31 +891,18 @@ fn probe_secure_boot(e: &mut Examination) {
 // ---------------------------------------------------------------------------
 
 fn probe_rocm_install(e: &mut Examination) {
-    let mut rocm_dir = String::new();
-    let rocm_path_env = std::env::var("ROCM_PATH").unwrap_or_default();
-    for candidate in ["/opt/rocm", rocm_path_env.as_str()] {
-        if !candidate.is_empty() && Path::new(candidate).is_dir() {
-            rocm_dir = candidate.to_owned();
-            break;
-        }
-    }
+    // Shared with the human `rocm examine` report and the fix-6 PATH runner so
+    // all three agree on which install is the active one. Handles versioned
+    // roots (`/opt/rocm-6.4.1`) as well as the conventional `/opt/rocm`.
+    let install = crate::discover_rocm_installs().into_iter().next();
+    let rocm_dir = install
+        .as_ref()
+        .map(|install| install.path.to_string_lossy().into_owned())
+        .unwrap_or_default();
     e.rocm_path = rocm_dir.clone();
-
-    if !rocm_dir.is_empty() {
-        for fname in ["version", "version-utils", "version-libs"] {
-            let f = Path::new(&rocm_dir).join(".info").join(fname);
-            if f.exists() {
-                e.rocm_version = read_text(&f.to_string_lossy()).trim().to_owned();
-                break;
-            }
-        }
-        if e.rocm_version.is_empty()
-            && let Ok(real) = std::fs::canonicalize(&rocm_dir)
-            && let Some(version) = extract_rocm_version(&real.to_string_lossy())
-        {
-            e.rocm_version = version;
-        }
-    }
+    e.rocm_version = install
+        .and_then(|install| install.version)
+        .unwrap_or_default();
 
     for marker in AMDGPU_INSTALL_MARKERS {
         if Path::new(marker).exists() {
@@ -963,7 +950,7 @@ fn probe_rocm_install(e: &mut Examination) {
 }
 
 /// Pull `X.Y[.Z]` out of a `rocm-X.Y.Z` path component.
-fn extract_rocm_version(path: &str) -> Option<String> {
+pub(crate) fn extract_rocm_version(path: &str) -> Option<String> {
     let idx = path.find("rocm-")?;
     let tail = &path[idx + "rocm-".len()..];
     let version: String = tail

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -160,7 +160,7 @@ const RECIPES: &[FixRecipe] = &[
     FixRecipe {
         fix_id: "fix-6-path",
         title: "Add the ROCm/HIP bin directory to PATH",
-        rationale: "Linux: ROCm is installed at /opt/rocm but its bin directory isn't on PATH, so `rocminfo` / `hipcc` aren't visible to the shell. Windows: the HIP SDK is installed but its bin directory isn't on the User PATH, so `hipInfo.exe` and the runtime DLLs can't be found.",
+        rationale: "Linux: ROCm is installed but its bin directory isn't on PATH, so `rocminfo` / `hipcc` aren't visible to the shell. Windows: the HIP SDK is installed but its bin directory isn't on the User PATH, so `hipInfo.exe` and the runtime DLLs can't be found.",
         auto_applicable: true,
         commands: &[
             "# Linux:",
@@ -740,11 +740,22 @@ fn run_path_export(opts: &FixOptions) -> i32 {
 }
 
 fn run_path_export_linux(opts: &FixOptions) -> i32 {
-    let bin_dir = "/opt/rocm/bin";
-    if !Path::new(bin_dir).is_dir() {
-        println!("{bin_dir} does not exist; nothing to add to PATH.");
+    // Same resolver `examine` uses, so the line we append names the install the
+    // report pointed at -- including a versioned root like /opt/rocm-6.4.1.
+    let Some(install) = crate::discover_rocm_installs().into_iter().next() else {
+        println!("No ROCm install found; nothing to add to PATH.");
+        return 3;
+    };
+    let bin_path = install.path.join("bin");
+    if !bin_path.is_dir() {
+        println!(
+            "{} does not exist; nothing to add to PATH.",
+            bin_path.display()
+        );
         return 3;
     }
+    let bin_dir_owned = bin_path.to_string_lossy().into_owned();
+    let bin_dir = bin_dir_owned.as_str();
     let Some(rc_file) = shell_rc_file() else {
         println!("Could not determine your home directory.");
         return 3;

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1456,6 +1456,19 @@ pub struct LegacyRocmSummary {
     pub status: String,
     pub paths: Vec<PathBuf>,
     pub detail: Option<String>,
+    /// Version of the best-ranked detected install, when one could be read.
+    ///
+    /// The resolver establishes this already; without carrying it here the human
+    /// report named a path but never a version, so a machine with ROCm 7.14
+    /// installed could not tell you which ROCm it had.
+    ///
+    /// `None` when no install was found, or when one was found whose layout
+    /// declares no version anywhere.
+    ///
+    /// Optional and defaulted so the daemon's serialised snapshot
+    /// (`apps/rocmd/src/lib.rs`) written before this field existed still loads.
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1672,7 +1685,7 @@ impl ExamineSummary {
             "false (this run's output is captured, so the CLI will not prompt)"
         };
         format!(
-            "rocm examine\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
+            "rocm examine\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_version: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
             self.os,
             self.arch,
             self.kernel.as_deref().unwrap_or("<unknown>"),
@@ -1694,6 +1707,7 @@ impl ExamineSummary {
             self.driver.detail.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm.status,
             legacy_paths,
+            self.legacy_rocm.version.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm.detail.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm_guidance(),
             wsl.is_some_and(|summary| summary.is_wsl),
@@ -2081,7 +2095,7 @@ const LINUX_ROCM_SEARCH_DIRS: &[&str] = &["/opt", "/usr/local"];
 /// Directories the Windows HIP SDK installer writes into.
 ///
 /// Each is an install root in its own right and also the parent of versioned
-/// installs — see [`RocmLayout::Windows`].
+/// installs — see [`RocmLayout::Children`].
 const WINDOWS_ROCM_SEARCH_DIRS: &[&str] = &[r"C:\Program Files\AMD\ROCm", r"C:\Program Files\ROCm"];
 
 /// How versioned installs are arranged under a search directory.
@@ -2284,10 +2298,12 @@ fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
     // the fix-6 runner cannot disagree about which installs exist or which one
     // is active. `discover_rocm_installs` picks the search roots and layout for
     // the host.
-    let paths: Vec<PathBuf> = discover_rocm_installs()
-        .into_iter()
-        .map(|install| install.path)
-        .collect();
+    let installs = discover_rocm_installs();
+    // The resolver ranks best-first, so the leading install's version is the one
+    // that describes this machine. Keeping it costs nothing here and is the
+    // difference between naming a path and naming the ROCm the user has.
+    let version = installs.first().and_then(|install| install.version.clone());
+    let paths: Vec<PathBuf> = installs.into_iter().map(|install| install.path).collect();
 
     let status = if paths.is_empty() {
         "not_detected"
@@ -2304,6 +2320,7 @@ fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
         status: status.to_owned(),
         paths,
         detail,
+        version,
     }
 }
 
@@ -8545,6 +8562,7 @@ Class Name:                Display
                 status: "detected_unmanaged".to_owned(),
                 paths: vec![PathBuf::from("C:\\Program Files\\AMD\\ROCm")],
                 detail: Some("legacy install".to_owned()),
+                version: Some("6.4.1".to_owned()),
             },
             wsl: None,
             managed_runtime_count: 2,
@@ -8601,6 +8619,7 @@ Class Name:                Display
                 status: "not_detected".to_owned(),
                 paths: Vec::new(),
                 detail: None,
+                version: None,
             },
             wsl: None,
             managed_runtime_count: 0,
@@ -8653,6 +8672,7 @@ Class Name:                Display
                 status: "detected_unmanaged".to_owned(),
                 paths: vec![PathBuf::from("/opt/rocm")],
                 detail: Some("legacy install".to_owned()),
+                version: Some("7.14.0".to_owned()),
             },
             wsl: None,
             managed_runtime_count: 0,

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -43,6 +43,7 @@ pub use disk_space::{
     estimated_extracted_size, format_bytes, insufficient_space_message, map_write_error,
     mount_for_path, on_same_filesystem, warn_if_low_space, with_margin,
 };
+use examine::extract_rocm_version;
 pub use examine::{Examination, FrameworkProbe, WSL_ROUTE_OUT_NOTE};
 pub use fix::{FixOptions, apply as apply_fix, list_recipes as list_fix_recipes};
 pub use proc_lifecycle::{
@@ -2071,28 +2072,222 @@ fn windows_driver_summary(detail: Option<String>) -> DriverSummary {
     }
 }
 
-fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
-    let mut paths = Vec::new();
-    let mut candidates = Vec::new();
+/// Directories that hold conventional unmanaged ROCm install roots on Linux.
+///
+/// Each is searched for both the unversioned `rocm` root and the versioned
+/// `rocm-X.Y[.Z]` siblings that a side-by-side install produces.
+const LINUX_ROCM_SEARCH_DIRS: &[&str] = &["/opt", "/usr/local"];
 
-    if let Some(path) = std::env::var_os("ROCM_PATH") {
-        candidates.push(PathBuf::from(path));
-    }
+/// Directories the Windows HIP SDK installer writes into.
+///
+/// Each is an install root in its own right and also the parent of versioned
+/// installs — see [`RocmLayout::Windows`].
+const WINDOWS_ROCM_SEARCH_DIRS: &[&str] = &[r"C:\Program Files\AMD\ROCm", r"C:\Program Files\ROCm"];
 
-    if runtime_is_windows() {
-        candidates.push(PathBuf::from(r"C:\Program Files\AMD\ROCm"));
-        candidates.push(PathBuf::from(r"C:\Program Files\ROCm"));
+/// How versioned installs are arranged under a search directory.
+///
+/// The two platforms disagree, so the resolver has to be told which shape it is
+/// walking rather than assuming one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RocmLayout {
+    /// `<dir>/rocm` alongside `rocm-X.Y[.Z]` siblings, e.g. `/opt/rocm` and
+    /// `/opt/rocm-6.4.1`.
+    Siblings,
+    /// `<dir>` itself, with versions as bare `X.Y[.Z]` children, e.g.
+    /// `C:\Program Files\AMD\ROCm` and `C:\Program Files\AMD\ROCm\6.4`.
+    Children,
+}
+
+/// An unmanaged ("legacy") ROCm install root found on disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RocmInstall {
+    pub(crate) path: PathBuf,
+    pub(crate) version: Option<String>,
+}
+
+/// Every unmanaged ROCm install on this host, best candidate first.
+///
+/// Supplies the platform's search roots, layout, and `$ROCM_PATH` to
+/// [`discover_rocm_installs_in_layout`].
+pub(crate) fn discover_rocm_installs() -> Vec<RocmInstall> {
+    let env_override = std::env::var_os("ROCM_PATH").map(PathBuf::from);
+    let (dirs, layout) = if runtime_is_windows() {
+        (WINDOWS_ROCM_SEARCH_DIRS, RocmLayout::Children)
     } else {
-        candidates.push(PathBuf::from("/opt/rocm"));
-        candidates.push(PathBuf::from("/usr/local/rocm"));
+        (LINUX_ROCM_SEARCH_DIRS, RocmLayout::Siblings)
+    };
+    let search_dirs: Vec<PathBuf> = dirs.iter().map(PathBuf::from).collect();
+    discover_rocm_installs_in_layout(&search_dirs, env_override.as_deref(), layout)
+}
+
+/// [`discover_rocm_installs_in_layout`] for the Linux sibling layout.
+///
+/// Production callers go through [`discover_rocm_installs`], which picks the
+/// layout for the host; this spares the sibling-layout tests from restating it.
+#[cfg(test)]
+pub(crate) fn discover_rocm_installs_in(
+    search_dirs: &[PathBuf],
+    env_override: Option<&Path>,
+) -> Vec<RocmInstall> {
+    discover_rocm_installs_in_layout(search_dirs, env_override, RocmLayout::Siblings)
+}
+
+/// Rank the ROCm installs reachable from `search_dirs`, best candidate first.
+///
+/// Precedence, highest first:
+///
+/// 1. `env_override` (`$ROCM_PATH`) — an install the user named explicitly wins
+///    over anything found by convention.
+/// 2. The conventional active root, which is what lands on `PATH` and in the
+///    linker cache on a normal install: `<dir>/rocm` under [`RocmLayout::Siblings`],
+///    or `<dir>` itself under [`RocmLayout::Children`].
+/// 3. Versioned installs, newest first.
+///
+/// Versions are ordered by numeric component, not lexically, so `6.10` beats
+/// `6.2` — on both layouts. Candidates are deduplicated by canonical path, so
+/// the common `/opt/rocm -> /opt/rocm-6.4.1` symlink yields one install rather
+/// than two.
+pub(crate) fn discover_rocm_installs_in_layout(
+    search_dirs: &[PathBuf],
+    env_override: Option<&Path>,
+    layout: RocmLayout,
+) -> Vec<RocmInstall> {
+    let mut found: Vec<RocmInstall> = Vec::new();
+    let mut seen: Vec<PathBuf> = Vec::new();
+
+    if let Some(path) = env_override {
+        push_rocm_candidate(path.to_path_buf(), &mut found, &mut seen);
     }
 
-    for candidate in candidates {
-        if legacy_rocm_candidate_exists(&candidate) && !paths.iter().any(|path| path == &candidate)
-        {
-            paths.push(candidate);
+    for dir in search_dirs {
+        let root = match layout {
+            RocmLayout::Siblings => dir.join("rocm"),
+            RocmLayout::Children => dir.clone(),
+        };
+        push_rocm_candidate(root, &mut found, &mut seen);
+    }
+
+    for dir in search_dirs {
+        let Ok(entries) = fs::read_dir(dir) else {
+            continue;
+        };
+        let version_of = |path: &Path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| versioned_dir_version(name, layout))
+        };
+        let mut versioned: Vec<PathBuf> = entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| version_of(path).is_some())
+            .collect();
+        // Newest first, by numeric version component.
+        versioned.sort_by(|a, b| {
+            let key = |path: &Path| {
+                version_of(path)
+                    .map(|version| rocm_version_sort_key(&version))
+                    .unwrap_or_default()
+            };
+            key(b).cmp(&key(a))
+        });
+        for candidate in versioned {
+            push_rocm_candidate(candidate, &mut found, &mut seen);
         }
     }
+
+    found
+}
+
+/// Record `candidate` as an install when it looks like one and is not already
+/// recorded under another name (a symlink to a root already seen).
+fn push_rocm_candidate(candidate: PathBuf, found: &mut Vec<RocmInstall>, seen: &mut Vec<PathBuf>) {
+    if !legacy_rocm_candidate_exists(&candidate) {
+        return;
+    }
+    let key = fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+    if seen.contains(&key) {
+        return;
+    }
+    seen.push(key);
+    let version = rocm_install_version(&candidate);
+    found.push(RocmInstall {
+        path: candidate,
+        version,
+    });
+}
+
+/// The ROCm version an install root reports, if it reports one.
+///
+/// Prefers the `.info/version*` files the packaged installs ship, and falls
+/// back to the version embedded in the resolved directory name — either a
+/// `rocm-X.Y[.Z]` root (or the symlink pointing at one) or the bare `X.Y` the
+/// Windows installer uses.
+pub(crate) fn rocm_install_version(root: &Path) -> Option<String> {
+    for name in ["version", "version-utils", "version-libs"] {
+        let file = root.join(".info").join(name);
+        if let Ok(text) = fs::read_to_string(&file) {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_owned());
+            }
+        }
+    }
+    // Only the final component: an ancestor directory may itself contain
+    // "rocm-" (a checkout, a home directory) and must not be mistaken for the
+    // install's version. Canonicalizing first resolves `/opt/rocm` to the
+    // `rocm-X.Y.Z` it points at.
+    let resolved = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let name = resolved.file_name().and_then(|name| name.to_str())?;
+    extract_rocm_version(name).or_else(|| bare_version(name))
+}
+
+/// The version a directory *name* advertises, for the given layout, or `None`
+/// when the name is not a versioned install directory at all.
+///
+/// The two layouts name their versioned directories differently: Linux uses
+/// `rocm-6.4.1` siblings, while the Windows installer uses a bare `6.4` under
+/// its ROCm root. Matching the wrong shape is not harmless — accepting a bare
+/// number on Linux would sweep in unrelated `/opt` and `/usr/local` entries.
+fn versioned_dir_version(name: &str, layout: RocmLayout) -> Option<String> {
+    match layout {
+        RocmLayout::Siblings => extract_rocm_version(name),
+        RocmLayout::Children => bare_version(name),
+    }
+}
+
+/// `X.Y[.Z]` when `name` is exactly a dotted numeric version, else `None`.
+///
+/// Requires at least one dot so a lone number cannot pass, and every component
+/// to be numeric so a directory such as `6.4-beta` or `docs` is rejected.
+fn bare_version(name: &str) -> Option<String> {
+    let mut parts = name.split('.');
+    let mut count = 0;
+    for part in &mut parts {
+        if part.is_empty() || !part.chars().all(|ch| ch.is_ascii_digit()) {
+            return None;
+        }
+        count += 1;
+    }
+    (count >= 2).then(|| name.to_owned())
+}
+
+/// Sort key that orders ROCm versions numerically: `6.10` outranks `6.2`.
+fn rocm_version_sort_key(version: &str) -> Vec<u32> {
+    version
+        .split('.')
+        .map(|part| part.parse::<u32>().unwrap_or(0))
+        .collect()
+}
+
+fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
+    // One resolver on both platforms, so the human report, the JSON probe and
+    // the fix-6 runner cannot disagree about which installs exist or which one
+    // is active. `discover_rocm_installs` picks the search roots and layout for
+    // the host.
+    let paths: Vec<PathBuf> = discover_rocm_installs()
+        .into_iter()
+        .map(|install| install.path)
+        .collect();
 
     let status = if paths.is_empty() {
         "not_detected"
@@ -8514,6 +8709,241 @@ Class Name:                Display
         fs::create_dir_all(rocm.join("bin"))?;
         fs::write(rocm.join("bin").join("rocminfo"), "")?;
         assert!(legacy_rocm_candidate_exists(&rocm));
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    /// Plant a directory that `legacy_rocm_candidate_exists` accepts as a real
+    /// install, optionally shipping the `.info/version` a packaged install has.
+    fn fake_rocm_install(root: &Path, info_version: Option<&str>) -> Result<()> {
+        fs::create_dir_all(root.join("bin"))?;
+        fs::write(root.join("bin").join("rocminfo"), "")?;
+        if let Some(version) = info_version {
+            fs::create_dir_all(root.join(".info"))?;
+            fs::write(root.join(".info").join("version"), version)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn discovers_versioned_rocm_install_without_a_default_root() -> Result<()> {
+        // A box whose only ROCm lives at /opt/rocm-6.4.1: before the shared
+        // resolver this reported nothing at all, which silently disabled the
+        // structural scoring in fix-3, fix-6 and fix-8.
+        let (root, _) = temp_app_paths("rocm-versioned-only");
+        let opt = root.join("opt");
+        fake_rocm_install(&opt.join("rocm-6.4.1"), None)?;
+
+        let found = discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+
+        assert_eq!(found.len(), 1, "expected exactly one install: {found:?}");
+        assert_eq!(found[0].path, opt.join("rocm-6.4.1"));
+        assert_eq!(
+            found[0].version.as_deref(),
+            Some("6.4.1"),
+            "version must fall back to the directory name"
+        );
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn newest_rocm_install_is_chosen_numerically_not_lexically() -> Result<()> {
+        // 6.10 outranks 6.2. A lexicographic sort -- the bug still live in the
+        // Windows scans -- would pick 6.2 here.
+        let (root, _) = temp_app_paths("rocm-newest");
+        let opt = root.join("opt");
+        fake_rocm_install(&opt.join("rocm-6.2.0"), None)?;
+        fake_rocm_install(&opt.join("rocm-6.10.0"), None)?;
+
+        let found = discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+
+        assert_eq!(
+            found.len(),
+            2,
+            "both installs should be reported: {found:?}"
+        );
+        assert_eq!(
+            found[0].path,
+            opt.join("rocm-6.10.0"),
+            "6.10 must outrank 6.2"
+        );
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn explicitly_selected_rocm_install_outranks_the_default_root() -> Result<()> {
+        // $ROCM_PATH is the user naming an install; it must beat the
+        // conventional root, which is the precedence examine had inverted.
+        let (root, _) = temp_app_paths("rocm-env-override");
+        let opt = root.join("opt");
+        fake_rocm_install(&opt.join("rocm"), None)?;
+        let chosen = root.join("elsewhere").join("rocm-6.4.1");
+        fake_rocm_install(&chosen, None)?;
+
+        let found = discover_rocm_installs_in(&[opt], Some(&chosen));
+
+        assert_eq!(found[0].path, chosen);
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn conventional_rocm_root_outranks_versioned_siblings() -> Result<()> {
+        // Guards the claim that versioned support is purely additive: on a
+        // conventional box the answer must not change.
+        let (root, _) = temp_app_paths("rocm-conventional");
+        let opt = root.join("opt");
+        fake_rocm_install(&opt.join("rocm"), None)?;
+        fake_rocm_install(&opt.join("rocm-6.2.0"), None)?;
+
+        let found = discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+
+        assert_eq!(found[0].path, opt.join("rocm"));
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_default_root_symlinked_to_a_versioned_one_is_reported_once() -> Result<()> {
+        // The common packaged layout: /opt/rocm -> /opt/rocm-6.4.1. One
+        // install, reported once, carrying the version from the target.
+        let (root, _) = temp_app_paths("rocm-symlink");
+        let opt = root.join("opt");
+        let versioned = opt.join("rocm-6.4.1");
+        fake_rocm_install(&versioned, None)?;
+        std::os::unix::fs::symlink(&versioned, opt.join("rocm"))?;
+
+        let found = discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+
+        assert_eq!(
+            found.len(),
+            1,
+            "symlink and target are one install: {found:?}"
+        );
+        assert_eq!(found[0].path, opt.join("rocm"));
+        assert_eq!(found[0].version.as_deref(), Some("6.4.1"));
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn a_host_without_rocm_reports_no_installs() -> Result<()> {
+        let (root, _) = temp_app_paths("rocm-absent");
+        let opt = root.join("opt");
+        fs::create_dir_all(opt.join("rocm-6.4.1"))?; // no marker files
+        fs::create_dir_all(&opt)?;
+
+        assert!(discover_rocm_installs_in(&[opt], None).is_empty());
+
+        fs::remove_dir_all(root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn discovers_windows_versioned_installs_under_the_rocm_root() -> Result<()> {
+        // The Windows installer nests versions under its ROCm directory as bare
+        // `X.Y` children, rather than the `rocm-X.Y` siblings Linux uses. Before
+        // the layout split, only Linux was searched, so a Windows box with no
+        // ROCM_PATH reported no install at all.
+        let (root, _) = temp_app_paths("rocm-windows-versioned");
+        let base = root.join("ROCm");
+        fake_rocm_install(&base.join("6.2"), None)?;
+        fake_rocm_install(&base.join("6.10"), None)?;
+
+        let found = discover_rocm_installs_in_layout(
+            std::slice::from_ref(&base),
+            None,
+            RocmLayout::Children,
+        );
+
+        let paths: Vec<_> = found.iter().map(|install| install.path.clone()).collect();
+        let versions: Vec<_> = found
+            .iter()
+            .map(|install| install.version.clone())
+            .collect();
+        fs::remove_dir_all(root).ok();
+
+        assert_eq!(
+            paths,
+            vec![base.join("6.10"), base.join("6.2")],
+            "newest first, and 6.10 outranks 6.2 numerically rather than lexically"
+        );
+        assert_eq!(
+            versions,
+            vec![Some("6.10".to_owned()), Some("6.2".to_owned())],
+            "the bare directory name is the version on this layout"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn windows_layout_treats_the_rocm_root_itself_as_an_install() -> Result<()> {
+        // A single-version HIP SDK puts the install directly in the ROCm root
+        // with no version subdirectory, and it must outrank any versioned child.
+        let (root, _) = temp_app_paths("rocm-windows-root");
+        let base = root.join("ROCm");
+        fake_rocm_install(&base, None)?;
+        fake_rocm_install(&base.join("6.4"), None)?;
+
+        let found = discover_rocm_installs_in_layout(
+            std::slice::from_ref(&base),
+            None,
+            RocmLayout::Children,
+        );
+        let first = found.first().map(|install| install.path.clone());
+        fs::remove_dir_all(root).ok();
+
+        assert_eq!(first, Some(base), "the conventional root wins");
+        Ok(())
+    }
+
+    #[test]
+    fn a_bare_version_directory_is_not_an_install_on_the_linux_layout() -> Result<()> {
+        // Guard the layouts against each other: accepting bare numbers under the
+        // sibling layout would sweep in unrelated /opt and /usr/local entries.
+        let (root, _) = temp_app_paths("rocm-bare-version-linux");
+        let opt = root.join("opt");
+        fake_rocm_install(&opt.join("6.4"), None)?;
+
+        let found = discover_rocm_installs_in(std::slice::from_ref(&opt), None);
+        fs::remove_dir_all(root).ok();
+
+        assert!(found.is_empty(), "expected no installs, got {found:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn bare_version_accepts_only_dotted_numbers() {
+        assert_eq!(bare_version("6.4"), Some("6.4".to_owned()));
+        assert_eq!(bare_version("6.4.1"), Some("6.4.1".to_owned()));
+        // A lone number is a directory name, not a version.
+        assert_eq!(bare_version("6"), None);
+        // Anything non-numeric in any component disqualifies it.
+        assert_eq!(bare_version("6.4-beta"), None);
+        assert_eq!(bare_version("docs"), None);
+        assert_eq!(bare_version("6."), None);
+        assert_eq!(bare_version(".4"), None);
+        assert_eq!(bare_version(""), None);
+    }
+
+    #[test]
+    fn packaged_version_file_wins_over_the_directory_name() -> Result<()> {
+        // A repackaged tree can sit in a differently-named directory; the
+        // shipped .info/version is authoritative.
+        let (root, _) = temp_app_paths("rocm-info-version");
+        let install = root.join("opt").join("rocm-6.2.0");
+        fake_rocm_install(&install, Some("6.4.1\n"))?;
+
+        assert_eq!(rocm_install_version(&install).as_deref(), Some("6.4.1"));
 
         fs::remove_dir_all(root).ok();
         Ok(())

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -37,9 +37,16 @@ Feature: GPU detection and system inspection
     When the user inspects the system
     Then the inspection names the engine this host serves on by default
 
-  @id:examine-distinguishes-unmanaged-rocm @requires-gpu
+  # No GPU needed: the install is planted by the harness (`plant_unmanaged_rocm`,
+  # written precisely so this does not depend on an ambient `/opt/rocm`), and
+  # every assertion here is about how a detected install is reported, not about
+  # hardware. Dropping `@requires-gpu` gains per-PR mock-lane coverage for the
+  # reporting this scenario exists to pin.
+  @id:examine-distinguishes-unmanaged-rocm
   Scenario: 4 - System inspection distinguishes CLI-managed from pre-existing ROCm
     Given a machine with a ROCm install that was not set up by the CLI
     When the user inspects the system
     Then the inspection reports the install as pre-existing
+    And the inspection names that install's version
+    And the inspection does not claim nothing is installed
     And the inspection suggests setting up a CLI-managed install

--- a/tests/e2e-cucumber/tests/e2e/examine_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/examine_steps.rs
@@ -168,6 +168,32 @@ async fn assert_rocm_unmanaged(world: &mut E2eWorld) {
     );
 }
 
+#[then("the inspection names that install's version")]
+async fn assert_reports_legacy_version(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    // `plant_unmanaged_rocm` writes `.info/version` containing this. The resolver
+    // establishes the version already; the report used to name a path but never
+    // a version, so a machine with ROCm installed could not tell you which.
+    assert!(
+        output.contains("legacy_rocm_version: 6.0.0"),
+        "the pre-existing install's version must be reported:\n{output}"
+    );
+}
+
+#[then("the inspection does not claim nothing is installed")]
+async fn assert_does_not_claim_empty(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    // The summary line counted only CLI-managed runtimes, so a machine with ROCm
+    // already installed was greeted with a bare "No ROCm installs saved yet".
+    let claims_empty = output
+        .lines()
+        .any(|line| line.trim() == "No ROCm installs saved yet");
+    assert!(
+        !claims_empty,
+        "an install was detected, so the summary must not say there is none:\n{output}"
+    );
+}
+
 #[then("the inspection suggests setting up a CLI-managed install")]
 async fn assert_suggests_managed_runtime(world: &mut E2eWorld) {
     let output = world.cli_output.as_ref().expect("no command was run");


### PR DESCRIPTION
## Summary

`rocm examine` and `rocm diagnose` could not see a ROCm install that lives in a version-suffixed directory such as `/opt/rocm-6.4.1`. On Linux the probe tried exactly `/opt/rocm` and then `$ROCM_PATH`, and nothing enumerated `/opt/rocm-*`.

Windows had the mirror-image gap. Its versioned scan lives inside the HIP SDK probe, so the install summary and the JSON probe could not see a versioned HIP SDK at all — without `$ROCM_PATH` they reported nothing.

The user-visible effect on either platform: `rocm_path` and `rocm_version` both come back empty. Three diagnosis checks are guarded on those being non-empty — `fix-3-rocm-kernel`, `fix-6-path` and `fix-8-wheel-rocm` — so they silently score zero. When `fix-6-path` does fire from symptom keywords, its guidance names `/opt/rocm/bin`, which does not exist on that machine.

**Root cause:** two independent install-discovery implementations. The `--json` / `diagnose` probe had its own two-candidate list, and the human `rocm examine` report had a different one. Neither enumerated versioned roots.

**The fix is the sharing** — one resolver, three call sites, both platforms:

- `discover_rocm_installs` searches the platform's install roots for both the conventional root and its versioned installs. Versions are ordered numerically, so `6.10` outranks `6.2`, and candidates are deduplicated by canonical path so the usual `/opt/rocm -> /opt/rocm-6.4.1` symlink is one install rather than two.
- The two platforms arrange versions differently, so the resolver is told which shape it is walking: Linux has `rocm-X.Y[.Z]` siblings of `/opt/rocm`, while the Windows installer nests bare `X.Y` children under its ROCm root. The layouts are kept apart deliberately — accepting a bare number on Linux would sweep in unrelated `/opt` and `/usr/local` entries, and there is a test for exactly that.
- It is used by the JSON/diagnose probe, by the human report's legacy-ROCm summary on both platforms, and by the `fix-6-path` runner, which no longer hardcodes `/opt/rocm/bin`.
- `$ROCM_PATH` now outranks the conventional root. `examine` had this inverted, so a stale default directory beat an install the user named explicitly; the human report already got this right.
- The fallback version is derived from the final path component only. Scanning the whole path matched the first `rocm-` anywhere in it, so an install below a directory such as a checkout named `rocm-cli` reported a bogus version.

### Behaviour changes worth a reviewer's attention

- `examine` now requires the same install markers the human report already required, so a leftover empty `/opt/rocm` is no longer reported as a tarball install. That shared definition of "is an install" is the point of the change. Nothing reads the affected `rocm_install_method` values other than `"amdgpu-install"`, so no diagnosis score moves.
- The human report now lists every install it finds rather than at most two fixed paths.
- On Windows the install summary is now marker-gated too, where it previously accepted any of its three candidate directories that merely existed.

### Non-goals

Completing probe parity for the `--framework` flag and WSL detection-predicate unification is left to follow-up changes. The HIP SDK probe keeps its own lexicographic scan for now, so `6.10` still loses to `6.2` *there*; this PR fixes the ordering only on the paths that go through the shared resolver.

## Test plan

- Fourteen unit tests: versioned-only discovery, numeric-vs-lexical ordering, `$ROCM_PATH` precedence, conventional-root precedence, symlink dedup, marker-gated rejection, `.info/version` precedence, the Windows child layout (including `6.10` beating `6.2` and the root outranking its versioned children), the cross-layout guard, the bare-version parser, and an end-to-end case that drives the resolver into `fix-6-path` and asserts the guidance names the discovered root. That last test was mutation-checked — it fails when versioned discovery is disabled.
- `cargo test -p rocm-core`: 243 pass. Two `proc_lifecycle::tree_*` failures are a known WSL2-local issue on the dev machine and reproduce unchanged on `main`.
- `cargo fmt --check` and workspace `cargo clippy --all-targets -- -D warnings` are clean.
- Manually verified the human `rocm examine` path against a planted versioned install: `detected_unmanaged` with the versioned path present, `not_detected` when absent.

**Verification gap:** the `--json` and `diagnose` entry points short-circuit on WSL2 and the dev machine is WSL2, so those two are covered by unit tests rather than an end-to-end manual run. The Windows layout is likewise covered by unit tests against planted directories, not a real HIP SDK install.

**Risk:** low. The resolver is additive on a conventional box — the conventional root still wins — and the behaviour changes above are the intended ones.

---

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. No rows reference this behaviour.