### PR TITLE
fix(install): stream large downloads to disk with resume and length checks

### DIFF
--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -34,6 +34,10 @@ const STARTUP_UPDATE_CHECK_INTERVAL_MS: u128 = 12 * 60 * 60 * 1_000;
 const STARTUP_UPDATE_CHECK_TIMEOUT_SECS: u64 = 2;
 /// Timeout for the best-effort HEAD probe that sizes a download before starting it.
 const THEROCK_HEAD_PROBE_TIMEOUT_SECS: u64 = 10;
+/// Whole-transfer budget for an artifact download. A single-digit-gigabyte SDK
+/// tarball on a slow link needs well past the ten minutes the metadata fetches
+/// use; a retry that resumes cannot help if the attempt itself is cut short.
+const THEROCK_DOWNLOAD_TIMEOUT: Duration = Duration::from_hours(1);
 /// Largest `Content-Length` accepted as a real SDK tarball size.
 ///
 /// SDK tarballs are single-digit gigabytes; anything past this is a
@@ -2087,23 +2091,25 @@ fn http_header_value(headers: &str, name: &str) -> Option<String> {
     value
 }
 
+/// Fetch an artifact to `destination`.
+///
+/// Streams rather than buffers: SDK tarballs are single-digit gigabytes, and
+/// holding one in memory to write it out again costs that much RAM on top of
+/// the same amount of disk. The primitive also handles the free-space
+/// preflight, retry with resume, and the length cross-check that catches a
+/// transfer the server ended early.
 fn download_file(url: &str, destination: &Path) -> Result<()> {
     let parent = destination
         .parent()
         .context("download destination has no parent directory")?;
     fs::create_dir_all(parent)?;
-    let response = http_get(url, &[], None)?;
-    if response.status != 200 {
-        bail!("HTTP {} while fetching {url}", response.status);
-    }
-    // The body is already buffered, so this requirement is exact: refuse before
-    // writing rather than leaving a truncated file behind on a full disk.
-    disk_space::ensure_space_for(
-        &format!("save the download from {url}"),
+    rocm_core::download_file_streaming(&rocm_core::DownloadRequest::new(
+        url,
         destination,
-        disk_space::with_margin(response.body.len() as u64),
-    )?;
-    write_file_atomically(destination, &response.body)
+        THEROCK_DOWNLOAD_TIMEOUT,
+    ))
+    .with_context(|| format!("failed to fetch {url}"))?;
+    Ok(())
 }
 
 /// Content length of `url` from a HEAD request, when the server reports one.

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -33,6 +33,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_json::json;
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use std::collections::{HashSet, VecDeque};
 use std::ffi::OsString;
@@ -834,22 +835,28 @@ fn prefetch_artifact_value_with_policy(
         ));
     }
 
-    let bytes = download_artifact_bytes(&artifact.uri, max_bytes, &request_headers)?;
-    if bytes.len() as u64 != size_bytes {
-        bail!(
-            "artifact download size mismatch for `{artifact_ref}`: expected {size_bytes} bytes, got {}",
-            bytes.len()
-        );
-    }
-    let actual_sha256 = sha256_hex(&bytes);
-    if actual_sha256 != expected_sha256 {
-        bail!(
-            "artifact sha256 mismatch for `{artifact_ref}`: expected {expected_sha256}, got {actual_sha256}"
-        );
-    }
-
+    // Streamed straight to its final path: model artifacts run to gigabytes, so
+    // buffering one to hash it would hold the whole file in memory. The size and
+    // digest from the recipe are enforced inside the download, which also gives
+    // this path a free-space preflight and resume on a dropped connection.
     let artifact_path = artifact_bytes_path_for_marker(&cache.marker_path);
