### PR TITLE
feat(help): mark commands outside the Tech Preview scope

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -83,13 +83,19 @@ and run OpenAI-compatible model servers on AMD GPUs.\n\n\
 Run `rocm` with no subcommand to open the interactive dashboard (TUI). Use `rocm examine` \
 to check that your GPU and ROCm install are ready, then `rocm serve <model>` to start a server.",
     version,
+    // The `chat` example was dropped from this list when `chat` became
+    // `[preview]`: promoting a command as a headline example while marking it
+    // preview elsewhere contradicts itself. `engines list` keeps the six-step
+    // narrative and is in scope.
     after_help = "EXAMPLES:\n  \
 rocm examine                      Check GPU, ROCm install, and engines\n  \
 rocm install sdk                  Install ROCm wheels into a managed environment\n  \
+rocm engines list                 Show the local inference engines available\n  \
 rocm model                        List models this machine can run\n  \
 rocm serve qwen2.5-7b-instruct    Start a local OpenAI-compatible server\n  \
-rocm services list                Show running model servers\n  \
-rocm chat --prompt \"Hi\"           Chat with a configured assistant provider\n\n\
+rocm services list                Show running model servers\n\n\
+Commands marked [preview] work but are outside the Tech Preview's supported\n\
+scope: treat them as unfinished and do not depend on their behaviour yet.\n\n\
 Run `rocm <command> --help` for details and examples on any command."
 )]
 struct Cli {
@@ -201,7 +207,7 @@ enum Command {
         #[arg(long)]
         allow_mutation: bool,
     },
-    /// Send a one-shot chat prompt to a configured assistant provider.
+    /// [preview] Send a one-shot chat prompt to a configured assistant provider.
     ///
     /// Reads the prompt from --prompt or, if omitted, from standard input. Use
     /// `rocm config enable-provider` and `rocm config set-provider-key` first to
@@ -345,7 +351,7 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         #[arg(long)]
         api_key: Option<String>,
     },
-    /// Install, start, stop, or inspect ComfyUI.
+    /// [preview] Install, start, stop, or inspect ComfyUI.
     #[command(alias = "comfy")]
     Comfyui {
         #[command(subcommand)]
@@ -356,7 +362,7 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         #[command(subcommand)]
         command: Option<ServicesCommand>,
     },
-    /// Manage optional background checks and review requests.
+    /// [preview] Manage optional background checks and review requests.
     Automations {
         #[command(subcommand)]
         command: Option<AutomationsCommand>,
@@ -16519,6 +16525,43 @@ mod tests {
     #[test]
     fn cli_command_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn out_of_scope_commands_are_marked_preview_in_help() {
+        let help = Cli::command().render_long_help().to_string();
+        for command in ["chat", "comfyui", "automations"] {
+            let line = help
+                .lines()
+                .find(|line| line.trim_start().starts_with(command))
+                .unwrap_or_else(|| panic!("`{command}` missing from help:\n{help}"));
+            assert!(
+                line.contains("[preview]"),
+                "`{command}` is outside the Tech Preview scope and must say so:\n{line}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_preview_marker_is_explained_and_not_contradicted() {
+        let help = Cli::command().render_long_help().to_string();
+        // A marker nobody can interpret is no better than no marker.
+        assert!(
+            help.contains("Commands marked [preview]"),
+            "the marker must be explained in the help footer:\n{help}"
+        );
+        // A command cannot be promoted as a headline example while being marked
+        // unfinished — that is the contradiction this pairing exists to prevent.
+        let examples = help
+            .split_once("EXAMPLES:")
+            .map(|(_, rest)| rest)
+            .unwrap_or_default();
+        for command in ["chat", "comfyui", "automations"] {
+            assert!(
+                !examples.contains(&format!("rocm {command}")),
+                "`{command}` is marked preview, so it must not headline the examples:\n{examples}"
+            );
+        }
     }
 
     /// Regression test for the engine child-stdin write under the process-wide


### PR DESCRIPTION
## Summary

`rocm help` listed every command with nothing distinguishing what the Tech Preview actually supports, so `chat`, `comfyui` and `automations` read as finished features. They now carry a `[preview]` marker, with a footer explaining it:

```
  chat         [preview] Send a one-shot chat prompt to a configured assistant provider
  comfyui      [preview] Install, start, stop, or inspect ComfyUI
  automations  [preview] Manage optional background checks and review requests

Commands marked [preview] work but are outside the Tech Preview's supported
scope: treat them as unfinished and do not depend on their behaviour yet.
```

## Marked, not hidden

`#[command(hide = true)]` removes a command from help but **does not stop it running**. Hiding would conceal the problem rather than state it, and leave anyone who already knows the command with no signal at all. A marker is honest about what these are and stays useful to people mid-flow.

Easy to flip if the team decides these should be withdrawn rather than labelled — but that is a different change, and it should also refuse to run, not just disappear from help.

## `chat` also stopped being a headline example

It was one of the six `EXAMPLES:` entries. Promoting a command as an example while marking it unfinished contradicts itself, so it is replaced with `rocm engines list` — in scope, and it keeps the six-step narrative intact.

## Scope: diagnose, fix and examine deliberately unmarked

The ticket names these alongside the others, but they are being **made to work** rather than withdrawn:

- `diagnose`/`fix` UX was just reworked (EAI-7951, targeting the same 0.1.0).
- `examine`'s reported default engine was corrected (EAI-7954), and its ambiguous field clarified (EAI-7963).
- A P2 is open to make `examine` report an existing ROCm install properly (EAI-7955).

Marking them preview would contradict that investment. Flagging it explicitly because it narrows the ticket's stated scope — worth a second opinion if the Tech Preview boundary was set elsewhere.

## Verification

Two unit tests, because the risk here is drift rather than breakage: one asserts the three commands carry the marker, the other that the footer explains it **and** that no marked command appears in the examples — so the self-contradiction cannot come back.

`cargo test -p rocm` (406 pass), workspace and e2e-harness clippy with `-D warnings`, `cargo fmt --check`. The e2e help scenario parses the first token of each `Commands:` line, which is unchanged — confirmed by a full e2e run: it resolved as its usual declared xfail, not a regression.

## Risk

Very low — help text plus one example line. No command's behaviour, name, or availability changes.