### PR TITLE
fix(examine): report a real OS version instead of the OS name

### DIFF
--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -405,7 +405,20 @@ const MEDIUM: Duration = Duration::from_secs(8);
 // ---------------------------------------------------------------------------
 
 fn probe_os(e: &mut Examination) {
-    e.os_version = std::env::consts::OS.to_owned();
+    // The OS *version*, mirroring examine.py's `platform.version()`. This used
+    // to hold `std::env::consts::OS`, which is the OS *name* and so merely
+    // repeated `os_family`, telling a reader of the report nothing.
+    //
+    // Left empty on platforms the CLI does not support rather than guessed at:
+    // an empty field reads as "not collected", while a wrong one would be
+    // reasoned over by the diagnosis catalog.
+    e.os_version = if runtime_is_linux() {
+        run("uname", &["-v"], SHORT).1.trim().to_owned()
+    } else if runtime_is_windows() {
+        run("cmd", &["/C", "ver"], SHORT).1.trim().to_owned()
+    } else {
+        String::new()
+    };
     if runtime_is_linux() {
         e.os_family = "linux".to_owned();
         e.kernel_release = run("uname", &["-r"], SHORT).1.trim().to_owned();
@@ -1679,5 +1692,37 @@ mod tests {
             Some("6.4.1".to_owned())
         );
         assert_eq!(extract_rocm_version("/opt/rocm"), None);
+    }
+
+    #[test]
+    fn os_version_carries_a_version_not_the_os_name() {
+        // This field used to hold `std::env::consts::OS`, so it repeated
+        // `os_family` and told a reader of the report nothing.
+        let mut e = Examination::default();
+        probe_os(&mut e);
+
+        // Holds on every platform: a real version on the supported ones, and
+        // empty on the rest -- neither of which is the OS name.
+        assert_ne!(
+            e.os_version,
+            std::env::consts::OS,
+            "os_version must not merely repeat the OS name"
+        );
+
+        if runtime_is_linux() || runtime_is_windows() {
+            assert!(
+                !e.os_version.is_empty(),
+                "a supported host must report an OS version"
+            );
+            assert_ne!(e.os_version, e.os_family);
+        } else {
+            // Blank by choice on a host the CLI does not support, rather than
+            // a guess the diagnosis catalog would then reason over.
+            assert!(
+                e.os_version.is_empty(),
+                "unsupported hosts report no version, got {:?}",
+                e.os_version
+            );
+        }
     }
 }


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. No rows reference this behaviour.

## Problem

`Examination::os_version` held `std::env::consts::OS` — the OS *name*. So the field just repeated `os_family`, and a reader of `rocm examine --json` learned nothing from it:

```json
"os_family": "linux",
"os_version": "linux",
```

## Fix

Populate it with an actual version, mirroring what `examine.py`'s `platform.version()` reports: `uname -v` on Linux, `cmd /C ver` on Windows.

On a host the CLI does not support the field stays empty rather than being guessed at. An empty value reads as "not collected"; a wrong one would be reasoned over by the diagnosis catalog.

No field was added or removed, so the frozen wire contract with the catalog is unchanged.

## Scope

This was originally part of #197 (versioned ROCm install detection). It is a genuine fix but an unrelated one — that PR is about install discovery — so it is split out here to keep each change to one concern. #197 no longer touches `os_version`.

## Test plan

`cargo fmt --check` and `cargo clippy -p rocm-core --all-targets -- -D warnings` clean. `cargo test -p rocm-core` passes apart from the two known WSL2-local `proc_lifecycle::tree_*` failures, which reproduce unchanged on `main`.

The new test asserts the invariant that holds on every platform — `os_version` is never the OS name — then branches: non-empty on Linux and Windows, deliberately empty elsewhere. Written that way on purpose: a flat non-empty assertion would fail for anyone running the suite on macOS, where the field is intentionally blank.

**Verified on Linux only.** The Windows branch shells out to `cmd /C ver` and has not been run on a Windows host; CI's `windows-build-and-test` is the check that exercises it.