### PR TITLE
fix(examine): report the ROCm install that is already there

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -11097,10 +11097,27 @@ fn render_examine_plain_header(summary: &ExamineSummary) -> String {
     } else {
         "AMD GPU not detected yet"
     };
-    let runtime = match summary.managed_runtime_count {
-        0 => "No ROCm installs saved yet".to_owned(),
-        1 => "1 ROCm install saved".to_owned(),
-        count => format!("{count} ROCm installs saved"),
+    // This line used to count only CLI-managed runtimes, so a machine with ROCm
+    // already installed at /opt/rocm was greeted with "No ROCm installs saved
+    // yet" -- read, reasonably, as "nothing is installed". Account for what is
+    // actually on the machine, and say plainly that a pre-existing install is
+    // left alone on purpose rather than missed.
+    let managed = match summary.managed_runtime_count {
+        0 => None,
+        1 => Some("1 ROCm install saved".to_owned()),
+        count => Some(format!("{count} ROCm installs saved")),
+    };
+    let existing = (summary.legacy_rocm.status != "not_detected").then(|| {
+        summary.legacy_rocm.version.as_deref().map_or_else(
+            || "existing ROCm install found, left unmanaged by design".to_owned(),
+            |version| format!("existing ROCm {version} found, left unmanaged by design"),
+        )
+    });
+    let runtime = match (managed, existing) {
+        (Some(managed), Some(existing)) => format!("{managed}; {existing}"),
+        (Some(managed), None) => managed,
+        (None, Some(existing)) => format!("No ROCm installs saved yet; {existing}"),
+        (None, None) => "No ROCm installs saved yet".to_owned(),
     };
     format!(
         "ROCm setup check\n  {gpu}\n  {runtime}\n  Driver: {}\n\nDetails\n",
@@ -16521,6 +16538,112 @@ mod tests {
         Cli::command().debug_assert();
     }
 
+    /// An `ExamineSummary` with the legacy-install fields under test and
+    /// everything else inert.
+    fn summary_with_legacy(
+        managed_runtime_count: usize,
+        legacy_status: &str,
+        legacy_version: Option<&str>,
+    ) -> ExamineSummary {
+        ExamineSummary {
+            os: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
+            kernel: None,
+            distro: None,
+            cpu: None,
+            system_ram_gib: None,
+            interactive_terminal: false,
+            default_engine: "vllm".to_owned(),
+            detected_gfx_target: None,
+            compatible_therock_family: None,
+            detected_therock_family: None,
+            driver: rocm_core::DriverSummary {
+                policy: "linux_official_amd_dkms_wrapper".to_owned(),
+                status: "amdgpu_available".to_owned(),
+                detail: None,
+            },
+            legacy_rocm: rocm_core::LegacyRocmSummary {
+                status: legacy_status.to_owned(),
+                paths: Vec::new(),
+                detail: None,
+                version: legacy_version.map(str::to_owned),
+            },
+            wsl: None,
+            managed_runtime_count,
+            managed_service_count: 0,
+            model_cache_entries: 0,
+            config_dir: PathBuf::from("config"),
+            data_dir: PathBuf::from("data"),
+            cache_dir: PathBuf::from("cache"),
+        }
+    }
+
+    #[test]
+    fn header_does_not_claim_nothing_is_installed_when_rocm_is_present() {
+        // The reported case: ROCm on the machine, none of it CLI-managed. The
+        // header counted only managed runtimes, so it said "No ROCm installs
+        // saved yet" — read as "nothing is installed".
+        let header = render_examine_plain_header(&summary_with_legacy(
+            0,
+            "detected_unmanaged",
+            Some("7.14.0"),
+        ));
+        assert!(
+            header.contains("existing ROCm 7.14.0 found"),
+            "the detected install and its version must appear:\n{header}"
+        );
+        assert!(
+            header.contains("left unmanaged by design"),
+            "it must read as a deliberate choice, not an oversight:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_reports_a_detected_install_whose_version_is_unknown() {
+        // Degrades to naming the install without inventing a version.
+        let header =
+            render_examine_plain_header(&summary_with_legacy(0, "detected_unmanaged", None));
+        assert!(
+            header.contains("existing ROCm install found"),
+            "the install must still be reported:\n{header}"
+        );
+        assert!(
+            !header.contains("ROCm  found") && !header.contains("<unknown>"),
+            "an unknown version must not leak a placeholder into the summary:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_accounts_for_managed_and_existing_installs_together() {
+        let header = render_examine_plain_header(&summary_with_legacy(
+            2,
+            "detected_unmanaged",
+            Some("6.4.1"),
+        ));
+        assert!(
+            header.contains("2 ROCm installs saved"),
+            "the managed count must survive:\n{header}"
+        );
+        assert!(
+            header.contains("existing ROCm 6.4.1 found"),
+            "the unmanaged install must be reported alongside it:\n{header}"
+        );
+    }
+
+    #[test]
+    fn header_still_says_nothing_is_installed_when_nothing_is() {
+        // The wording only changes when there is something to report.
+        let header = render_examine_plain_header(&summary_with_legacy(0, "not_detected", None));
+        assert!(
+            header.contains("No ROCm installs saved yet"),
+            "an empty machine must keep the original wording:\n{header}"
+        );
+        assert!(
+            !header.contains("existing ROCm"),
+            "nothing should be claimed on an empty machine:\n{header}"
+        );
+    }
+
     /// Regression test for the engine child-stdin write under the process-wide
     /// `SIG_DFL` that `main` installs via [`reset_sigpipe`]. If an engine child
     /// exits before reading its stdin, the parent's write to that pipe must
@@ -17454,6 +17577,7 @@ mod tests {
                 status: "not_detected".to_owned(),
                 paths: Vec::new(),
                 detail: None,
+                version: None,
             },
             wsl: wsl.then_some(rocm_core::WslSummary {
                 is_wsl: true,

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -901,20 +901,10 @@ fn probe_rocm_install(e: &mut Examination) {
     }
     e.rocm_path = rocm_dir.clone();
 
-    if !rocm_dir.is_empty() {
-        for fname in ["version", "version-utils", "version-libs"] {
-            let f = Path::new(&rocm_dir).join(".info").join(fname);
-            if f.exists() {
-                e.rocm_version = read_text(&f.to_string_lossy()).trim().to_owned();
-                break;
-            }
-        }
-        if e.rocm_version.is_empty()
-            && let Ok(real) = std::fs::canonicalize(&rocm_dir)
-            && let Some(version) = extract_rocm_version(&real.to_string_lossy())
-        {
-            e.rocm_version = version;
-        }
+    if !rocm_dir.is_empty()
+        && let Some(version) = detect_rocm_version_at(Path::new(&rocm_dir))
+    {
+        e.rocm_version = version;
     }
 
     for marker in AMDGPU_INSTALL_MARKERS {
@@ -963,8 +953,40 @@ fn probe_rocm_install(e: &mut Examination) {
 }
 
 /// Pull `X.Y[.Z]` out of a `rocm-X.Y.Z` path component.
+/// The ROCm version of the install rooted at `dir`, if it can be established.
+///
+/// Tries the `.info` version files a packaged ROCm writes, then falls back to a
+/// version embedded in the resolved directory name (`/opt/rocm` is commonly a
+/// symlink to `/opt/rocm-7.14.0`).
+///
+/// Shared deliberately: the human `rocm examine` report and the `--json`
+/// `Examination` used to detect ROCm installs independently, and the human one
+/// only ever checked *existence* — so a machine with ROCm 7.14 was reported
+/// without a version while `--json` had it all along. One implementation means
+/// the two cannot disagree again.
+#[must_use]
+pub fn detect_rocm_version_at(dir: &Path) -> Option<String> {
+    for fname in ["version", "version-utils", "version-libs"] {
+        let file = dir.join(".info").join(fname);
+        if file.exists() {
+            let version = read_text(&file.to_string_lossy()).trim().to_owned();
+            if !version.is_empty() {
+                return Some(version);
+            }
+        }
+    }
+
+    std::fs::canonicalize(dir)
+        .ok()
+        .and_then(|real| extract_rocm_version(&real.to_string_lossy()))
+}
+
 fn extract_rocm_version(path: &str) -> Option<String> {
-    let idx = path.find("rocm-")?;
+    // Search from the right: the version belongs to the ROCm directory itself,
+    // which is the last `rocm-` in the path. Matching the first one lets an
+    // unrelated earlier component (`/home/rocm-user/opt/rocm-7.14.0`) swallow the
+    // match and report no version for an install that plainly declares one.
+    let idx = path.rfind("rocm-")?;
     let tail = &path[idx + "rocm-".len()..];
     let version: String = tail
         .chars()
@@ -1679,5 +1701,96 @@ mod tests {
             Some("6.4.1".to_owned())
         );
         assert_eq!(extract_rocm_version("/opt/rocm"), None);
+        // An unrelated earlier `rocm-` must not swallow the match.
+        assert_eq!(
+            extract_rocm_version("/home/rocm-user/opt/rocm-7.14.0"),
+            Some("7.14.0".to_owned())
+        );
+    }
+
+    /// A unique scratch directory for the version-probe tests.
+    fn version_probe_dir(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "rocm-core-version-probe-{}-{name}-{}",
+            std::process::id(),
+            crate::unix_time_millis()
+        ));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    fn write_info_version(root: &Path, fname: &str, contents: &str) {
+        let info = root.join(".info");
+        std::fs::create_dir_all(&info).expect("create .info");
+        std::fs::write(info.join(fname), contents).expect("write version file");
+    }
+
+    #[test]
+    fn rocm_version_read_from_the_info_marker() {
+        // The packaged-install case, and the one that was being ignored: the
+        // detector already stats this file to decide an install exists.
+        let root = version_probe_dir("info-version");
+        write_info_version(&root, "version", "7.14.0-abc123\n");
+
+        assert_eq!(
+            detect_rocm_version_at(&root),
+            Some("7.14.0-abc123".to_owned()),
+            "trailing newline must be trimmed"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rocm_version_falls_back_through_the_other_info_files() {
+        for fname in ["version-utils", "version-libs"] {
+            let root = version_probe_dir(fname);
+            write_info_version(&root, fname, "6.4.1");
+            assert_eq!(
+                detect_rocm_version_at(&root),
+                Some("6.4.1".to_owned()),
+                "{fname} should be consulted when `version` is absent"
+            );
+            let _ = std::fs::remove_dir_all(&root);
+        }
+    }
+
+    #[test]
+    fn rocm_version_falls_back_to_the_resolved_directory_name() {
+        // `/opt/rocm` is commonly a symlink to `/opt/rocm-<version>`, which is
+        // the only version source on installs that ship no `.info` files.
+        let base = version_probe_dir("symlink");
+        let real = base.join("rocm-7.14.0");
+        std::fs::create_dir_all(&real).expect("create versioned dir");
+
+        // Each branch binds `probe` exactly once: a `let` that only one platform
+        // consumes trips `unused_variables` on the other.
+        #[cfg(unix)]
+        let probe = {
+            let link = base.join("rocm");
+            std::os::unix::fs::symlink(&real, &link).expect("symlink");
+            link
+        };
+        // Creating a symlink on Windows needs a privilege CI does not grant, so
+        // probe the versioned directory directly. What is under test is parsing
+        // the version out of the resolved name, not the symlink itself.
+        #[cfg(not(unix))]
+        let probe = real;
+
+        assert_eq!(detect_rocm_version_at(&probe), Some("7.14.0".to_owned()));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn rocm_version_is_absent_when_nothing_declares_one() {
+        // Must degrade to `None` rather than guessing: a wrong version in a
+        // diagnostic report is worse than an admitted unknown.
+        let root = version_probe_dir("bare");
+        std::fs::create_dir_all(root.join("bin")).expect("create bin");
+        assert_eq!(detect_rocm_version_at(&root), None);
+
+        // An empty marker file is not a version either.
+        write_info_version(&root, "version", "   \n");
+        assert_eq!(detect_rocm_version_at(&root), None);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1447,6 +1447,16 @@ pub struct LegacyRocmSummary {
     pub status: String,
     pub paths: Vec<PathBuf>,
     pub detail: Option<String>,
+    /// Version of the first detected install, when it could be established.
+    ///
+    /// `None` on a machine with no pre-existing ROCm, and on installs whose
+    /// layout carries no version we can read — notably Windows, where the
+    /// version lives in a directory name below the path we detect.
+    ///
+    /// Optional and defaulted so the daemon's serialised snapshot
+    /// (`apps/rocmd/src/lib.rs`) written before this field existed still loads.
+    #[serde(default)]
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1643,7 +1653,7 @@ impl ExamineSummary {
         };
         let wsl = self.wsl.as_ref();
         format!(
-            "rocm examine\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
+            "rocm examine\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_version: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
             self.os,
             self.arch,
             self.kernel.as_deref().unwrap_or("<unknown>"),
@@ -1665,6 +1675,7 @@ impl ExamineSummary {
             self.driver.detail.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm.status,
             legacy_paths,
+            self.legacy_rocm.version.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm.detail.as_deref().unwrap_or("<unknown>"),
             self.legacy_rocm_guidance(),
             wsl.is_some_and(|summary| summary.is_wsl),
@@ -2051,11 +2062,19 @@ fn detect_legacy_rocm_summary() -> LegacyRocmSummary {
     } else {
         Some("legacy ROCm installs are reported for compatibility only; rocm-cli manages TheRock runtimes separately".to_owned())
     };
+    // Reuse the probe that already backs `examine --json` rather than reading
+    // the marker files again here. `legacy_rocm_candidate_exists` above already
+    // *stats* `.info/version` to decide an install is present; not reading it was
+    // why a machine with ROCm 7.14 was reported without a version.
+    let version = paths
+        .first()
+        .and_then(|path| crate::examine::detect_rocm_version_at(path));
 
     LegacyRocmSummary {
         status: status.to_owned(),
         paths,
         detail,
+        version,
     }
 }
 
@@ -8224,6 +8243,9 @@ Class Name:                Display
                 status: "detected_unmanaged".to_owned(),
                 paths: vec![PathBuf::from("C:\\Program Files\\AMD\\ROCm")],
                 detail: Some("legacy install".to_owned()),
+                // Windows keeps the version in a directory below the detected
+                // base path, so this stays unknown there for now.
+                version: None,
             },
             wsl: None,
             managed_runtime_count: 2,
@@ -8276,6 +8298,7 @@ Class Name:                Display
                 status: "detected_unmanaged".to_owned(),
                 paths: vec![PathBuf::from("/opt/rocm")],
                 detail: Some("legacy install".to_owned()),
+                version: Some("7.14.0".to_owned()),
             },
             wsl: None,
             managed_runtime_count: 0,

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -25,9 +25,16 @@ Feature: GPU detection and system inspection
     Then the inspection reports which GPU is installed
     And the inspection reports that the driver is available
 
-  @id:examine-distinguishes-unmanaged-rocm @requires-gpu
+  # No GPU needed: the install is planted by the harness (`plant_unmanaged_rocm`,
+  # written precisely so this does not depend on an ambient `/opt/rocm`), and
+  # every assertion here is about how a detected install is reported, not about
+  # hardware. Dropping `@requires-gpu` gains per-PR mock-lane coverage for the
+  # reporting this scenario exists to pin.
+  @id:examine-distinguishes-unmanaged-rocm
   Scenario: 4 - System inspection distinguishes CLI-managed from pre-existing ROCm
     Given a machine with a ROCm install that was not set up by the CLI
     When the user inspects the system
     Then the inspection reports the install as pre-existing
+    And the inspection names that install's version
+    And the inspection does not claim nothing is installed
     And the inspection suggests setting up a CLI-managed install

--- a/tests/e2e-cucumber/tests/e2e/examine_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/examine_steps.rs
@@ -136,6 +136,32 @@ async fn assert_rocm_unmanaged(world: &mut E2eWorld) {
     );
 }
 
+#[then("the inspection names that install's version")]
+async fn assert_reports_legacy_version(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    // `plant_unmanaged_rocm` writes `.info/version` containing this, which is the
+    // same marker file the detector already stats to decide an install exists —
+    // it just never read it, so a machine with ROCm reported no version at all.
+    assert!(
+        output.contains("legacy_rocm_version: 6.0.0"),
+        "the pre-existing install's version must be reported:\n{output}"
+    );
+}
+
+#[then("the inspection does not claim nothing is installed")]
+async fn assert_does_not_claim_empty(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    // The summary line counted only CLI-managed runtimes, so a machine with ROCm
+    // already installed was greeted with a bare "No ROCm installs saved yet".
+    let claims_empty = output
+        .lines()
+        .any(|line| line.trim() == "No ROCm installs saved yet");
+    assert!(
+        !claims_empty,
+        "an install was detected, so the summary must not say there is none:\n{output}"
+    );
+}
+
 #[then("the inspection suggests setting up a CLI-managed install")]
 async fn assert_suggests_managed_runtime(world: &mut E2eWorld) {
     let output = world.cli_output.as_ref().expect("no command was run");


### PR DESCRIPTION
## Summary

On a node with ROCm 7.14 installed, `rocm examine` named no version and opened with **"No ROCm installs saved yet"** — read, reasonably, as nothing being installed.

```
  No ROCm installs saved yet; existing ROCm 7.14.0 found, left unmanaged by design
  ...
  legacy_rocm_version: 7.14.0
```

## Root cause: the CLI already knew

Two detectors exist, and the human report used the weaker one:

| | `Examination` (`examine.rs`) | `ExamineSummary` (`lib.rs`) |
|---|---|---|
| Surfaced in | `rocm examine --json` | `rocm examine` human text |
| Reports version | **yes** — reads `.info/version` and the resolved directory name | **no** — existence only |

The human-side detector already **stats `.info/version`** to decide an install is present; it just never read it. Rather than add a third reader, the version-reading half of the working probe is now a shared function both paths call, so they cannot drift apart again.

Separately, the summary line counted only CLI-managed runtimes, so a pre-existing install could not influence it whatever was found on disk. It now accounts for both.

## A related weakness the extraction surfaced

The directory-name fallback matched the **first** `rocm-` in the path, so an unrelated earlier component — `/home/rocm-user/opt/rocm-7.14.0` — swallowed the match and produced no version for an install that plainly declares one. It now matches from the right. Found because my own scratch directory tripped it.

## Verification

All four combinations checked by hand against planted installs, including the real-world `/opt/rocm -> /opt/rocm-7.14.0` symlink:

| Machine | Summary line |
|---|---|
| nothing installed | `No ROCm installs saved yet` (unchanged) |
| existing, version readable | `...; existing ROCm 7.14.0 found, left unmanaged by design` |
| existing, no version anywhere | `...; existing ROCm install found, left unmanaged by design` |
| managed + existing | `2 ROCm installs saved; existing ROCm 6.4.1 found...` |

Unit tests for the probe (each `.info` file, the directory-name fallback, and `None` rather than a guess when nothing declares a version) and for all four header cases. `cargo test -p rocm-core -p rocm` — 408 pass; workspace and e2e-harness clippy with `-D warnings`; `cargo fmt --check`.

**The E2E scenario lost its `@requires-gpu` tag.** Nothing it asserts needs hardware — the install is planted by the harness (`plant_unmanaged_rocm`, written precisely so it does not depend on an ambient `/opt/rocm`), and every assertion is about how a detected install is *reported*. It now runs on the per-PR mock lane, and I confirmed it genuinely catches this: with version detection disabled, the scenario fails.

## Risk

Low, with one thing worth a reviewer's eye: the new `version` field on `LegacyRocmSummary` is optional and `#[serde(default)]` because `ExamineSummary` is serialised into the daemon's snapshot (`apps/rocmd/src/lib.rs`), so payloads written before this field existed must still load.

Touching `examine.rs` warrants care as it carries the `diagnose.py` wire contract, but this is a pure extraction — no field added, removed or renamed, and `probe_rocm_install` keeps its behaviour.

## Known gap

**Windows still reports no version.** There the version lives in a directory *below* the base path we detect (`C:\Program Files\AMD\ROCm\<version>`). Rather than ship Windows logic I cannot test, the field renders as absent and this is called out as follow-up. The reported machine is Linux.