### PR TITLE
fix(runtime): keep the managed runtime root flat on re-provisioning (EAI-7384)

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -55,18 +55,19 @@ use runtime::home_rocm_dir;
 pub use runtime::{
     RuntimeHost, RuntimePlatform, current_executable_path, default_cache_dir, default_config_dir,
     default_data_dir, default_interactive_shell_program, managed_logs_dir, managed_pip_cache_dir,
-    managed_runtime_cache_dir, managed_tools_dir, normalize_runtime_path_for_host,
-    normalize_runtime_path_for_storage, normalize_runtime_path_text_for_host,
-    normalize_runtime_path_text_for_platform, normalize_runtime_path_text_for_storage,
-    platform_binary_name, prepend_runtime_path, runtime_directory_label,
-    runtime_drive_root_for_key, runtime_drive_roots, runtime_exe_suffix, runtime_home_dir,
-    runtime_install_root_is_protected, runtime_is_linux, runtime_is_windows, runtime_os_name,
-    runtime_path_for_child, runtime_path_for_windows_child, runtime_path_is_same_or_inside,
-    runtime_path_list_join, runtime_path_list_split, runtime_path_sort_key,
-    runtime_path_text_is_absolute_for_host, runtime_path_text_is_absolute_for_platform,
-    runtime_paths_equivalent, runtime_python_activation_hint, runtime_python_activation_script,
-    runtime_python_bin_dir_name, runtime_python_env_bin_dir, runtime_python_executable_in_env,
-    runtime_python_executable_name, runtime_rocm_library_filename, shell_command_for_host,
+    managed_runtime_cache_dir, managed_runtime_data_root, managed_tools_dir,
+    normalize_runtime_path_for_host, normalize_runtime_path_for_storage,
+    normalize_runtime_path_text_for_host, normalize_runtime_path_text_for_platform,
+    normalize_runtime_path_text_for_storage, platform_binary_name, prepend_runtime_path,
+    runtime_directory_label, runtime_drive_root_for_key, runtime_drive_roots, runtime_exe_suffix,
+    runtime_home_dir, runtime_install_root_is_protected, runtime_is_linux, runtime_is_windows,
+    runtime_os_name, runtime_path_for_child, runtime_path_for_windows_child,
+    runtime_path_is_same_or_inside, runtime_path_list_join, runtime_path_list_split,
+    runtime_path_sort_key, runtime_path_text_is_absolute_for_host,
+    runtime_path_text_is_absolute_for_platform, runtime_paths_equivalent,
+    runtime_python_activation_hint, runtime_python_activation_script, runtime_python_bin_dir_name,
+    runtime_python_env_bin_dir, runtime_python_executable_in_env, runtime_python_executable_name,
+    runtime_rocm_library_filename, shell_command_for_host,
 };
 pub use uv::{
     DEFAULT_UV_TIMEOUT_SECS, ensure_uv_binary, uv_binary_name, uv_command_env,
@@ -1245,7 +1246,7 @@ impl AppPaths {
 
     #[must_use]
     pub fn with_managed_root(mut self, root: impl Into<PathBuf>, keep_cache_dir: bool) -> Self {
-        self.data_dir = normalize_runtime_path_for_host(&root.into());
+        self.data_dir = managed_runtime_data_root(&root.into());
         if !keep_cache_dir {
             self.cache_dir = managed_runtime_cache_dir(&self.data_dir);
         }
@@ -9335,6 +9336,38 @@ Class Name:                Display
         assert!(tool.managed);
         assert_eq!(tool.path.as_deref(), Some(python.as_path()));
         Ok(())
+    }
+
+    #[test]
+    fn with_managed_root_keeps_reprovisioning_flat_from_runtime_leaf() {
+        let data_root = PathBuf::from("/tmp/rocm-cli-reprovision");
+        let paths = AppPaths {
+            config_dir: data_root.clone(),
+            data_dir: data_root.clone(),
+            cache_dir: data_root.join("cache"),
+        };
+        // A prior install persisted the runtime's own install_root as the managed
+        // root; rebasing onto it must recover the canonical data root, not append
+        // a second `runtimes/wheel` when the next runtime is provisioned.
+        let leaf = data_root
+            .join("runtimes")
+            .join("wheel")
+            .join("release-wheel-gfx942-7-0");
+        let rebased = paths.with_managed_root(leaf, false);
+
+        assert_eq!(rebased.data_dir, data_root);
+        let next_root = rebased
+            .data_dir
+            .join("runtimes")
+            .join("wheel")
+            .join("nightly-wheel-gfx942-7-1");
+        // Count path components, not a literal separator, so the assertion holds
+        // on Windows too.
+        let runtimes_segments = next_root
+            .components()
+            .filter(|component| component.as_os_str() == std::ffi::OsStr::new("runtimes"))
+            .count();
+        assert_eq!(runtimes_segments, 1);
     }
 
     #[test]

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -362,6 +362,30 @@ pub fn runtime_path_is_same_or_inside(path: &Path, base: &Path) -> bool {
         .any(|ancestor| runtime_paths_equivalent(ancestor, &base))
 }
 
+const MANAGED_RUNTIME_FORMATS: [&str; 2] = ["wheel", "tarball"];
+
+/// Strip trailing managed runtime leaves to recover the canonical data root.
+pub fn managed_runtime_data_root(root: &Path) -> PathBuf {
+    let mut root = normalize_runtime_path_for_host(root);
+    while let Some(parent) = strip_managed_runtime_leaf(&root) {
+        root = parent;
+    }
+    root
+}
+
+fn strip_managed_runtime_leaf(path: &Path) -> Option<PathBuf> {
+    let format_dir = path.parent()?;
+    let format = format_dir.file_name()?.to_str()?;
+    if !MANAGED_RUNTIME_FORMATS.contains(&format) {
+        return None;
+    }
+    let runtimes_dir = format_dir.parent()?;
+    if runtimes_dir.file_name()? != std::ffi::OsStr::new("runtimes") {
+        return None;
+    }
+    runtimes_dir.parent().map(Path::to_path_buf)
+}
+
 pub fn runtime_install_root_is_protected(path: &Path) -> bool {
     let path = normalize_runtime_path_for_host(path);
     if let Some(home) = runtime_home_dir() {
@@ -763,6 +787,29 @@ mod tests {
             r"\\server\share\rocm",
             RuntimePlatform::Windows
         ));
+    }
+
+    #[test]
+    fn managed_runtime_data_root_strips_runtime_leaf_nesting() {
+        let data_root = PathBuf::from("/tmp/rocm-cli");
+        let release_root = data_root
+            .join("runtimes")
+            .join("wheel")
+            .join("release-wheel-gfx942-7-0");
+        let nested_root = release_root
+            .join("runtimes")
+            .join("wheel")
+            .join("nightly-wheel-gfx942-7-1");
+
+        assert_eq!(managed_runtime_data_root(&release_root), data_root);
+        assert_eq!(managed_runtime_data_root(&nested_root), data_root);
+    }
+
+    #[test]
+    fn managed_runtime_data_root_preserves_custom_prefix() {
+        let custom_prefix = PathBuf::from("/tmp/therock_venvs");
+
+        assert_eq!(managed_runtime_data_root(&custom_prefix), custom_prefix);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Re-provisioning a managed runtime wrote the new runtime *inside* the previous one, producing recursively nested paths such as:

```
.../runtimes/wheel/release-.../runtimes/wheel/nightly-.../bin/python
```

This bloated paths, broke `services/*.log` glob patterns, and could cause path-resolution failures in services that resolve paths from the manifest.

**Root cause.** A managed runtime installs to `<data_dir>/runtimes/<format>/<key>`. After a successful install, that *leaf* path was persisted as the managed root. On the next provision, the app rebased its data directory onto that leaf and then appended `runtimes/<format>/<key>` a second time — nesting the tree one level deeper on every re-provision.

**Fix.** Normalize a configured managed root back to the canonical data root when rebasing application paths, so `runtimes/<format>` appears at most once. The normalization loops, so configs already poisoned by earlier re-provisioning self-heal on the next run. A custom `--prefix` install root does not follow the managed layout and is returned unchanged.

Applying this at the path-rebasing boundary means every call site (startup discovery, install finalization, runtime-selector recovery) inherits the fix. The stored setup value itself is unchanged, so folder display, runtime recovery, and uninstall behave exactly as before — only the interpretation of that value as a data root is corrected.

## Changes

- Add `managed_runtime_data_root()` in `crates/rocm-core/src/runtime.rs`, which strips trailing `runtimes/<format>/<key>` segments (wheel, tarball) to recover the canonical data root.
- Route `AppPaths::with_managed_root` through it instead of storing the configured root verbatim.

## Test plan

- [x] New unit tests: strips a runtime leaf and an already-nested path; preserves a custom `--prefix` root.
- [x] New regression test at the `AppPaths` level: rebasing onto a runtime leaf recovers the canonical root, so the next provisioned runtime path contains `runtimes/wheel` exactly once.
- [x] Existing install-finalization and runtime-selector-recovery tests pass unchanged.
- [x] Full check in the Linux container: 403 passed. The single failure (`extracting_the_sdk_archive_removes_it`) is a pre-existing container environment gap — the image has no `tar` — and is green on GitHub CI; it is unrelated to this change.
- [ ] GPU-gated E2E scenario `@id:runtime-path-not-nested` (already present in `tests/e2e-cucumber/features/runtime_setup.feature`) runs in CI.