### PR TITLE
fix(engines): default to vLLM on Instinct, not Lemonade

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -7264,10 +7264,12 @@ fn read_provider_key_from_user(provider: &str) -> Result<String> {
 }
 
 pub(crate) fn render_launch_summary(paths: &AppPaths, config: &RocmCliConfig) -> String {
+    // User-facing text, so it must agree with what `serve` would pick — the same
+    // contradiction `examine` used to show on Instinct.
     let selected_default_engine = config
         .default_engine
         .as_deref()
-        .unwrap_or(default_engine_for_platform());
+        .unwrap_or_else(|| host_default_engine(Some(paths)));
     let mut output = String::new();
     let _ = writeln!(output, "rocm interactive shell");
     let _ = writeln!(output, "  terminal: non-interactive");
@@ -14109,20 +14111,41 @@ impl PlannedToolCall {
 
 #[cfg(test)]
 fn build_freeform_plan(request: &str, config: &RocmCliConfig) -> StructuredRequestPlan {
-    build_freeform_plan_with_recipes(request, config, None)
+    build_freeform_plan_with_recipes(request, config, None, host_default_engine(None))
 }
 
+/// The engine this host serves on, for callers that need it as an owned default.
+///
+/// Kept separate from the planner so the planner stays a pure function of its
+/// inputs: it bakes the engine into a `rocm serve --engine <engine>` command, and
+/// an explicit `--engine` outranks every other signal in [`select_serve_engine`],
+/// so a probe hidden inside it would make that command silently host-dependent
+/// and its tests unreproducible.
+fn host_default_engine(paths: Option<&AppPaths>) -> &'static str {
+    rocm_core::default_engine_for_host(&rocm_core::detect_host_gpu_summary(paths))
+}
+
+/// `host_default_engine` is the engine this GPU serves on, resolved by the
+/// caller. It is the last resort: an engine named in the request wins, then the
+/// configured default, then the matched recipe's preference.
+///
+/// It must NOT be [`default_engine_for_platform`]. The value chosen here is
+/// written into a literal `--engine` argument, which outranks even the
+/// configured default when the generated command runs — so a GPU-blind constant
+/// here forces Lemonade onto an Instinct host through the strongest override
+/// available, which is the defect this whole path is meant to avoid.
 fn build_freeform_plan_with_recipes(
     request: &str,
     config: &RocmCliConfig,
     recipes: Option<&[ModelRecipeRecord]>,
+    host_default_engine: &str,
 ) -> StructuredRequestPlan {
     let trimmed = request.trim();
     let lower = trimmed.to_ascii_lowercase();
     let default_engine = config
         .default_engine
         .as_deref()
-        .unwrap_or(default_engine_for_platform());
+        .unwrap_or(host_default_engine);
 
     if planner_is_serve_request(&lower) {
         let requested_model = infer_model_from_request(trimmed)
@@ -14582,10 +14605,14 @@ fn build_freeform_plan_with_context(
     paths: &AppPaths,
     config: &RocmCliConfig,
 ) -> StructuredRequestPlan {
+    // Resolved once here, where `paths` is in scope, so the generated
+    // `rocm serve --engine <engine>` names the engine this GPU actually serves on.
+    let host_engine = host_default_engine(Some(paths));
     let registry = match load_model_recipe_registry() {
         Ok(registry) => Some(registry),
         Err(error) => {
-            let mut plan = build_freeform_plan_with_recipes(request, config, Some(&[]));
+            let mut plan =
+                build_freeform_plan_with_recipes(request, config, Some(&[]), host_engine);
             plan.confidence = "medium";
             plan.notes.push(format!(
                 "Model recipe registry could not be loaded: {error}. Fix the recipe index before using registry aliases."
@@ -14599,6 +14626,7 @@ fn build_freeform_plan_with_context(
         registry
             .as_ref()
             .map(|registry| registry.recipes.as_slice()),
+        host_engine,
     );
     if !freeform_plan_needs_ambiguity_resolution(&deterministic) {
         return deterministic;
@@ -17575,6 +17603,7 @@ mod tests {
             "serve signedtiny",
             &RocmCliConfig::default(),
             Some(&[recipe]),
+            "lemonade",
         );
 
         assert_eq!(plan.intent, PlannerIntent::Serve);
@@ -17710,8 +17739,75 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_planner_bakes_the_host_engine_into_the_generated_serve_command() {
+        // The generated command carries an explicit `--engine`, which outranks
+        // every other signal in `select_serve_engine` -- including the configured
+        // default. So whatever this planner picks IS what runs, and on an Instinct
+        // host that must be vLLM. A GPU-blind constant here reintroduced the very
+        // bug this PR fixes, through the strongest override available.
+        //
+        // An empty recipe set is what reaches the host default: a request naming
+        // an engine, or a matched recipe that prefers one, is answered before the
+        // fallback -- correctly, since a GGUF model only Lemonade can serve must
+        // not be forced onto vLLM by the host.
+        let plan = build_freeform_plan_with_recipes(
+            "serve some/unmatched-model",
+            &RocmCliConfig::default(),
+            Some(&[]),
+            "vllm",
+        );
+
+        let engine_arg = plan
+            .actions
+            .iter()
+            .find_map(|action| {
+                let index = action.args.iter().position(|arg| arg == "--engine")?;
+                action.args.get(index + 1).cloned()
+            })
+            .expect("the generated serve command must name an engine");
+        assert_eq!(
+            engine_arg, "vllm",
+            "the host's engine must reach the generated command:\n{:?}",
+            plan.actions
+        );
+    }
+
+    #[test]
+    fn hybrid_planner_lets_a_configured_engine_outrank_the_host_default() {
+        let config = RocmCliConfig {
+            default_engine: Some("lemonade".to_owned()),
+            ..RocmCliConfig::default()
+        };
+        let plan = build_freeform_plan_with_recipes(
+            "serve some/unmatched-model",
+            &config,
+            Some(&[]),
+            "vllm",
+        );
+
+        let engine_arg = plan
+            .actions
+            .iter()
+            .find_map(|action| {
+                let index = action.args.iter().position(|arg| arg == "--engine")?;
+                action.args.get(index + 1).cloned()
+            })
+            .expect("the generated serve command must name an engine");
+        assert_eq!(
+            engine_arg, "lemonade",
+            "an engine the user configured must still win:\n{:?}",
+            plan.actions
+        );
+    }
+
+    #[test]
     fn hybrid_planner_defaults_generic_local_assistant_to_validated_qwen() {
-        let plan = build_freeform_plan("start a local model", &RocmCliConfig::default());
+        let plan = build_freeform_plan_with_recipes(
+            "start a local model",
+            &RocmCliConfig::default(),
+            None,
+            "lemonade",
+        );
 
         assert_eq!(plan.intent, PlannerIntent::Serve);
         assert_eq!(plan.confidence, "high");

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -11087,7 +11087,7 @@ fn examine_human_report(
     let mut output = render_examine_plain_header(&summary);
     output.push_str(&summary.render_text());
     append_examine_runtime_state(&mut output, paths, config)?;
-    append_examine_engine_inventory(&mut output, paths, config);
+    append_examine_engine_inventory(&mut output, paths, config, &summary.default_engine);
     Ok((output, summary))
 }
 
@@ -11118,7 +11118,10 @@ pub(crate) fn render_engine_inventory_text() -> String {
 }
 
 fn render_engine_inventory_text_with_paths(paths: Option<&AppPaths>) -> String {
-    let default_engine = default_engine_for_platform();
+    // Mark the engine this GPU actually serves on as primary. Using the platform
+    // constant put the `*` on Lemonade even on Instinct, where `serve` picks vLLM.
+    let host_gpu = rocm_core::detect_host_gpu_summary(paths);
+    let default_engine = rocm_core::default_engine_for_host(&host_gpu);
     let mut output = String::new();
     let _ = writeln!(output, "Local model engines");
     let _ = writeln!(
@@ -11243,13 +11246,23 @@ fn append_examine_runtime_state(
     Ok(())
 }
 
-fn append_examine_engine_inventory(output: &mut String, paths: &AppPaths, config: &RocmCliConfig) {
+/// `host_default_engine` is the engine this GPU serves on, already resolved by
+/// the caller from the `ExamineSummary` it holds — passed in rather than
+/// re-probed so the two halves of one `rocm examine` run cannot disagree.
+fn append_examine_engine_inventory(
+    output: &mut String,
+    paths: &AppPaths,
+    config: &RocmCliConfig,
+    host_default_engine: &str,
+) {
     let configured_default = config.default_engine.as_deref();
-    let effective_default = match configured_default {
-        Some(engine) => engine,
-        None => default_engine_for_platform(),
-    };
+    // A configured value still wins, mirroring `select_serve_engine`. Only the
+    // fallback becomes GPU-aware: it used to be the platform constant, which
+    // reported Lemonade on Instinct where serve picks vLLM.
+    let effective_default = configured_default.unwrap_or(host_default_engine);
     let _ = writeln!(output, "engine_inventory:");
+    // Unchanged on purpose: this line means "what the user configured", so an
+    // unset value must keep reading as unset rather than borrowing the host default.
     let _ = writeln!(
         output,
         "  configured_default_engine: {}",
@@ -24109,7 +24122,9 @@ ID_LIKE="suse opensuse"
             Some("therock-release:gfx120X-all".to_owned());
         let mut output = String::new();
 
-        append_examine_engine_inventory(&mut output, &paths, &config);
+        // Host default deliberately disagrees with the configured value: an
+        // engine the user chose must outrank whatever the GPU would prefer.
+        append_examine_engine_inventory(&mut output, &paths, &config, "lemonade");
 
         assert!(output.contains("engine_inventory:"));
         assert!(output.contains("configured_default_engine: vllm"));
@@ -24117,6 +24132,28 @@ ID_LIKE="suse opensuse"
         assert!(output.contains("* vllm"));
         assert!(output.contains("runtime_pref=therock-release:gfx120X-all"));
         assert!(output.contains("plugin_dirs:"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn examine_engine_inventory_falls_back_to_the_host_engine_when_unconfigured() {
+        // With nothing configured, the reported default must be the engine this
+        // GPU actually serves on. On an Instinct host that is vLLM; reporting the
+        // platform constant here is what made `examine` contradict `serve`.
+        let (root, paths) = test_paths("examine-engine-inventory-host");
+        let config = RocmCliConfig::default();
+        let mut output = String::new();
+
+        append_examine_engine_inventory(&mut output, &paths, &config, "vllm");
+
+        // The configured line still reads as unset — the host default must not be
+        // mistaken for something the user chose.
+        assert!(output.contains("configured_default_engine: <platform default>"));
+        assert!(output.contains("effective_default_engine: vllm"));
+        assert!(
+            output.contains("* vllm"),
+            "the primary marker should follow the host engine:\n{output}"
+        );
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -11271,6 +11271,20 @@ fn append_examine_engine_inventory(
         configured_default.unwrap_or("<platform default>")
     );
     let _ = writeln!(output, "  effective_default_engine: {effective_default}");
+    // Say so when a configured engine is holding this host off the one its GPU
+    // would pick. Installs provisioned before the installer stopped seeding
+    // `default_engine` still carry `lemonade` on disk, and nothing distinguishes
+    // that seed from a deliberate choice -- so point at the fix rather than
+    // rewriting a file the user owns on a guess. This also catches a genuinely
+    // stale choice made by hand, which no migration would have covered.
+    if let Some(configured) = configured_default
+        && configured != host_default_engine
+    {
+        let _ = writeln!(
+            output,
+            "  configured_default_note: overrides this host's {host_default_engine} preference; run `rocm config clear-default-engine` to follow the host"
+        );
+    }
     let _ = writeln!(
         output,
         "  plugin_policy: first-party engines are built in; external data-dir plugins are optional overrides"
@@ -24249,6 +24263,60 @@ ID_LIKE="suse opensuse"
         assert!(
             output.contains("* vllm"),
             "the primary marker should follow the host engine:\n{output}"
+        );
+        // Nothing is being overridden, so there is nothing to warn about.
+        assert!(
+            !output.contains("configured_default_note"),
+            "an unconfigured host must not be warned about an override:\n{output}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn examine_flags_a_configured_engine_that_overrides_the_host() {
+        // Installs provisioned before the installer stopped seeding
+        // `default_engine` still carry `lemonade` on disk. That seed is
+        // indistinguishable from a deliberate choice, so it is not rewritten --
+        // but the user is told why their Instinct box is not on vLLM, and how to
+        // change it.
+        let (root, paths) = test_paths("examine-engine-inventory-override");
+        let config = RocmCliConfig {
+            default_engine: Some("lemonade".to_owned()),
+            ..RocmCliConfig::default()
+        };
+        let mut output = String::new();
+
+        append_examine_engine_inventory(&mut output, &paths, &config, "vllm");
+
+        assert!(
+            output.contains("effective_default_engine: lemonade"),
+            "the configured engine still wins:\n{output}"
+        );
+        assert!(
+            output.contains("configured_default_note:"),
+            "the override must be called out:\n{output}"
+        );
+        assert!(
+            output.contains("rocm config clear-default-engine"),
+            "the note must name the remedy, not just the problem:\n{output}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn examine_is_silent_when_the_configured_engine_agrees_with_the_host() {
+        let (root, paths) = test_paths("examine-engine-inventory-agrees");
+        let config = RocmCliConfig {
+            default_engine: Some("vllm".to_owned()),
+            ..RocmCliConfig::default()
+        };
+        let mut output = String::new();
+
+        append_examine_engine_inventory(&mut output, &paths, &config, "vllm");
+
+        assert!(
+            !output.contains("configured_default_note"),
+            "there is no override to report when the two agree:\n{output}"
         );
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1599,6 +1599,17 @@ impl ExamineSummary {
             .as_deref()
             .and_then(normalize_therock_family);
         let detected_therock_family = detect_managed_therock_family(&paths);
+        // Report the engine this GPU actually serves on, not the platform
+        // constant. `compatible_therock_family` is the right input: it is
+        // normalised from the real GPU, whereas `detected_therock_family`
+        // describes the installed managed runtime and is absent before one
+        // exists — which would silently downgrade the answer to the constant on
+        // a fresh machine.
+        let host_gpu = HostGpuSummary {
+            name: None,
+            gfx_target: detected_gfx_target.clone(),
+            therock_family: compatible_therock_family.clone(),
+        };
         Ok(Self {
             os: runtime_os_name().to_owned(),
             arch: std::env::consts::ARCH.to_owned(),
@@ -1609,7 +1620,7 @@ impl ExamineSummary {
                 windows_inventory.as_ref(),
             ),
             interactive_terminal: interactive_terminal(),
-            default_engine: default_engine_for_platform().to_owned(),
+            default_engine: default_engine_for_host(&host_gpu).to_owned(),
             detected_gfx_target,
             compatible_therock_family,
             detected_therock_family,
@@ -1703,6 +1714,22 @@ pub fn interactive_terminal() -> bool {
 
 pub const fn default_engine_for_platform() -> &'static str {
     "lemonade"
+}
+
+/// The engine this host serves on by default, absent an explicit choice.
+///
+/// [`default_engine_for_platform`] alone answers "what does this OS fall back
+/// to", which is not the same question: on Instinct data-center parts serving
+/// goes through vLLM, and reporting the platform constant there contradicts what
+/// `serve` actually selects. Use this wherever the CLI *tells the user* what the
+/// default engine is; `default_engine_for_platform` remains correct as the
+/// last-resort fallback once GPU and recipe preferences have been exhausted.
+///
+/// A value the user configured still outranks this — callers that have a
+/// configured engine must prefer it, mirroring `select_serve_engine`.
+#[must_use]
+pub fn default_engine_for_host(summary: &HostGpuSummary) -> &'static str {
+    preferred_serve_engine_for_host_gpu_summary(summary).unwrap_or_else(default_engine_for_platform)
 }
 
 const VLLM_PREFERRED_THEROCK_FAMILIES: &[&str] = &["gfx906", "gfx908", "gfx90a"];
@@ -7507,6 +7534,79 @@ mod tests {
         } else {
             assert_eq!(preferred, Some("vllm"));
         }
+    }
+
+    #[test]
+    fn host_default_engine_is_vllm_on_instinct() {
+        // What `rocm examine` and `rocm engines list` report on an MI300X. The
+        // platform constant said "lemonade" here while serve picked vLLM, so the
+        // reported default contradicted the actual behaviour.
+        let summary = HostGpuSummary {
+            name: Some("AMD Instinct MI300X".to_owned()),
+            gfx_target: Some("gfx942".to_owned()),
+            therock_family: Some("gfx94X-dcgpu".to_owned()),
+        };
+        if cfg!(windows) {
+            assert_eq!(default_engine_for_host(&summary), "lemonade");
+        } else {
+            assert_eq!(default_engine_for_host(&summary), "vllm");
+        }
+    }
+
+    #[test]
+    fn host_default_engine_covers_every_vllm_preferred_family() {
+        // Guards the whole preferred set, not just the dcgpu branch, so adding a
+        // family to VLLM_PREFERRED_THEROCK_FAMILIES cannot leave the reported
+        // default behind.
+        for family in VLLM_PREFERRED_THEROCK_FAMILIES {
+            let summary = HostGpuSummary {
+                name: None,
+                gfx_target: Some((*family).to_owned()),
+                therock_family: Some((*family).to_owned()),
+            };
+            let expected = if cfg!(windows) { "lemonade" } else { "vllm" };
+            assert_eq!(
+                default_engine_for_host(&summary),
+                expected,
+                "unexpected default for {family}"
+            );
+        }
+    }
+
+    #[test]
+    fn host_default_engine_is_lemonade_without_a_vllm_preference() {
+        // Strix Halo (gfx1151), a consumer family, and a machine whose GPU has not
+        // been identified at all must all keep the platform default.
+        for summary in [
+            HostGpuSummary {
+                name: Some("AMD Radeon 8060S".to_owned()),
+                gfx_target: Some("gfx1151".to_owned()),
+                therock_family: Some("gfx1151".to_owned()),
+            },
+            HostGpuSummary {
+                name: Some("AMD Radeon".to_owned()),
+                gfx_target: Some("gfx1100".to_owned()),
+                therock_family: Some("gfx110X-all".to_owned()),
+            },
+            HostGpuSummary::default(),
+        ] {
+            assert_eq!(default_engine_for_host(&summary), "lemonade");
+        }
+    }
+
+    #[test]
+    fn host_default_engine_never_reports_vllm_on_native_windows() {
+        // The vLLM adapter bails on native Windows, so no GPU may talk the
+        // reported default into vLLM there — including an Instinct part.
+        if !cfg!(windows) {
+            return;
+        }
+        let summary = HostGpuSummary {
+            name: Some("AMD Instinct MI300X".to_owned()),
+            gfx_target: Some("gfx942".to_owned()),
+            therock_family: Some("gfx94X-dcgpu".to_owned()),
+        };
+        assert_eq!(default_engine_for_host(&summary), "lemonade");
     }
 
     #[test]

--- a/install.ps1
+++ b/install.ps1
@@ -414,9 +414,14 @@ function Write-MinimalConfigIfMissing {
     }
 
     New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+    # Deliberately no "default_engine": the CLI picks the serving engine from the
+    # host GPU (vLLM on Instinct data-center parts, Lemonade elsewhere). Seeding a
+    # value here would be treated as an explicit user choice and short-circuit that
+    # detection -- which is how every installed Instinct box ended up on Lemonade.
+    # On native Windows the detection resolves to Lemonade anyway, so nothing
+    # changes there; the key is dropped on both platforms to keep them identical.
     $json = @'
 {
-  "default_engine": "lemonade",
   "telemetry": {
     "mode": "local"
   },

--- a/install.sh
+++ b/install.sh
@@ -161,9 +161,12 @@ write_minimal_config_if_missing() {
 
   mkdir -p "${config_dir}"
   config_tmp="${tmp_dir}/config.json"
+  # Deliberately no "default_engine": the CLI picks the serving engine from the
+  # host GPU (vLLM on Instinct data-center parts, Lemonade elsewhere). Seeding a
+  # value here would be treated as an explicit user choice and short-circuit that
+  # detection -- which is how every installed Instinct box ended up on Lemonade.
   cat > "${config_tmp}" <<'JSON'
 {
-  "default_engine": "lemonade",
   "telemetry": {
     "mode": "local"
   },

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -25,6 +25,18 @@ Feature: GPU detection and system inspection
     Then the inspection reports which GPU is installed
     And the inspection reports that the driver is available
 
+  # `examine` used to report a hardcoded platform constant as the default engine,
+  # so on Instinct it named Lemonade while `serve` selected vLLM. The assertion is
+  # host-agnostic: it compares what `examine` reports against the engine the
+  # harness works out for this host from the GPU family and OS, so it resolves to
+  # vLLM on Instinct and Lemonade on Strix Halo and on the no-GPU lane without
+  # naming either. The harness derives its answer from the GPU probe rather than
+  # from `examine`, so this is a cross-check and not a tautology.
+  @id:examine-reports-host-default-engine
+  Scenario: 6 - System inspection names the engine this machine serves on
+    When the user inspects the system
+    Then the inspection names the engine this host serves on by default
+
   @id:examine-distinguishes-unmanaged-rocm @requires-gpu
   Scenario: 4 - System inspection distinguishes CLI-managed from pre-existing ROCm
     Given a machine with a ROCm install that was not set up by the CLI

--- a/tests/e2e-cucumber/features/install_lifecycle.feature
+++ b/tests/e2e-cucumber/features/install_lifecycle.feature
@@ -28,7 +28,7 @@ Feature: Release install lifecycle
     And the installer reports the shell profile updated
     And the installed rocm and rocmd binaries are present
     And the install manifest is present
-    And a minimal config is seeded with the lemonade default engine
+    And the seeded config does not pin a serving engine
     And the shell profile lists the install directory
 
   @id:lifecycle-linux-install-signed-pem @lifecycle @requires-os:linux

--- a/tests/e2e-cucumber/src/capability.rs
+++ b/tests/e2e-cucumber/src/capability.rs
@@ -10,14 +10,17 @@
 //! by spawning the real binary (`rocm examine` + `rocm engines list`) once at
 //! startup and caching the result.
 //!
-//! IMPORTANT — the effective serve engine is currently RE-IMPLEMENTED here (see
-//! [`effective_serve_engine`]) because no `rocm` command exposes it directly
-//! (`examine`'s `default_engine` is a constant `"lemonade"` decoy, not what
-//! `serve` selects). This duplicates the product's `select_serve_engine` /
-//! `preferred_serve_engine_for_therock_family` logic and WILL drift if the
-//! product changes engine support. Task #16 tracks adding a product probe
-//! (`examine --json` → `effective_serve_engine`) so the harness can read the
-//! product's own decision instead. Until then, the unit tests below guard drift.
+//! IMPORTANT — the effective serve engine is RE-IMPLEMENTED here (see
+//! [`effective_serve_engine`]), duplicating the product's `select_serve_engine` /
+//! `preferred_serve_engine_for_therock_family` logic. It will drift if the product
+//! changes engine support, so the unit tests below guard it.
+//!
+//! `examine`'s `default_engine` now reports the host's real engine rather than the
+//! old hardcoded `"lemonade"` constant, so this could in principle be replaced by
+//! reading the product's own answer. Deliberately KEEP the re-implementation: the
+//! `examine-reports-host-default-engine` scenario asserts the product's value
+//! against this one, and that check is only meaningful while the two are derived
+//! independently. Reading the product value here would turn it into a tautology.
 
 use std::sync::OnceLock;
 

--- a/tests/e2e-cucumber/tests/e2e/examine_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/examine_steps.rs
@@ -89,6 +89,38 @@ async fn assert_subcommands_alphabetical(world: &mut E2eWorld) {
     );
 }
 
+#[then("the inspection names the engine this host serves on by default")]
+async fn assert_host_default_engine_reported(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    let Some(reported) = output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("default_engine:"))
+        .map(str::trim)
+    else {
+        panic!("no default_engine line in examine output:\n{output}");
+    };
+
+    // Independently derived by the harness from the GPU family + OS (see
+    // `capability::effective_serve_engine`), NOT read back out of `examine` — so
+    // a product that reports a constant fails here rather than agreeing with
+    // itself.
+    let expected = &e2e_cucumber::capability::host_capability().effective_serve_engine;
+    assert_eq!(
+        reported, expected,
+        "examine reports '{reported}' as the default engine, but this host serves on \
+         '{expected}':\n{output}"
+    );
+
+    // The same value must appear in the engine inventory block, which is what the
+    // `*` primary marker follows — the two used to be able to disagree.
+    assert!(
+        output
+            .lines()
+            .any(|line| line.trim() == format!("effective_default_engine: {expected}")),
+        "engine_inventory did not report '{expected}' as the effective default:\n{output}"
+    );
+}
+
 #[then("all supported engines are listed")]
 async fn assert_all_engines_listed(world: &mut E2eWorld) {
     let output = world.cli_output.as_ref().expect("no command was run");

--- a/tests/e2e-cucumber/tests/e2e/lifecycle_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/lifecycle_steps.rs
@@ -1068,14 +1068,23 @@ async fn then_manifest_present(world: &mut E2eWorld) {
     assert_exists(&st.install_dir.join(".rocm-cli-manifest"));
 }
 
-#[then("a minimal config is seeded with the lemonade default engine")]
+#[then("the seeded config does not pin a serving engine")]
 async fn then_config_seeded(world: &mut E2eWorld) {
     let config = installed_config_file(world);
     let contents = std::fs::read_to_string(&config)
         .unwrap_or_else(|_| panic!("installed config not found: {}", config.display()));
+    // The installer used to write `"default_engine": "lemonade"` here on every
+    // platform. A configured engine outranks the GPU-family preference, so that
+    // seed silently forced Lemonade onto Instinct machines where serve should
+    // pick vLLM. Leaving the key out lets the CLI decide from the host.
     assert!(
-        contents.contains("\"default_engine\"") && contents.contains("\"lemonade\""),
-        "config did not seed the lemonade default engine:\n{contents}"
+        !contents.contains("\"default_engine\""),
+        "the seeded config must not pin a serving engine:\n{contents}"
+    );
+    // Still a real config, not an empty file — the rest of the seed must survive.
+    assert!(
+        contents.contains("\"telemetry\""),
+        "the seeded config lost its other defaults:\n{contents}"
     );
 }
 


### PR DESCRIPTION
## Summary

On MI300X the CLI defaulted to Lemonade where vLLM is the intended serving path for Instinct. The reported symptom was that `rocm examine` *named* the wrong engine — but on a real installed machine `rocm serve` was also *running* the wrong one. Two separate defects, and fixing only the reporting would have left the behaviour unchanged.

- **The installers pinned the engine.** `install.sh` and `install.ps1` seeded `"default_engine": "lemonade"` into `config.json` on every platform. A configured engine outranks the GPU-family preference in `select_serve_engine`, so on any installer-provisioned Instinct box that seed short-circuited detection entirely. The key is now omitted, leaving the choice to the host detection the CLI already has. On Windows that detection resolves to Lemonade anyway, so nothing changes there.
- **The reporting surfaces ignored the GPU.** `examine`'s `default_engine` / `effective_default_engine` and `engines list`'s primary marker all read a hardcoded platform constant, so they named Lemonade even where serve would pick vLLM. They now resolve through one helper.

A value the user configured still wins, and `configured_default_engine` keeps reading as unset when it is unset — it means "what the user chose", not "what the host prefers".

## Why CI never caught it

The E2E suite runs against an isolated config directory with nothing seeded, so `configured_default` is absent, the GPU preference wins, and the existing "vLLM is the default serving engine on Instinct" scenario passes — against a machine configured unlike any real one. The installer path is only exercised by the opt-in lifecycle scenarios, and the one covering the seeded config asserted the Lemonade default, i.e. it encoded the bug. It now asserts the opposite.

## Verification

- New unit coverage for the host resolution: vLLM across the whole preferred-family set, Lemonade for consumer/unknown/absent families, and never vLLM on native Windows regardless of GPU.
- Lifecycle E2E run locally against a real package → install → uninstall: **9 scenarios, 72 steps, all passing**, including the changed seeded-config assertion. This is the only coverage that exercises the installer, so it was run explicitly rather than left to the default suite.
- New E2E scenario asserts the engine `examine` reports equals the one the harness derives independently for the host, so it resolves to vLLM on Instinct and Lemonade elsewhere without host-specific assertions. The harness's separate implementation of the rule is deliberately kept — the check is only meaningful while the two are derived independently, which is noted in that file.

## Risk

Medium, and worth a reviewer's attention on one point: **existing installs are not migrated.** They already have the value on disk and will keep getting Lemonade on Instinct; only fresh installs are fixed. Rewriting a user-owned config file felt like a separate decision rather than something to fold in silently — happy to add a migration if that is the preference.

Otherwise low: serve's selection logic is untouched, and the reporting change is a value change with no field added or removed.

## Scope

Deliberately untouched: the launcher summary, the codex bridge inventory and the daemon also use the platform constant, but they are machine-facing or peripheral.