### PR TITLE
fix(diagnose): give every finding a command you can run

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -106,6 +106,15 @@ enum Command {
         json: bool,
     },
     /// Diagnose known ROCm/PyTorch/llama.cpp failure modes against a closed catalog.
+    ///
+    /// Matches this machine against a fixed catalog of known misconfigurations and
+    /// ranks what it finds. It can only recognise failure modes that are in the
+    /// catalog: no match means "not recognised", not "nothing is wrong" — in that
+    /// case it points you at where to report the symptom.
+    ///
+    /// Each cause is printed with an `id:` and an `apply with:` command. The
+    /// leading `#1`, `#2` are ranking positions for reading order only; `rocm fix`
+    /// takes the id, not the position.
     Diagnose {
         /// Raw error text from the user; sharpens keyword scoring.
         #[arg(long)]
@@ -118,6 +127,15 @@ enum Command {
         json: bool,
     },
     /// Apply a known fix by id (see `rocm diagnose`); run with no id to list fixes.
+    ///
+    /// Takes the `id:` that `rocm diagnose` reports against a cause — not the
+    /// `#1`/`#2` ranking position, which belongs to one report and is not a name.
+    /// With no id it lists the whole catalog.
+    ///
+    /// Fixes are marked AUTO or PRINT-ONLY: AUTO means this command carries the
+    /// change out, PRINT-ONLY means it prints the steps for you to run yourself
+    /// (typically because they need sudo or a reboot). Use `--dry-run` to see any
+    /// fix's plan without changing anything.
     Fix {
         /// Fix id, e.g. fix-4-render-group. Omit to list available fixes.
         fix_id: Option<String>,

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1360,7 +1360,18 @@ pub fn render_report_text(report: &DiagnoseReport, top: usize) -> String {
         } else {
             "WEAK"
         };
-        let _ = writeln!(out, "#{} [{tier} score={}/100] {}", i + 1, d.score, d.title);
+        // The ordinal is a ranking position, not a handle -- naming the fix-id on
+        // the same line stops it reading like something `rocm fix` would accept.
+        // Users were typing `rocm fix #1` because the two were shown apart, with
+        // only the ordinal looking like an identifier.
+        let _ = writeln!(
+            out,
+            "#{} ({}) [{tier} score={}/100] {}",
+            i + 1,
+            d.id,
+            d.score,
+            d.title
+        );
         let _ = writeln!(out, "   id: {}", d.id);
         for ev in &d.evidence {
             let _ = writeln!(out, "   - {ev}");
@@ -1393,12 +1404,42 @@ pub fn render_report_text(report: &DiagnoseReport, top: usize) -> String {
                 let _ = writeln!(out, "   verify after fix: {}", fix.verify);
             }
         }
+        // Every finding carries the command that acts on it. Previously only the
+        // summary at the end named one, and only when some match cleared
+        // HIGH_CONFIDENCE -- so a report of low-confidence matches showed ids but
+        // never said what to run, which is what sent users guessing at the
+        // ordinal.
+        let _ = writeln!(out, "   apply with: rocm fix {}", d.id);
         out.push('\n');
     }
+
+    // A truncated list must say so: otherwise the matches shown read as
+    // everything the CLI found.
+    let shown = report.matched.len().min(top);
+    if report.matched.len() > shown {
+        let _ = writeln!(
+            out,
+            "Showing {shown} of {} matches; pass `--top {}` to see the rest.\n",
+            report.matched.len(),
+            report.matched.len()
+        );
+    }
+
     if let Some(high) = report.matched.iter().find(|d| d.score >= HIGH_CONFIDENCE) {
         let _ = writeln!(out, "Next step: run `rocm fix {}`.", high.id);
-    } else {
-        out.push_str("Highest-scoring match is below the HIGH_CONFIDENCE threshold. Confirm one more piece of evidence before applying.\n");
+    } else if let Some(best) = report.matched.first() {
+        // Below the threshold the caution still stands, but it is advice about
+        // confidence -- not a reason to withhold the command. Ending here was the
+        // bug: the user was told to confirm more evidence and given nothing to
+        // run once they had.
+        out.push_str(
+            "Highest-scoring match is below the HIGH_CONFIDENCE threshold. Confirm one more piece of evidence before applying.\n",
+        );
+        let _ = writeln!(
+            out,
+            "When you are ready, run `rocm fix {}` (the highest-scoring match), or use the `apply with:` line of whichever cause fits.",
+            best.id
+        );
     }
     out
 }
