### PR TITLE
fix(bench): post to the versioned chat endpoint

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -430,7 +430,7 @@ fn ensure_bench_csv_parent(csv_path: &std::path::Path) -> Result<()> {
 /// aggregate CSV row per concurrency level. Output defaults to the daemon's
 /// tailed `<data_dir>/bench/results.csv` unless `--out` is specified explicitly.
 pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
-    use rocm_dash_daemon::bench_load::{LoadSpec, run_and_append_csv, run_auto_ramp};
+    use rocm_dash_daemon::bench_load::{LoadSpec, run_and_append_csv, run_auto_ramp, v1_base};
 
     let BenchLoadArgs {
         endpoint,
@@ -451,19 +451,26 @@ pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
         );
     }
 
-    // Resolve the model: use the provided value or probe GET {endpoint}/v1/models.
+    // Normalise once, here, so the model probe and the load generator agree on
+    // where the API root is. They used to disagree — the probe appended
+    // `/v1/models` while the generator appended `/chat/completions` — so
+    // whichever form the user supplied, one of the two 404'd.
+    let endpoint = v1_base(&endpoint);
+
+    // Resolve the model: use the provided value or probe GET {endpoint}/models.
     let model = if let Some(m) = model {
         m
     } else {
-        let models_url = format!("{}/v1/models", endpoint.trim_end_matches('/'));
+        let models_url = format!("{endpoint}/models");
         let resp = ureq::get(&models_url)
             .timeout(std::time::Duration::from_secs(5))
             .call()
-            .context("fetching /v1/models to detect the default model")?;
-        let body: serde_json::Value = resp.into_json().context("parsing /v1/models response")?;
-        rocm_dash_tui::llm::pick_first_model(&body).with_context(|| {
-            format!("no model found at {endpoint}/v1/models — pass --model explicitly")
-        })?
+            .with_context(|| format!("fetching {models_url} to detect the default model"))?;
+        let body: serde_json::Value = resp
+            .into_json()
+            .with_context(|| format!("parsing the {models_url} response"))?;
+        rocm_dash_tui::llm::pick_first_model(&body)
+            .with_context(|| format!("no model found at {models_url} — pass --model explicitly"))?
     };
 
     // Resolve the output path: default to the same `<data_dir>/bench/results.csv`
@@ -500,7 +507,7 @@ pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
     }
 
     let rt = build_dashboard_runtime()?;