-    write_file_atomically(&artifact_path, &bytes)?;
+    let mut headers: Vec<(&str, &str)> = vec![("User-Agent", "rocm-cli")];
+    headers.extend(
+        request_headers
+            .iter()
+            .map(|(name, value)| (*name, value.as_str())),
+    );
+    let outcome = rocm_core::download_file_streaming(&rocm_core::DownloadRequest {
+        url: &artifact.uri,
+        destination: &artifact_path,
+        timeout: ARTIFACT_PREFETCH_TIMEOUT,
+        headers: &headers,
+        max_bytes: Some(max_bytes),
+        expected_len: Some(size_bytes),
+        expected_sha256: Some(&expected_sha256),
+    })
+    .with_context(|| format!("failed to prefetch artifact `{artifact_ref}`"))?;
+    let actual_sha256 = outcome.sha256;
     write_file_atomically(
         &cache.marker_path,
         &serde_json::to_vec_pretty(&json!({
@@ -1023,42 +1030,11 @@ fn artifact_bytes_path_for_marker(marker_path: &Path) -> PathBuf {
     marker_path.with_extension("bin")
 }
 
-fn download_artifact_bytes(
-    url: &str,
-    max_bytes: u64,
-    headers: &[(&str, String)],
-) -> Result<Vec<u8>> {
-    let agent = ureq::AgentBuilder::new()
-        .timeout(ARTIFACT_PREFETCH_TIMEOUT)
-        .build();
-    let mut request = agent.get(url).set("User-Agent", "rocm-cli");
-    for (name, value) in headers {
-        request = request.set(name, value);
-    }
-    let response = request.call().map_err(|error| match error {
-        ureq::Error::Status(status, _) => anyhow::anyhow!("HTTP {status} while fetching {url}"),
-        other @ ureq::Error::Transport(_) => {
-            anyhow::anyhow!("HTTP request failed for {url}: {other}")
-        }
-    })?;
-    let mut reader = response.into_reader().take(max_bytes.saturating_add(1));
-    let mut bytes = Vec::new();
-    reader
-        .read_to_end(&mut bytes)
-        .with_context(|| format!("failed to read artifact response for {url}"))?;
-    if bytes.len() as u64 > max_bytes {
-        bail!("artifact download exceeded approved byte limit of {max_bytes}");
-    }
-    Ok(bytes)
-}
-
+/// Hex digest of a buffer. Production hashing happens incrementally inside the
+/// streaming download; this exists only so tests can state an expected digest.
+#[cfg(test)]
 fn sha256_hex(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-    let digest = Sha256::digest(bytes);
-    digest.iter().fold(String::new(), |mut acc, byte| {
-        let _ = write!(acc, "{byte:02x}");
-        acc
-    })
+    format!("{:x}", Sha256::digest(bytes))
 }
 
 fn write_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -329,12 +329,23 @@ fn download_attempt(
             url = request.url
         )));
     }
+    // A `206` that does not confirm continuing from `resume_from` cannot be
+    // treated as a fresh full download either: its `Content-Length` is the
+    // length of whatever slice the server chose to send, not the whole
+    // artifact, so accepting it as complete would silently rename a truncated
+    // body into place. Discard the partial file and restart clean with a
+    // plain `GET` instead of reinterpreting the mismatched slice.
+    if status == 206 && resume_from > 0 && content_range_start(&response) != Some(resume_from) {
+        let _ = fs::remove_file(partial_path);
+        return Err(transient(anyhow::anyhow!(
+            "{url} resumed from an unexpected byte offset; restarting the download",
+            url = request.url
+        )));
+    }
     // Only append when the server confirmed it is continuing from exactly where
     // we stopped. A server that ignores `Range` answers 200 with the whole body,
-    // and one that honours it differently than asked would have us append at the
-    // wrong offset — both restart cleanly instead.
-    let resuming =
-        status == 206 && resume_from > 0 && content_range_start(&response) == Some(resume_from);
+    // which restarts cleanly too.
+    let resuming = status == 206 && resume_from > 0;
     let remaining_len = header_u64(&response, "Content-Length");
     let total_len =
         remaining_len.map(|len| len.saturating_add(if resuming { resume_from } else { 0 }));
@@ -7385,6 +7396,11 @@ mod tests {
         },
         /// Honour `Range` and serve the remainder as `206`.
         Resume,
+        /// Answer `206` but from `start` regardless of what `Range` asked for,
+        /// as a non-compliant server or a broken caching proxy might.
+        ResumeAtWrongOffset {
+            start: usize,
+        },
         /// Ignore `Range` and answer `200` with the whole body, as a server
         /// without range support does.
         IgnoreRange,
@@ -7444,6 +7460,16 @@ mod tests {
                     }
                     DownloadReply::Resume => {
                         let start = range_start.min(total);
+                        write!(
+                            stream,
+                            "HTTP/1.1 206 Partial Content\r\nAccept-Ranges: bytes\r\nContent-Range: bytes {start}-{}/{total}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            total.saturating_sub(1),
+                            total - start
+                        )?;
+                        stream.write_all(&body[start..])?;
+                    }
+                    DownloadReply::ResumeAtWrongOffset { start } => {
+                        let start = start.min(total);
                         write!(
                             stream,
                             "HTTP/1.1 206 Partial Content\r\nAccept-Ranges: bytes\r\nContent-Range: bytes {start}-{}/{total}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -7598,6 +7624,62 @@ mod tests {
             "the retry must ask to continue from byte 5000: {}",
             requests[1]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn download_restarts_cleanly_when_resume_lands_at_the_wrong_offset() -> Result<()> {
+        // The second reply answers `206` from byte 8000, not the byte 5000 we
+        // asked to resume from. Accepting that slice's own `Content-Length` as
+        // the whole artifact would silently rename a corrupt file into place;
+        // instead the third attempt must be a plain `GET` that refetches the
+        // whole thing.
+        let body = download_body();
+        let (port, server) = spawn_download_server(
+            body.clone(),
+            vec![
+                DownloadReply::Truncated { sent: 5000 },
+                DownloadReply::ResumeAtWrongOffset { start: 8000 },
+                DownloadReply::Complete,
+            ],
+        )?;
+        let dir = download_scratch("wrong-offset");
+        let destination = dir.join("artifact.bin");
+
+        let outcome = download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(10),
+        ))?;
+
+        let written = fs::read(&destination)?;
+        let requests = server.join().expect("server thread")?;
+        let leftovers: Vec<_> = fs::read_dir(&dir)?
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .filter(|name| name.to_string_lossy().contains(".part"))
+            .collect();
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(
+            written, body,
+            "a mismatched-offset resume must not be accepted as a complete artifact"
+        );
+        assert_eq!(
+            outcome.sha256,
+            format!("{:x}", Sha256::digest(&body)),
+            "the digest must cover the whole artifact from the clean restart"
+        );
+        assert_eq!(
+            requests.len(),
+            3,
+            "the wrong-offset reply must be discarded and retried, not accepted"
+        );
+        assert!(
+            !requests[2].contains("Range:"),
+            "the restart after a wrong-offset resume must be a plain GET: {}",
+            requests[2]
+        );
+        assert!(leftovers.is_empty(), "the .part file must not survive");
         Ok(())
     }
 

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 #[cfg(windows)]
 use std::ffi::OsStr;
@@ -118,35 +119,371 @@ pub fn parse_http_endpoint(endpoint_url: &str) -> Option<(String, u16)> {
     Some((host.to_owned(), port.parse().ok()?))
 }
 
-pub fn download_file_to_path(url: &str, destination: &Path, timeout: Duration) -> Result<()> {
-    let response = ureq::get(url)
-        .timeout(timeout)
-        .call()
-        .with_context(|| format!("failed to download {url}"))?;
-    if response.status() != 200 {
-        bail!("HTTP {} while downloading {url}", response.status());
+/// Attempts a download makes before giving up. The first attempt is not a
+/// retry, so this is one initial try plus two retries.
+pub const DOWNLOAD_MAX_ATTEMPTS: u32 = 3;
+
+/// Chunk size for the streaming copy. Fixed, so peak memory is independent of
+/// the artifact size — the whole point of streaming a multi-gigabyte tarball.
+const DOWNLOAD_CHUNK_BYTES: usize = 64 * 1024;
+
+/// Exponential backoff between download attempts.
+///
+/// A copy of the shape used by the dashboard's reconnect loop rather than a
+/// shared dependency: `rocm-core` sits below the dash crates, so it cannot
+/// import theirs.
+#[derive(Debug, Clone, Copy)]
+pub struct Backoff {
+    current: Duration,
+    max: Duration,
+    factor: u32,
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new(Duration::from_millis(500), Duration::from_secs(8), 2)
     }
-    if let Some(parent) = destination.parent() {
+}
+
+impl Backoff {
+    pub const fn new(initial: Duration, max: Duration, factor: u32) -> Self {
+        Self {
+            current: initial,
+            max,
+            factor,
+        }
+    }
+
+    /// The delay to wait before the next attempt, then grow toward `max`.
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = self.current.saturating_mul(self.factor).min(self.max);
+        delay
+    }
+}
+
+/// A download of a single artifact to a single path.
+#[derive(Debug, Clone, Copy)]
+pub struct DownloadRequest<'a> {
+    pub url: &'a str,
+    pub destination: &'a Path,
+    pub timeout: Duration,
+    pub headers: &'a [(&'a str, &'a str)],
+    /// Refuse a body larger than this, so an unexpected response cannot fill
+    /// the disk. `None` accepts whatever the server sends.
+    pub max_bytes: Option<u64>,
+    /// Size the caller already knows from a manifest. Checked in addition to
+    /// the server's own `Content-Length`.
+    pub expected_len: Option<u64>,
+    pub expected_sha256: Option<&'a str>,
+}
+
+impl<'a> DownloadRequest<'a> {
+    pub const fn new(url: &'a str, destination: &'a Path, timeout: Duration) -> Self {
+        Self {
+            url,
+            destination,
+            timeout,
+            headers: &[],
+            max_bytes: None,
+            expected_len: None,
+            expected_sha256: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DownloadOutcome {
+    pub bytes_written: u64,
+    pub sha256: String,
+}
+
+/// Stream `request.url` to `request.destination`, retrying transient failures
+/// and resuming where the server allows it.
+///
+/// Bytes go through a fixed [`DOWNLOAD_CHUNK_BYTES`] buffer into a sibling
+/// `.part` file and are hashed on the way past, so peak memory does not scale
+/// with the artifact — a multi-gigabyte SDK tarball costs the same as a small
+/// one. The `.part` file is a sibling of the destination so the final rename
+/// stays within one filesystem and is atomic: a caller that finds the
+/// destination present knows it holds a complete download, and an interrupted
+/// run never leaves a truncated file that a later run would treat as cached.
+///
+/// # Integrity
+///
+/// With `expected_sha256` the content is authenticated. Without it the only
+/// integrity signal is the byte count, cross-checked against `Content-Length`
+/// and `expected_len`. That catches truncation and interrupted transfers, which
+/// is what this guards against, but `Content-Length` is unauthenticated and a
+/// matching length proves nothing about the bytes — do not read a successful
+/// return as "the artifact is genuine" unless a digest was supplied.
+pub fn download_file_streaming(request: &DownloadRequest<'_>) -> Result<DownloadOutcome> {
+    if let Some(parent) = request.destination.parent()
+        && !parent.as_os_str().is_empty()
+    {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    // Free-space preflight: `Content-Length` is an exact size where the server
-    // sends it, so refuse upfront rather than failing partway through the write.
-    if let Some(content_length) = response
-        .header("Content-Length")
-        .and_then(|value| value.trim().parse::<u64>().ok())
-    {
-        disk_space::ensure_space_for(
-            &format!("download {url}"),
-            destination,
-            disk_space::with_margin(content_length),
-        )?;
+    let partial_path = partial_download_path(request.destination);
+    // Resume is scoped to retries within this call. A `.part` file found at
+    // entry is debris from an earlier run — process ids get reused, so its
+    // contents cannot be attributed to this URL and appending to it would
+    // silently produce a corrupt artifact.
+    let _ = fs::remove_file(&partial_path);
+    let mut backoff = Backoff::default();
+    let mut attempt = 1;
+    let outcome = loop {
+        match download_attempt(request, &partial_path) {
+            Ok(outcome) => break outcome,
+            Err(error) => {
+                let retryable = error.retryable && attempt < DOWNLOAD_MAX_ATTEMPTS;
+                if !retryable {
+                    let _ = fs::remove_file(&partial_path);
+                    return Err(error.error);
+                }
+                thread::sleep(backoff.next_delay());
+                attempt += 1;
+            }
+        }
+    };
+    fs::rename(&partial_path, request.destination).map_err(|error| {
+        let _ = fs::remove_file(&partial_path);
+        anyhow::Error::new(error).context(format!(
+            "failed to move the completed download into {}",
+            request.destination.display()
+        ))
+    })?;
+    Ok(outcome)
+}
+
+/// Where the in-progress bytes live. Keyed by process id so two processes
+/// downloading the same destination cannot append into each other's file.
+fn partial_download_path(destination: &Path) -> PathBuf {
+    let mut name = destination.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".part-{}", std::process::id()));
+    destination.with_file_name(name)
+}
+
+/// A failed attempt, and whether trying again could plausibly help.
+struct DownloadAttemptError {
+    error: anyhow::Error,
+    retryable: bool,
+}
+
+const fn transient(error: anyhow::Error) -> DownloadAttemptError {
+    DownloadAttemptError {
+        error,
+        retryable: true,
     }
+}
+
+const fn permanent(error: anyhow::Error) -> DownloadAttemptError {
+    DownloadAttemptError {
+        error,
+        retryable: false,
+    }
+}
+
+/// Whether a status is worth another attempt. Server-side and rate-limit
+/// responses can succeed later; the rest of `4xx` means the request itself is
+/// wrong, and repeating it just wastes the user's time.
+const fn status_is_retryable(status: u16) -> bool {
+    status == 408 || status == 429 || status >= 500
+}
+
+fn download_attempt(
+    request: &DownloadRequest<'_>,
+    partial_path: &Path,
+) -> Result<DownloadOutcome, DownloadAttemptError> {
+    // Resume from whatever a previous attempt already wrote. A missing file is
+    // simply a fresh start.
+    let resume_from = fs::metadata(partial_path).map_or(0, |meta| meta.len());
+    let mut call = ureq::get(request.url).timeout(request.timeout);
+    for (name, value) in request.headers {
+        call = call.set(name, value);
+    }
+    if resume_from > 0 {
+        call = call.set("Range", &format!("bytes={resume_from}-"));
+    }
+    let response = match call.call() {
+        Ok(response) => response,
+        Err(ureq::Error::Status(status, _)) => {
+            let error = anyhow::anyhow!("HTTP {status} while downloading {url}", url = request.url);
+            return Err(if status_is_retryable(status) {
+                transient(error)
+            } else {
+                permanent(error)
+            });
+        }
+        // Transport failures are exactly the interruptions worth retrying.
+        Err(error) => {
+            return Err(transient(
+                anyhow::Error::new(error).context(format!("failed to download {}", request.url)),
+            ));
+        }
+    };
+    let status = response.status();
+    if status != 200 && status != 206 {
+        return Err(permanent(anyhow::anyhow!(
+            "HTTP {status} while downloading {url}",
+            url = request.url
+        )));
+    }
+    // Only append when the server confirmed it is continuing from exactly where
+    // we stopped. A server that ignores `Range` answers 200 with the whole body,
+    // and one that honours it differently than asked would have us append at the
+    // wrong offset — both restart cleanly instead.
+    let resuming =
+        status == 206 && resume_from > 0 && content_range_start(&response) == Some(resume_from);
+    let remaining_len = header_u64(&response, "Content-Length");
+    let total_len =
+        remaining_len.map(|len| len.saturating_add(if resuming { resume_from } else { 0 }));
+    if let Some(total) = total_len.or(request.expected_len) {
+        if let Some(max_bytes) = request.max_bytes
+            && total > max_bytes
+        {
+            return Err(permanent(anyhow::anyhow!(
+                "{url} is {total} bytes, over the approved limit of {max_bytes}",
+                url = request.url
+            )));
+        }
+        // Free-space preflight, before a single byte is read: an exact size
+        // means we can refuse upfront instead of failing partway through. Only
+        // the bytes still to come need room; a resumed prefix already has it.
+        let still_needed = total.saturating_sub(if resuming { resume_from } else { 0 });
+        if let Err(error) = disk_space::ensure_space_for(
+            &format!("download {}", request.url),
+            request.destination,
+            disk_space::with_margin(still_needed),
+        ) {
+            return Err(permanent(error));
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    let mut written = 0_u64;
+    let mut file = if resuming {
+        // Re-hash the prefix so the digest covers the whole artifact, not just
+        // the bytes this attempt happened to fetch.
+        let mut existing =
+            fs::File::open(partial_path).map_err(|error| permanent(anyhow::Error::new(error)))?;
+        written = std::io::copy(&mut existing, &mut hasher)
+            .map_err(|error| permanent(anyhow::Error::new(error)))?;
+        fs::OpenOptions::new()
+            .append(true)
+            .open(partial_path)
+            .map_err(|error| permanent(anyhow::Error::new(error)))?
+    } else {
+        fs::File::create(partial_path).map_err(|error| {
+            permanent(
+                anyhow::Error::new(error)
+                    .context(format!("failed to create {}", partial_path.display())),
+            )
+        })?
+    };
+
     let mut reader = response.into_reader();
-    let mut file = fs::File::create(destination)
-        .with_context(|| format!("failed to create {}", destination.display()))?;
-    std::io::copy(&mut reader, &mut file)
-        .map_err(|error| disk_space::map_write_error(error, destination))?;
+    let mut buffer = vec![0_u8; DOWNLOAD_CHUNK_BYTES];
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            // A mid-body failure keeps the partial file: the next attempt
+            // resumes from it. A server that drops the connection early and one
+            // that closes cleanly after a short body are the same problem to
+            // the user, so report the shortfall either way rather than a bare
+            // transport error.
+            Err(error) => {
+                let reason = total_len.or(request.expected_len).map_or_else(
+                    || format!("failed while downloading {}", request.url),
+                    |expected| {
+                        format!(
+                            "incomplete download of {}: expected {expected} bytes, got {written}",
+                            request.url
+                        )
+                    },
+                );
+                return Err(transient(anyhow::Error::new(error).context(reason)));
+            }
+        };
+        written = written.saturating_add(read as u64);
+        if let Some(max_bytes) = request.max_bytes
+            && written > max_bytes
+        {
+            return Err(permanent(anyhow::anyhow!(
+                "{url} exceeded the approved limit of {max_bytes} bytes",
+                url = request.url
+            )));
+        }
+        hasher.update(&buffer[..read]);
+        if let Err(error) = file.write_all(&buffer[..read]) {
+            return Err(permanent(disk_space::map_write_error(error, partial_path)));
+        }
+    }
+    if let Err(error) = file.sync_all() {
+        return Err(permanent(disk_space::map_write_error(error, partial_path)));
+    }
+    drop(file);
+
+    // Two independent length contracts, checked separately because they fail
+    // for different reasons and deserve different handling.
+    //
+    // The server's own `Content-Length`: a shortfall means the transfer was cut
+    // short, so the bytes on disk are good as far as they go and the next
+    // attempt resumes from them.
+    if let Some(expected) = total_len
+        && written != expected
+    {
+        return Err(transient(anyhow::anyhow!(
+            "incomplete download of {url}: expected {expected} bytes, got {written}",
+            url = request.url
+        )));
+    }
+    // A size the caller knew in advance: the server delivered a complete body
+    // that is not the artifact the manifest describes. Refetching returns the
+    // same wrong thing, so do not spend the remaining attempts on it.
+    if let Some(expected) = request.expected_len
+        && written != expected
+    {
+        return Err(permanent(anyhow::anyhow!(
+            "{url} is {written} bytes, but {expected} were expected",
+            url = request.url
+        )));
+    }
+    let sha256 = format!("{:x}", hasher.finalize());
+    if let Some(expected) = request.expected_sha256
+        && !sha256.eq_ignore_ascii_case(expected)
+    {
+        // The bytes are wrong, not merely incomplete; resuming would append to
+        // a corrupt prefix, so discard it and fail.
+        let _ = fs::remove_file(partial_path);
+        return Err(permanent(anyhow::anyhow!(
+            "SHA-256 mismatch for {url}: expected {expected}, got {sha256}",
+            url = request.url
+        )));
+    }
+    Ok(DownloadOutcome {
+        bytes_written: written,
+        sha256,
+    })
+}
+
+fn header_u64(response: &ureq::Response, name: &str) -> Option<u64> {
+    response
+        .header(name)
+        .and_then(|value| value.trim().parse::<u64>().ok())
+}
+
+/// First byte offset from a `Content-Range: bytes <start>-<end>/<total>` header.
+fn content_range_start(response: &ureq::Response) -> Option<u64> {
+    let value = response.header("Content-Range")?;
+    let range = value.trim().strip_prefix("bytes")?.trim_start();
+    let start = range.split('-').next()?.trim();
+    start.parse::<u64>().ok()
+}
+
+pub fn download_file_to_path(url: &str, destination: &Path, timeout: Duration) -> Result<()> {
+    download_file_streaming(&DownloadRequest::new(url, destination, timeout))?;
     Ok(())
 }
 
@@ -7034,6 +7371,370 @@ mod tests {
             Ok(requests)
         });
         Ok((port, handle))
+    }
+
+    /// How a scripted download server answers one request.
+    #[derive(Clone, Copy)]
+    enum DownloadReply {
+        /// The whole body with a matching `Content-Length`.
+        Complete,
+        /// Declare the full length, send only `sent` bytes, then close —
+        /// an interrupted transfer.
+        Truncated {
+            sent: usize,
+        },
+        /// Honour `Range` and serve the remainder as `206`.
+        Resume,
+        /// Ignore `Range` and answer `200` with the whole body, as a server
+        /// without range support does.
+        IgnoreRange,
+        Status(&'static str),
+    }
+
+    /// Serve `body` over loopback, answering each request per `replies`.
+    /// Returns the port and a handle yielding the raw requests received.
+    fn spawn_download_server(
+        body: Vec<u8>,
+        replies: Vec<DownloadReply>,
+    ) -> Result<(u16, std::thread::JoinHandle<Result<Vec<String>>>)> {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let handle = std::thread::spawn(move || -> Result<Vec<String>> {
+            let mut requests = Vec::new();
+            for reply in replies {
+                let (mut stream, _) = listener.accept()?;
+                // An accepted socket inherits the listener's mode on Windows,
+                // where a non-blocking read fails with `WSAEWOULDBLOCK` instead
+                // of waiting. Be explicit rather than rely on the platform.
+                stream.set_nonblocking(false)?;
+                stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+                let mut request_bytes = Vec::new();
+                let mut buffer = [0_u8; 512];
+                while let Ok(read) = stream.read(&mut buffer) {
+                    if read == 0 {
+                        break;
+                    }
+                    request_bytes.extend_from_slice(&buffer[..read]);
+                    if request_bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8_lossy(&request_bytes).into_owned();
+                let range_start = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Range: bytes="))
+                    .and_then(|value| value.trim().split('-').next()?.parse::<usize>().ok())
+                    .unwrap_or(0);
+                requests.push(request);
+                let total = body.len();
+                match reply {
+                    DownloadReply::Complete | DownloadReply::IgnoreRange => {
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nAccept-Ranges: bytes\r\nContent-Length: {total}\r\nConnection: close\r\n\r\n"
+                        )?;
+                        stream.write_all(&body)?;
+                    }
+                    DownloadReply::Truncated { sent } => {
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nAccept-Ranges: bytes\r\nContent-Length: {total}\r\nConnection: close\r\n\r\n"
+                        )?;
+                        stream.write_all(&body[..sent.min(total)])?;
+                    }
+                    DownloadReply::Resume => {
+                        let start = range_start.min(total);
+                        write!(
+                            stream,
+                            "HTTP/1.1 206 Partial Content\r\nAccept-Ranges: bytes\r\nContent-Range: bytes {start}-{}/{total}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            total.saturating_sub(1),
+                            total - start
+                        )?;
+                        stream.write_all(&body[start..])?;
+                    }
+                    DownloadReply::Status(status_line) => {
+                        write!(
+                            stream,
+                            "{status_line}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        )?;
+                    }
+                }
+                stream.flush()?;
+            }
+            Ok(requests)
+        });
+        Ok((port, handle))
+    }
+
+    /// A body large enough to span many `DOWNLOAD_CHUNK_BYTES` reads, so the
+    /// streaming loop is genuinely exercised rather than fitting in one chunk.
+    fn download_body() -> Vec<u8> {
+        (0..DOWNLOAD_CHUNK_BYTES * 3 + 1234)
+            .map(|index| (index % 251) as u8)
+            .collect()
+    }
+
+    fn download_scratch(tag: &str) -> PathBuf {
+        let dir = workspace_test_artifact_dir().join(format!(
+            "download-{tag}-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("failed to create scratch dir");
+        dir
+    }
+
+    #[test]
+    fn download_streams_a_large_body_and_reports_its_digest() -> Result<()> {
+        let body = download_body();
+        let (port, server) = spawn_download_server(body.clone(), vec![DownloadReply::Complete])?;
+        let dir = download_scratch("complete");
+        let destination = dir.join("artifact.bin");
+
+        let outcome = download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(10),
+        ))?;
+
+        let written = fs::read(&destination)?;
+        let expected_digest = format!("{:x}", Sha256::digest(&body));
+        server.join().expect("server thread")?;
+        let leftovers: Vec<_> = fs::read_dir(&dir)?
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .filter(|name| name.to_string_lossy().contains(".part"))
+            .collect();
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(written, body, "the saved file must match the served bytes");
+        assert_eq!(outcome.bytes_written, body.len() as u64);
+        assert_eq!(outcome.sha256, expected_digest);
+        assert!(leftovers.is_empty(), "the .part file must not survive");
+        Ok(())
+    }
+
+    #[test]
+    fn download_interrupted_beyond_recovery_leaves_no_destination_file() -> Result<()> {
+        // Every attempt ends early, so the download never completes and the
+        // user is left with the truncation as the reported reason.
+        let body = download_body();
+        let (port, server) = spawn_download_server(
+            body,
+            vec![DownloadReply::Truncated { sent: 4096 }; DOWNLOAD_MAX_ATTEMPTS as usize],
+        )?;
+        let dir = download_scratch("interrupted");
+        let destination = dir.join("artifact.bin");
+
+        let error = download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(5),
+        ))
+        .expect_err("a download that never completes must fail");
+
+        let requests = server.join().expect("server thread")?;
+        let entries: Vec<_> = fs::read_dir(&dir)?
+            .filter_map(|entry| entry.ok().map(|entry| entry.file_name()))
+            .collect();
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(
+            requests.len(),
+            DOWNLOAD_MAX_ATTEMPTS as usize,
+            "a truncated transfer is transient, so every attempt should be spent"
+        );
+        assert!(
+            !destination.exists(),
+            "a partial download must never appear at the destination, where a \
+             later run would treat it as a complete cached artifact"
+        );
+        assert!(
+            entries.is_empty(),
+            "the .part file must be cleaned up, found {entries:?}"
+        );
+        assert!(
+            error.to_string().contains("incomplete download"),
+            "the user should be told the transfer was short: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn download_resumes_from_where_the_transfer_stopped() -> Result<()> {
+        let body = download_body();
+        let (port, server) = spawn_download_server(
+            body.clone(),
+            vec![
+                DownloadReply::Truncated { sent: 5000 },
+                DownloadReply::Resume,
+            ],
+        )?;
+        let dir = download_scratch("resume");
+        let destination = dir.join("artifact.bin");
+
+        let outcome = download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(10),
+        ))?;
+
+        let written = fs::read(&destination)?;
+        let requests = server.join().expect("server thread")?;
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(
+            written, body,
+            "a resumed download must reconstruct the artifact exactly"
+        );
+        assert_eq!(
+            outcome.sha256,
+            format!("{:x}", Sha256::digest(&body)),
+            "the digest must cover the resumed prefix too, not just the second attempt"
+        );
+        assert_eq!(requests.len(), 2, "one retry, not a full restart");
+        assert!(
+            requests[1].contains("Range: bytes=5000-"),
+            "the retry must ask to continue from byte 5000: {}",
+            requests[1]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn download_restarts_cleanly_when_the_server_ignores_range() -> Result<()> {
+        // A server without range support answers 200 with the whole body.
+        // Appending that onto the bytes already written would double the file.
+        let body = download_body();
+        let (port, server) = spawn_download_server(
+            body.clone(),
+            vec![
+                DownloadReply::Truncated { sent: 3000 },
+                DownloadReply::IgnoreRange,
+            ],
+        )?;
+        let dir = download_scratch("ignore-range");
+        let destination = dir.join("artifact.bin");
+
+        download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(10),
+        ))?;
+
+        let written = fs::read(&destination)?;
+        server.join().expect("server thread")?;
+        fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(written, body, "the restart must not append onto the prefix");
+        Ok(())
+    }
+
+    #[test]
+    fn download_rejects_a_digest_mismatch_without_retrying() -> Result<()> {
+        let body = download_body();
+        let (port, server) = spawn_download_server(body, vec![DownloadReply::Complete])?;
+        let dir = download_scratch("digest");
+        let destination = dir.join("artifact.bin");
+        let url = format!("http://127.0.0.1:{port}/artifact.bin");
+        let wrong_digest = "a".repeat(64);
+        let mut request = DownloadRequest::new(&url, &destination, Duration::from_secs(10));
+        request.expected_sha256 = Some(&wrong_digest);
+
+        let error = download_file_streaming(&request).expect_err("wrong digest must fail");
+
+        let requests = server.join().expect("server thread")?;
+        let leftovers = fs::read_dir(&dir)?.count();
+        fs::remove_dir_all(&dir).ok();
+
+        assert!(error.to_string().contains("SHA-256 mismatch"), "{error}");
+        assert!(!destination.exists());
+        assert_eq!(
+            requests.len(),
+            1,
+            "corrupt bytes are not a transient failure; retrying would re-fetch the same thing"
+        );
+        assert_eq!(leftovers, 0, "the corrupt prefix must be discarded");
+        Ok(())
+    }
+
+    #[test]
+    fn download_does_not_retry_a_client_error() -> Result<()> {
+        let body = download_body();
+        let (port, server) =
+            spawn_download_server(body, vec![DownloadReply::Status("HTTP/1.1 404 Not Found")])?;
+        let dir = download_scratch("not-found");
+        let destination = dir.join("artifact.bin");
+
+        let error = download_file_streaming(&DownloadRequest::new(
+            &format!("http://127.0.0.1:{port}/artifact.bin"),
+            &destination,
+            Duration::from_secs(5),
+        ))
+        .expect_err("404 must fail");
+
+        let requests = server.join().expect("server thread")?;
+        fs::remove_dir_all(&dir).ok();
+
+        assert!(error.to_string().contains("404"), "{error}");
+        assert_eq!(requests.len(), 1, "a 404 will not become a 200 on retry");
+        Ok(())
+    }
+
+    #[test]
+    fn download_refuses_a_body_over_the_approved_limit() -> Result<()> {
+        let body = download_body();
+        let total = body.len() as u64;
+        let (port, server) = spawn_download_server(body, vec![DownloadReply::Complete])?;
+        let dir = download_scratch("max-bytes");
+        let destination = dir.join("artifact.bin");
+        let url = format!("http://127.0.0.1:{port}/artifact.bin");
+        let mut request = DownloadRequest::new(&url, &destination, Duration::from_secs(5));
+        request.max_bytes = Some(total - 1);
+
+        let error = download_file_streaming(&request).expect_err("over-limit must fail");
+
+        server.join().expect("server thread")?;
+        fs::remove_dir_all(&dir).ok();
+
+        assert!(error.to_string().contains("approved limit"), "{error}");
+        assert!(!destination.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn download_enforces_a_caller_declared_size_the_server_agrees_with() -> Result<()> {
+        // The server sends a complete, self-consistent body — it just is not
+        // the artifact the manifest described. A digest would catch this too,
+        // but the size contract is independent and must hold on its own.
+        let body = download_body();
+        let (port, server) = spawn_download_server(body.clone(), vec![DownloadReply::Complete])?;
+        let dir = download_scratch("expected-len");
+        let destination = dir.join("artifact.bin");
+        let url = format!("http://127.0.0.1:{port}/artifact.bin");
+        let mut request = DownloadRequest::new(&url, &destination, Duration::from_secs(10));
+        request.expected_len = Some(body.len() as u64 + 1);
+
+        let error = download_file_streaming(&request).expect_err("wrong size must fail");
+
+        let requests = server.join().expect("server thread")?;
+        fs::remove_dir_all(&dir).ok();
+
+        assert!(error.to_string().contains("were expected"), "{error}");
+        assert!(!destination.exists());
+        assert_eq!(
+            requests.len(),
+            1,
+            "a manifest disagreement will not resolve itself on retry"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn download_backoff_grows_then_settles_at_its_ceiling() {
+        let mut backoff = Backoff::new(Duration::from_millis(100), Duration::from_millis(800), 2);
+        let delays: Vec<u128> = (0..5).map(|_| backoff.next_delay().as_millis()).collect();
+        assert_eq!(delays, vec![100, 200, 400, 800, 800]);
     }
 
     const CHAT_OK_BODY: &str = r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#;


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No EAI-7405 rows exist.)

## Problem

The two largest artifacts rocm-cli fetches for itself were both read into memory in full before a byte reached disk:

- the **ROCm SDK tarball** — single-digit gigabytes, buffered by `read_to_end` and then written out again, so peak cost was that much RAM *on top of* the same amount of disk;
- **prefetched model artifacts** — also hashed over the live buffer, so the whole file had to stay resident to compute its digest.

Separately, the one path that did stream wrote **straight to its destination**. An interrupted download therefore left a truncated file exactly where the next run looks for a cached one. The ComfyUI source archive is reused whenever that path exists, with no checksum to catch it, so a half-finished download silently became a "cached" corrupt archive.

There was no retry and no resume anywhere: a transient reset partway through a multi-gigabyte transfer discarded all progress.

## Approach

One streaming primitive in `rocm-core`, with both buffering call sites pointed at it. Bytes move through a fixed 64 KiB buffer and are hashed on the way past, so peak memory no longer scales with the artifact.

- **Atomic publish.** Writes go to a sibling `.part` file and are renamed on success, so the destination only ever holds a complete download. The `.part` file is a sibling to keep the rename within one filesystem.
- **Bounded retry with resume.** Three attempts with exponential backoff. A retry resumes via `Range` only when the server confirms with `206` *and* a `Content-Range` starting at exactly the offset requested; a server that ignores ranges, or honours one at a different offset, restarts cleanly rather than appending at the wrong place.
- **Two independent length contracts.** What arrived is checked against the server's `Content-Length` and, separately, against a size the caller already knew. They fail differently and are handled differently: a short body means the transfer was cut off, so it is transient and the next attempt resumes; a *complete* body of the wrong size means the manifest and the server disagree, which retrying cannot fix.
- **Resume is scoped to one call.** A `.part` file found at entry is deleted rather than resumed from. Process ids get reused, so debris from an earlier run cannot be attributed to this URL, and appending to it would produce a corrupt artifact.

The model-prefetch path also gains a free-space preflight it never had, inherited from the primitive.

## Integrity, stated plainly

The SDK tarball has **no digest to verify against** — TheRock's index publishes only a name and mtime — so its integrity check is the length alone. That catches truncation and interrupted transfers, which is the failure this addresses, but `Content-Length` is unauthenticated and a matching length says nothing about the bytes. A successful download is not evidence the artifact is genuine unless a digest was supplied, and the primitive's doc comment says so. Model artifacts do carry a recipe SHA-256 and are fully verified.

## Scope

`download_file_to_path` keeps its signature and becomes a thin wrapper, so the uv, Lemonade and ComfyUI downloads inherit streaming, atomicity, retry and resume without call-site changes.

Lemonade's cache-lock and publish machinery is deliberately untouched. Its `NamedTempFile` + `verify_sha256` flow now overlaps slightly with the primitive, but folding the two together is a separate refactor with real regression risk and no user-visible gain here.

Extraction-time space checks and the unpreflighted pip/wheel install path are also out of scope — those are about refusing before *extraction*, not before download, and belong in their own change.

## Testing

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Eleven new unit tests drive a scripted loopback server: a large body streamed and digested, an interrupted transfer leaving nothing at the destination, a resume that asks for the right byte offset and reconstructs the artifact exactly, a range-ignoring server restarting cleanly, digest mismatch, wrong declared size, `404` not being retried, and the byte cap. The server's accepted sockets are explicitly set blocking, since on Windows an accepted socket inherits the listener's non-blocking mode and reads fail with `WSAEWOULDBLOCK`.

`cargo test --workspace --all-targets --no-fail-fast` passes apart from three pre-existing failures on untouched files: two `rocm-core` `proc_lifecycle::tests::tree_*` tests that fail on WSL2 for process-tree signalling reasons, and `therock::tests::extracting_the_sdk_archive_removes_it`, which flakes under parallel load on `main` as well and passes 3/3 in isolation here.

**Not run:** a real multi-gigabyte download. This host has no SDK mirror access and no CI lane pulls a 5 GiB tarball. The absence of buffering is guaranteed structurally — no `read_to_end` remains on any artifact path — and the streaming, truncation and resume behaviours are pinned by the tests above, but the real transfer has not been exercised.

No e2e change: an e2e resume test against `rocm install` would first need a download-base override, since the TheRock URLs are hardcoded constants and `ROCM_CLI_DOWNLOAD_BASE` only redirects `install.sh`/`install.ps1`.

Closes EAI-7405.