@@ -1425,6 +1466,85 @@ mod tests {
         assert_eq!(top.id, "fix-4-render-group");
         assert_eq!(top.score, 45); // 35 render + 10 video
         assert!(top.fix.as_ref().unwrap().auto_applicable);
+    }
+
+    #[test]
+    fn a_low_confidence_report_still_names_a_command_to_run() {
+        // The reported case: every match below HIGH_CONFIDENCE. The report used
+        // to end at "confirm one more piece of evidence" and never say what to
+        // run, so users guessed at the `#1` ordinal.
+        let mut e = linux_base();
+        e.in_render_group = Some(false);
+        e.in_video_group = Some(false);
+        let report = diagnose(&e, "");
+        assert!(
+            report.matched.iter().all(|d| d.score < HIGH_CONFIDENCE),
+            "fixture must stay below the threshold for this test to mean anything"
+        );
+
+        let out = render_report_text(&report, 5);
+        assert!(
+            out.contains("below the HIGH_CONFIDENCE threshold"),
+            "the confidence caution must survive:\n{out}"
+        );
+        assert!(
+            out.contains("rocm fix fix-4-render-group"),
+            "a below-threshold report must still name a runnable command:\n{out}"
+        );
+    }
+
+    #[test]
+    fn every_reported_cause_carries_its_own_apply_command() {
+        let mut e = linux_base();
+        e.in_render_group = Some(false);
+        e.in_video_group = Some(false);
+        let report = diagnose(&e, "");
+        let out = render_report_text(&report, 5);
+
+        let applies = out.matches("apply with: rocm fix ").count();
+        let shown = report.matched.len().min(5);
+        assert_eq!(
+            applies, shown,
+            "each of the {shown} shown causes needs its own command:\n{out}"
+        );
+        for d in report.matched.iter().take(shown) {
+            assert!(
+                out.contains(&format!("apply with: rocm fix {}", d.id)),
+                "no command for {}:\n{out}",
+                d.id
+            );
+        }
+    }
+
+    #[test]
+    fn the_ranking_position_is_shown_with_the_id_it_stands_for() {
+        // `#1` alone looked like a handle `rocm fix` would take. Pairing it with
+        // the id on the same line is what stops that read.
+        let mut e = linux_base();
+        e.in_render_group = Some(false);
+        let report = diagnose(&e, "");
+        let out = render_report_text(&report, 5);
+        let top = &report.matched[0];
+        assert!(
+            out.contains(&format!("#1 ({})", top.id)),
+            "the ordinal must name the id it refers to:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_truncated_report_says_it_was_truncated() {
+        let mut e = linux_base();
+        e.in_render_group = Some(false);
+        e.in_video_group = Some(false);
+        let report = diagnose(&e, "");
+        if report.matched.len() < 2 {
+            return; // nothing to truncate on this fixture
+        }
+        let out = render_report_text(&report, 1);
+        assert!(
+            out.contains("Showing 1 of"),
+            "a truncated list must not read as the complete set:\n{out}"
+        );
     }
 
     #[test]

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -380,11 +380,27 @@ const fn current_os() -> &'static str {
     }
 }
 
