### PR TITLE
fix(serve): wait on the engine's readiness budget, fail fast on a dead engine

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4824,16 +4824,37 @@ fn start_managed_service(
     #[cfg(windows)]
     thread::sleep(Duration::from_millis(200));
 
+    // Wait on the engine's own readiness budget, not a shorter CLI-side one: a
+    // cold vLLM start (torch import, aiter/triton JIT, KV-cache warmup) routinely
+    // runs past a minute, and reporting "not ready" for a server that answers ten
+    // seconds later reads as a failed launch. Watching the engine's own state file
+    // keeps a genuine crash fast instead of spinning out the whole budget: the
+    // supervisor is our child, so `process_is_running` still reports it alive
+    // while it sits unreaped as a zombie, but the engine writes a terminal status
+    // before it exits.
     let readiness = wait_for_service_http_ready_with_progress(
         engine,
         host,
         port,
         &resolve.canonical_model_id,
         endpoint_api_key,
-        Duration::from_secs(45),
-        on_wait_tick,
+        managed_ready_timeout(engine),
+        &mut |elapsed| {
+            on_wait_tick(elapsed);
+            let _ = record.refresh_from_engine_state();
+            managed_service_running_state(&record.status) != "not_running"
+        },
     );
-    let launch_status = status_for_readiness(readiness);
+    // A launch the engine already gave up on is failed, not merely slow — but a
+    // reachable endpoint still wins, since a service that answers is serving
+    // whatever its state file last claimed.
+    let launch_status = if readiness == EndpointReadiness::Unreachable
+        && managed_service_running_state(&record.status) == "not_running"
+    {
+        "failed"
+    } else {
+        status_for_readiness(readiness)
+    };
     record.status = launch_status.to_owned();
     if readiness == EndpointReadiness::Serving {
         // Latch the verification the wait just performed, so the readiness checks
@@ -13038,7 +13059,7 @@ fn restart_internal_managed_service(
         record.port,
         &record.canonical_model_id,
         endpoint_api_key.as_deref(),
-        Duration::from_secs(45),
+        managed_ready_timeout(&record.engine),
     );
     record.status = status_for_readiness(readiness).to_owned();
     if readiness == EndpointReadiness::Serving {
@@ -16189,6 +16210,17 @@ fn apply_app_path_env(command: &mut ProcessCommand, paths: &AppPaths) {
     }
 }
 
+/// Readiness budget for a managed launch, taken from the engine's own startup
+/// timeout so the CLI never contradicts it. vLLM's is 5 minutes by default and
+/// tunable via `ROCM_CLI_VLLM_READY_TIMEOUT_SECS`; other engines start fast
+/// enough that the historical 45 s is still generous.
+fn managed_ready_timeout(engine: &str) -> Duration {
+    match engine {
+        "vllm" => rocm_engine_vllm::ready_timeout(),
+        _ => Duration::from_secs(45),
+    }
+}
+
 fn wait_for_service_http_ready(
     engine: &str,
     host: &str,
@@ -16204,7 +16236,7 @@ fn wait_for_service_http_ready(
         canonical_model_id,
         endpoint_api_key,
         timeout,
-        &mut |_elapsed| {},
+        &mut |_elapsed| true,
     )
 }
 
@@ -16219,10 +16251,12 @@ fn wait_for_service_http_ready(
 /// result seen before `timeout` is what gets returned.
 ///
 /// Polls until `timeout` elapses, invoking `on_tick(elapsed)` once per iteration
-/// so a caller can animate a spinner. Engine-neutral: `service_http_readiness_paths`
-/// maps each engine to the right listing path. `endpoint_api_key` is sent as a
-/// bearer token so both the listing check and the inference probe still succeed
-/// against a public endpoint that requires authentication.
+/// so a caller can animate a spinner and, by returning `false`, abandon a wait it
+/// knows is hopeless (e.g. the engine died) rather than burn the whole budget.
+/// Engine-neutral: `service_http_readiness_paths` maps each engine to the right
+/// listing path. `endpoint_api_key` is sent as a bearer token so both the listing
+/// check and the inference probe still succeed against a public endpoint that
+/// requires authentication.
 fn wait_for_service_http_ready_with_progress(
     engine: &str,
     host: &str,
@@ -16230,7 +16264,7 @@ fn wait_for_service_http_ready_with_progress(
     canonical_model_id: &str,
     endpoint_api_key: Option<&str>,
     timeout: Duration,
-    on_tick: &mut dyn FnMut(Duration),
+    on_tick: &mut dyn FnMut(Duration) -> bool,
 ) -> EndpointReadiness {
     let start = std::time::Instant::now();
     let endpoint = format_http_base_url(host, port);
@@ -16267,7 +16301,9 @@ fn wait_for_service_http_ready_with_progress(
                 return EndpointReadiness::Serving;
             }
         }
-        on_tick(start.elapsed());
+        if !on_tick(start.elapsed()) {
+            return best;
+        }
         thread::sleep(Duration::from_millis(250));
     }
     best
@@ -16519,6 +16555,44 @@ mod tests {
     #[test]
     fn cli_command_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    /// Regression: the managed launch used a hardcoded 45 s wait while vLLM's own
+    /// startup budget is minutes, so every cold vLLM start was reported as "not
+    /// ready" seconds before the server came up.
+    #[test]
+    fn managed_ready_timeout_follows_the_engine_budget() {
+        assert_eq!(
+            managed_ready_timeout("vllm"),
+            rocm_engine_vllm::ready_timeout()
+        );
+        assert!(managed_ready_timeout("vllm") > Duration::from_secs(45));
+        assert_eq!(managed_ready_timeout("lemonade"), Duration::from_secs(45));
+    }
+
+    /// A caller that knows the engine is gone can end the wait early instead of
+    /// burning the whole (now much longer) budget, and still reports how far the
+    /// endpoint actually got.
+    #[test]
+    fn readiness_wait_stops_when_the_tick_gives_up() {
+        let start = std::time::Instant::now();
+        let mut ticks = 0u32;
+        let readiness = wait_for_service_http_ready_with_progress(
+            "vllm",
+            "127.0.0.1",
+            // Port 9 (discard) refuses locally, so the probe just fails.
+            9,
+            "model",
+            None,
+            Duration::from_mins(2),
+            &mut |_elapsed| {
+                ticks += 1;
+                false
+            },
+        );
+        assert_eq!(readiness, EndpointReadiness::Unreachable);
+        assert_eq!(ticks, 1, "the wait must stop at the first refusal");
+        assert!(start.elapsed() < Duration::from_secs(30));
     }
 
     /// Regression test for the engine child-stdin write under the process-wide

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -166,11 +166,15 @@ pub(crate) fn render_summary(summary: &DeploymentSummary) -> String {
         );
     }
     if !ready && !summary.already_running {
-        // Two different ways to miss "ready", and conflating them misleads: a
+        // Three different ways to miss "ready", and conflating them misleads: a
+        // `failed` service is over and needs its engine error read, while a
         // `running` service answered and advertised the model but could not serve
         // a request yet, which is also why the metrics rows are empty — the smoke
         // test only runs against a service that can actually serve.
-        let explanation = if summary.status == "running" {
+        let explanation = if summary.status == "failed" {
+            "the server exited during startup, so the launch is over; the engine error is \
+             at the end of its log"
+        } else if summary.status == "running" {
             "the server is up and lists the model, but it could not serve a request yet, \
              so no smoke test was run; it is most likely still loading"
         } else {
@@ -338,6 +342,32 @@ mod tests {
         assert_eq!(format_ttft(Some(Duration::from_millis(180))), "180 ms");
         assert_eq!(format_ttft(Some(Duration::from_millis(1500))), "1.50 s");
         assert_eq!(format_ttft(None), "n/a");
+    }
+
+    /// A launch whose engine died must not be described as "may still be
+    /// loading" — the wait ended because the server is gone, not because it is
+    /// slow, and the next action is reading the engine error.
+    #[test]
+    fn failed_launch_note_points_at_the_engine_error() {
+        let summary = DeploymentSummary {
+            status: "failed".to_owned(),
+            ..base_summary()
+        };
+        let rendered = render_summary(&summary);
+        assert!(rendered.contains("exited during startup"), "{rendered}");
+        assert!(!rendered.contains("may still be loading"), "{rendered}");
+    }
+
+    /// A launch that merely ran out of wait keeps the "give it more time" wording.
+    #[test]
+    fn starting_launch_note_says_it_may_still_be_loading() {
+        let summary = DeploymentSummary {
+            status: "starting".to_owned(),
+            ..base_summary()
+        };
+        let rendered = render_summary(&summary);
+        assert!(rendered.contains("may still be loading"), "{rendered}");
+        assert!(!rendered.contains("exited during startup"), "{rendered}");
     }
 
     #[test]

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -603,7 +603,7 @@ fn serve_http(mut request: ServeHttpRequest) -> Result<()> {
         &request.host,
         request.port,
         &request.model_ref,
-        vllm_ready_timeout(),
+        ready_timeout(),
         request.log_path.as_deref(),
     ) {
         // Terminate the whole vLLM process tree so the EngineCore worker (which
@@ -1340,8 +1340,9 @@ fn resolve_vllm_rocm_extra_index_url(override_value: Option<String>) -> String {
 /// Defaults to [`DEFAULT_VLLM_READY_TIMEOUT`]. A valid-but-slow cold start
 /// (large weight download, first-decode compile) can exceed the default, so the
 /// timeout is configurable via `ROCM_CLI_VLLM_READY_TIMEOUT_SECS` (a positive
-/// integer number of seconds).
-fn vllm_ready_timeout() -> Duration {
+/// integer number of seconds). Public so the CLI's managed-launch path waits on
+/// the same budget the engine itself honors instead of a shorter one of its own.
+pub fn ready_timeout() -> Duration {
     resolve_vllm_ready_timeout(std::env::var("ROCM_CLI_VLLM_READY_TIMEOUT_SECS").ok())
 }
 


### PR DESCRIPTION
## Problem

`rocm serve` reports a healthy vLLM launch as a failure.

`start_managed_service` and `restart_internal_managed_service` both waited a hardcoded `Duration::from_secs(45)`, while vLLM's own startup budget is 5 minutes (`DEFAULT_VLLM_READY_TIMEOUT`, tunable via `ROCM_CLI_VLLM_READY_TIMEOUT_SECS`). A cold vLLM start — torch import, aiter/triton JIT, KV-cache warmup — routinely runs past a minute, so the CLI gave up while the engine was still legitimately starting:

```
14:38:37  vllm boot
14:39:22  rocm serve gives up  ->  "Deployment summary (not ready yet)"
14:39:31  Application startup complete  ->  service actually ready
```

The user-visible result is a scary "the server did not report ready before the startup timeout" note on a server that is fine nine seconds later — which reads as "vLLM does not work here".

## Change

1. **Take the budget from the engine.** New public `rocm_engine_vllm::ready_timeout()`; `managed_ready_timeout(engine)` uses it for vLLM and keeps 45 s elsewhere. The CLI can no longer contradict the engine it is waiting on. Applied to both the launch and restart paths.
2. **Keep crashes fast.** A longer budget must not slow down a real failure, so `on_tick` can now return `false` to end the wait; `start_managed_service` does that once the engine records a terminal status, and reports `failed`.
   Process liveness is *not* usable as the signal here: the supervisor is our own child, so `process_is_running` (a `kill(pid, 0)`) keeps reporting it alive while it sits unreaped as a zombie. Measured: that approach spun the full 5 minutes on an engine that had already died. The engine's own state file is the reliable signal.
3. **Say which failure it was.** The summary note now distinguishes `failed` ("the server exited during startup … the engine error is at the end of its log") from `running`/`starting` ("may still be loading").

## Verification

Hardware: Radeon AI PRO R9700 (`gfx1201`), TheRock nightly wheel runtime, vLLM 0.23.0.

| Scenario | Before | After |
|---|---|---|
| `Qwen/Qwen3-0.6B` | "not ready yet", no metrics | `status ready`, TTFT 27 ms, 166.9 tok/s |
| model crashing in engine-core init | 5 min spinner → "may still be loading" | **7.9 s** → `status failed` → note points at the engine error |
| model crashing 81 s in (KV-cache sizing) | "not ready" at 45 s, real cause hidden | waits past 45 s, reports the real outcome |

Tests:

- `managed_ready_timeout_follows_the_engine_budget` — pins the budget to the engine's and to `> 45 s`.
- `readiness_wait_stops_when_the_tick_gives_up` — the wait ends at the first refusal and still reports how far the endpoint got.
- `failed_launch_note_points_at_the_engine_error` / `starting_launch_note_says_it_may_still_be_loading`.

Gates: `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `python3 scripts/smoke_local.py` — all clean.

`cargo test --workspace --all-targets` is green except `therock::tests::extracting_the_sdk_archive_removes_it`, which fails identically on unmodified `main` in my shell because `tar` is not on `PATH` there (`Error: failed to launch tar`). Unrelated to this change; CI has `tar`.

## Notes

- [x] Searched `tests/e2e-cucumber/expectations.toml`; no xfail rows relate to this behavior.