-    let rows = if auto_ramp {
+    let reports = if auto_ramp {
         rt.block_on(run_auto_ramp(&spec, &csv_path))
             .context("running bench auto-ramp")?
     } else {
@@ -508,7 +515,8 @@ pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
             .context("running bench load sweep")?
     };
 
-    for row in &rows {
+    for report in &reports {
+        let row = &report.row;
         let conc = row
             .concurrency
             .map_or_else(|| "-".to_string(), |v| v.to_string());
@@ -528,11 +536,38 @@ pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
             "cell={} concurrency={conc} gen_tps={gen_tps} prompt_tps={prompt_tps} wall={wall}s n={n}",
             row.cell
         );
+        // Name the failures. A cell that measured nothing used to print the same
+        // dashes as an idle one, leaving the user no way to tell a broken
+        // endpoint from a slow model.
+        if report.failed > 0 {
+            let reason = report
+                .first_error
+                .as_deref()
+                .unwrap_or("no reason recorded");
+            eprintln!(
+                "warning: {}/{} requests failed in {} — first failure: {reason}",
+                report.failed, report.attempted, row.cell
+            );
+        }
     }
     println!(
         "note: local saturation smoke-test — client-measured throughput, not an official ROCm/AMD benchmark."
     );
-    println!("wrote {} row(s) to {}", rows.len(), csv_path.display());
+    println!("wrote {} row(s) to {}", reports.len(), csv_path.display());
+
+    // Nothing measured anywhere is a failed benchmark, not a clean run. Exiting 0
+    // here is what let a wrong request path look like a successful empty result.
+    // The emptiness guard matters: `all` is vacuously true for no cells at all,
+    // which would report "every request failed" for a run that sent none.
+    if !reports.is_empty() && reports.iter().all(|report| report.succeeded == 0) {
+        let reason = reports
+            .iter()
+            .find_map(|report| report.first_error.as_deref())
+            .unwrap_or("no reason recorded");
+        anyhow::bail!(
+            "every benchmark request failed against {endpoint} — first failure: {reason}"
+        );
+    }
 
     Ok(())
 }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -457,10 +457,11 @@ enum BenchCommand {
     /// long-context tool traffic and is not comparable to the *-agent-bench quality
     /// harnesses.
     Load {
-        /// Base URL of the OpenAI-compatible endpoint, e.g. http://127.0.0.1:8000
+        /// OpenAI-compatible endpoint, e.g. http://127.0.0.1:8000/v1 (as shown by
+        /// `rocm services list`). A plain host address without /v1 also works.
         #[arg(long, value_name = "URL")]
         endpoint: String,
-        /// Model name (defaults to the first model returned by GET {endpoint}/v1/models)
+        /// Model name (defaults to the first model the endpoint reports)
         #[arg(long)]
         model: Option<String>,
         /// Concurrency levels to sweep, comma-separated

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -39,7 +39,10 @@ pub const CSV_HEADER: &str = "cell,run,concurrency,model,engine,input_len,output
 /// Parameters for a single concurrency-level load cell.
 #[derive(Debug, Clone)]
 pub struct LoadSpec {
-    /// Base URL of the OpenAI-compatible endpoint, e.g. `http://127.0.0.1:8000`.
+    /// OpenAI-compatible endpoint, e.g. `http://127.0.0.1:8000/v1` — the same
+    /// form `rocm services list` prints. A plain host address without the `/v1`
+    /// suffix is also accepted: request URLs are built through [`v1_base`],
+    /// which supplies the suffix when it is missing.
     pub endpoint: String,
     /// Model name to pass in the request body.
     pub model: String,
@@ -56,6 +59,33 @@ struct Outcome {
     prompt_tokens: u64,
     completion_tokens: u64,
 }
+
+/// One cell's [`BenchmarkRow`] plus the delivery facts the row cannot carry.
+///
+/// [`BenchmarkRow`] is the CSV schema and is guarded by a header check, so
+/// per-request failure detail cannot live there. It travels alongside instead,
+/// so the CLI can warn about a partially-failed cell and refuse to report a
+/// run in which nothing succeeded as a success.
+#[derive(Debug, Clone)]
+pub struct CellReport {
+    /// The aggregate row for this cell, as appended to the CSV.
+    pub row: BenchmarkRow,
+    /// Requests dispatched for this cell.
+    pub attempted: u32,
+    /// Requests that returned usable token counts.
+    pub succeeded: u32,
+    /// Requests that failed for any reason.
+    pub failed: u32,
+    /// Reason from the first failure observed, for the operator-facing warning.
+    pub first_error: Option<String>,
+}
+
+/// Why a single benchmark request produced no usable measurement.
+///
+/// Kept as a short human-readable string rather than a typed enum: it is only
+/// ever rendered into a warning line, and the underlying causes (transport,
+/// status, malformed body) have no distinct programmatic handling.
+type RequestFailure = String;
 
 /// Error type for the bench load writer.
 #[derive(Debug, thiserror::Error)]
@@ -82,9 +112,35 @@ pub enum BenchLoadError {
     },
 }
 
+/// Normalise an endpoint to the OpenAI-compatible `/v1` API root that request
+/// paths are built relative to.
+///
+/// Everything else in the product treats an "endpoint" as already carrying the
+/// `/v1` suffix — `rocm services list` prints one (see `endpoint_url`, built as
+/// `{base}/v1`), and the chat client appends `chat/completions` to it. Bench
+/// used to be split-brained: it POSTed to `{endpoint}/chat/completions` (which
+/// assumes the suffix is present) while probing `{endpoint}/v1/models` (which
+/// assumes it is absent), so whichever form the user supplied, one of the two
+/// 404'd. Routing both through here removes the ambiguity and lets a user paste
+/// either form.
+///
+/// Idempotent: an endpoint already ending in `/v1` is returned unchanged apart
+/// from trailing-slash trimming.
+#[must_use]
+pub fn v1_base(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v1")
+    }
+}
+
 /// Build the `/metrics` URL from an OpenAI-compatible endpoint base URL.
 ///
 /// Returns `None` if the endpoint cannot be parsed (no host:port component).
+/// Unaffected by the `/v1` suffix: the path is discarded and `/metrics` is
+/// resolved against `host:port`, which is where the engine serves it.
 fn metrics_url(endpoint: &str) -> Option<String> {
     let url_base = endpoint.trim_end_matches('/');
     let (scheme, rest) = if let Some(r) = url_base.strip_prefix("https://") {
@@ -153,14 +209,16 @@ impl BenchClients {
     }
 }
 
-/// Send `spec.requests` POST `/chat/completions` requests with `concurrency`
+/// Send `spec.requests` POST `/v1/chat/completions` requests with `concurrency`
 /// in-flight at a time.
 ///
-/// Returns one aggregate `BenchmarkRow` with client-side `gen_tps` and
+/// Returns one aggregate [`CellReport`] with client-side `gen_tps` and
 /// `prompt_tps`. Per-request failures are isolated: a non-2xx response or
 /// missing `usage` fields excludes that request from the sums but does not
-/// abort the cell.
-pub async fn run_cell(spec: &LoadSpec, concurrency: u32) -> Result<BenchmarkRow, BenchLoadError> {
+/// abort the cell. Unlike earlier revisions, such failures are *counted and
+/// reported* rather than silently dropped — a cell where every request failed
+/// used to be indistinguishable from a cell that was never asked to do work.
+pub async fn run_cell(spec: &LoadSpec, concurrency: u32) -> Result<CellReport, BenchLoadError> {
     run_cell_with_clients(spec, concurrency, &BenchClients::new()?).await
 }
 
@@ -168,12 +226,12 @@ async fn run_cell_with_clients(
     spec: &LoadSpec,
     concurrency: u32,
     clients: &BenchClients,
-) -> Result<BenchmarkRow, BenchLoadError> {
+) -> Result<CellReport, BenchLoadError> {
     if concurrency == 0 {
         return Err(BenchLoadError::InvalidConcurrency(concurrency));
     }
     let sem = Arc::new(Semaphore::new(concurrency as usize));
-    let url = format!("{}/chat/completions", spec.endpoint.trim_end_matches('/'));
+    let url = format!("{}/chat/completions", v1_base(&spec.endpoint));
 
     // Before scrape: used only for TTFT/TPOT histogram deltas.
     let prom_before = try_scrape_prom(&clients.metrics, &spec.endpoint).await;
@@ -209,7 +267,11 @@ async fn run_cell_with_clients(
     // Capture makespan BEFORE spawning so the clock includes queue wait time.
     let t0 = Instant::now();
 
-    let mut js: JoinSet<Option<Outcome>> = JoinSet::new();
+    // Each request reports *why* it produced no measurement rather than
+    // collapsing to `None`. A cell whose every request 404'd used to be
+    // indistinguishable from a healthy cell that measured nothing, which is how
+    // a wrong request path reached users as a silent empty result.
+    let mut js: JoinSet<Result<Outcome, RequestFailure>> = JoinSet::new();
     for _ in 0..spec.requests {
         let client = clients.post.clone();
         let sem = Arc::clone(&sem);
@@ -220,7 +282,10 @@ async fn run_cell_with_clients(
 
         js.spawn(async move {
             // Named binding: permit is held for the entire request.
-            let _permit = sem.acquire_owned().await.ok()?;
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .map_err(|_| "load generator stopped before the request started".to_owned())?;
 
             let body = serde_json::json!({
                 "model": model,
@@ -236,25 +301,38 @@ async fn run_cell_with_clients(
                 .body(body.to_string())
                 .send()
                 .await
-                .ok()?;
+                .map_err(|error| format!("POST {url} failed: {error}"))?;
 
-            if !resp.status().is_success() {
-                return None;
+            let status = resp.status();
+            if !status.is_success() {
+                return Err(format!("POST {url} returned HTTP {status}"));
             }
 
-            let text = resp.text().await.ok()?;
-            let v: Value = serde_json::from_str(&text).ok()?;
-            let usage = v.get("usage")?;
+            let text = resp
+                .text()
+                .await
+                .map_err(|error| format!("reading the response body failed: {error}"))?;
+            let value: Value = serde_json::from_str(&text)
+                .map_err(|error| format!("the response was not JSON: {error}"))?;
+            let usage = value
+                .get("usage")
+                .ok_or_else(|| "the response carried no `usage` object".to_owned())?;
 
-            let prompt_tokens = usage.get("prompt_tokens")?.as_u64()?;
-            let completion_tokens = usage.get("completion_tokens")?;
-            // Treat missing/zero completion_tokens as failure (excluded from sums).
-            let completion_tokens = completion_tokens.as_u64()?;
+            let prompt_tokens = usage
+                .get("prompt_tokens")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| "`usage` carried no numeric `prompt_tokens`".to_owned())?;
+            let completion_tokens = usage
+                .get("completion_tokens")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| "`usage` carried no numeric `completion_tokens`".to_owned())?;
+            // A response that generated nothing measures nothing: exclude it from
+            // the sums rather than crediting a makespan it did not earn.
             if completion_tokens == 0 {
-                return None;
+                return Err("the response reported zero completion_tokens".to_owned());
             }
 
-            Some(Outcome {
+            Ok(Outcome {
                 prompt_tokens,
                 completion_tokens,
             })
@@ -264,12 +342,25 @@ async fn run_cell_with_clients(
     let mut sum_prompt: u64 = 0;
     let mut sum_completion: u64 = 0;
     let mut n_success: u32 = 0;
+    let mut n_failed: u32 = 0;
+    let mut first_error: Option<String> = None;
 
     while let Some(res) = js.join_next().await {
-        if let Ok(Some(outcome)) = res {
-            sum_prompt += outcome.prompt_tokens;
-            sum_completion += outcome.completion_tokens;
-            n_success += 1;
+        let failure = match res {
+            Ok(Ok(outcome)) => {
+                sum_prompt += outcome.prompt_tokens;
+                sum_completion += outcome.completion_tokens;
+                n_success += 1;
+                continue;
+            }
+            Ok(Err(reason)) => reason,
+            // A panicked request task is still a request that did not measure
+            // anything, so it counts as a failure rather than vanishing.
+            Err(join_error) => format!("the request task did not complete: {join_error}"),
+        };
+        n_failed += 1;
+        if first_error.is_none() {
+            first_error = Some(failure);
         }
     }
 
@@ -302,7 +393,7 @@ async fn run_cell_with_clients(
     // TTFT/TPOT deltas come from the before/after histogram scrapes (unchanged).
     let (_, _, ttft_ms, tpot_ms) = prom_deltas(prom_before.as_ref(), prom_after.as_ref());
 
-    Ok(BenchmarkRow {
+    let row = BenchmarkRow {
         cell: format!("bench-c{concurrency}"),
         run: 1,
         model: Some(spec.model.clone()),
@@ -321,6 +412,14 @@ async fn run_cell_with_clients(
         ttft_ms,
         tpot_ms,
         ..Default::default()
+    };
+
+    Ok(CellReport {
+        row,
+        attempted: spec.requests,
+        succeeded: n_success,
+        failed: n_failed,
+        first_error,
     })
 }
 
@@ -409,22 +508,24 @@ fn append_one_row(row: &BenchmarkRow, csv_path: &Path) -> Result<(), BenchLoadEr
 /// serialized into a `Vec<u8>` ending in `\n` and written with a single
 /// `write_all` call (O_APPEND safe on regular files).
 ///
-/// Returns the rows appended (one per concurrency level).
+/// Returns the reports for the rows appended (one per concurrency level).
 pub async fn run_and_append_csv(
     spec: &LoadSpec,
     concurrency_levels: &[u32],
     csv_path: &Path,
-) -> Result<Vec<BenchmarkRow>, BenchLoadError> {
+) -> Result<Vec<CellReport>, BenchLoadError> {
     let clients = BenchClients::new()?;
 
-    let mut rows = Vec::with_capacity(concurrency_levels.len());
+    let mut reports = Vec::with_capacity(concurrency_levels.len());
     for &conc in concurrency_levels {
-        let row = run_cell_with_clients(spec, conc, &clients).await?;
-        append_one_row(&row, csv_path)?;
-        rows.push(row);
+        let report = run_cell_with_clients(spec, conc, &clients).await?;
+        // A fully-failed cell is still appended: the dashboard tailer expects one
+        // row per cell, and the caller reports the failure separately.
+        append_one_row(&report.row, csv_path)?;
+        reports.push(report);
     }
 
-    Ok(rows)
+    Ok(reports)
 }
 
 /// Decide whether the auto-ramp should stop after `row`.
@@ -476,30 +577,30 @@ fn next_prev_gen_tps(previous: Option<f64>, current: Option<f64>) -> Option<f64>
 /// daemon tailer shows progress live. Stops after a cell when
 /// [`should_stop_ramp`] returns `true`.
 ///
-/// Returns the rows appended (one per concurrency level run).
+/// Returns the reports for the rows appended (one per concurrency level run).
 pub async fn run_auto_ramp(
     spec: &LoadSpec,
     csv_path: &Path,
-) -> Result<Vec<BenchmarkRow>, BenchLoadError> {
-    let mut rows = Vec::new();
+) -> Result<Vec<CellReport>, BenchLoadError> {
+    let mut reports = Vec::new();
     let mut prev_gen_tps: Option<f64> = None;
     let clients = BenchClients::new()?;
 
     for &conc in RAMP_SEQUENCE {
-        let row = run_cell_with_clients(spec, conc, &clients).await?;
-        append_one_row(&row, csv_path)?;
+        let report = run_cell_with_clients(spec, conc, &clients).await?;
+        append_one_row(&report.row, csv_path)?;
 
         let is_last = conc == *RAMP_SEQUENCE.last().unwrap_or(&conc);
-        let stop = should_stop_ramp(prev_gen_tps, &row, is_last);
-        prev_gen_tps = next_prev_gen_tps(prev_gen_tps, row.gen_tps);
-        rows.push(row);
+        let stop = should_stop_ramp(prev_gen_tps, &report.row, is_last);
+        prev_gen_tps = next_prev_gen_tps(prev_gen_tps, report.row.gen_tps);
+        reports.push(report);
 
         if stop {
             break;
         }
     }
 
-    Ok(rows)
+    Ok(reports)
 }
 
 /// Serialize one `BenchmarkRow` to the 18-column CSV line (with trailing `\n`).
@@ -617,7 +718,7 @@ mod tests {
     async fn t1_run_cell_fields_and_tps() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(100, 50))
             .expect(4)
             .mount(&server)
@@ -627,7 +728,7 @@ mod tests {
         // requests=4, each returns prompt=100 completion=50
         let mut spec4 = spec.clone();
         spec4.requests = 4;
-        let row = run_cell(&spec4, 2).await.unwrap();
+        let row = run_cell(&spec4, 2).await.unwrap().row;
 
         assert_eq!(row.cell, "bench-c2");
         assert_eq!(row.run, 1);
@@ -683,7 +784,7 @@ mod tests {
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(
                 stub_response(10, 5).set_delay(std::time::Duration::from_millis(DELAY_MS)),
             )
@@ -693,7 +794,7 @@ mod tests {
 
         let mut spec = make_spec(&server.uri());
         spec.requests = REQUESTS;
-        let row = run_cell(&spec, N).await.unwrap();
+        let row = run_cell(&spec, N).await.unwrap().row;
 
         // Structural check: concurrency column matches N.
         assert_eq!(row.concurrency, Some(N));
@@ -726,7 +827,7 @@ mod tests {
     async fn t3_csv_round_trip() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(50, 25))
             .mount(&server)
             .await;
@@ -766,7 +867,7 @@ mod tests {
     async fn d2_header_mismatch_returns_error_without_modifying_file() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(50, 25))
             .mount(&server)
             .await;
@@ -883,7 +984,7 @@ mod tests {
 
         // /chat/completions returns token data.
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(100, 50))
             .expect(4)
             .mount(&server)
@@ -909,7 +1010,7 @@ mod tests {
 
         let mut spec = make_spec(&server.uri());
         spec.requests = 4;
-        let row = run_cell(&spec, 2).await.unwrap();
+        let row = run_cell(&spec, 2).await.unwrap().row;
 
         // Peaks come from the poller (which only sees the catch-all stub).
         assert_eq!(
@@ -940,7 +1041,7 @@ mod tests {
 
         // Normal chat completions succeed.
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(100, 50))
             .mount(&server)
             .await;
@@ -954,7 +1055,7 @@ mod tests {
 
         let mut spec = make_spec(&server.uri());
         spec.requests = 4;
-        let row = run_cell(&spec, 2).await.unwrap();
+        let row = run_cell(&spec, 2).await.unwrap().row;
 
         assert_eq!(
             row.max_running_reqs, None,
@@ -978,7 +1079,7 @@ mod tests {
     async fn t8_csv_round_trip_18_cols() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(50, 25))
             .mount(&server)
             .await;
@@ -1025,7 +1126,7 @@ mod tests {
     async fn t9_old_14col_file_returns_header_mismatch() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(50, 25))
             .mount(&server)
             .await;
@@ -1067,7 +1168,7 @@ mod tests {
         let server = MockServer::start().await;
         // Same token counts for all requests → flat gen_tps.
         Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+            .and(path("/v1/chat/completions"))
             .respond_with(stub_response(50, 25))
             .mount(&server)
             .await;
@@ -1093,7 +1194,7 @@ mod tests {
             RAMP_SEQUENCE.len()
         );
         // Last concurrency must not be 128.
-        let last_conc = rows.last().and_then(|r| r.concurrency).unwrap_or(0);
+        let last_conc = rows.last().and_then(|r| r.row.concurrency).unwrap_or(0);
         assert_ne!(last_conc, 128, "should not have reached concurrency=128");
         // Must have appended at least the first cell.
         assert!(!rows.is_empty(), "at least one row must be produced");
@@ -1232,5 +1333,177 @@ mod tests {
         update_peak_pair(&peak, 8, 1);
 
         assert_eq!(peak_pair(&peak), Some((8, 1)));
+    }
+
+    // ---------- endpoint normalisation ----------
+
+    #[test]
+    fn v1_base_supplies_the_suffix_when_it_is_missing() {
+        // The form `--endpoint`'s help used to advertise, and the form a user
+        // types from memory. Both must reach the versioned API root.
+        assert_eq!(v1_base("http://127.0.0.1:8000"), "http://127.0.0.1:8000/v1");
+        assert_eq!(
+            v1_base("http://127.0.0.1:8000/"),
+            "http://127.0.0.1:8000/v1"
+        );
+        assert_eq!(
+            v1_base("  http://127.0.0.1:8000  "),
+            "http://127.0.0.1:8000/v1"
+        );
+    }
+
+    #[test]
+    fn v1_base_is_idempotent_for_an_already_versioned_endpoint() {
+        // The canonical form — what `rocm services list` prints. Appending a
+        // second `/v1` here is the mirror-image bug of omitting the first.
+        assert_eq!(
+            v1_base("http://127.0.0.1:8000/v1"),
+            "http://127.0.0.1:8000/v1"
+        );
+        assert_eq!(
+            v1_base("http://127.0.0.1:8000/v1/"),
+            "http://127.0.0.1:8000/v1"
+        );
+        assert_eq!(
+            v1_base(&v1_base("http://127.0.0.1:8000")),
+            "http://127.0.0.1:8000/v1"
+        );
+    }
+
+    #[test]
+    fn v1_base_preserves_a_gateway_path_prefix() {
+        // A reverse-proxied endpoint keeps its prefix; only the API root is added.
+        assert_eq!(
+            v1_base("http://gw.example.com/openai"),
+            "http://gw.example.com/openai/v1"
+        );
+        assert_eq!(
+            v1_base("http://gw.example.com/openai/v1"),
+            "http://gw.example.com/openai/v1"
+        );
+    }
+
+    /// The regression guard for the reported bug: requests must land on the
+    /// versioned path even when the caller supplies a bare host address. A mock
+    /// that answers ONLY `/v1/chat/completions` fails this if the `/v1` is
+    /// dropped, which is exactly what shipped.
+    #[tokio::test]
+    async fn plain_host_endpoint_still_reaches_the_versioned_chat_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(stub_response(100, 50))
+            .mount(&server)
+            .await;
+
+        // Deliberately NOT `{uri}/v1` — the bare form the old help text taught.
+        let spec = make_spec(&server.uri());
+        let report = run_cell(&spec, 2).await.unwrap();
+
+        assert_eq!(report.succeeded, 4, "every request should have been served");
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.row.n_requests, Some(4));
+    }
+
+    // ---------- failures are reported, not swallowed ----------
+
+    #[tokio::test]
+    async fn a_cell_whose_every_request_is_rejected_reports_the_failures() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let spec = make_spec(&server.uri());
+        let report = run_cell(&spec, 2).await.unwrap();
+
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 4, "all four requests must be counted failed");
+        assert_eq!(report.attempted, 4);
+        let reason = report
+            .first_error
+            .expect("a failure reason must be recorded");
+        assert!(
+            reason.contains("500"),
+            "the reason should name the status the server returned, got: {reason}"
+        );
+        // The row still reports nothing measured — the point is that the caller
+        // can now tell that apart from a healthy idle cell.
+        assert_eq!(report.row.gen_tps, None);
+        assert_eq!(report.row.n_requests, Some(0));
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_endpoint_reports_a_transport_failure() {
+        // Port 1 on loopback: reserved and never listening, so every send errors.
+        let spec = make_spec("http://127.0.0.1:1");
+        let report = run_cell(&spec, 1).await.unwrap();
+
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 4);
+        let reason = report
+            .first_error
+            .expect("a failure reason must be recorded");
+        assert!(
+            reason.contains("POST") && reason.contains("failed"),
+            "the reason should describe the failed request, got: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_partially_failing_cell_reports_both_throughput_and_failures() {
+        let server = MockServer::start().await;
+        // First two requests succeed, the rest are rejected.
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(stub_response(100, 50))
+            .up_to_n_times(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let spec = make_spec(&server.uri());
+        let report = run_cell(&spec, 1).await.unwrap();
+
+        assert_eq!(report.succeeded, 2);
+        assert_eq!(report.failed, 2);
+        assert!(
+            report.row.gen_tps.unwrap_or(0.0) > 0.0,
+            "throughput from the successful requests must still be reported"
+        );
+        assert_eq!(report.row.completion_tokens, Some(100), "2 * 50");
+        assert!(report.first_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_response_without_usage_counts_as_a_named_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#,
+                "application/json",
+            ))
+            .mount(&server)
+            .await;
+
+        let spec = make_spec(&server.uri());
+        let report = run_cell(&spec, 2).await.unwrap();
+
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 4);
+        let reason = report
+            .first_error
+            .expect("a failure reason must be recorded");
+        assert!(
+            reason.contains("usage"),
+            "the reason should name the missing field, got: {reason}"
+        );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/bench_run.rs
+++ b/crates/rocm-dash-tui/src/ui/bench_run.rs
@@ -258,7 +258,7 @@ pub fn draw_bench_run(f: &mut Frame, area: Rect, state: &BenchRunState, theme: &
         rows[1],
         "endpoint",
         &state.endpoint,
-        "(http://127.0.0.1:8000)",
+        "(http://127.0.0.1:8000/v1)",
         state.active_field == Field::Endpoint,
         theme,
     );

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -145,3 +145,23 @@ reason = "rocm help lists subcommands in declaration order, not alphabetically."
 when = {}
 bug = "EAI-7384"
 reason = "Managed runtime path nests recursively (runtimes/wheel/...) on re-provisioning."
+
+# The GPU-backed bench scenario benchmarks a really served model, so on a
+# lemonade LINUX host it inherits the same managed-serve bug as the sibling
+# serve/chat rows below `serve-default-engine-working-endpoint`: the serve
+# reaches ready then shuts down immediately, so this scenario's `a model is
+# being served on GPU` precondition never yields a live endpoint. Scoped
+# identically — os=linux only, because native Windows lemonade serve works, and
+# therock_family=gfx* so it applies only on a real GPU host. `flaky = true`
+# matches those rows too: which of them pass varies run to run on that lane, and
+# a deterministic-XPASS row would fail the lane on unrelated PRs.
+#
+# This does NOT weaken the coverage the bench fix relies on: the three
+# MockServer-backed bench scenarios run unxfail'd on every lane, including this
+# one, and they are what pin the request path and the failure reporting.
+[["bench-load-real-serve"]]
+when = { effective_engine = "lemonade", os = "linux", therock_family = "gfx*" }
+bug = "EAI-7423"
+reason = "Lemonade managed serve reaches ready then shuts down immediately, so the benchmark never reaches a live model."
+serve_timeout_secs = 90
+flaky = true

--- a/tests/e2e-cucumber/features/bench.feature
+++ b/tests/e2e-cucumber/features/bench.feature
@@ -1,0 +1,49 @@
+Feature: Benchmarking a served endpoint
+
+  # `rocm bench load` had no E2E coverage, which is how it reached users
+  # measuring nothing: it POSTed to an unversioned chat path while its own model
+  # probe used the versioned one, so whichever endpoint form the user supplied,
+  # one of the two 404'd — and every request failure was swallowed, so the run
+  # still exited 0 with a row of blanks.
+  #
+  # Scenarios 1-3 run on every lane (MockServer-backed, no GPU needed) and are
+  # what pin the request path and the failure reporting. Scenario 4 is the
+  # hardware proof against a really served model.
+
+  # The mock answers chat on BOTH the versioned and unversioned routes, so
+  # "the benchmark succeeded" alone would pass even with the bug present. This
+  # scenario therefore asserts which route the requests actually landed on.
+  @id:bench-load-reports-throughput
+  Scenario: 1 - Benchmarking a running server reports measured throughput
+    Given a model is being served
+    When the user benchmarks the served endpoint
+    Then the benchmark reports measured throughput
+    And the benchmark requests reached the versioned chat route
+
+  @id:bench-load-accepts-plain-address
+  Scenario: 2 - A plain host address is accepted and still reaches the server
+    Given a model is being served
+    When the user benchmarks the server using its plain host address
+    Then the benchmark reports measured throughput
+    And the benchmark requests reached the versioned chat route
+
+  @id:bench-load-surfaces-failures
+  Scenario: 3 - A benchmark whose every request is rejected fails loudly
+    Given an endpoint that rejects every request
+    When the user benchmarks the served endpoint
+    Then the benchmark reports that the requests failed
+    And the benchmark does not report a successful run
+
+  # Hardware proof: a real `rocm serve` on this host (vLLM on Instinct, lemonade
+  # on Strix Halo) benchmarked through the endpoint the CLI itself reports.
+  #
+  # The runtime precondition is load-bearing on Instinct, where serving goes
+  # through vLLM under a `gpu_required` device policy and is refused outright
+  # without an active ROCm runtime. Lemonade hosts do not need it, so omitting it
+  # fails on Instinct alone — mirror the sibling GPU serve scenarios and keep it.
+  @id:bench-load-real-serve @requires-gpu
+  Scenario: 4 - Benchmarking a really served model reports throughput
+    Given a managed runtime is active
+    And a model is being served on GPU
+    When the user benchmarks the served endpoint
+    Then the benchmark reports measured throughput

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -34,6 +34,14 @@ struct ServerState {
     /// CLI sent — not just on the (fixed) canned reply, which would silently
     /// mask a corrupted or missing prompt. `None` until a chat request arrives.
     last_chat_request: Arc<Mutex<Option<Value>>>,
+    /// Every URI path a chat request has arrived on, in order.
+    ///
+    /// This server answers chat on BOTH `/v1/chat/completions` and the
+    /// unversioned `/chat/completions`, so a scenario that only checks "did the
+    /// request succeed" cannot tell the two apart — and a client that drops the
+    /// `/v1` prefix would pass while 404ing against a real engine. Recording the
+    /// path lets a scenario assert the versioned route was the one used.
+    chat_paths: Arc<Mutex<Vec<String>>>,
 }
 
 /// Deterministic, monotonically-advancing state behind the mock `/metrics`
@@ -108,6 +116,8 @@ pub struct MockServer {
     server: ServerHandle,
     /// Shared with the running server's `ServerState`; see the field doc there.
     last_chat_request: Arc<Mutex<Option<Value>>>,
+    /// Shared with the running server's `ServerState`; see the field doc there.
+    chat_paths: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockServer {
@@ -127,10 +137,12 @@ impl MockServer {
 
     async fn spawn(model_name: &str, with_metrics: bool) -> Self {
         let last_chat_request = Arc::new(Mutex::new(None));
+        let chat_paths = Arc::new(Mutex::new(Vec::new()));
         let state = ServerState {
             model_name: model_name.to_string(),
             metrics: with_metrics.then(|| Arc::new(MetricsCounter::new())),
             last_chat_request: Arc::clone(&last_chat_request),
+            chat_paths: Arc::clone(&chat_paths),
         };
 
         let mut app = Router::new()
@@ -146,6 +158,44 @@ impl MockServer {
         Self {
             server: http_server::spawn(app).await,
             last_chat_request,
+            chat_paths,
+        }
+    }
+
+    /// Every URI path a chat request has arrived on, in order.
+    ///
+    /// Use this to assert the client used the versioned `/v1/chat/completions`
+    /// route: this server also answers the unversioned `/chat/completions`, so
+    /// a bare "the request succeeded" assertion cannot tell them apart and would
+    /// pass for a client that 404s against a real engine.
+    #[must_use]
+    pub fn chat_paths(&self) -> Vec<String> {
+        self.chat_paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// A server that is reachable but rejects every request with `503`.
+    ///
+    /// Models an engine that is listening but cannot serve — the case a client
+    /// must report rather than quietly recording zero measurements. Its
+    /// `/v1/models` route rejects too, so callers must pass an explicit model.
+    pub async fn start_rejecting() -> Self {
+        async fn reject() -> axum::http::StatusCode {
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        }
+
+        let app = Router::new()
+            .route("/v1/models", get(reject))
+            .route("/models", get(reject))
+            .route("/v1/chat/completions", post(reject))
+            .route("/chat/completions", post(reject));
+
+        Self {
+            server: http_server::spawn(app).await,
+            last_chat_request: Arc::new(Mutex::new(None)),
+            chat_paths: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -304,7 +354,19 @@ async fn handle_metrics(State(state): State<ServerState>) -> String {
         .scrape()
 }
 
-async fn handle_chat(State(state): State<ServerState>, Json(body): Json<Value>) -> Json<Value> {
+async fn handle_chat(
+    State(state): State<ServerState>,
+    uri: axum::http::Uri,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    // Record which of the two chat routes the client actually used, so a
+    // scenario can distinguish the versioned path from the unversioned one.
+    state
+        .chat_paths
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(uri.path().to_string());
+
     let model = body
         .get("model")
         .and_then(Value::as_str)

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -15,6 +15,7 @@ use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions, write_service_
 use tempfile::TempDir;
 
 mod e2e {
+    pub mod bench_steps;
     pub mod chat_steps;
     pub mod dash_steps;
     pub mod diagnose_steps;

--- a/tests/e2e-cucumber/tests/e2e/bench_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/bench_steps.rs
@@ -1,0 +1,175 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Steps for `rocm bench load`.
+//!
+//! These pin two things the command previously got wrong together: which chat
+//! route the load generator posts to, and whether a run in which every request
+//! failed is reported as a failure. Either alone is insufficient — the wrong
+//! route was only invisible because the failures were swallowed.
+
+use cucumber::{given, then, when};
+use e2e_cucumber::mock_server::MockServer;
+
+use crate::E2eWorld;
+
+/// Requests per cell. Small: these scenarios assert on reporting behaviour, not
+/// on throughput accuracy, and the GPU lane pays real inference time for each.
+const BENCH_REQUESTS: &str = "2";
+
+#[given("an endpoint that rejects every request")]
+async fn setup_rejecting_endpoint(world: &mut E2eWorld) {
+    let mock = MockServer::start_rejecting().await;
+    world.endpoint = Some(mock.base_url());
+    world.model_name = Some("TestModel/E2E-1B".to_string());
+    world.mock = Some(mock);
+}
+
+/// Benchmark the endpoint exactly as the CLI reports it — for a served model
+/// that is the `/v1`-suffixed form printed by `rocm services list`.
+#[when("the user benchmarks the served endpoint")]
+async fn benchmark_served_endpoint(world: &mut E2eWorld) {
+    let endpoint = world
+        .endpoint
+        .clone()
+        .expect("no endpoint configured for the benchmark");
+    run_bench(world, &endpoint);
+}
+
+/// Benchmark using the bare `scheme://host:port` form, dropping the API-root
+/// suffix. Users type this because it is what the `--endpoint` help used to
+/// show; it must reach the same place as the fuller form.
+#[when("the user benchmarks the server using its plain host address")]
+async fn benchmark_plain_host_address(world: &mut E2eWorld) {
+    let endpoint = world
+        .endpoint
+        .clone()
+        .expect("no endpoint configured for the benchmark");
+    let plain = endpoint
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+        .trim_end_matches('/')
+        .to_string();
+    assert!(
+        !plain.ends_with("/v1"),
+        "the plain form must not keep the API-root suffix: {plain}"
+    );
+    run_bench(world, &plain);
+}
+
+fn run_bench(world: &mut E2eWorld, endpoint: &str) {
+    let model = world
+        .model_name
+        .clone()
+        .expect("no model configured for the benchmark");
+    // `--out` lands inside the scenario's isolated data dir by default; the
+    // explicit model avoids depending on the endpoint's model-listing route,
+    // which the rejecting server deliberately fails.
+    let (stdout, stderr, rc) = crate::run_rocm(
+        world,
+        &[
+            "bench",
+            "load",
+            "--endpoint",
+            endpoint,
+            "--model",
+            &model,
+            "--concurrency",
+            "1",
+            "--isl",
+            "8",
+            "--osl",
+            "4",
+            "--requests",
+            BENCH_REQUESTS,
+        ],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[then("the benchmark reports measured throughput")]
+async fn assert_throughput_reported(world: &mut E2eWorld) {
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    let stderr = world.cli_stderr.as_deref().unwrap_or("");
+    let rc = world.cli_rc.expect("no command was run");
+    assert!(
+        rc == 0,
+        "rocm bench load failed (rc={rc}):\n{stdout}{stderr}"
+    );
+
+    let cell = stdout
+        .lines()
+        .find(|line| line.starts_with("cell="))
+        .unwrap_or_else(|| panic!("no benchmark cell line in output:\n{stdout}"));
+
+    // `n=` counts requests that returned usable token counts. Zero is the exact
+    // symptom this coverage exists to catch: the command used to print a cell
+    // line with `n=0` and exit 0.
+    let served = cell
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("n="))
+        .unwrap_or("");
+    assert!(
+        served.parse::<u32>().is_ok_and(|n| n > 0),
+        "no requests were served (n={served}):\n{cell}"
+    );
+
+    let gen_tps = cell
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("gen_tps="))
+        .unwrap_or("");
+    assert!(
+        gen_tps != "-" && gen_tps.parse::<f64>().is_ok_and(|v| v > 0.0),
+        "no throughput was measured (gen_tps={gen_tps}):\n{cell}"
+    );
+}
+
+#[then("the benchmark requests reached the versioned chat route")]
+async fn assert_versioned_route_used(world: &mut E2eWorld) {
+    // The mock answers chat on both the versioned and unversioned routes, so a
+    // successful benchmark alone does not prove the client used the route a
+    // real engine serves. Assert the path it actually hit.
+    let mock = world
+        .mock
+        .as_ref()
+        .expect("this assertion needs the mock server");
+    let paths = mock.chat_paths();
+    assert!(
+        !paths.is_empty(),
+        "the benchmark sent no chat requests to the mock"
+    );
+    assert!(
+        paths.iter().all(|path| path == "/v1/chat/completions"),
+        "benchmark requests must use the versioned chat route, got: {paths:?}"
+    );
+}
+
+#[then("the benchmark reports that the requests failed")]
+async fn assert_failures_reported(world: &mut E2eWorld) {
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    let stderr = world.cli_stderr.as_deref().unwrap_or("");
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("failed"),
+        "the run reported no failure at all:\n{combined}"
+    );
+    // The reason must be actionable, not just a count — the original defect was
+    // that the user had nothing to act on.
+    assert!(
+        combined.contains("503") || combined.contains("chat/completions"),
+        "the failure was reported without naming a cause:\n{combined}"
+    );
+}
+
+#[then("the benchmark does not report a successful run")]
+async fn assert_run_not_successful(world: &mut E2eWorld) {
+    let rc = world.cli_rc.expect("no command was run");
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    assert!(
+        rc != 0,
+        "a benchmark in which every request failed exited 0:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`rocm bench load` could run to completion, print a result line, exit 0 — and have measured nothing. Reported from manual testing on MI300X: `n=0`, `gen_tps=-`, `wall=0.26s`, and a row of blanks appended to `results.csv`, with nothing explaining why.

Two defects combined:

- **The command disagreed with itself about what `--endpoint` means.** The load generator posted to `{endpoint}/chat/completions`, assuming the value already carried `/v1`, while the model probe fetched `{endpoint}/v1/models`, assuming it did not. Whichever form the user supplied, one of the two 404'd. The rest of the product is unambiguous — an endpoint includes `/v1`: that is what `rocm services list` prints, and what the chat client appends to. Both halves now normalise through one function, which also accepts the plain host form the `--endpoint` help had been advertising.
- **Every request failure was swallowed.** A connect error, a non-2xx, a malformed body, or a missing `usage` object all collapsed to "no measurement" and were silently dropped. A 100% failure rate still exited 0. This is why the wrong path surfaced as a silent empty result instead of a loud 404 — and why it reached a user. Failures now carry a reason out to the CLI, which warns per cell and exits non-zero when nothing succeeded anywhere.

Fixing only the path would leave the next such bug just as invisible, so both are in scope here.

## Root cause

The two URL-building sites were written against opposite conventions and no test covered the real one — every existing unit test mocked the unversioned route, so the suite agreed with the bug. Those mocks now assert the versioned path.

## Verification

- Reproduced against a mock server that logs request paths, before and after:

  | `--endpoint` | request path | result |
  |---|---|---|
  | `http://host:18099` (before) | `/chat/completions` | `n=0`, exit 0 |
  | `http://host:18099` (after) | `/v1/chat/completions` | `n=2`, `gen_tps=39` |
  | `http://host:18099/v1` (after) | `/v1/chat/completions` | identical |

- An endpoint that rejects every request now exits 1 and names the cause on stderr instead of printing dashes.
- Regression guard checked honestly: reintroducing the old URL construction fails 9 tests, including the new ones.
- New E2E scenarios cover both endpoint forms and the failure reporting. Note the shared mock answers chat on *both* routes, so those scenarios assert which route the requests actually reached — otherwise they would pass with the bug still present.

## Risk

Low for the path fix — normalisation is idempotent, so both endpoint forms converge on the same URL.

Worth a reviewer's attention: `rocm bench load` now **exits non-zero** when no request succeeded, where it previously always exited 0. That is the intended correction, but it is a behaviour change for anything scripting this command. A fully-failed cell is still appended to the CSV, so the dashboard's row-per-cell contract is unchanged.

## Scope

Only the benchmark path. Other findings from the same manual-testing session — the reported default engine on Instinct, the `engines shell` prompt, and the `help` command list — are tracked separately and deliberately untouched here.