+/// Whether `value` is a `rocm diagnose` ranking position (`#2`, or a bare `2`)
+/// rather than a fix-id.
+///
+/// Used only to turn an unknown-id refusal into a corrective one; it never
+/// selects a fix, because a position is meaningful only within the report that
+/// produced it and `fix` has no memory of that report.
+fn looks_like_a_diagnosis_position(value: &str) -> bool {
+    let trimmed = value.trim();
+    let digits = trimmed.strip_prefix('#').unwrap_or(trimmed);
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
 /// List every fix-id (id, kind, OS scope, title).
 #[must_use]
 pub fn list_recipes() -> String {
     use std::fmt::Write as _;
     let mut out = String::from("Available fix-ids (mirror the diagnosis catalog):\n");
+    // The markers were printed with nothing saying what they mean.
+    out.push_str(
+        "  AUTO = `rocm fix <id>` can carry it out; PRINT-ONLY = it prints the steps for you to run.\n",
+    );
     for r in RECIPES {
         let kind = if r.auto_applicable {
             "AUTO"
@@ -440,7 +456,20 @@ fn print_recipe(r: &FixRecipe) {
 pub fn apply(fix_id: &str, opts: &FixOptions) -> i32 {
     let Some(recipe) = find_recipe(fix_id) else {
         eprintln!("Unknown fix-id: {fix_id}");
-        eprintln!("Run `rocm diagnose` to see which fix-id applies.");
+        if looks_like_a_diagnosis_position(fix_id) {
+            // `rocm diagnose` ranks findings `#1`, `#2`, and users reach for that
+            // number here. It is a position in one report, not a name -- and it
+            // does not line up with the catalog's `fix-1 … fix-15` either, so a
+            // bare "unknown id" left them with nothing to correct.
+            eprintln!(
+                "`{fix_id}` looks like a position in a `rocm diagnose` report, not a fix-id."
+            );
+            eprintln!(
+                "Use the `id:` shown against that cause — `rocm diagnose` prints an `apply with:` line you can copy."
+            );
+        } else {
+            eprintln!("Run `rocm diagnose` to see which fix-id applies.");
+        }
         return 2;
     };
     print_recipe(recipe);
@@ -1039,5 +1068,51 @@ mod tests {
         for r in RECIPES {
             assert!(listing.contains(r.fix_id), "listing missing {}", r.fix_id);
         }
+    }
+
+    #[test]
+    fn listing_explains_its_applicability_markers() {
+        // The markers were emitted with nothing saying what they mean, leaving
+        // the reader to guess whether PRINT-ONLY was a debug flag.
+        let listing = list_recipes();
+        assert!(
+            listing.contains("AUTO =") && listing.contains("PRINT-ONLY ="),
+            "the listing must explain its markers:\n{listing}"
+        );
+    }
+
+    #[test]
+    fn diagnosis_positions_are_recognised_as_positions() {
+        // What `rocm diagnose` shows as `#1`/`#2`, plus the bare number a user
+        // might type instead.
+        for value in ["#1", "#2", "1", "12", " #3 "] {
+            assert!(
+                looks_like_a_diagnosis_position(value),
+                "{value} should read as a ranking position"
+            );
+        }
+        // Real ids and other typos must keep the generic refusal — claiming a
+        // fix-id is a "position" would be worse than saying nothing.
+        for value in [
+            "fix-4-render-group",
+            "fix-1-arch",
+            "bogus",
+            "#",
+            "",
+            "fix-#1",
+        ] {
+            assert!(
+                !looks_like_a_diagnosis_position(value),
+                "{value} should NOT read as a ranking position"
+            );
+        }
+    }
+
+    #[test]
+    fn a_position_argument_is_refused_with_the_same_exit_code() {
+        // Still 2: this is clearer wording on an existing refusal, not a new
+        // behaviour that a script could start depending on.
+        assert_eq!(apply("#1", &FixOptions::default()), 2);
+        assert_eq!(apply("bogus", &FixOptions::default()), 2);
     }
 }

--- a/tests/e2e-cucumber/features/diagnose.feature
+++ b/tests/e2e-cucumber/features/diagnose.feature
@@ -15,6 +15,7 @@ Feature: Diagnosing failures and listing fixes
     Given a user who hit a known ROCm failure
     When the user asks the CLI to diagnose that symptom
     Then the CLI reports a likely cause with a suggested fix
+    And every reported cause comes with a command that applies it
 
   @id:diagnose-always-offers-a-way-forward
   Scenario: 2 - Diagnosing any failure always gives the user a way to escalate
@@ -33,6 +34,7 @@ Feature: Diagnosing failures and listing fixes
     When the user asks the CLI which fixes it offers
     Then the CLI lists the fixes it can apply
     And each fix indicates whether the CLI can apply it automatically
+    And the listing explains what those indicators mean
 
   @id:fix-dry-run-changes-nothing
   Scenario: 5 - Previewing a fix explains the change without making it
@@ -46,3 +48,11 @@ Feature: Diagnosing failures and listing fixes
     Given a user who names a fix the CLI does not offer
     When the user asks the CLI to apply that fix
     Then the CLI refuses and explains that the fix is not recognised
+
+  # A diagnosis ranks causes `#1`, `#2`; reaching for that number here is the
+  # natural mistake, and it used to get the same bare "unknown id" as a typo.
+  @id:fix-position-argument-rejected
+  Scenario: 7 - Asking for a fix by its position in the diagnosis is corrected
+    Given a user who refers to a cause by its position in the diagnosis
+    When the user asks the CLI to apply that fix
+    Then the CLI refuses and explains that a position is not a fix-id

--- a/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
@@ -44,6 +44,14 @@ async fn user_named_unknown_fix(world: &mut E2eWorld) {
     world.model_name = Some("fix-does-not-exist".to_string());
 }
 
+#[given("a user who refers to a cause by its position in the diagnosis")]
+async fn user_named_diagnosis_position(world: &mut E2eWorld) {
+    // Quoted deliberately: unquoted, the shell treats `#1` as a comment and the
+    // CLI never sees it. The product behaviour under test is what happens when
+    // the argument does arrive.
+    world.model_name = Some("#1".to_string());
+}
+
 // ── When ───────────────────────────────────────────────────────────
 
 #[when("the user asks the CLI to diagnose that symptom")]
@@ -106,6 +114,35 @@ async fn assert_reports_cause_and_fix(world: &mut E2eWorld) {
     assert!(
         output.contains("plan:"),
         "expected a suggested fix plan:\n{output}"
+    );
+}
+
+#[then("every reported cause comes with a command that applies it")]
+async fn assert_every_cause_has_a_command(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no diagnose output");
+    // A plan alone is not actionable: the report used to name a `rocm fix`
+    // command only when some match cleared the confidence threshold, so a report
+    // of low-confidence causes left the user with nothing to run.
+    let causes = output.lines().filter(|l| l.contains("score=")).count();
+    let commands = output
+        .lines()
+        .filter(|l| l.trim().starts_with("apply with: rocm fix "))
+        .count();
+    assert!(causes > 0, "no scored causes to check:\n{output}");
+    assert_eq!(
+        commands, causes,
+        "each of the {causes} causes needs its own apply command:\n{output}"
+    );
+}
+
+#[then("the listing explains what those indicators mean")]
+async fn assert_markers_explained(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no fix list output");
+    // The markers were printed with no legend, so a reader could not tell
+    // whether PRINT-ONLY meant "advisory" or "not implemented yet".
+    assert!(
+        output.contains("AUTO =") && output.contains("PRINT-ONLY ="),
+        "expected the listing to explain its AUTO/PRINT-ONLY markers:\n{output}"
     );
 }
 
@@ -235,5 +272,30 @@ async fn assert_unknown_fix_refused(world: &mut E2eWorld) {
     assert!(
         combined.contains("Unknown fix-id"),
         "expected an 'Unknown fix-id' message:\n{combined}"
+    );
+}
+
+#[then("the CLI refuses and explains that a position is not a fix-id")]
+async fn assert_position_argument_corrected(world: &mut E2eWorld) {
+    // Same exit code as any unknown id — this is clearer wording on an existing
+    // refusal, not a new outcome a script could come to depend on.
+    assert_eq!(
+        world.cli_rc,
+        Some(2),
+        "a position argument should exit 2 like any unknown id"
+    );
+    let combined = format!(
+        "{}{}",
+        world.cli_output.as_deref().unwrap_or(""),
+        world.cli_stderr.as_deref().unwrap_or("")
+    );
+    assert!(
+        combined.contains("position"),
+        "the refusal must say the argument was read as a position:\n{combined}"
+    );
+    // And it must point at what to use instead, or the correction is useless.
+    assert!(
+        combined.contains("id:"),
+        "the refusal must name the identifier to use instead:\n{combined}"
     );
 }


### PR DESCRIPTION
## Summary

A user diagnosed a problem on MI300X and had no working way to act on either finding.

`rocm fix #1` is a red herring: in bash, unquoted `#1` is a **comment**, so it never reaches the CLI and `rocm fix` runs bare — which lists the catalog by design. Quoted, `rocm fix '#1'` already exits 2. **No amount of `#N` support fixes the command as typed.**

What actually failed them: `render_report_text` emitted `Next step: run 'rocm fix <id>'` **only** when some match cleared `HIGH_CONFIDENCE`. Both their findings were `WEAK`, so the report ended at *"confirm one more piece of evidence"* and stopped. Guessing the `#1` on screen was the only thing left to try.

## What changed

- **Every finding carries `apply with: rocm fix <id>`.** The below-threshold path keeps the confidence caution but now follows it with a command. The two were never in conflict; treating them as mutually exclusive was the bug.
- **The ordinal names the id it stands for**, so `#1` reads as a position rather than a handle. Note the reporter's `#1` was `fix-7` and `#2` was `fix-6` — two numbering schemes were on screen at once with nothing distinguishing them.
- **A truncated report says so** (`--top` defaults to 5), instead of looking like the complete set.
- **A position-shaped argument to `fix` is corrected**, naming what to use instead — same exit code 2, so this is clearer wording on an existing refusal rather than new behaviour a script could depend on.
- **`AUTO`/`PRINT-ONLY` are explained** in the listing, and both commands' `--help` now states what they can and cannot do.

## Deliberately not done: `#N` as a selector

This is the ticket's headline ask, and I'd push back on it:

1. It cannot fix the reported command — the shell consumes `#1` before the CLI sees it, so only users who quote would benefit.
2. `fix` has no memory of the previous `diagnose` run, so `#N` would have to be resolved by re-running the diagnosis. The ranking depends on `--symptom`, so `rocm diagnose --symptom "…"` followed by `rocm fix '#1'` could silently apply a **different** fix than the one displayed. Applying the wrong remediation is materially worse than the confusion being fixed.

The ticket's own criterion permits this: it asks that the ordinal work **"or clearly explain why it can't"**.

## Verification

- Unit: a below-threshold report still yields a runnable command; every cause gets its own; the ordinal carries its id; truncation is announced. For `fix`: `#1`/`1`/` #3 ` read as positions while real ids and other typos keep the generic refusal, all at exit 2.
- E2E: extended the two existing scenarios rather than duplicating them, plus one new scenario for the position-shaped argument.
- Read the rendered output by hand — the point of this ticket is legibility, which a passing assertion doesn't demonstrate.

**Verification gap, stated plainly:** the catalog is out-of-scope on WSL2, where I develop, so the two match-dependent diagnose scenarios already fail locally as known noise and my new `every reported cause comes with a command` assertion is never reached there. It fails at the pre-existing step, not the new one. That assertion is proven on the CI lanes, not locally.

## Risk

Low. Output-only, plus one refusal message. No exit codes change; bare `rocm fix` still lists the catalog and `rocm fix <fix-id>` still applies, both of which the ticket asks to keep.

## Out of scope

Withdrawing `AUTO`/`PRINT-ONLY` from releases, which the ticket floats as an alternative. They describe real behaviour — whether the CLI acts or only advises — so explaining them beats hiding them.