### PR TITLE
fix(dash): keep scrape warnings between scrape ticks

### DIFF
--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -220,6 +220,11 @@ pub async fn run_loop(
 
     let mut tick_count: u64 = 0;
     let mut last_sysinfo_refresh: u64 = 0;
+    // Discovery/scrape warnings are produced on their own (slower) cadences, so
+    // holding them only for the tick that produced them makes the header ⚠ badge
+    // blink on and off. Keep the last result until that cadence runs again.
+    let mut docker_warn: Option<String> = None;
+    let mut scrape_warns: Vec<String> = Vec::new();
 
     loop {
         ticker.tick().await;
@@ -321,8 +326,9 @@ pub async fn run_loop(
                         );
                     }
                     known_instances = seen;
+                    docker_warn = None;
                 }
-                Err(e) => warnings.push(format!("docker discover: {e}")),
+                Err(e) => docker_warn = Some(format!("docker discover: {e}")),
             }
         }
 
@@ -459,6 +465,9 @@ pub async fn run_loop(
             }
             known_services = disc.seen;
         }
+        if tick_count.is_multiple_of(instance_ticks) {
+            scrape_warns.clear();
+        }
 
         // Per-instance vLLM metric scrape, parallel, on its own cadence. The
         // Lemonade instance (if any) is scraped via its own collector below, so
@@ -568,7 +577,7 @@ pub async fn run_loop(
                 }
             }
             if fail_count > 0 {
-                warnings.push(match last_err {
+                scrape_warns.push(match last_err {
                     Some(e) => format!("vllm scrape: {fail_count} failed (last: {e})"),
                     None => format!("vllm scrape: {fail_count} failed"),
                 });
@@ -612,7 +621,7 @@ pub async fn run_loop(
                 }
                 Err(e) => {
                     trace!(id = %id, error = %e, "lemonade scrape failed");
-                    warnings.push(format!("lemonade scrape: {e}"));
+                    scrape_warns.push(format!("lemonade scrape: {e}"));
                     // EAI-7960: retain tracker during validity window on failure.
                     // gen_tps is assembled from the tracker snapshot below;
                     // no explicit clearing needed here.
@@ -704,12 +713,14 @@ pub async fn run_loop(
                 })
                 .count();
             if vram_fallbacks > 0 {
-                warnings.push(format!(
+                scrape_warns.push(format!(
                     "vram attribution: {vram_fallbacks} instance(s) fell back to device-summed \
                      VRAM (no per-process cgroup match; check /proc access)"
                 ));
             }
         }
+        warnings.extend(docker_warn.iter().cloned());
+        warnings.extend(scrape_warns.iter().cloned());
         let snap = Snapshot {
             timestamp: cycle_at,
             host: host.tick(),

--- a/crates/rocm-dash-daemon/tests/end_to_end.rs
+++ b/crates/rocm-dash-daemon/tests/end_to_end.rs
@@ -258,3 +258,64 @@ async fn socket_is_created_with_restricted_permissions() {
     let _ = handle.await;
     assert_eq!(mode, 0o600, "socket must not be group- or world-accessible");
 }
+
+/// Regression: a scrape warning must persist on the ticks BETWEEN scrapes.
+/// The vLLM scrape runs on the slower `instance_tick` cadence, so rebuilding
+/// `warnings` per tick made the header ⚠ badge appear and vanish alternately.
+#[tokio::test]
+async fn scrape_warning_persists_between_scrape_ticks() {
+    let dir = tempfile::tempdir().unwrap();
+    // A "running" managed vLLM service on a port nothing listens on: every
+    // scrape fails, so the warning must be present on EVERY snapshot.
+    std::fs::write(
+        dir.path().join("svc.json"),
+        r#"{"service_id":"svc-dead","engine":"vllm","model_ref":"m","canonical_model_id":"m",
+            "host":"127.0.0.1","port":1,"endpoint_url":"http://127.0.0.1:1/v1","mode":"managed",
+            "status":"running","created_at_unix_ms":1}"#,
+    )
+    .unwrap();
+
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let services_dir = dir.path().to_path_buf();
+    let handle = tokio::spawn(async move {
+        let opts = runner::RunnerOptions {
+            services_dir: Some(services_dir),
+            ..Default::default()
+        };
+        runner::run_loop(
+            Some(Duration::from_millis(100)),
+            tx,
+            Arc::new(Mutex::new(SnapshotRing::new(32))),
+            Arc::new(Mutex::new(BenchRing::new(4))),
+            None,
+            opts,
+        )
+        .await;
+    });
+
+    // Collect snapshots after the first failed scrape and require an unbroken
+    // run of warnings — the pre-fix behavior alternated warned/clean.
+    let mut seen_warned = false;
+    let mut checked = 0;
+    while checked < 6 {
+        let ev = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("event timeout")
+            .expect("recv");
+        let Event::Snapshot(snap) = ev else { continue };
+        let warned = snap.warnings.iter().any(|w| w.starts_with("vllm scrape:"));
+        if !seen_warned {
+            seen_warned = warned;
+            continue;
+        }
+        assert!(
+            warned,
+            "vllm scrape warning dropped on a non-scrape tick: {:?}",
+            snap.warnings
+        );
+        checked += 1;
+    }
+
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Problem

The dashboard's header warning badge (`⚠ N`) blinks on and off instead of staying lit while a fault persists.

`runner.rs` rebuilds `warnings` from scratch on every GPU tick, but the docker-discovery, vLLM/Lemonade-scrape and VRAM-attribution warnings are only *produced* on their own slower cadences (`discovery_ticks` / `instance_ticks`). A permanent failure therefore lands in one tick in N and is absent from the rest.

Captured from a live daemon socket on an unpatched build, consecutive snapshots alternated:

```
["vllm scrape: 1 failed (last: transport: GET http://127.0.0.1:11435/metrics ...)"]
[]
["vllm scrape: 1 failed (last: transport: GET http://127.0.0.1:11435/metrics ...)"]
[]
```

## Change

Hold each cadence-gated warning until its cadence runs again:

- docker discovery keeps its last result in `docker_warn` (cleared on a successful discovery),
- the instance-cadence producers (vLLM scrape, Lemonade scrape, VRAM attribution fallback) share `scrape_warns`, cleared once per instance tick.

Per-tick warnings (`amd-smi metric`, `tokens_per_watt` id-join misses) are unchanged.

## Verification

- New regression test `scrape_warning_persists_between_scrape_ticks` in `crates/rocm-dash-daemon/tests/end_to_end.rs`: registers a managed vLLM service on a closed port and asserts an unbroken run of warned snapshots. Confirmed **FAILS** on `main` and passes with this change.
- Live daemon after the fix: 43/43 consecutive snapshots carried the warning, steady.
- `cargo test -p rocm-dash-daemon`, `cargo clippy -p rocm-dash-daemon --all-targets -- -D warnings`, `cargo fmt --all -- --check`: clean.

## Notes

- [x] Searched `tests/e2e-cucumber/expectations.toml`; no xfail rows relate to this behavior.