### PR TITLE
fix(dash): retain generation throughput across transient scrapes

### DIFF
--- a/crates/rocm-dash-core/src/lib.rs
+++ b/crates/rocm-dash-core/src/lib.rs
@@ -23,7 +23,9 @@ pub mod vram;
 
 pub use bench_rollup::{PassNRollup, rollup_pass_n, row_verdict};
 pub use bench_schema::BenchmarkRow;
-pub use metrics::{GpuMetrics, Instance, Snapshot, SystemMetrics};
+pub use metrics::{
+    GpuMetrics, Instance, ObservationFreshness, ObservationMetadata, Snapshot, SystemMetrics,
+};
 pub use partition::{ComputePartitionMode, MemoryPartitionMode};
 pub use protocol::{Command, Event};
 pub use state::{SideEffect, State, StateEvent};

--- a/crates/rocm-dash-core/src/lib.rs
+++ b/crates/rocm-dash-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bench_schema;
 pub mod config;
 pub mod efficiency;
 pub mod metrics;
+pub mod observation;
 pub mod partition;
 pub mod persist;
 pub mod protocol;
@@ -26,6 +27,7 @@ pub use bench_schema::BenchmarkRow;
 pub use metrics::{
     GpuMetrics, Instance, ObservationFreshness, ObservationMetadata, Snapshot, SystemMetrics,
 };
+pub use observation::{GenerationObservationTracker, observation_validity, rate_window};
 pub use partition::{ComputePartitionMode, MemoryPartitionMode};
 pub use protocol::{Command, Event};
 pub use state::{SideEffect, State, StateEvent};

--- a/crates/rocm-dash-core/src/metrics.rs
+++ b/crates/rocm-dash-core/src/metrics.rs
@@ -146,6 +146,36 @@ impl InstanceStatus {
     }
 }
 
+/// Whether a sampled metric value originated in the current scrape window or
+/// was carried forward from a prior one.
+///
+/// A `gen_tps` paired with `Held` means the counter did not advance during the
+/// last window; the value is shown for continuity. A `gen_tps` with no metadata
+/// (i.e. `gen_tps_observation == None`) means the freshness is unknown —
+/// typically a legacy snapshot recorded before this field was introduced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationFreshness {
+    /// Value measured during the most recent scrape window.
+    Fresh,
+    /// Value carried forward from a prior scrape; the source counter did not
+    /// advance in the last window.
+    Held,
+}
+
+/// Provenance metadata for a sampled observation.
+///
+/// Attached to an `Option<ObservationMetadata>` field alongside the numeric
+/// value. Absent metadata (`None`) means freshness is unknown — never fabricated
+/// as `Fresh` for legacy payloads.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ObservationMetadata {
+    /// UTC instant at which this value was recorded.
+    pub observed_at: DateTime<Utc>,
+    /// Whether the value is from the current scrape or held from a prior one.
+    pub freshness: ObservationFreshness,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Instance {
     pub container_id: String,
@@ -166,6 +196,11 @@ pub struct Instance {
     /// `generation_tokens_total` counter rate. `None` until two scrapes seen.
     #[serde(default)]
     pub gen_tps: Option<f64>,
+    /// Freshness provenance for [`Instance::gen_tps`]. `None` when unknown
+    /// (legacy snapshots) — absence is never interpreted as `Fresh`.
+    /// Omitted from JSON when `None` to preserve wire back-compat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gen_tps_observation: Option<ObservationMetadata>,
     /// Efficiency: `gen_tps` ÷ summed power (W) of the GPUs this instance
     /// occupies. `None` when throughput or GPU power telemetry is unavailable.
     #[serde(default)]
@@ -303,5 +338,132 @@ mod tests {
             assert_eq!(StartupPhase::from_token(&token), Some(phase));
         }
         assert_eq!(StartupPhase::from_token("nonsense"), None);
+    }
+
+    // ── Observation metadata tests (EAI-7960) ────────────────────────────────
+
+    fn fixed_ts() -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339("2024-01-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    }
+
+    #[test]
+    fn instance_legacy_gen_tps_deserializes_without_observation() {
+        // Legacy JSON with gen_tps but no observation metadata must deserialize
+        // with gen_tps_observation == None (unknown freshness, numeric value preserved).
+        let legacy = r#"{
+            "container_id": "c1", "container_name": "vllm-a", "status": "running",
+            "model_name": "deepseek-r1", "gpu_ids": ["0"], "partition_info": null,
+            "quantization": null, "tensor_parallel_size": 1, "port": 8000,
+            "vram_used_mb": 0, "vram_total_mb": 0, "gen_tps": 42.5,
+            "launch_args": [], "env_vars": {}, "log_file": null
+        }"#;
+        let inst: Instance = serde_json::from_str(legacy).expect("legacy instance must parse");
+        assert_eq!(inst.gen_tps, Some(42.5), "numeric value must be preserved");
+        assert!(
+            inst.gen_tps_observation.is_none(),
+            "legacy JSON must not fabricate a freshness claim"
+        );
+    }
+
+    #[test]
+    fn observation_freshness_fresh_round_trips() {
+        let ts = fixed_ts();
+        let meta = ObservationMetadata {
+            observed_at: ts,
+            freshness: ObservationFreshness::Fresh,
+        };
+        let json = serde_json::to_string(&meta).expect("serialize");
+        let back: ObservationMetadata = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.observed_at, ts, "UTC timestamp must be preserved");
+        assert_eq!(back.freshness, ObservationFreshness::Fresh);
+    }
+
+    #[test]
+    fn observation_freshness_held_round_trips() {
+        let ts = fixed_ts();
+        let meta = ObservationMetadata {
+            observed_at: ts,
+            freshness: ObservationFreshness::Held,
+        };
+        let json = serde_json::to_string(&meta).expect("serialize");
+        let back: ObservationMetadata = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.observed_at, ts, "UTC timestamp must be preserved");
+        assert_eq!(back.freshness, ObservationFreshness::Held);
+    }
+
+    #[test]
+    fn freshness_serializes_as_snake_case_strings() {
+        let fresh_json = serde_json::to_string(&ObservationFreshness::Fresh).expect("serialize");
+        let held_json = serde_json::to_string(&ObservationFreshness::Held).expect("serialize");
+        assert_eq!(fresh_json, "\"fresh\"");
+        assert_eq!(held_json, "\"held\"");
+    }
+
+    #[test]
+    fn instance_gen_tps_observation_none_omitted_in_serialization() {
+        // skip_serializing_if = "Option::is_none" must suppress the field entirely.
+        let inst = Instance {
+            gen_tps: Some(10.0),
+            gen_tps_observation: None,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&inst).expect("serialize");
+        assert!(
+            !json.contains("gen_tps_observation"),
+            "None observation must be omitted, not encoded as null; got: {json}"
+        );
+    }
+
+    #[test]
+    fn instance_gen_tps_observation_some_round_trips() {
+        let ts = fixed_ts();
+        let inst = Instance {
+            gen_tps: Some(10.0),
+            gen_tps_observation: Some(ObservationMetadata {
+                observed_at: ts,
+                freshness: ObservationFreshness::Fresh,
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&inst).expect("serialize");
+        assert!(
+            json.contains("gen_tps_observation"),
+            "metadata must be present when Some"
+        );
+        assert!(json.contains("\"fresh\""), "freshness must be present");
+        let back: Instance = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.gen_tps, Some(10.0));
+        let obs = back.gen_tps_observation.expect("must deserialize metadata");
+        assert_eq!(obs.observed_at, ts);
+        assert_eq!(obs.freshness, ObservationFreshness::Fresh);
+    }
+
+    #[test]
+    fn instance_held_observation_round_trips() {
+        // gen_tps is the sole numeric carrier; Held metadata accompanies the same
+        // value without duplicating it into a separate held field.
+        let ts = fixed_ts();
+        let inst = Instance {
+            gen_tps: Some(5.0),
+            gen_tps_observation: Some(ObservationMetadata {
+                observed_at: ts,
+                freshness: ObservationFreshness::Held,
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&inst).expect("serialize");
+        let back: Instance = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            back.gen_tps,
+            Some(5.0),
+            "numeric value preserved through held round-trip"
+        );
+        let obs = back
+            .gen_tps_observation
+            .expect("held metadata must survive round-trip");
+        assert_eq!(obs.observed_at, ts);
+        assert_eq!(obs.freshness, ObservationFreshness::Held);
     }
 }

--- a/crates/rocm-dash-core/src/observation.rs
+++ b/crates/rocm-dash-core/src/observation.rs
@@ -1,0 +1,945 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Pure observation-policy helpers for generation-throughput sampling.
+//!
+//! All timing is caller-injected; no wall-clock access inside this module.
+//! See the EAI-7960 contract for timing constants and freshness semantics.
+
+// ── Imports (used by the impl below) ────────────────────────────────────────
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::metrics::{ObservationFreshness, ObservationMetadata};
+
+// ── Timing constants (from the frozen contract) ──────────────────────────────
+
+const MIN_RATE_WINDOW: Duration = Duration::from_secs(10);
+const MAX_RATE_WINDOW: Duration = Duration::from_secs(30);
+const MIN_VALIDITY: Duration = Duration::from_secs(6);
+const MAX_VALIDITY: Duration = Duration::from_secs(30);
+
+/// Minimum number of counter samples retained in the rolling window.
+const MIN_CAPACITY: usize = 3;
+
+/// Maximum number of counter samples retained in the rolling window.
+///
+/// For supported real cadences (instance_tick ≥ 1 s) the derived capacity is
+/// at most `ceil(30 / 1) + 2 = 32`, well inside this ceiling — `MAX_CAPACITY`
+/// is non-binding for all production deployments.
+///
+/// It only binds for sub-161 ms ticks. At such rates the buffer holds 64
+/// samples spanning less than `rate_window`, which shortens the effective
+/// averaging span but retains a valid bounded rate and preserves the
+/// memory-safety guarantee.
+const MAX_CAPACITY: usize = 64;
+
+// ── Public helpers ───────────────────────────────────────────────────────────
+
+/// Rate-computation window: `clamp(5 × instance_tick, 10 s, 30 s)`.
+///
+/// Zero or extremely large ticks are handled without panic or overflow via
+/// [`Duration::saturating_mul`].
+pub fn rate_window(instance_tick: Duration) -> Duration {
+    instance_tick
+        .saturating_mul(5)
+        .clamp(MIN_RATE_WINDOW, MAX_RATE_WINDOW)
+}
+
+/// Validity window for a held observation: `clamp(3 × instance_tick, 6 s, 30 s)`.
+///
+/// Zero or extremely large ticks are handled without panic or overflow via
+/// [`Duration::saturating_mul`].
+pub fn observation_validity(instance_tick: Duration) -> Duration {
+    instance_tick
+        .saturating_mul(3)
+        .clamp(MIN_VALIDITY, MAX_VALIDITY)
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Convert a [`std::time::Duration`] to a [`chrono::Duration`], saturating
+/// on overflow (only possible for durations > ~292 years).
+fn to_chrono(d: Duration) -> chrono::Duration {
+    // `unwrap_or_else` — lazy so the fallback is never evaluated on the happy
+    // path. i64::MAX * 1e9 overflows; use i64::MAX / 1e9 ≈ 292 years instead.
+    chrono::Duration::from_std(d)
+        .unwrap_or_else(|_| chrono::Duration::seconds(i64::MAX / 1_000_000_000))
+}
+
+/// Derive counter-sample buffer capacity from the rate window and cadence.
+///
+/// Capacity is `ceil(rate_window / instance_tick) + 2`, clamped to
+/// `[MIN_CAPACITY, MAX_CAPACITY]`. A zero or sub-millisecond tick uses
+/// `MAX_CAPACITY` as a safe fallback.
+fn derive_capacity(rw: Duration, instance_tick: Duration) -> usize {
+    if instance_tick.is_zero() {
+        return MAX_CAPACITY;
+    }
+    let ratio = rw.as_secs_f64() / instance_tick.as_secs_f64();
+    if !ratio.is_finite() {
+        return MAX_CAPACITY;
+    }
+    (ratio.ceil() as usize + 2).clamp(MIN_CAPACITY, MAX_CAPACITY)
+}
+
+// ── GenerationObservationTracker ─────────────────────────────────────────────
+
+/// Tracks `gen_tps` (generation tokens/s) observations for a single engine
+/// instance with allocation-conscious, time-bounded rolling counter samples.
+///
+/// # Invariants
+///
+/// * All time is injected by the caller; no wall-clock access inside this type.
+/// * Samples in the VecDeque are strictly monotonically increasing in timestamp.
+/// * Counter resets (new total < last total) immediately clear the window and
+///   value so recovery is clean.
+/// * Expiry during [`Self::snapshot`] clears the window so subsequent observe
+///   calls re-baseline rather than reusing stale anchors.
+/// * [`Self::observe_counter`] and [`Self::observe_direct`] never erase each
+///   other's windows; both update the same `current_value` / `last_observed_at`
+///   slot on success.
+///
+/// # Caller responsibilities
+///
+/// * Call [`Self::invalidate`] on identity change, container removal, or any
+///   transition to a confirmed non-serving terminal state.
+/// * Supply monotonically increasing timestamps to `observe_counter`; out-of-
+///   order or duplicate timestamps are silently ignored.
+/// * Pass `now` to [`Self::snapshot`] at or after the latest `observed_at`;
+///   a `now` earlier than `observed_at` yields a negative signed duration that
+///   never exceeds the positive validity window, causing a stale hold rather
+///   than correct expiry.
+pub struct GenerationObservationTracker {
+    /// Derived from constructor cadence; exposed via accessor.
+    rate_window: Duration,
+    /// Derived from constructor cadence; exposed via accessor.
+    validity: Duration,
+    /// Maximum number of cumulative-counter samples retained.
+    capacity: usize,
+    /// Rolling window of `(timestamp, cumulative_count)` samples.
+    ///
+    /// Invariant: strictly increasing timestamps; len ≤ capacity; all
+    /// timestamps are within `rate_window` of the newest entry.
+    samples: VecDeque<(DateTime<Utc>, f64)>,
+    /// Most recently computed or directly observed rate (tokens/s), or `None`
+    /// when no valid observation has been made (or after expiry/invalidation).
+    current_value: Option<f64>,
+    /// Timestamp of the observation that produced `current_value`. `None` iff
+    /// `current_value` is `None`. Set only on successful rate computation or
+    /// valid direct-rate injection; never set on missing/transient data.
+    last_observed_at: Option<DateTime<Utc>>,
+}
+
+impl GenerationObservationTracker {
+    /// Construct a tracker for the given polling cadence.
+    ///
+    /// Derives `rate_window` and `validity` from `instance_tick` according to
+    /// the frozen EAI-7960 contract and sizes the internal buffer accordingly.
+    pub fn new(instance_tick: Duration) -> Self {
+        let rw = rate_window(instance_tick);
+        let validity = observation_validity(instance_tick);
+        let capacity = derive_capacity(rw, instance_tick);
+        Self {
+            rate_window: rw,
+            validity,
+            capacity,
+            samples: VecDeque::with_capacity(capacity.min(16)),
+            current_value: None,
+            last_observed_at: None,
+        }
+    }
+
+    /// The rolling rate-computation window.
+    pub const fn rate_window(&self) -> Duration {
+        self.rate_window
+    }
+
+    /// The observation validity window (how long a value stays Held).
+    pub const fn validity(&self) -> Duration {
+        self.validity
+    }
+
+    /// Record a new cumulative counter sample (`total` tokens generated so far).
+    ///
+    /// **Non-finite or negative values** are treated as missing and ignored;
+    /// neither the counter window nor the current observation is modified.
+    ///
+    /// **Counter reset** (new total < most-recent total): the counter window
+    /// and current observation are cleared, the new sample becomes the sole
+    /// baseline, and no rate is emitted until a second sample arrives.
+    ///
+    /// **Out-of-order or duplicate timestamps** are silently discarded.
+    ///
+    /// **Unchanged counter** over a window with ≥ 2 samples produces
+    /// `Some(0.0)` — zero is a real value, not "unavailable".
+    pub fn observe_counter(&mut self, total: f64, observed_at: DateTime<Utc>) {
+        // Non-finite or negative total is missing, not zero.
+        if !total.is_finite() || total < 0.0 {
+            return;
+        }
+
+        if let Some(&(back_ts, back_count)) = self.samples.back() {
+            // Out-of-order or duplicate timestamp.
+            if observed_at <= back_ts {
+                return;
+            }
+            // Counter reset: lower total than most-recent sample.
+            if total < back_count {
+                self.samples.clear();
+                self.current_value = None;
+                self.last_observed_at = None;
+                // New baseline; no rate until second sample.
+                self.samples.push_back((observed_at, total));
+                return;
+            }
+        }
+
+        // Add sample (enforce capacity before pushing to avoid over-allocation).
+        if self.samples.len() >= self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples.push_back((observed_at, total));
+
+        // Discard samples outside the rate window (older than newest − rate_window).
+        let window_chrono = to_chrono(self.rate_window);
+        while self.samples.len() > 1 {
+            let front_ts = self.samples.front().unwrap().0;
+            if observed_at.signed_duration_since(front_ts) > window_chrono {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Compute rate when ≥ 2 samples exist in the window.
+        if self.samples.len() >= 2 {
+            let &(oldest_ts, oldest_count) = self.samples.front().unwrap();
+            let newest_count = total; // self.samples.back() is (observed_at, total)
+            let dt_ms = observed_at
+                .signed_duration_since(oldest_ts)
+                .num_milliseconds();
+            if dt_ms > 0 {
+                let dt_s = dt_ms as f64 / 1000.0;
+                let rate = (newest_count - oldest_count) / dt_s;
+                // rate is always ≥ 0 here because:
+                //   - newest_count ≥ oldest_count (reset guard above)
+                //   - dt_s > 0
+                if rate.is_finite() && rate >= 0.0 {
+                    self.current_value = Some(rate);
+                    self.last_observed_at = Some(observed_at);
+                }
+            }
+            // dt_ms == 0: identical timestamps should not reach here (guard
+            // above returns on observed_at <= back_ts), but be safe.
+        }
+        // Single sample: baseline established; no rate yet.
+    }
+
+    /// Record an engine-reported direct rate (tokens/s).
+    ///
+    /// Valid means: finite and non-negative. Invalid or missing values
+    /// (`f64::NAN`, `f64::INFINITY`, negative) are silently ignored;
+    /// the existing observation and counter window are preserved.
+    ///
+    /// Does not touch the counter-sample window.
+    pub fn observe_direct(&mut self, rate: f64, observed_at: DateTime<Utc>) {
+        if !rate.is_finite() || rate < 0.0 {
+            return;
+        }
+        self.current_value = Some(rate);
+        self.last_observed_at = Some(observed_at);
+    }
+
+    /// Return the current rate and observation metadata for the given `now`.
+    ///
+    /// | Condition | Returns |
+    /// |---|---|
+    /// | No valid observation | `(None, None)` |
+    /// | Expired (`now − last_observed_at > validity`) | `(None, None)` + clears window |
+    /// | Observed at this snapshot timestamp | `(Some(rate), Some(Fresh))` |
+    /// | Valid but from a prior scrape | `(Some(rate), Some(Held))` |
+    ///
+    /// **Expiry clears the counter window** so subsequent `observe_counter`
+    /// calls re-baseline rather than computing a rate from stale anchors.
+    ///
+    /// **Freshness** is `Fresh` when `observed_at == now` (value was computed
+    /// in this scrape cycle) and `Held` when `observed_at < now`.
+    pub fn snapshot(&mut self, now: DateTime<Utc>) -> (Option<f64>, Option<ObservationMetadata>) {
+        let (Some(value), Some(observed_at)) = (self.current_value, self.last_observed_at) else {
+            return (None, None);
+        };
+
+        // Expiry check.
+        let validity_chrono = to_chrono(self.validity);
+        if now.signed_duration_since(observed_at) > validity_chrono {
+            // Clear everything so the next observe_counter call re-baselines.
+            self.samples.clear();
+            self.current_value = None;
+            self.last_observed_at = None;
+            return (None, None);
+        }
+
+        // Fresh iff the value was produced at this exact snapshot timestamp;
+        // any earlier observed_at means the datum came from a prior scrape.
+        let freshness = if observed_at == now {
+            ObservationFreshness::Fresh
+        } else {
+            ObservationFreshness::Held
+        };
+
+        (
+            Some(value),
+            Some(ObservationMetadata {
+                observed_at,
+                freshness,
+            }),
+        )
+    }
+
+    /// Immediately clear all state (value, counter window, freshness tracking).
+    ///
+    /// Call on identity change, container removal, or any confirmed
+    /// non-serving terminal state. The next `observe_counter` call after
+    /// `invalidate` re-establishes the baseline from scratch.
+    pub fn invalidate(&mut self) {
+        self.samples.clear();
+        self.current_value = None;
+        self.last_observed_at = None;
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// A fixed UTC epoch for deterministic test timestamps.
+    fn t(secs_offset: i64) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0)
+            .unwrap()
+            .checked_add_signed(chrono::Duration::seconds(secs_offset))
+            .unwrap()
+    }
+
+    // ── cadence-clamp tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn cadence_rate_window_clamps_to_minimum() {
+        // tick = 1 s  →  5×1 = 5 s < 10 s  →  rate_window = 10 s
+        let rw = rate_window(Duration::from_secs(1));
+        assert_eq!(
+            rw,
+            Duration::from_secs(10),
+            "below minimum must clamp to 10 s"
+        );
+    }
+
+    #[test]
+    fn cadence_observation_validity_clamps_to_minimum() {
+        // tick = 1 s  →  3×1 = 3 s < 6 s  →  validity = 6 s
+        let v = observation_validity(Duration::from_secs(1));
+        assert_eq!(v, Duration::from_secs(6), "below minimum must clamp to 6 s");
+    }
+
+    #[test]
+    fn cadence_rate_window_clamps_to_maximum() {
+        // tick = 20 s  →  5×20 = 100 s > 30 s  →  rate_window = 30 s
+        let rw = rate_window(Duration::from_secs(20));
+        assert_eq!(
+            rw,
+            Duration::from_secs(30),
+            "above maximum must clamp to 30 s"
+        );
+    }
+
+    #[test]
+    fn cadence_observation_validity_clamps_to_maximum() {
+        // tick = 20 s  →  3×20 = 60 s > 30 s  →  validity = 30 s
+        let v = observation_validity(Duration::from_secs(20));
+        assert_eq!(
+            v,
+            Duration::from_secs(30),
+            "above maximum must clamp to 30 s"
+        );
+    }
+
+    #[test]
+    fn cadence_rate_window_mid_range() {
+        // tick = 4 s  →  5×4 = 20 s  →  rate_window = 20 s
+        let rw = rate_window(Duration::from_secs(4));
+        assert_eq!(rw, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn cadence_observation_validity_mid_range() {
+        // tick = 4 s  →  3×4 = 12 s  →  validity = 12 s
+        let v = observation_validity(Duration::from_secs(4));
+        assert_eq!(v, Duration::from_secs(12));
+    }
+
+    #[test]
+    fn cadence_exact_minimum_boundary() {
+        // tick = 2 s  →  5×2 = 10 s  →  rate_window exactly at minimum = 10 s
+        let rw = rate_window(Duration::from_secs(2));
+        assert_eq!(
+            rw,
+            Duration::from_secs(10),
+            "exact min boundary must not be clamped"
+        );
+
+        // tick = 2 s  →  3×2 = 6 s  →  validity exactly at minimum = 6 s
+        let v = observation_validity(Duration::from_secs(2));
+        assert_eq!(
+            v,
+            Duration::from_secs(6),
+            "exact min boundary must not be clamped"
+        );
+    }
+
+    #[test]
+    fn cadence_exact_maximum_boundary() {
+        // tick = 6 s  →  5×6 = 30 s  →  rate_window exactly at maximum = 30 s
+        let rw = rate_window(Duration::from_secs(6));
+        assert_eq!(
+            rw,
+            Duration::from_secs(30),
+            "exact max boundary must not be clamped"
+        );
+
+        // tick = 10 s  →  3×10 = 30 s  →  validity exactly at maximum = 30 s
+        let v = observation_validity(Duration::from_secs(10));
+        assert_eq!(
+            v,
+            Duration::from_secs(30),
+            "exact max boundary must not be clamped"
+        );
+    }
+
+    #[test]
+    fn cadence_zero_tick_no_panic() {
+        // Zero tick must clamp to the respective minimums, not panic.
+        let rw = rate_window(Duration::ZERO);
+        assert_eq!(rw, MIN_RATE_WINDOW, "zero tick rate_window must be minimum");
+        let v = observation_validity(Duration::ZERO);
+        assert_eq!(v, MIN_VALIDITY, "zero tick validity must be minimum");
+    }
+
+    #[test]
+    fn cadence_extreme_tick_no_overflow() {
+        // u64::MAX seconds would overflow a plain `*5`; saturating_mul must handle it.
+        let huge = Duration::from_secs(u64::MAX);
+        let rw = rate_window(huge);
+        assert_eq!(rw, MAX_RATE_WINDOW, "saturated tick must clamp to 30 s");
+        let v = observation_validity(huge);
+        assert_eq!(v, MAX_VALIDITY, "saturated tick must clamp to 30 s");
+    }
+
+    // ── tracker construction ─────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_new_exposes_derived_windows() {
+        let tick = Duration::from_secs(4);
+        let tracker = GenerationObservationTracker::new(tick);
+        assert_eq!(tracker.rate_window(), Duration::from_secs(20));
+        assert_eq!(tracker.validity(), Duration::from_secs(12));
+    }
+
+    // ── single-sample baseline ───────────────────────────────────────────────
+
+    #[test]
+    fn tracker_first_sample_no_rate() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(100.0, t(0));
+        // First sample establishes baseline; no rate yet.
+        let (val, meta) = tracker.snapshot(t(0));
+        assert!(val.is_none(), "first sample must not produce a rate");
+        assert!(meta.is_none(), "no metadata without a rate");
+    }
+
+    // ── rolling counter rate ─────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_two_samples_positive_rate() {
+        // 200 tokens in 10 s = 20 tok/s.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(200.0, t(10));
+        let (val, meta) = tracker.snapshot(t(10));
+        let rate = val.expect("two samples must produce a rate");
+        assert!(
+            (rate - 20.0).abs() < 1e-9,
+            "rate must be 20 tok/s, got {rate}"
+        );
+        let obs = meta.expect("metadata must be present");
+        assert_eq!(obs.freshness, ObservationFreshness::Fresh);
+    }
+
+    #[test]
+    fn tracker_unchanged_counter_yields_zero_rate() {
+        // Same count across two samples = 0 tok/s, not "unavailable".
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(500.0, t(0));
+        tracker.observe_counter(500.0, t(10));
+        let (val, meta) = tracker.snapshot(t(10));
+        assert_eq!(val, Some(0.0), "unchanged counter must yield 0.0, not None");
+        assert!(meta.is_some());
+    }
+
+    #[test]
+    fn tracker_zero_counter_value_is_valid() {
+        // A counter that starts and stays at 0 is real, not missing.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(0.0, t(5));
+        let (val, _) = tracker.snapshot(t(5));
+        assert_eq!(val, Some(0.0), "zero counter must yield 0.0, not None");
+    }
+
+    // ── counter reset ────────────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_counter_reset_clears_and_rebaselines() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        // Establish a valid rate first.
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        let (val, _) = tracker.snapshot(t(5));
+        assert!(val.is_some(), "pre-reset rate must exist");
+
+        // Simulate counter reset (engine restarted: count drops).
+        tracker.observe_counter(10.0, t(6)); // 10 < 100 → reset
+        let (val2, _) = tracker.snapshot(t(6));
+        assert!(
+            val2.is_none(),
+            "immediately after reset, rate must be unavailable (re-baselining)"
+        );
+
+        // Second sample after reset → rate resumes.
+        tracker.observe_counter(30.0, t(8)); // 20 tokens in 2 s = 10 tok/s
+        let (val3, meta3) = tracker.snapshot(t(8));
+        let rate = val3.expect("rate must resume after reset + second sample");
+        assert!(
+            (rate - 10.0).abs() < 1e-9,
+            "rate after reset must be 10 tok/s, got {rate}"
+        );
+        assert_eq!(meta3.unwrap().freshness, ObservationFreshness::Fresh);
+    }
+
+    // ── non-finite / invalid counter values ──────────────────────────────────
+
+    #[test]
+    fn tracker_nonfinite_counter_nan_ignored() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        let (before, _) = tracker.snapshot(t(5));
+        assert!(before.is_some());
+
+        // NaN is not finite → ignored; observation not refreshed.
+        tracker.observe_counter(f64::NAN, t(6));
+        let (after, meta) = tracker.snapshot(t(6));
+        // Value should still be held from t(5).
+        assert!(after.is_some(), "NaN observe must not erase existing value");
+        assert_eq!(meta.unwrap().freshness, ObservationFreshness::Held);
+    }
+
+    #[test]
+    fn tracker_nonfinite_counter_inf_ignored() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(50.0, t(5));
+        tracker.observe_counter(f64::INFINITY, t(6)); // ignored
+        let (val, _) = tracker.snapshot(t(6));
+        // Rate from (0,t0)→(50,t5) = 10 tok/s; inf must not alter it.
+        assert!(val.is_some());
+    }
+
+    #[test]
+    fn tracker_negative_counter_ignored() {
+        // Negative totals are physically impossible for a counter; treat as missing.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        tracker.observe_counter(-1.0, t(6)); // ignored
+        let (val, _) = tracker.snapshot(t(6));
+        assert!(
+            val.is_some(),
+            "negative counter must be ignored, not treated as reset"
+        );
+    }
+
+    // ── out-of-order / duplicate timestamps ─────────────────────────────────
+
+    #[test]
+    fn tracker_out_of_order_timestamp_ignored() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(10));
+        tracker.observe_counter(100.0, t(20));
+        // An older timestamp must be silently dropped.
+        tracker.observe_counter(200.0, t(15)); // t(15) < t(20) → ignored
+        let (val, _) = tracker.snapshot(t(20));
+        // Rate should still be from (0,t10)→(100,t20) = 10 tok/s.
+        let rate = val.expect("rate must exist");
+        assert!(
+            (rate - 10.0).abs() < 1e-9,
+            "out-of-order sample must not corrupt rate, got {rate}"
+        );
+    }
+
+    #[test]
+    fn tracker_duplicate_timestamp_ignored() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(10));
+        tracker.observe_counter(150.0, t(10)); // same ts → ignored
+        let (val, _) = tracker.snapshot(t(10));
+        let rate = val.expect("rate must exist");
+        // Rate should still be (0→100)/10 = 10, not (0→150)/10 = 15.
+        assert!(
+            (rate - 10.0).abs() < 1e-9,
+            "duplicate timestamp must not update rate, got {rate}"
+        );
+    }
+
+    // ── direct-rate injection ────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_observe_direct_sets_value_immediately() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(42.5, t(0));
+        let (val, meta) = tracker.snapshot(t(0));
+        assert_eq!(val, Some(42.5));
+        assert_eq!(meta.unwrap().freshness, ObservationFreshness::Fresh);
+    }
+
+    #[test]
+    fn tracker_direct_zero_rate_is_valid() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(0.0, t(0));
+        let (val, _) = tracker.snapshot(t(0));
+        assert_eq!(val, Some(0.0), "zero direct rate must be valid");
+    }
+
+    #[test]
+    fn tracker_direct_nan_does_not_refresh() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(10.0, t(0));
+        tracker.observe_direct(f64::NAN, t(5)); // ignored
+        let (val, meta) = tracker.snapshot(t(5));
+        assert_eq!(val, Some(10.0), "NaN direct must be ignored");
+        assert_eq!(meta.unwrap().freshness, ObservationFreshness::Held);
+    }
+
+    #[test]
+    fn tracker_direct_infinity_does_not_refresh() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(5.0, t(0));
+        tracker.observe_direct(f64::INFINITY, t(5));
+        let (val, _) = tracker.snapshot(t(5));
+        assert_eq!(val, Some(5.0));
+    }
+
+    #[test]
+    fn tracker_direct_negative_does_not_refresh() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(7.0, t(0));
+        tracker.observe_direct(-1.0, t(5));
+        let (val, _) = tracker.snapshot(t(5));
+        assert_eq!(val, Some(7.0), "negative direct rate must be ignored");
+    }
+
+    // ── transient hold: missing data preserves valid observation ─────────────
+
+    #[test]
+    fn tracker_transient_missing_preserves_held_observation() {
+        // After a valid rate, a missing counter cycle must hold the value.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        let (_, m1) = tracker.snapshot(t(5));
+        assert_eq!(m1.unwrap().freshness, ObservationFreshness::Fresh);
+
+        // Missing data cycle: NaN counter, no direct rate.
+        tracker.observe_counter(f64::NAN, t(7)); // ignored
+
+        // Snapshot before validity expires: value must still be Held.
+        let (val2, m2) = tracker.snapshot(t(7));
+        assert!(
+            val2.is_some(),
+            "transient missing must not erase held observation"
+        );
+        assert_eq!(
+            m2.unwrap().freshness,
+            ObservationFreshness::Held,
+            "must be Held, not Fresh, when no new observation"
+        );
+    }
+
+    #[test]
+    fn tracker_counter_window_preserved_through_missing_data() {
+        // Counter window must survive a missing-data cycle for recovery.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+
+        // Simulate missing cycle.
+        tracker.observe_counter(f64::NAN, t(7));
+
+        // New valid counter: rate should use the existing window for computation.
+        tracker.observe_counter(110.0, t(8)); // 10 tokens from t(0) to t(8) = 110/8 ≠ 10/3
+        let (val, _) = tracker.snapshot(t(8));
+        // Window has (t0,0), (t5,100), (t8,110) → oldest is t0, newest is t8
+        // rate = (110-0)/8 = 13.75 tok/s
+        let rate = val.expect("rate must recover after missing cycle");
+        assert!(
+            rate > 0.0,
+            "rate after missing cycle must be positive, got {rate}"
+        );
+    }
+
+    // ── fresh vs held ────────────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_snapshot_fresh_on_new_observation_held_on_repeat() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+
+        // First snapshot: Fresh (observed since last snapshot = never).
+        let (_, m1) = tracker.snapshot(t(5));
+        assert_eq!(m1.unwrap().freshness, ObservationFreshness::Fresh);
+
+        // Second snapshot without new observe: Held.
+        let (_, m2) = tracker.snapshot(t(6));
+        assert_eq!(
+            m2.unwrap().freshness,
+            ObservationFreshness::Held,
+            "repeated snapshot without new observe must be Held"
+        );
+
+        // New observation: Fresh again.
+        tracker.observe_counter(150.0, t(7));
+        let (_, m3) = tracker.snapshot(t(7));
+        assert_eq!(
+            m3.unwrap().freshness,
+            ObservationFreshness::Fresh,
+            "observation after Held snapshot must be Fresh again"
+        );
+    }
+
+    // ── expiry ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_snapshot_expiry_returns_none_and_clears() {
+        // validity = clamp(3×2, 6, 30) = 6 s.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        let (before, _) = tracker.snapshot(t(5));
+        assert!(before.is_some(), "pre-expiry snapshot must have a value");
+
+        // Advance past validity (6 s from t(5) = t(11)).
+        let (expired, meta) = tracker.snapshot(t(12));
+        assert!(expired.is_none(), "post-expiry snapshot must return None");
+        assert!(meta.is_none(), "no metadata after expiry");
+    }
+
+    #[test]
+    fn tracker_expiry_at_exact_boundary() {
+        // Snapshot exactly at observed_at + validity must return None (strict >).
+        let validity = observation_validity(Duration::from_secs(2)); // 6 s
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        tracker.snapshot(t(5)); // mark as seen
+
+        // At exactly t(5) + 6 s = t(11): still within validity (not strictly >).
+        let boundary_secs =
+            5 + i64::try_from(validity.as_secs()).expect("validity ≤ 30 s; fits i64");
+        let (at_boundary, _) = tracker.snapshot(t(boundary_secs));
+        // The boundary behavior depends on whether > or >= is used; document actual:
+        // Our contract uses strict `>` so at-boundary is still Held.
+        assert!(
+            at_boundary.is_some(),
+            "at exact validity boundary must still be Held (strictly >, not >=)"
+        );
+    }
+
+    #[test]
+    fn tracker_expiry_clears_counter_window_for_recovery() {
+        // After expiry, counter window must be cleared so the next observe_counter
+        // starts a fresh baseline rather than computing a rate from stale anchors.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(1000.0, t(5));
+        tracker.snapshot(t(5));
+
+        // Expire.
+        tracker.snapshot(t(12));
+
+        // First new sample after expiry → baseline only.
+        tracker.observe_counter(50.0, t(13));
+        let (after_first, _) = tracker.snapshot(t(13));
+        assert!(
+            after_first.is_none(),
+            "first sample after expiry must be baseline, not a rate"
+        );
+
+        // Second sample → rate computed fresh (from baseline at t13).
+        tracker.observe_counter(70.0, t(15)); // 20 tok in 2 s = 10 tok/s
+        let (after_second, _) = tracker.snapshot(t(15));
+        let rate = after_second.expect("second sample after re-baseline must yield rate");
+        assert!(
+            (rate - 10.0).abs() < 1e-9,
+            "re-baselined rate must be 10 tok/s, got {rate}"
+        );
+    }
+
+    // ── explicit invalidation ────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_invalidate_clears_all_state() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        tracker.snapshot(t(5));
+
+        tracker.invalidate();
+
+        let (val, meta) = tracker.snapshot(t(6));
+        assert!(val.is_none(), "invalidate must clear value");
+        assert!(meta.is_none(), "invalidate must clear metadata");
+    }
+
+    #[test]
+    fn tracker_invalidate_forces_rebaseline_on_next_observe() {
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5));
+        tracker.invalidate();
+
+        // First sample after invalidate: baseline only, no rate.
+        tracker.observe_counter(200.0, t(10));
+        let (val, _) = tracker.snapshot(t(10));
+        assert!(
+            val.is_none(),
+            "first observe after invalidate must be baseline"
+        );
+
+        // Second sample: rate resumes.
+        tracker.observe_counter(250.0, t(15)); // 50 tok in 5 s = 10 tok/s
+        let (val2, _) = tracker.snapshot(t(15));
+        let rate = val2.expect("must have rate after re-baseline");
+        assert!(
+            (rate - 10.0).abs() < 1e-9,
+            "rate must be 10 tok/s, got {rate}"
+        );
+    }
+
+    // ── storage bound ────────────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_storage_cannot_grow_without_bound() {
+        // Feed 1000 samples at 1 s intervals; the VecDeque must stay ≤ capacity.
+        let tick = Duration::from_secs(2);
+        let mut tracker = GenerationObservationTracker::new(tick);
+        let cap = tracker.capacity;
+
+        for i in 0..1000_i64 {
+            tracker.observe_counter(i as f64 * 10.0, t(i));
+        }
+        assert!(
+            tracker.samples.len() <= cap,
+            "sample buffer must not exceed capacity ({cap}), got {}",
+            tracker.samples.len()
+        );
+    }
+
+    #[test]
+    fn tracker_capacity_is_bounded_by_constants() {
+        // All cadences must produce a capacity in [MIN_CAPACITY, MAX_CAPACITY].
+        for tick_secs in [0u64, 1, 2, 5, 10, 20, 100, u64::MAX / 2] {
+            let tick = Duration::from_secs(tick_secs);
+            let rw = rate_window(tick);
+            let cap = derive_capacity(rw, tick);
+            assert!(
+                cap >= MIN_CAPACITY,
+                "capacity {cap} below MIN_CAPACITY for tick={tick_secs} s"
+            );
+            assert!(
+                cap <= MAX_CAPACITY,
+                "capacity {cap} above MAX_CAPACITY for tick={tick_secs} s"
+            );
+        }
+    }
+
+    // ── direct rate parity ───────────────────────────────────────────────────
+
+    #[test]
+    fn tracker_direct_and_counter_rates_use_same_slot() {
+        // observe_direct and observe_counter both update the same value/metadata.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_direct(99.0, t(0));
+        let (v1, _) = tracker.snapshot(t(0));
+        assert_eq!(v1, Some(99.0));
+
+        // Counter replaces the direct rate on next successful compute.
+        tracker.observe_counter(0.0, t(1));
+        tracker.observe_counter(50.0, t(6)); // 50/5 = 10 tok/s
+        let (v2, _) = tracker.snapshot(t(6));
+        assert!(
+            (v2.unwrap() - 10.0).abs() < 1e-9,
+            "counter rate must supersede prior direct rate"
+        );
+    }
+
+    // ── counter→direct→counter interleaving (M3) ─────────────────────────────
+
+    #[test]
+    fn tracker_direct_does_not_clear_counter_window() {
+        // observe_direct must not touch the counter VecDeque; a subsequent
+        // observe_counter call must still compute its rate from the retained
+        // window anchors as if the direct injection never happened.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        // Establish counter window: (t0, 0) and (t5, 100).
+        tracker.observe_counter(0.0, t(0));
+        tracker.observe_counter(100.0, t(5)); // rate = 20 tok/s
+        // Direct injection overrides current_value but must not clear samples.
+        tracker.observe_direct(50.0, t(6));
+        // Resume counter. If the window was cleared this would be a lone
+        // baseline (no rate). Retained: window is (t0,0),(t5,100),(t8,130).
+        tracker.observe_counter(130.0, t(8));
+        let (val, _) = tracker.snapshot(t(8));
+        let rate = val.expect("counter must resume from retained window after direct injection");
+        // rate = (130 - 0) / (8 - 0) = 16.25 tok/s.
+        assert!(
+            (rate - 16.25).abs() < 1e-9,
+            "rate must be (130-0)/(8-0) = 16.25 tok/s, got {rate}"
+        );
+    }
+
+    // ── supported-cadence capacity bound (M4) ────────────────────────────────
+
+    #[test]
+    fn tracker_capacity_within_max_for_supported_cadences() {
+        // For all real deployment cadences (instance_tick >= 1 s) the derived
+        // capacity is at most ceil(30/1)+2 = 32, well below MAX_CAPACITY = 64.
+        for tick_secs in [1u64, 2, 4, 5, 6, 10, 20] {
+            let tick = Duration::from_secs(tick_secs);
+            let cap = derive_capacity(rate_window(tick), tick);
+            assert!(
+                cap < MAX_CAPACITY,
+                "tick={tick_secs}s cap={cap} must be below MAX_CAPACITY={MAX_CAPACITY}"
+            );
+        }
+        // 1 s tick: rate_window = 10 s → ceil(10/1)+2 = 12.
+        let cap_1s = derive_capacity(rate_window(Duration::from_secs(1)), Duration::from_secs(1));
+        assert_eq!(cap_1s, 12, "1 s tick must yield capacity exactly 12");
+    }
+}

--- a/crates/rocm-dash-core/src/traits.rs
+++ b/crates/rocm-dash-core/src/traits.rs
@@ -155,6 +155,9 @@ pub fn merge_instance(
         // fills `gen_tps` from the `gen_tokens_total` delta. `tokens_per_watt`
         // is derived at snapshot assembly.
         gen_tps: sample.gen_tps,
+        // Freshness provenance: unknown at merge time; set by the runner when
+        // a counter-rate delta is computed.
+        gen_tps_observation: None,
         tokens_per_watt: None,
         // Derived at the runner by windowing the sample's cumulative histogram
         // readings (mirrors gen_tps); left None at merge time.

--- a/crates/rocm-dash-daemon/src/demo.rs
+++ b/crates/rocm-dash-daemon/src/demo.rs
@@ -625,6 +625,7 @@ fn build_instances(t_s: f64, seed: &mut u64) -> Vec<Instance> {
                 running_reqs: Some(running),
                 waiting_reqs: Some(waiting),
                 gen_tps: Some(gen_tps),
+                gen_tps_observation: None,
                 tokens_per_watt: None,
                 ttft_ms,
                 tpot_ms,

--- a/crates/rocm-dash-daemon/src/registry.rs
+++ b/crates/rocm-dash-daemon/src/registry.rs
@@ -34,9 +34,8 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
-use crate::runner::instance_from_discovered;
 use rocm_dash_collectors::engine_registry::EngineKind;
-use rocm_dash_core::metrics::{Instance, InstanceStatus, StartupPhase};
+use rocm_dash_core::metrics::{InstanceStatus, StartupPhase};
 use rocm_dash_core::traits::DiscoveredService;
 use serde::Deserialize;
 
@@ -187,7 +186,7 @@ pub fn engine_kind_for(record: &ServiceRecord) -> Option<EngineKind> {
 /// not mis-parsed). Pure — the runner applies it (upsert/broadcast/Gone-diff).
 #[derive(Debug, Default)]
 pub struct ManagedDiscovery {
-    pub instances: Vec<Instance>,
+    pub svcs: Vec<DiscoveredService>,
     pub seen: HashSet<String>,
     pub non_vllm: HashSet<String>,
 }
@@ -211,7 +210,7 @@ pub fn discover_managed_services(records: &[ServiceRecord]) -> ManagedDiscovery 
         if engine_kind_for(record) != Some(EngineKind::Vllm) {
             out.non_vllm.insert(svc.container_id.clone());
         }
-        out.instances.push(instance_from_discovered(&svc));
+        out.svcs.push(svc);
     }
     out
 }
@@ -219,9 +218,10 @@ pub fn discover_managed_services(records: &[ServiceRecord]) -> ManagedDiscovery 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runner::gen_tps_from_delta;
     use chrono::{DateTime, TimeZone, Utc};
+    use rocm_dash_core::observation::GenerationObservationTracker;
     use std::path::PathBuf;
+    use std::time::Duration;
 
     fn at(secs: i64) -> DateTime<Utc> {
         Utc.timestamp_opt(secs, 0).unwrap()
@@ -566,7 +566,7 @@ mod tests {
 
         let disc = discover_managed_services(&records);
         // Two live, scrapeable instances (dead + zero-port dropped).
-        assert_eq!(disc.instances.len(), 2);
+        assert_eq!(disc.svcs.len(), 2);
         assert!(disc.seen.contains("svc-vllm"));
         assert!(disc.seen.contains("svc-lemon"));
         assert!(!disc.seen.contains("svc-dead"));
@@ -576,9 +576,9 @@ mod tests {
         assert!(!disc.non_vllm.contains("svc-vllm"));
         // Instances carry the registry port + Running status.
         let vllm = disc
-            .instances
+            .svcs
             .iter()
-            .find(|i| i.container_id == "svc-vllm")
+            .find(|s| s.container_id == "svc-vllm")
             .unwrap();
         assert_eq!(vllm.port, Some(8000));
         assert_eq!(
@@ -591,7 +591,7 @@ mod tests {
     /// GPU required): a `rocm serve`-style managed record on disk → loaded →
     /// converted to a scrape target on the **registry port** → the engine-kind
     /// parser turns two successive vLLM Prometheus bodies into a cumulative
-    /// counter → the runner's delta yields a live `gen_tps`. This is the
+    /// counter → the tracker yields a live `gen_tps`. This is the
     /// test-level proof for Phase-2 acceptance criterion 3 (no ROCm GPU here).
     #[test]
     fn serve_record_to_live_gen_tps_end_to_end() {
@@ -621,8 +621,11 @@ mod tests {
         let c0 = s0.gen_tokens_total.expect("counter at t0");
         let c1 = s1.gen_tokens_total.expect("counter at t1");
 
-        // 4. Runner delta → live gen_tps: 400 tokens over 2 s = 200 tok/s.
-        let gen_tps = gen_tps_from_delta(Some((c0, at(10))), c1, at(12));
+        // 4. Tracker-based delta → live gen_tps: 400 tokens over 2 s = 200 tok/s.
+        let mut tracker = GenerationObservationTracker::new(Duration::from_secs(2));
+        tracker.observe_counter(c0, at(10));
+        tracker.observe_counter(c1, at(12));
+        let (gen_tps, _meta) = tracker.snapshot(at(12));
         assert_eq!(gen_tps, Some(200.0));
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -23,6 +23,7 @@ use rocm_dash_collectors::lemonade::LemonadeCollector;
 use rocm_dash_collectors::parallel::parallel_scrape;
 use rocm_dash_collectors::vllm_prom::VllmPrometheusCollector;
 use rocm_dash_core::metrics::{GpuMetrics, GpuSystemInfo, Instance, InstanceStatus, Snapshot};
+use rocm_dash_core::observation::GenerationObservationTracker;
 use rocm_dash_core::protocol::Event;
 use rocm_dash_core::state::{State, StateEvent};
 use rocm_dash_core::traits::{BenchTailer, DiscoveredService, InstanceSample, merge_instance};
@@ -186,8 +187,10 @@ pub async fn run_loop(
     // the vLLM Prometheus scrape so they aren't mis-parsed).
     let mut known_services: HashSet<String> = HashSet::new();
     let mut managed_non_vllm: HashSet<String> = HashSet::new();
-    // Previous `generation_tokens_total` reading per instance, for rate calc.
-    let mut prev_gen_tokens: HashMap<String, (f64, DateTime<Utc>)> = HashMap::new();
+    // Per-instance generation-throughput tracker. Keyed by container_id.
+    // Constructed lazily from opts.instance_tick; survives scrape failures so
+    // the last-observed rate is held for the validity window before clearing.
+    let mut gen_trackers: HashMap<String, GenerationObservationTracker> = HashMap::new();
     // Previous TTFT / TPOT histogram readings (sum_s, count, at) per instance,
     // for the windowed avg-ms derivation (mirrors `prev_gen_tokens`).
     let mut prev_ttft: HashMap<String, (f64, f64, DateTime<Utc>)> = HashMap::new();
@@ -221,6 +224,10 @@ pub async fn run_loop(
     loop {
         ticker.tick().await;
         tick_count += 1;
+        // Single wall-clock anchor for this loop iteration. All counter/direct
+        // observations and the assembled Snapshot timestamp share this instant so
+        // every instance refreshed in this cycle serialises Fresh deterministically.
+        let cycle_at = Utc::now();
 
         let mut warnings = Vec::new();
         let gpus = if let Some(g) = &gpu {
@@ -254,7 +261,21 @@ pub async fn run_loop(
                     let seen: HashSet<String> =
                         svcs.iter().map(|s| s.container_id.clone()).collect();
                     for svc in &svcs {
-                        let inst = instance_from_discovered(svc);
+                        let existing = runner.state.instances.get(&svc.container_id).cloned();
+                        // Endpoint change: same id, new port → new logical service.
+                        if existing.as_ref().map_or(false, |ex| ex.port != svc.port) {
+                            if let Some(t) = gen_trackers.get_mut(&svc.container_id) {
+                                t.invalidate();
+                            }
+                        }
+                        let inst = merge_discovery_refresh(
+                            svc,
+                            if existing.as_ref().map_or(false, |ex| ex.port != svc.port) {
+                                None
+                            } else {
+                                existing.as_ref()
+                            },
+                        );
                         runner
                             .state
                             .apply(StateEvent::InstanceUpserted(inst.clone()));
@@ -274,7 +295,7 @@ pub async fn run_loop(
                     }
                     for gone in known_instances.difference(&seen) {
                         info!(id = %gone, "instance gone");
-                        prev_gen_tokens.remove(gone);
+                        gen_trackers.remove(gone);
                         prev_ttft.remove(gone);
                         prev_tpot.remove(gone);
                         runner
@@ -302,11 +323,23 @@ pub async fn run_loop(
         {
             match l.discover().await {
                 Some(svc) => {
-                    let inst = instance_from_discovered(&svc);
+                    let is_new_id = lemonade_id.as_deref() != Some(svc.container_id.as_str());
+                    if is_new_id {
+                        // New identity: remove old tracker so stale telemetry
+                        // is not carried into the new instance.
+                        if let Some(old_id) = lemonade_id.as_deref() {
+                            gen_trackers.remove(old_id);
+                        }
+                    }
+                    let existing = runner.state.instances.get(&svc.container_id).cloned();
+                    let inst = merge_discovery_refresh(
+                        &svc,
+                        if is_new_id { None } else { existing.as_ref() },
+                    );
                     runner
                         .state
                         .apply(StateEvent::InstanceUpserted(inst.clone()));
-                    if lemonade_id.as_deref() != Some(svc.container_id.as_str()) {
+                    if is_new_id {
                         info!(
                             id = %svc.container_id,
                             model = %svc.model_name,
@@ -323,7 +356,7 @@ pub async fn run_loop(
                 None => {
                     if let Some(id) = lemonade_id.take() {
                         info!(id = %id, "lemonade instance gone");
-                        prev_gen_tokens.remove(&id);
+                        gen_trackers.remove(&id);
                         prev_ttft.remove(&id);
                         prev_tpot.remove(&id);
                         runner.state.apply(StateEvent::InstanceRemoved(id.clone()));
@@ -348,9 +381,25 @@ pub async fn run_loop(
             let records = crate::registry::load_service_records(services_dir);
             let disc = crate::registry::discover_managed_services(&records);
             managed_non_vllm = disc.non_vllm;
-            for inst in disc.instances {
-                let is_new = !known_services.contains(&inst.container_id);
-                let id = inst.container_id.clone();
+            for svc in disc.svcs {
+                let id = svc.container_id.clone();
+                let is_new = !known_services.contains(&id);
+                let existing = runner.state.instances.get(&id).cloned();
+                // Endpoint change → new logical service; invalidate tracker immediately.
+                let same_endpoint = existing.as_ref().map_or(true, |ex| ex.port == svc.port);
+                if !same_endpoint {
+                    if let Some(t) = gen_trackers.get_mut(&id) {
+                        t.invalidate();
+                    }
+                }
+                let inst = merge_discovery_refresh(
+                    &svc,
+                    if same_endpoint {
+                        existing.as_ref()
+                    } else {
+                        None
+                    },
+                );
                 runner
                     .state
                     .apply(StateEvent::InstanceUpserted(inst.clone()));
@@ -361,7 +410,7 @@ pub async fn run_loop(
             }
             for gone in known_services.difference(&disc.seen) {
                 info!(id = %gone, "managed service gone");
-                prev_gen_tokens.remove(gone);
+                gen_trackers.remove(gone);
                 prev_ttft.remove(gone);
                 prev_tpot.remove(gone);
                 runner
@@ -412,13 +461,20 @@ pub async fn run_loop(
             for ((id, _port), fetch) in results {
                 match fetch {
                     Ok(sample) => {
-                        // Difference the cumulative token counter into a live
-                        // rate; first reading (or a restart) yields None.
-                        let now = Utc::now();
-                        let gen_tps = sample.gen_tokens_total.and_then(|cur| {
-                            let prev = prev_gen_tokens.insert(id.clone(), (cur, now));
-                            gen_tps_from_delta(prev, cur, now)
-                        });
+                        // EAI-7960: drive the per-instance tracker with the
+                        // cumulative counter when present; omitted counter leaves
+                        // the tracker (and its held value) untouched.
+                        if let Some(cur) = sample.gen_tokens_total {
+                            gen_trackers
+                                .entry(id.clone())
+                                .or_insert_with(|| {
+                                    GenerationObservationTracker::new(opts.instance_tick)
+                                })
+                                .observe_counter(cur, cycle_at);
+                        }
+                        // gen_tps is written to the instance in the snapshot
+                        // assembly below (tracker.snapshot per cycle_at).
+                        //
                         // Windowed avg latency (ms) from the cumulative TTFT/TPOT
                         // histograms; cumulative-average fallback on first scrape.
                         let ttft_ms = avg_ms_from_histogram(
@@ -426,20 +482,19 @@ pub async fn run_loop(
                             &id,
                             sample.ttft_sum_s,
                             sample.ttft_count,
-                            now,
+                            cycle_at,
                         );
                         let tpot_ms = avg_ms_from_histogram(
                             &mut prev_tpot,
                             &id,
                             sample.tpot_sum_s,
                             sample.tpot_count,
-                            now,
+                            cycle_at,
                         );
                         if let Some(mut inst) = runner.state.instances.get(&id).cloned() {
                             inst.kv_cache_usage_pct = sample.kv_cache_usage_pct;
                             inst.running_reqs = sample.running_reqs;
                             inst.waiting_reqs = sample.waiting_reqs;
-                            inst.gen_tps = gen_tps;
                             inst.ttft_ms = ttft_ms;
                             inst.tpot_ms = tpot_ms;
                             // Docker-discovered instances have no
@@ -459,18 +514,19 @@ pub async fn run_loop(
                         let msg = format!("{e}");
                         trace!(id = %id, error = %msg, "vllm scrape failed");
                         last_err = Some(msg);
-                        // Don't let a dead instance show a frozen rate/latency:
-                        // clear throughput + latency and drop the baselines so
-                        // recovery re-bases.
-                        prev_gen_tokens.remove(&id);
+                        // EAI-7960: do NOT clear or remove gen_trackers on failure.
+                        // The tracker holds the last-observed rate for the validity
+                        // window (clamp(3×instance_tick, 6s, 30s)) and only clears
+                        // it after expiry — satisfying the "held" contract.
+                        //
+                        // Clear TTFT/TPOT baselines so recovery re-baselines from
+                        // the next successful scrape (latency clearing semantics
+                        // are unchanged; freshness generalization is out of scope).
                         prev_ttft.remove(&id);
                         prev_tpot.remove(&id);
                         if let Some(mut inst) = runner.state.instances.get(&id).cloned()
-                            && (inst.gen_tps.is_some()
-                                || inst.ttft_ms.is_some()
-                                || inst.tpot_ms.is_some())
+                            && (inst.ttft_ms.is_some() || inst.tpot_ms.is_some())
                         {
-                            inst.gen_tps = None;
                             inst.ttft_ms = None;
                             inst.tpot_ms = None;
                             runner.state.apply(StateEvent::InstanceUpserted(inst));
@@ -494,14 +550,27 @@ pub async fn run_loop(
         {
             match l.fetch_stats().await {
                 Ok(sample) => {
+                    // EAI-7960: drive the tracker with a direct rate reading when
+                    // the sample carries one. A missing direct rate (None) does not
+                    // erase or refresh the tracker; the held value stays valid until
+                    // the validity window expires.
+                    if let Some(rate) = sample.gen_tps {
+                        gen_trackers
+                            .entry(id.clone())
+                            .or_insert_with(|| {
+                                GenerationObservationTracker::new(opts.instance_tick)
+                            })
+                            .observe_direct(rate, cycle_at);
+                    }
                     if let Some(mut inst) = runner.state.instances.get(&id).cloned() {
-                        inst.gen_tps = sample.gen_tps;
+                        // gen_tps is written in the snapshot assembly below;
+                        // set the KV/request fields immediately so they are
+                        // present in state for subsequent snapshots.
                         inst.kv_cache_usage_pct = sample.kv_cache_usage_pct;
                         inst.running_reqs = sample.running_reqs;
                         inst.waiting_reqs = sample.waiting_reqs;
-                        // See the vLLM scrape-success handler above: a
-                        // successful stats fetch is proof the Lemonade
-                        // instance is serving, so promote it out of Starting.
+                        // See the vLLM scrape-success handler: a successful stats
+                        // fetch proves the instance is serving; promote out of Starting.
                         if matches!(inst.status, InstanceStatus::Starting { .. }) {
                             inst.status = InstanceStatus::Ready;
                         }
@@ -511,6 +580,9 @@ pub async fn run_loop(
                 Err(e) => {
                     trace!(id = %id, error = %e, "lemonade scrape failed");
                     warnings.push(format!("lemonade scrape: {e}"));
+                    // EAI-7960: retain tracker during validity window on failure.
+                    // gen_tps is assembled from the tracker snapshot below;
+                    // no explicit clearing needed here.
                 }
             }
         }
@@ -541,7 +613,19 @@ pub async fn run_loop(
         }
 
         let mut instances: Vec<Instance> = runner.state.instances.values().cloned().collect();
-        // Derive per-instance efficiency now that this tick's GPU power is known.
+        // EAI-7960: apply per-instance tracker snapshots (gen_tps + observation
+        // metadata) before computing tokens_per_watt so the efficiency field
+        // always derives from the current cycle's valid/held/expired rate.
+        for inst in &mut instances {
+            let (gen_tps, meta) = gen_trackers
+                .get_mut(&inst.container_id)
+                .map(|t| t.snapshot(cycle_at))
+                .unwrap_or((None, None));
+            inst.gen_tps = gen_tps;
+            inst.gen_tps_observation = meta;
+        }
+        // Derive per-instance efficiency now that this tick's GPU power is known
+        // and gen_tps reflects the tracker state for this cycle.
         // Count instances that have throughput + live GPUs but whose gpu_ids
         // don't line up with any amd-smi device_id — the silent-None failure
         // mode on real hardware, surfaced via the header ⚠ badge.
@@ -585,7 +669,7 @@ pub async fn run_loop(
             }
         }
         let snap = Snapshot {
-            timestamp: Utc::now(),
+            timestamp: cycle_at,
             host: host.tick(),
             gpus,
             gpu_system_info: gpu_system_info.clone(),
@@ -632,6 +716,38 @@ pub async fn run_loop(
 /// scraping fills the KV/req sample fields in a later collector tick.
 pub(crate) fn instance_from_discovered(svc: &DiscoveredService) -> Instance {
     merge_instance(svc, &InstanceSample::default(), 0, 0)
+}
+
+/// Merge a rediscovered service's identity/metadata into a fresh Instance,
+/// preserving live collector-owned fields from the existing state when the
+/// identity is unchanged.
+///
+/// **Discovery metadata wins** (model name, GPU ids, port, status, launch args).
+/// **Collector-owned fields survive** (KV/running/waiting, gen_tps, observation
+/// metadata, tokens_per_watt, TTFT/TPOT). Passing `existing = None` — on a new
+/// identity or after an endpoint change — starts the instance with all-None live
+/// fields (correct baseline).
+///
+/// This is the sole point for merging discovery and collector state; call it
+/// from every discovery source (Docker, managed registry, Lemonade) to keep
+/// per-service telemetry visible across rediscovery without stale telemetry
+/// leaking across identity boundaries.
+pub(crate) fn merge_discovery_refresh(
+    svc: &DiscoveredService,
+    existing: Option<&Instance>,
+) -> Instance {
+    let mut inst = instance_from_discovered(svc);
+    if let Some(ex) = existing {
+        inst.kv_cache_usage_pct = ex.kv_cache_usage_pct;
+        inst.running_reqs = ex.running_reqs;
+        inst.waiting_reqs = ex.waiting_reqs;
+        inst.gen_tps = ex.gen_tps;
+        inst.gen_tps_observation = ex.gen_tps_observation.clone();
+        inst.tokens_per_watt = ex.tokens_per_watt;
+        inst.ttft_ms = ex.ttft_ms;
+        inst.tpot_ms = ex.tpot_ms;
+    }
+    inst
 }
 
 /// Set `vram_used_mb`/`vram_total_mb` on each instance from the per-process
@@ -685,33 +801,13 @@ fn ticks_per(period: Duration, tick: Duration) -> u64 {
 /// wall-clock jump (NTP, VM resume), so we re-baseline instead.
 const MAX_RATE_INTERVAL_S: f64 = 60.0;
 
-/// Instantaneous generation tok/s from two cumulative counter readings.
-///
-/// Returns `None` on the first reading (`prev` is `None`), a non-positive or
-/// stale interval (backwards/forward clock jump, scrape outage), or a counter
-/// reset (`cur < prev`, e.g. the vLLM process restarted) — so the rate is
-/// never negative, stale, or otherwise bogus.
-pub(crate) fn gen_tps_from_delta(
-    prev: Option<(f64, DateTime<Utc>)>,
-    cur: f64,
-    now: DateTime<Utc>,
-) -> Option<f64> {
-    let (prev_val, prev_at) = prev?;
-    let dt = (now - prev_at).num_milliseconds() as f64 / 1000.0;
-    if dt <= 0.0 || dt > MAX_RATE_INTERVAL_S || cur < prev_val {
-        return None;
-    }
-    Some((cur - prev_val) / dt)
-}
-
 /// Average latency (ms) from a cumulative histogram's `_sum` (seconds) and
 /// `_count` series, windowed over successive scrapes: `(Δsum / Δcount) × 1000`.
 /// Updates the per-instance baseline in `prev`. On the FIRST reading (or after a
 /// counter reset / stale interval / no new requests) it falls back to the
 /// cumulative average `sum/count × 1000`, so a single scrape already yields a
 /// value. Returns `None` when the histogram is absent (`sum`/`count` `None`) or
-/// `count == 0` — Observe then shows `—` (never a fabricated number). Mirrors
-/// [`gen_tps_from_delta`] (the proven counter-windowing template).
+/// `count == 0` — Observe then shows `—` (never a fabricated number).
 fn avg_ms_from_histogram(
     prev: &mut HashMap<String, (f64, f64, DateTime<Utc>)>,
     id: &str,
@@ -747,11 +843,6 @@ mod tests {
     }
 
     #[test]
-    fn gen_tps_none_on_first_reading() {
-        assert_eq!(gen_tps_from_delta(None, 100.0, at(10)), None);
-    }
-
-    #[test]
     fn avg_ms_first_scrape_uses_cumulative_then_windows() {
         let mut prev = HashMap::new();
         // First scrape: cumulative average = 2.0s / 4 × 1000 = 500 ms.
@@ -781,41 +872,6 @@ mod tests {
             avg_ms_from_histogram(&mut p2, "d", Some(0.2), Some(2.0), at(12)),
             Some(100.0),
             "reset falls back to cumulative 0.2/2×1000"
-        );
-    }
-
-    #[test]
-    fn gen_tps_computes_rate() {
-        // 200 tokens accumulated over 2 s → 100 tok/s.
-        assert_eq!(
-            gen_tps_from_delta(Some((100.0, at(10))), 300.0, at(12)),
-            Some(100.0)
-        );
-    }
-
-    #[test]
-    fn gen_tps_none_on_stale_interval() {
-        // Gap beyond MAX_RATE_INTERVAL_S → re-baseline rather than a bogus avg.
-        assert_eq!(
-            gen_tps_from_delta(Some((100.0, at(10))), 9000.0, at(10 + 120)),
-            None
-        );
-    }
-
-    #[test]
-    fn gen_tps_none_on_counter_reset() {
-        // Process restarted: cur < prev → no negative rate.
-        assert_eq!(
-            gen_tps_from_delta(Some((500.0, at(10))), 20.0, at(12)),
-            None
-        );
-    }
-
-    #[test]
-    fn gen_tps_none_on_nonpositive_interval() {
-        assert_eq!(
-            gen_tps_from_delta(Some((100.0, at(12))), 300.0, at(12)),
-            None
         );
     }
 

--- a/crates/rocm-dash-daemon/src/runner.rs
+++ b/crates/rocm-dash-daemon/src/runner.rs
@@ -262,18 +262,24 @@ pub async fn run_loop(
                         svcs.iter().map(|s| s.container_id.clone()).collect();
                     for svc in &svcs {
                         let existing = runner.state.instances.get(&svc.container_id).cloned();
-                        // Endpoint change: same id, new port → new logical service.
-                        if existing.as_ref().map_or(false, |ex| ex.port != svc.port) {
-                            if let Some(t) = gen_trackers.get_mut(&svc.container_id) {
-                                t.invalidate();
-                            }
+                        // Endpoint change: same container-id, new port → new logical service.
+                        // Invalidate the rate baseline and latency windows so the new
+                        // scrape address starts fresh.
+                        let same_endpoint = existing.as_ref().is_none_or(|ex| ex.port == svc.port);
+                        if !same_endpoint {
+                            invalidate_on_endpoint_change(
+                                &svc.container_id,
+                                &mut gen_trackers,
+                                &mut prev_ttft,
+                                &mut prev_tpot,
+                            );
                         }
                         let inst = merge_discovery_refresh(
                             svc,
-                            if existing.as_ref().map_or(false, |ex| ex.port != svc.port) {
-                                None
-                            } else {
+                            if same_endpoint {
                                 existing.as_ref()
+                            } else {
+                                None
                             },
                         );
                         runner
@@ -286,18 +292,23 @@ pub async fn run_loop(
                                 model = %svc.model_name,
                                 "instance discovered"
                             );
+                            // InstanceDiscovered is a discovery-metadata event; broadcast
+                            // a clean instance (no prior collector-owned telemetry).
                             broadcast_and_persist(
                                 &tx,
                                 persist.as_ref(),
-                                Event::InstanceDiscovered(inst),
+                                Event::InstanceDiscovered(instance_from_discovered(svc)),
                             );
                         }
                     }
                     for gone in known_instances.difference(&seen) {
                         info!(id = %gone, "instance gone");
-                        gen_trackers.remove(gone);
-                        prev_ttft.remove(gone);
-                        prev_tpot.remove(gone);
+                        purge_telemetry_state(
+                            gone,
+                            &mut gen_trackers,
+                            &mut prev_ttft,
+                            &mut prev_tpot,
+                        );
                         runner
                             .state
                             .apply(StateEvent::InstanceRemoved(gone.clone()));
@@ -318,6 +329,10 @@ pub async fn run_loop(
         // Lemonade discovery — probe the endpoint on the discovery cadence; add a
         // Lemonade Instance when reachable, emit Gone when it disappears, and stay
         // a clean no-op (no warning/panic) when no endpoint is configured.
+        //
+        // The Lemonade `container_id` encodes the host and port
+        // (`<host>:<port>`), so a port or host change produces a new id string
+        // and is treated as a full identity change (old gone, new discovered).
         if let Some(l) = lemonade.as_ref()
             && (tick_count == 1 || tick_count.is_multiple_of(discovery_ticks))
         {
@@ -325,10 +340,15 @@ pub async fn run_loop(
                 Some(svc) => {
                     let is_new_id = lemonade_id.as_deref() != Some(svc.container_id.as_str());
                     if is_new_id {
-                        // New identity: remove old tracker so stale telemetry
-                        // is not carried into the new instance.
+                        // New identity: purge all telemetry state for the old id so
+                        // stale rate baseline, TTFT, and TPOT do not bleed across.
                         if let Some(old_id) = lemonade_id.as_deref() {
-                            gen_trackers.remove(old_id);
+                            purge_telemetry_state(
+                                old_id,
+                                &mut gen_trackers,
+                                &mut prev_ttft,
+                                &mut prev_tpot,
+                            );
                         }
                     }
                     let existing = runner.state.instances.get(&svc.container_id).cloned();
@@ -345,10 +365,12 @@ pub async fn run_loop(
                             model = %svc.model_name,
                             "lemonade instance discovered"
                         );
+                        // InstanceDiscovered is a discovery-metadata event; broadcast
+                        // a clean instance (no prior collector-owned telemetry).
                         broadcast_and_persist(
                             &tx,
                             persist.as_ref(),
-                            Event::InstanceDiscovered(inst),
+                            Event::InstanceDiscovered(instance_from_discovered(&svc)),
                         );
                         lemonade_id = Some(svc.container_id.clone());
                     }
@@ -356,9 +378,12 @@ pub async fn run_loop(
                 None => {
                     if let Some(id) = lemonade_id.take() {
                         info!(id = %id, "lemonade instance gone");
-                        gen_trackers.remove(&id);
-                        prev_ttft.remove(&id);
-                        prev_tpot.remove(&id);
+                        purge_telemetry_state(
+                            &id,
+                            &mut gen_trackers,
+                            &mut prev_ttft,
+                            &mut prev_tpot,
+                        );
                         runner.state.apply(StateEvent::InstanceRemoved(id.clone()));
                         broadcast_and_persist(
                             &tx,
@@ -385,12 +410,16 @@ pub async fn run_loop(
                 let id = svc.container_id.clone();
                 let is_new = !known_services.contains(&id);
                 let existing = runner.state.instances.get(&id).cloned();
-                // Endpoint change → new logical service; invalidate tracker immediately.
-                let same_endpoint = existing.as_ref().map_or(true, |ex| ex.port == svc.port);
+                // Endpoint change → new logical service; reset rate baseline and
+                // latency windows so the new port starts fresh.
+                let same_endpoint = existing.as_ref().is_none_or(|ex| ex.port == svc.port);
                 if !same_endpoint {
-                    if let Some(t) = gen_trackers.get_mut(&id) {
-                        t.invalidate();
-                    }
+                    invalidate_on_endpoint_change(
+                        &id,
+                        &mut gen_trackers,
+                        &mut prev_ttft,
+                        &mut prev_tpot,
+                    );
                 }
                 let inst = merge_discovery_refresh(
                     &svc,
@@ -405,14 +434,18 @@ pub async fn run_loop(
                     .apply(StateEvent::InstanceUpserted(inst.clone()));
                 if is_new {
                     info!(id = %id, "managed service discovered");
-                    broadcast_and_persist(&tx, persist.as_ref(), Event::InstanceDiscovered(inst));
+                    // InstanceDiscovered is a discovery-metadata event; broadcast
+                    // a clean instance (no prior collector-owned telemetry).
+                    broadcast_and_persist(
+                        &tx,
+                        persist.as_ref(),
+                        Event::InstanceDiscovered(instance_from_discovered(&svc)),
+                    );
                 }
             }
             for gone in known_services.difference(&disc.seen) {
                 info!(id = %gone, "managed service gone");
-                gen_trackers.remove(gone);
-                prev_ttft.remove(gone);
-                prev_tpot.remove(gone);
+                purge_telemetry_state(gone, &mut gen_trackers, &mut prev_ttft, &mut prev_tpot);
                 runner
                     .state
                     .apply(StateEvent::InstanceRemoved(gone.clone()));
@@ -619,8 +652,7 @@ pub async fn run_loop(
         for inst in &mut instances {
             let (gen_tps, meta) = gen_trackers
                 .get_mut(&inst.container_id)
-                .map(|t| t.snapshot(cycle_at))
-                .unwrap_or((None, None));
+                .map_or((None, None), |t| t.snapshot(cycle_at));
             inst.gen_tps = gen_tps;
             inst.gen_tps_observation = meta;
         }
@@ -646,6 +678,16 @@ pub async fn run_loop(
                 "tokens_per_watt: gpu_ids matched no GPU for {id_join_misses} instance(s) \
                  (check HIP_VISIBLE_DEVICES vs amd-smi device_id)"
             ));
+        }
+        // Write tracker-derived gen_tps, observation metadata, and TPW back into
+        // runner.state.instances so that the next discovery merge reads current
+        // values (not stale pre-snapshot values from the last upsert).
+        for inst in &instances {
+            if let Some(entry) = runner.state.instances.get_mut(&inst.container_id) {
+                entry.gen_tps = inst.gen_tps;
+                entry.gen_tps_observation = inst.gen_tps_observation.clone();
+                entry.tokens_per_watt = inst.tokens_per_watt;
+            }
         }
         // Attribute per-instance VRAM (per-process where the cgroup join hit,
         // device-summed otherwise). Pure; uses this tick's `gpus` for totals.
@@ -705,6 +747,37 @@ pub async fn run_loop(
             }
         }
     }
+}
+
+/// Remove all per-service telemetry state for `id`: tracker, TTFT, and TPOT
+/// baselines.  Call on explicit removal (Docker Gone, Lemonade Gone, managed
+/// Gone) and whenever an identity change requires a clean slate.
+pub(crate) fn purge_telemetry_state(
+    id: &str,
+    gen_trackers: &mut HashMap<String, GenerationObservationTracker>,
+    prev_ttft: &mut HashMap<String, (f64, f64, DateTime<Utc>)>,
+    prev_tpot: &mut HashMap<String, (f64, f64, DateTime<Utc>)>,
+) {
+    gen_trackers.remove(id);
+    prev_ttft.remove(id);
+    prev_tpot.remove(id);
+}
+
+/// Invalidate the generation tracker for `id` (reset baseline without
+/// removing the map entry) and clear the TTFT/TPOT latency windows.
+/// Called when an endpoint changes within the same container/service id so
+/// the new scrape address starts with a fresh rate baseline.
+pub(crate) fn invalidate_on_endpoint_change(
+    id: &str,
+    gen_trackers: &mut HashMap<String, GenerationObservationTracker>,
+    prev_ttft: &mut HashMap<String, (f64, f64, DateTime<Utc>)>,
+    prev_tpot: &mut HashMap<String, (f64, f64, DateTime<Utc>)>,
+) {
+    if let Some(t) = gen_trackers.get_mut(id) {
+        t.invalidate();
+    }
+    prev_ttft.remove(id);
+    prev_tpot.remove(id);
 }
 
 /// Build an `Instance` from a `DiscoveredService` with no live KV/req sample yet.
@@ -796,9 +869,12 @@ fn ticks_per(period: Duration, tick: Duration) -> u64 {
     n.max(1) as u64
 }
 
-/// A gap longer than this between counter readings makes the baseline stale —
-/// the rate would be a misleadingly low average across an outage or a forward
-/// wall-clock jump (NTP, VM resume), so we re-baseline instead.
+/// Upper bound on the scrape interval accepted by `avg_ms_from_histogram`.
+/// Applies to TTFT/TPOT latency histograms only; generation-counter staleness
+/// is managed by `GenerationObservationTracker` (see `rocm-dash-core`).
+/// A gap longer than this makes the windowed delta stale (outage or forward
+/// wall-clock jump / NTP / VM resume), so the histogram falls back to the
+/// cumulative average for that sample.
 const MAX_RATE_INTERVAL_S: f64 = 60.0;
 
 /// Average latency (ms) from a cumulative histogram's `_sum` (seconds) and
@@ -985,6 +1061,76 @@ mod tests {
         assert_eq!(
             ticks_per(Duration::from_secs(30), Duration::from_millis(250)),
             120
+        );
+    }
+
+    // -- Identity/endpoint cleanup helper tests -----------------------------------
+
+    fn make_tracker(tick_secs: u64) -> GenerationObservationTracker {
+        GenerationObservationTracker::new(Duration::from_secs(tick_secs))
+    }
+
+    /// `purge_telemetry_state` removes the tracker entry, TTFT baseline, and
+    /// TPOT baseline for the target id and leaves other ids untouched.
+    #[test]
+    fn purge_telemetry_state_removes_all_three_maps_for_id() {
+        let mut trackers: HashMap<String, GenerationObservationTracker> = HashMap::new();
+        let mut ttft: HashMap<String, (f64, f64, DateTime<Utc>)> = HashMap::new();
+        let mut tpot: HashMap<String, (f64, f64, DateTime<Utc>)> = HashMap::new();
+
+        // Populate two ids.
+        trackers.insert("a".into(), make_tracker(2));
+        trackers.insert("b".into(), make_tracker(2));
+        ttft.insert("a".into(), (1.0, 1.0, at(10)));
+        ttft.insert("b".into(), (2.0, 2.0, at(10)));
+        tpot.insert("a".into(), (3.0, 3.0, at(10)));
+        tpot.insert("b".into(), (4.0, 4.0, at(10)));
+
+        purge_telemetry_state("a", &mut trackers, &mut ttft, &mut tpot);
+
+        // "a" must be gone from all maps.
+        assert!(!trackers.contains_key("a"), "tracker for a must be removed");
+        assert!(!ttft.contains_key("a"), "ttft for a must be removed");
+        assert!(!tpot.contains_key("a"), "tpot for a must be removed");
+        // "b" must be unaffected.
+        assert!(trackers.contains_key("b"), "tracker for b must survive");
+        assert!(ttft.contains_key("b"), "ttft for b must survive");
+        assert!(tpot.contains_key("b"), "tpot for b must survive");
+    }
+
+    /// `invalidate_on_endpoint_change` invalidates the tracker (resets its
+    /// window so subsequent snapshots return None) and removes the latency
+    /// baselines, without removing the tracker entry itself.
+    #[test]
+    fn invalidate_on_endpoint_change_resets_tracker_and_clears_latency() {
+        let mut trackers: HashMap<String, GenerationObservationTracker> = HashMap::new();
+        let mut ttft: HashMap<String, (f64, f64, DateTime<Utc>)> = HashMap::new();
+        let mut tpot: HashMap<String, (f64, f64, DateTime<Utc>)> = HashMap::new();
+
+        let mut tracker = make_tracker(2);
+        // Give the tracker a reading so it has a non-None baseline.
+        tracker.observe_counter(100.0, at(10));
+        tracker.observe_counter(200.0, at(12));
+        trackers.insert("svc".into(), tracker);
+        ttft.insert("svc".into(), (1.0, 10.0, at(10)));
+        tpot.insert("svc".into(), (0.5, 8.0, at(10)));
+
+        invalidate_on_endpoint_change("svc", &mut trackers, &mut ttft, &mut tpot);
+
+        // Tracker still exists but its window is reset: snapshot returns None.
+        let (rate, _meta) = trackers
+            .get_mut("svc")
+            .expect("tracker entry must remain")
+            .snapshot(at(12));
+        assert!(rate.is_none(), "invalidated tracker must yield None rate");
+        // Latency baselines must be cleared.
+        assert!(
+            !ttft.contains_key("svc"),
+            "ttft baseline must be cleared on endpoint change"
+        );
+        assert!(
+            !tpot.contains_key("svc"),
+            "tpot baseline must be cleared on endpoint change"
         );
     }
 }

--- a/crates/rocm-dash-daemon/tests/telemetry_contract.rs
+++ b/crates/rocm-dash-daemon/tests/telemetry_contract.rs
@@ -109,6 +109,39 @@ const INSTANCE_TICK: Duration = Duration::from_millis(400);
 const SCENARIO_DEADLINE: Duration = Duration::from_secs(15);
 const SVC_ID: &str = "contract-svc";
 
+/// Observation validity window derived from the contract formula.
+/// `clamp(3 × INSTANCE_TICK, 6 s, 30 s)` — with `INSTANCE_TICK = 400 ms`
+/// this evaluates to `max(1.2 s, 6 s) = 6 s`, matching the spec lower bound.
+fn observation_validity_window() -> Duration {
+    (3 * INSTANCE_TICK).clamp(Duration::from_secs(6), Duration::from_secs(30))
+}
+
+/// Drain all snapshot events already buffered in the broadcast receiver so
+/// that subsequent `wait_for_snapshot` calls return only snapshots assembled
+/// **after** the next mode switch. Must be called immediately before setting
+/// `MockMode::Failure` to avoid a stale-snapshot false pass.
+fn drain_snapshots(rx: &mut broadcast::Receiver<Event>) {
+    while rx.try_recv().is_ok() {}
+}
+
+/// Poll the mock's `failure_count` until it reaches `>= expected_min`, bounded
+/// by `SCENARIO_DEADLINE`. Guarantees that at least `expected_min` HTTP 503
+/// responses were actually served by the mock before the caller reads the next
+/// broadcast snapshot — eliminating the sleep-based race in M4.
+async fn await_failure_served(failure_count: &AtomicU64, expected_min: u64) {
+    let deadline = tokio::time::Instant::now() + SCENARIO_DEADLINE;
+    loop {
+        if failure_count.load(Ordering::Relaxed) >= expected_min {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "mock failure was never served within {SCENARIO_DEADLINE:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 // ── Scriptable mock HTTP server ─────────────────────────────────────────────
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -209,6 +242,7 @@ const HTTP_503: &str =
 async fn spawn_mock_server(
     mode: Arc<Mutex<MockMode>>,
     ticks: Arc<AtomicU64>,
+    failure_count: Arc<AtomicU64>,
     stop: Arc<AtomicBool>,
 ) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -226,6 +260,7 @@ async fn spawn_mock_server(
             }
             let mode = Arc::clone(&mode);
             let ticks = Arc::clone(&ticks);
+            let failure_count = Arc::clone(&failure_count);
             tokio::spawn(async move {
                 let mut buf = vec![0u8; 4096];
                 let _ = sock.read(&mut buf).await;
@@ -264,7 +299,10 @@ vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {gen_tokens_total}\n"
                     }
                     MockMode::Frozen(n) => http_ok(&prom_body(n, n.max(1))),
                     MockMode::Reset(n) => http_ok(&prom_body(n, 1)),
-                    MockMode::Failure => HTTP_503.to_string(),
+                    MockMode::Failure => {
+                        failure_count.fetch_add(1, Ordering::Relaxed);
+                        HTTP_503.to_string()
+                    }
                     MockMode::Omitted => {
                         let tick = ticks.fetch_add(1, Ordering::Relaxed) + 1;
                         http_ok(&prom_body_omitted(tick))
@@ -370,7 +408,14 @@ async fn zero_gen_tps_after_frozen_counter() {
     let mode = Arc::new(Mutex::new(MockMode::Frozen(1_000)));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -405,7 +450,14 @@ async fn counter_reset_invalidates_baseline_immediately() {
     let mode = Arc::new(Mutex::new(MockMode::Growing));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -461,7 +513,14 @@ async fn service_removal_fires_instance_gone() {
     let mode = Arc::new(Mutex::new(MockMode::Growing));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     let sdir = services_dir.clone();
     write_service_record(&services_dir, port);
@@ -531,7 +590,14 @@ async fn gen_tps_held_for_validity_window_after_single_failure() {
     let mode = Arc::new(Mutex::new(MockMode::Growing));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -545,16 +611,18 @@ async fn gen_tps_held_for_validity_window_after_single_failure() {
     .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
     assert!(baseline > 0.0);
 
-    // Step 2: inject one failure.
+    // Step 2: drain buffered pre-failure snapshots, then inject failure.
+    // Draining ensures wait_for_snapshot below only sees post-failure events.
+    drain_snapshots(&mut rx);
     *mode
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Failure;
 
-    // Step 3: allow one instance_tick for the failure scrape to complete, then
-    // read the very first post-failure Snapshot.
-    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
+    // Step 3: poll until the mock confirms ≥ 1 HTTP 503 was served — guarantees
+    // the runner has processed the failure before we read the next snapshot.
+    await_failure_served(&failure_count, 1).await;
 
-    let post_failure_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+    let post_failure_gen_tps = wait_for_snapshot(&mut rx, svc_gen_tps)
         .await
         .unwrap_or_else(|e| panic!("no snapshot arrived after failure: {e}"));
 
@@ -589,7 +657,14 @@ async fn omitted_counter_yields_none_not_zero() {
     let mode = Arc::new(Mutex::new(MockMode::Omitted));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -599,7 +674,7 @@ async fn omitted_counter_yields_none_not_zero() {
     // Two consecutive omitted scrapes are sufficient.
     let mut got_none = false;
     let mut got_zero = false;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+    let deadline = tokio::time::Instant::now() + SCENARIO_DEADLINE;
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -650,7 +725,14 @@ async fn omitted_preserves_baseline_so_recovery_is_immediate() {
     let mode = Arc::new(Mutex::new(MockMode::Growing));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -664,10 +746,19 @@ async fn omitted_preserves_baseline_so_recovery_is_immediate() {
     .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
 
     // Step 2: one omitted-counter scrape (success path, prev_gen_tokens preserved).
+    // Drain buffered pre-step snapshots, record ticks baseline, then switch to Omitted.
+    drain_snapshots(&mut rx);
+    let omit_baseline = ticks.load(Ordering::Relaxed);
     *mode
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Omitted;
-    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
+    // Poll until the mock confirms ≥ 1 Omitted response was served (ticks advances in Omitted mode).
+    loop {
+        if ticks.load(Ordering::Relaxed) > omit_baseline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 
     // Step 3: recover immediately — Growing again with preserved prev_gen_tokens.
     // A single successful scrape with a counter > prev_val should yield positive rate.
@@ -708,7 +799,14 @@ async fn malformed_payload_yields_none_not_zero() {
     let mode = Arc::new(Mutex::new(MockMode::Malformed));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -716,7 +814,7 @@ async fn malformed_payload_yields_none_not_zero() {
 
     let mut saw_none = false;
     let mut saw_zero = false;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+    let deadline = tokio::time::Instant::now() + SCENARIO_DEADLINE;
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -765,7 +863,14 @@ async fn running_idle_yields_gen_tps_and_zero_running_reqs() {
     let mode = Arc::new(Mutex::new(MockMode::RunningIdle));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -826,7 +931,14 @@ async fn gen_tps_expiry_boundary_held_then_unavailable() {
     let mode = Arc::new(Mutex::new(MockMode::Growing));
     let ticks = Arc::new(AtomicU64::new(0));
     let stop = Arc::new(AtomicBool::new(false));
-    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+    let failure_count = Arc::new(AtomicU64::new(0));
+    let port = spawn_mock_server(
+        Arc::clone(&mode),
+        Arc::clone(&ticks),
+        Arc::clone(&failure_count),
+        Arc::clone(&stop),
+    )
+    .await;
 
     write_service_record(&services_dir, port);
     let (tx, mut rx) = broadcast::channel::<Event>(64);
@@ -841,26 +953,30 @@ async fn gen_tps_expiry_boundary_held_then_unavailable() {
     assert!(baseline > 0.0);
 
     // Inject sustained failure — keep the mode locked to Failure.
+    // Drain buffered pre-failure snapshots so boundary-1 sees only post-failure events.
+    drain_snapshots(&mut rx);
     *mode
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Failure;
 
     // ── BOUNDARY 1 ──────────────────────────────────────────────────────────
-    // Allow one instance_tick for the failure scrape to propagate, then capture
+    // Poll until the mock confirms ≥ 1 HTTP 503 was served, then capture
     // the very first post-failure snapshot.  Contract: gen_tps must be Some(_).
     // Current: None (immediate clear). → RED assertion below.
-    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
-    let boundary1_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+    await_failure_served(&failure_count, 1).await;
+    let boundary1_gen_tps = wait_for_snapshot(&mut rx, svc_gen_tps)
         .await
         .unwrap_or_else(|e| panic!("no snapshot for boundary-1 check: {e}"));
 
     // ── BOUNDARY 2 ──────────────────────────────────────────────────────────
     // Wait for the full validity window + two instance-tick buffer to elapse.
     // Contract: gen_tps must then be None (expired/unavailable).
+    // NOTE: this sleep is necessary — the validity window is a real wall-clock
+    // duration that cannot be shortened without touching production code (non-goal).
     // This code is unreachable today because boundary-1 fails first.
-    let validity_window = Duration::from_secs(6); // clamp(3×400ms, 6s, 30s) = 6s
+    let validity_window = observation_validity_window(); // clamp(3×INSTANCE_TICK, 6s, 30s)
     tokio::time::sleep(validity_window + 2 * INSTANCE_TICK + Duration::from_millis(500)).await;
-    let boundary2_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+    let boundary2_gen_tps = wait_for_snapshot(&mut rx, svc_gen_tps)
         .await
         .unwrap_or_else(|e| panic!("no snapshot for boundary-2 check: {e}"));
 

--- a/crates/rocm-dash-daemon/tests/telemetry_contract.rs
+++ b/crates/rocm-dash-daemon/tests/telemetry_contract.rs
@@ -1,0 +1,888 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Deterministic lower-level contract scenarios for EAI-7960 telemetry correctness.
+//!
+//! These tests drive the real daemon runner through a scriptable local HTTP
+//! server (no PTY, no TUI) and assert on raw [`Snapshot`] broadcast events.
+//! They complement the principal black-box regression in
+//! `tests/e2e-cucumber/features/dash.feature` (Scenario 8) by covering each
+//! distinct state transition at the broadcast seam rather than the rendered screen.
+//!
+//! Coverage matrix:
+//!
+//! | #  | Scenario                                          | Contract           | Current     | State |
+//! |----|---------------------------------------------------|--------------------|-------------|-------|
+//! | 1  | Frozen counter → zero rate                        | `gen_tps ≈ 0.0`    | `≈ 0.0`     | GREEN |
+//! | 2  | Counter reset → invalidation + re-baseline        | None then positive | same        | GREEN |
+//! | 3  | Service removal → `InstanceGone` event            | fired next disc    | same        | GREEN |
+//! | 4  | Single failure → gen_tps held for validity window | Some(…) held       | None immed. | RED   |
+//! | 5  | Omitted counter → None (not zero, not panic)      | None, baseline kept| None, kept  | GREEN |
+//! | 6  | Omitted → success path preserves baseline (≠ Fail)| immediate recovery | same        | GREEN |
+//! | 7  | Malformed payload → None (not zero, not panic)    | None               | None        | GREEN |
+//! | 8  | RunningIdle → gen_tps present + running_reqs = 0  | Some(+), req=0     | same        | GREEN |
+//! | 9  | Expiry boundary: held inside window, gone after   | B1 held, B2 none   | B1 RED      | RED   |
+//!
+//! Scenarios 1–3, 5–8 verify already-correct or distinguishably-observable
+//! behaviour.  Scenarios 4 and 9 reproduce the EAI-7960 root cause.
+//!
+//! Timing: `tick_override = 200 ms`, `discovery_tick = 200 ms`,
+//! `instance_tick = 400 ms` (scrape every 2nd base tick).
+//! Expiry window boundary: `clamp(3 × 400ms, 6 s, 30 s) = 6 s`.
+//!
+//! ## Frozen observation schema (proposed — do not implement in production during this task)
+//!
+//! The controller-reviewed additive schema for EAI-7960 observation metadata.
+//! Production types (`rocm-dash-core`) are unchanged; this block is the
+//! candidate contract for the implementer to reference.
+//!
+//! ```rust,ignore
+//! // Existing value carrier — unchanged, remains the sole numeric source.
+//! // Instance.gen_tps: Option<f64>
+//!
+//! // New additive field on Instance (or on InstanceMetrics if that is the
+//! // structural container).  Absent for legacy snapshots.
+//! #[serde(default, skip_serializing_if = "Option::is_none")]
+//! pub gen_tps_observation: Option<ObservationMetadata>,
+//!
+//! pub struct ObservationMetadata {
+//!     /// Wall-clock time of the last successful Prometheus scrape for this
+//!     /// instance's gen_tps reading (UTC, RFC 3339 on the wire via serde).
+//!     pub observed_at: DateTime<Utc>,
+//!     /// Whether the value in `gen_tps` is freshly computed this tick or
+//!     /// retained from the last successful observation.
+//!     pub freshness: ObservationFreshness,
+//! }
+//!
+//! // serde rename_all = "snake_case"
+//! pub enum ObservationFreshness {
+//!     Fresh,  // serialises as "fresh"
+//!     Held,   // serialises as "held"
+//! }
+//! ```
+//!
+//! **Invariants:**
+//! - `Instance.gen_tps` is the **only** numeric value carrier; no parallel
+//!   `held_gen_tps`, `held_ttft_ms`, or `held_tpot_ms` fields.
+//! - Tokens-per-watt derives from `gen_tps` and uses the same freshness
+//!   metadata; it has no separate metadata source.
+//! - Legacy snapshots: absent `gen_tps_observation` ⇒ `None / unknown`; never
+//!   fabricated as `Fresh`.  Legacy `gen_tps` may render numerically without
+//!   any freshness claim.
+//!
+//! **Timing / invalidation rules (fixed):**
+//! - Internal counter rate window: `clamp(5 × instance_tick, 10 s, 30 s)`.
+//! - Observation validity after last successful scrape:
+//!   `clamp(3 × instance_tick, 6 s, 30 s)`.
+//! - Successful scrape: `gen_tps` is recomputed (Fresh), validity clock resets.
+//! - Missing / unparseable counter (HTTP 200, field absent): gen_tps holds,
+//!   validity clock NOT reset, `prev_gen_tokens` preserved.
+//! - Unchanged valid counter after full rate window: `gen_tps = Some(0.0)`
+//!   (Fresh — idle is not unknown).
+//! - Scrape failure (HTTP non-200): gen_tps holds (Held) until validity expires,
+//!   then `None`.  `prev_gen_tokens` cleared on failure so recovery re-baselines.
+//! - Counter reset (`cur < prev_val`): immediate `None`, new baseline set.
+//! - Identity change (host:port reassigned): treated as reset.
+//! - Service removal / non-serving terminal state: immediate `None`, no hold.
+//! - Daemon marks each assembled snapshot `Fresh` only when newly observed this
+//!   tick; otherwise `Held` until validity expires, then `gen_tps = None`.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rocm_dash_core::protocol::Event;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
+
+use rocm_dash_daemon::bench_ring::BenchRing;
+use rocm_dash_daemon::runner::{self, RunnerOptions};
+use rocm_dash_daemon::snapshot_ring::SnapshotRing;
+
+// ── Timing constants ────────────────────────────────────────────────────────
+
+const TICK: Duration = Duration::from_millis(200);
+const INSTANCE_TICK: Duration = Duration::from_millis(400);
+const SCENARIO_DEADLINE: Duration = Duration::from_secs(15);
+const SVC_ID: &str = "contract-svc";
+
+// ── Scriptable mock HTTP server ─────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum MockMode {
+    /// Monotonically-increasing counter; internal tick counter advances.
+    Growing,
+    /// Counter frozen at the given cumulative value.
+    Frozen(u64),
+    /// Counter reset to a value *below* any reasonable Growing accumulation.
+    Reset(u64),
+    /// Endpoint returns HTTP 503.
+    Failure,
+    /// HTTP 200 with a valid body that omits `vllm:generation_tokens_total`.
+    /// The runner's parser returns `sample.gen_tokens_total = None` (success
+    /// path); `prev_gen_tokens` is preserved unlike `Failure`.
+    Omitted,
+    /// HTTP 200 with a structurally invalid body; all parsed fields come back
+    /// `None` — same runner treatment as `Omitted` but triggered by parse error.
+    Malformed,
+    /// Growing counter but `running_reqs = 0` — idle engine, reqs shown as 0.
+    RunningIdle,
+}
+
+fn prom_body(gen_tokens_total: u64, tick: u64) -> String {
+    let ttft_sum_s = tick as f64 * 0.050;
+    let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+    format!(
+        "\
+# HELP vllm:num_requests_running running.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} 1
+# HELP vllm:num_requests_waiting waiting.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{{model=\"mock\"}} 0
+# HELP vllm:gpu_cache_usage_perc kv.
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc{{model=\"mock\"}} 0.25
+# HELP vllm:generation_tokens_total gen_tokens.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {gen_tokens_total}
+# HELP vllm:time_to_first_token_seconds ttft.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}
+# HELP vllm:time_per_output_token_seconds tpot.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {gen_tokens_total}
+"
+    )
+}
+
+fn http_ok(body: &str) -> String {
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+}
+
+/// Like [`prom_body`] but omits the `vllm:generation_tokens_total` line.
+/// The runner's parser returns `sample.gen_tokens_total = None` and takes the
+/// success path (HTTP 200); `prev_gen_tokens` is **not** removed.
+fn prom_body_omitted(tick: u64) -> String {
+    let ttft_sum_s = tick as f64 * 0.050;
+    let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+    format!(
+        "\
+# HELP vllm:num_requests_running running.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} 1
+# HELP vllm:num_requests_waiting waiting.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{{model=\"mock\"}} 0
+# HELP vllm:time_to_first_token_seconds ttft.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}
+# HELP vllm:time_per_output_token_seconds tpot.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tick}
+"
+    )
+}
+
+/// Invalid Prometheus exposition text; causes the parser to return all-None
+/// sample fields (same runner treatment as `Omitted`, but triggered by a parse
+/// error rather than a missing key).
+const MALFORMED_BODY: &str = "# malformed: not valid prometheus exposition format\n!!!invalid!!!\n";
+
+const HTTP_503: &str =
+    "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+
+/// Spawn a persistent looping HTTP server on a random port.
+/// Returns the bound port (ready before the future resolves).
+async fn spawn_mock_server(
+    mode: Arc<Mutex<MockMode>>,
+    ticks: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            let mode = Arc::clone(&mode);
+            let ticks = Arc::clone(&ticks);
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let current = *mode
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let response = match current {
+                    MockMode::Growing => {
+                        let tick = ticks.fetch_add(1, Ordering::Relaxed) + 1;
+                        http_ok(&prom_body(tick * 20, tick))
+                    }
+                    MockMode::RunningIdle => {
+                        // Counter grows identically to Growing but running_reqs=0.
+                        let tick = ticks.fetch_add(1, Ordering::Relaxed) + 1;
+                        let gen_tokens_total = tick * 20;
+                        let ttft_sum_s = tick as f64 * 0.050;
+                        let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+                        let body = format!(
+                            "\
+# HELP vllm:num_requests_running running.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} 0\n\
+# HELP vllm:generation_tokens_total gen.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {gen_tokens_total}\n\
+# HELP vllm:time_to_first_token_seconds ttft.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}\n\
+# HELP vllm:time_per_output_token_seconds tpot.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {gen_tokens_total}\n"
+                        );
+                        http_ok(&body)
+                    }
+                    MockMode::Frozen(n) => http_ok(&prom_body(n, n.max(1))),
+                    MockMode::Reset(n) => http_ok(&prom_body(n, 1)),
+                    MockMode::Failure => HTTP_503.to_string(),
+                    MockMode::Omitted => {
+                        let tick = ticks.fetch_add(1, Ordering::Relaxed) + 1;
+                        http_ok(&prom_body_omitted(tick))
+                    }
+                    MockMode::Malformed => http_ok(MALFORMED_BODY),
+                };
+                let _ = sock.write_all(response.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    port
+}
+
+fn write_service_record(services_dir: &std::path::Path, port: u16) {
+    std::fs::create_dir_all(services_dir).unwrap();
+    let json = format!(
+        r#"{{"service_id":"{SVC_ID}","engine":"vllm","model_ref":"ContractModel/1B","canonical_model_id":"ContractModel/1B","host":"127.0.0.1","port":{port},"status":"ready","created_at_unix_ms":0}}"#
+    );
+    std::fs::write(services_dir.join(format!("{SVC_ID}.json")), json).unwrap();
+}
+
+fn remove_service_record(services_dir: &std::path::Path) {
+    let _ = std::fs::remove_file(services_dir.join(format!("{SVC_ID}.json")));
+}
+
+fn fast_opts(services_dir: std::path::PathBuf) -> RunnerOptions {
+    RunnerOptions {
+        services_dir: Some(services_dir),
+        discovery_tick: TICK,
+        instance_tick: INSTANCE_TICK,
+        gpu_tick: TICK,
+        disable_vllm_metrics: false,
+        enable_docker: false,
+        enable_lemonade: false,
+        ..RunnerOptions::default()
+    }
+}
+
+async fn spawn_runner(
+    tx: broadcast::Sender<Event>,
+    opts: RunnerOptions,
+) -> tokio::task::JoinHandle<()> {
+    let ring = Arc::new(Mutex::new(SnapshotRing::new(16)));
+    let bench_ring = Arc::new(Mutex::new(BenchRing::new(4)));
+    tokio::spawn(runner::run_loop(
+        Some(TICK),
+        tx,
+        ring,
+        bench_ring,
+        None,
+        opts,
+    ))
+}
+
+/// Drain broadcast events until `pred(&snap)` returns `Some(T)`, or deadline expires.
+async fn wait_for_snapshot<T>(
+    rx: &mut broadcast::Receiver<Event>,
+    pred: impl Fn(&rocm_dash_core::metrics::Snapshot) -> Option<T>,
+) -> Result<T, String> {
+    let deadline = tokio::time::Instant::now() + SCENARIO_DEADLINE;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("timed out after {SCENARIO_DEADLINE:?}"));
+        }
+        match timeout(remaining, rx.recv()).await {
+            Ok(Ok(Event::Snapshot(snap))) => {
+                if let Some(v) = pred(&snap) {
+                    return Ok(v);
+                }
+            }
+            Ok(Ok(_)) | Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                return Err("broadcast channel closed".into());
+            }
+            Err(_) => return Err(format!("timed out after {SCENARIO_DEADLINE:?}")),
+        }
+    }
+}
+
+/// Extract the `contract-svc` instance's `gen_tps` from a snapshot.
+fn svc_gen_tps(snap: &rocm_dash_core::metrics::Snapshot) -> Option<Option<f64>> {
+    snap.instances
+        .iter()
+        .find(|i| i.container_id == SVC_ID)
+        .map(|i| i.gen_tps)
+}
+
+// ── Scenario 1: Frozen counter → zero rate ─────────────────────────────────
+
+/// Contract: a frozen cumulative counter produces `gen_tps = Some(0.0)` —
+/// distinct from `None` ("no data").  An idle engine is not the same as an
+/// unknown engine.
+///
+/// GREEN: `gen_tps_from_delta` computes `0 / dt = 0.0` (runner.rs:704).
+#[tokio::test]
+async fn zero_gen_tps_after_frozen_counter() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    // Frozen at 1 000 tokens; first scrape sets baseline, second computes delta=0.
+    let mode = Arc::new(Mutex::new(MockMode::Frozen(1_000)));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    let gen_tps = wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v < 0.1)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("frozen counter never produced zero gen_tps: {e}"));
+
+    stop.store(true, Ordering::Relaxed);
+    assert!(
+        (0.0..0.1).contains(&gen_tps),
+        "expected ~0.0 tok/s, got {gen_tps}"
+    );
+}
+
+// ── Scenario 2: Counter reset → invalidation + re-baseline ─────────────────
+
+/// Contract: a counter that drops below its previous reading (`cur < prev_val`)
+/// immediately yields `gen_tps = None` for that tick, and the new lower value
+/// becomes the baseline so recovery to a positive rate is possible.
+///
+/// GREEN: `gen_tps_from_delta` has an explicit guard `cur < prev_val → None`
+/// (runner.rs:701), and re-inserts the new value as the baseline.
+#[tokio::test]
+async fn counter_reset_invalidates_baseline_immediately() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Growing));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Step 1: establish positive baseline.
+    wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
+
+    // Step 2: reset counter to 5 — below the ≥40 tokens any Growing scrape produces.
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Reset(5);
+
+    // Step 3: expect gen_tps = None immediately after the reset scrape.
+    wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| if g.is_none() { Some(()) } else { None })
+    })
+    .await
+    .unwrap_or_else(|e| panic!("gen_tps never cleared after counter reset: {e}"));
+
+    // Step 4: resume Growing — new baseline of 5 means counter > 5 = positive rate.
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Growing;
+
+    // Step 5: gen_tps recovers.
+    wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("gen_tps never recovered after re-baseline: {e}"));
+
+    stop.store(true, Ordering::Relaxed);
+}
+
+// ── Scenario 3: Service removal → InstanceGone event ───────────────────────
+
+/// Contract: removing the managed-service JSON record fires an `InstanceGone`
+/// event on the next discovery tick and the instance is absent from subsequent
+/// Snapshots.
+///
+/// GREEN: runner.rs:362-377 computes `known_services.difference(&disc.seen)`
+/// and fires `InstanceGone` for each absent id.
+#[tokio::test]
+async fn service_removal_fires_instance_gone() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Growing));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    let sdir = services_dir.clone();
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Wait for the instance to appear.
+    wait_for_snapshot(&mut rx, |snap| {
+        snap.instances
+            .iter()
+            .find(|i| i.container_id == SVC_ID)
+            .map(|_| ())
+    })
+    .await
+    .unwrap_or_else(|e| panic!("instance never appeared: {e}"));
+
+    // Remove the record.
+    remove_service_record(&sdir);
+
+    // Wait for the InstanceGone event.
+    let deadline = tokio::time::Instant::now() + SCENARIO_DEADLINE;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "InstanceGone event never fired within {SCENARIO_DEADLINE:?}"
+        );
+        match timeout(remaining, rx.recv()).await {
+            Ok(Ok(Event::InstanceGone { container_id })) if container_id == SVC_ID => break,
+            Ok(Ok(_)) | Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(broadcast::error::RecvError::Closed)) => panic!("broadcast closed"),
+            Err(_) => panic!("timed out waiting for InstanceGone"),
+        }
+    }
+
+    // Confirm the instance is absent from subsequent Snapshots.
+    wait_for_snapshot(&mut rx, |snap| {
+        if snap.instances.iter().any(|i| i.container_id == SVC_ID) {
+            None
+        } else {
+            Some(())
+        }
+    })
+    .await
+    .unwrap_or_else(|e| panic!("instance still present after InstanceGone: {e}"));
+
+    stop.store(true, Ordering::Relaxed);
+}
+
+// ── Scenario 4: Single failure → gen_tps held for validity window (RED) ────
+
+/// Contract: after a single failed `/metrics` scrape, `gen_tps` must remain
+/// held at its last positive value for the validity window
+/// `clamp(3 × instance_tick, 6 s, 30 s)` before clearing.
+///
+/// **Current behaviour — RED:** `runner.rs:462-477` clears `gen_tps` to `None`
+/// and removes `prev_gen_tokens` on the very tick of the failure.  The first
+/// Snapshot after the failure already shows `gen_tps = None`.
+///
+/// This reproduces the same root cause as cucumber Scenario 8 at the daemon
+/// broadcast seam (no PTY / TUI layer).
+#[tokio::test]
+async fn gen_tps_held_for_validity_window_after_single_failure() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Growing));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Step 1: establish positive gen_tps.
+    let baseline = wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
+    assert!(baseline > 0.0);
+
+    // Step 2: inject one failure.
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Failure;
+
+    // Step 3: allow one instance_tick for the failure scrape to complete, then
+    // read the very first post-failure Snapshot.
+    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
+
+    let post_failure_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+        .await
+        .unwrap_or_else(|e| panic!("no snapshot arrived after failure: {e}"));
+
+    stop.store(true, Ordering::Relaxed);
+
+    // CONTRACT: the held value must still be present.
+    // CURRENT: None — immediate clear.  This assertion FAILS (RED).
+    assert!(
+        post_failure_gen_tps.is_some(),
+        "EAI-7960 REGRESSION (daemon broadcast seam): gen_tps was cleared to None \
+         immediately after the first failed /metrics scrape.\n\
+         Contract: hold for clamp(3 × {INSTANCE_TICK:?}, 6 s, 30 s).\n\
+         Root cause: runner.rs:462-477 clears gen_tps on the same tick as the failure.\n\
+         Baseline was {baseline:.2} tok/s; post-failure was None.\n\
+         This test must FAIL (RED) until the EAI-7960 fix is applied."
+    );
+}
+
+// ── Scenario 5: Omitted counter → None (not zero, not panic) ───────────────
+
+/// Contract: when the `/metrics` endpoint returns HTTP 200 but the body omits
+/// `vllm:generation_tokens_total`, `gen_tps` is `None` — not `Some(0.0)`.
+/// `prev_gen_tokens` must NOT be removed (success path, not failure path).
+///
+/// GREEN: `gen_tps_from_delta` is only reached when `gen_tokens_total.is_some()`;
+/// an absent counter falls straight to `None` without touching `prev_gen_tokens`.
+#[tokio::test]
+async fn omitted_counter_yields_none_not_zero() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Omitted));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Wait for a snapshot where the service is visible and gen_tps is stable.
+    // Two consecutive omitted scrapes are sufficient.
+    let mut got_none = false;
+    let mut got_zero = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await {
+            if let Some(gen_tps_opt) = svc_gen_tps(&snap) {
+                match gen_tps_opt {
+                    None => got_none = true,
+                    Some(v) if v < 0.01 => got_zero = true,
+                    _ => {}
+                }
+                if got_none {
+                    break; // contract satisfied
+                }
+            }
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+
+    assert!(
+        got_none,
+        "omitted counter never produced gen_tps = None; got_zero = {got_zero}"
+    );
+    assert!(
+        !got_zero,
+        "omitted counter produced gen_tps = Some(~0.0); \
+         contract requires None (missing ≠ zero)"
+    );
+}
+
+// ── Scenario 6: Omitted → success path preserves baseline (≠ Failure) ───────
+
+/// Contract: after an omitted-counter scrape (HTTP 200, counter absent),
+/// switching back to Growing gives an immediate positive `gen_tps` on the
+/// very next scrape — because `prev_gen_tokens` was preserved on the success
+/// path. This distinguishes `Omitted` from `Failure`, which removes the baseline.
+///
+/// GREEN: the success path in runner.rs only calls
+/// `prev_gen_tokens.insert(id, (cur, now))` inside `and_then`, so an absent
+/// counter leaves `prev_gen_tokens` untouched.
+#[tokio::test]
+async fn omitted_preserves_baseline_so_recovery_is_immediate() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Growing));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Step 1: establish positive baseline.
+    wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
+
+    // Step 2: one omitted-counter scrape (success path, prev_gen_tokens preserved).
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Omitted;
+    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
+
+    // Step 3: recover immediately — Growing again with preserved prev_gen_tokens.
+    // A single successful scrape with a counter > prev_val should yield positive rate.
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Growing;
+
+    // Step 4: expect positive rate to come back within ONE instance_tick.
+    // If baseline were erased (like Failure) this would take TWO ticks.
+    let recovered = wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await;
+
+    stop.store(true, Ordering::Relaxed);
+
+    recovered.unwrap_or_else(|e| {
+        panic!(
+            "gen_tps did not recover after omitted→growing: {e}\n\
+             If the baseline was erased (failure path taken), recovery requires \
+             two ticks instead of one."
+        )
+    });
+}
+
+// ── Scenario 7: Malformed payload → None (not zero, not panic) ──────────────
+
+/// Contract: an HTTP 200 response with a structurally invalid body produces
+/// `gen_tps = None`, not `Some(0.0)`, and does not panic.
+///
+/// GREEN: the parser extracts only named metric lines; an unrecognised body
+/// returns all-None sample fields, identical to Omitted at the runner level.
+#[tokio::test]
+async fn malformed_payload_yields_none_not_zero() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Malformed));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    let mut saw_none = false;
+    let mut saw_zero = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await {
+            if let Some(gen_tps_opt) = svc_gen_tps(&snap) {
+                match gen_tps_opt {
+                    None => {
+                        saw_none = true;
+                        break;
+                    }
+                    Some(v) if v < 0.01 => saw_zero = true,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+
+    assert!(
+        saw_none,
+        "malformed payload never produced gen_tps = None; saw_zero = {saw_zero}"
+    );
+    assert!(
+        !saw_zero,
+        "malformed payload produced gen_tps = Some(~0.0); \
+         contract requires None (unparseable ≠ zero)"
+    );
+}
+
+// ── Scenario 8: RunningIdle → gen_tps present + running_reqs = 0 ────────────
+
+/// Contract: a vLLM instance whose counter grows but whose
+/// `num_requests_running` is 0 (idle between bursts) shows a positive `gen_tps`
+/// and `running_reqs = Some(0)`.  This is distinct from an `Omitted` payload
+/// (counter present) and from a busy instance (running_reqs > 0).
+///
+/// GREEN: runner.rs reads both fields independently from the Prometheus scrape.
+#[tokio::test]
+async fn running_idle_yields_gen_tps_and_zero_running_reqs() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::RunningIdle));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Wait for a snapshot with positive gen_tps from this idle instance.
+    let snap_result = wait_for_snapshot(&mut rx, |snap| {
+        snap.instances
+            .iter()
+            .find(|i| i.container_id == SVC_ID)
+            .and_then(|i| {
+                // Both conditions must hold: counter-derived rate AND idle reqs.
+                let has_gen_tps = i.gen_tps.map_or(false, |v| v > 0.0);
+                let is_idle = i.running_reqs == Some(0);
+                if has_gen_tps && is_idle {
+                    Some((i.gen_tps.unwrap(), i.running_reqs.unwrap()))
+                } else {
+                    None
+                }
+            })
+    })
+    .await;
+
+    stop.store(true, Ordering::Relaxed);
+
+    let (gen_tps, running_reqs) = snap_result.unwrap_or_else(|e| {
+        panic!(
+            "RunningIdle never produced gen_tps > 0 with running_reqs = 0: {e}\n\
+             Check that the mock body sets num_requests_running to 0 and \
+             generation_tokens_total increments correctly."
+        )
+    });
+    assert!(gen_tps > 0.0, "gen_tps must be positive: {gen_tps}");
+    assert_eq!(running_reqs, 0, "running_reqs must be 0 for idle instance");
+}
+
+// ── Scenario 9: Expiry boundary — held inside window, gone after ─────────────
+
+/// Pins both boundaries of the EAI-7960 validity-window contract at the daemon
+/// broadcast seam.
+///
+/// **BOUNDARY 1 (held assertion — RED today):** immediately after the first
+/// failed scrape, `gen_tps` must still be `Some(_)` (held at its last observed
+/// value).  Current code clears it to `None` immediately — this assertion FAILS.
+///
+/// **BOUNDARY 2 (expired assertion — unreachable today):** after the full
+/// validity window `clamp(3 × instance_tick, 6 s, 30 s)` = 6 s elapses, the
+/// held value must be cleared and `gen_tps` must be `None`.
+///
+/// Both snapshots are captured before any assertion runs, so the test documents
+/// both boundaries even though only boundary 1 is checked by the final
+/// `assert!`. The boundary 2 assertion becomes GREEN once the fix is applied.
+#[tokio::test]
+async fn gen_tps_expiry_boundary_held_then_unavailable() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let services_dir = tmp.path().join("services");
+
+    let mode = Arc::new(Mutex::new(MockMode::Growing));
+    let ticks = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+    let port = spawn_mock_server(Arc::clone(&mode), Arc::clone(&ticks), Arc::clone(&stop)).await;
+
+    write_service_record(&services_dir, port);
+    let (tx, mut rx) = broadcast::channel::<Event>(64);
+    let _runner = spawn_runner(tx, fast_opts(services_dir)).await;
+
+    // Establish positive baseline.
+    let baseline = wait_for_snapshot(&mut rx, |snap| {
+        svc_gen_tps(snap).and_then(|g| g).filter(|&v| v > 0.0)
+    })
+    .await
+    .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
+    assert!(baseline > 0.0);
+
+    // Inject sustained failure — keep the mode locked to Failure.
+    *mode
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = MockMode::Failure;
+
+    // ── BOUNDARY 1 ──────────────────────────────────────────────────────────
+    // Allow one instance_tick for the failure scrape to propagate, then capture
+    // the very first post-failure snapshot.  Contract: gen_tps must be Some(_).
+    // Current: None (immediate clear). → RED assertion below.
+    tokio::time::sleep(INSTANCE_TICK + Duration::from_millis(50)).await;
+    let boundary1_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+        .await
+        .unwrap_or_else(|e| panic!("no snapshot for boundary-1 check: {e}"));
+
+    // ── BOUNDARY 2 ──────────────────────────────────────────────────────────
+    // Wait for the full validity window + two instance-tick buffer to elapse.
+    // Contract: gen_tps must then be None (expired/unavailable).
+    // This code is unreachable today because boundary-1 fails first.
+    let validity_window = Duration::from_secs(6); // clamp(3×400ms, 6s, 30s) = 6s
+    tokio::time::sleep(validity_window + 2 * INSTANCE_TICK + Duration::from_millis(500)).await;
+    let boundary2_gen_tps = wait_for_snapshot(&mut rx, |snap| svc_gen_tps(snap).map(|g| g))
+        .await
+        .unwrap_or_else(|e| panic!("no snapshot for boundary-2 check: {e}"));
+
+    stop.store(true, Ordering::Relaxed);
+
+    // Assert BOUNDARY 1 first; failure here prevents boundary-2 from running.
+    assert!(
+        boundary1_gen_tps.is_some(),
+        "EAI-7960 BOUNDARY-1 FAILED (daemon broadcast seam): gen_tps cleared to None \
+         immediately after first failure instead of being held.\n\
+         Contract: hold for clamp(3 × {INSTANCE_TICK:?}, 6 s, 30 s).\n\
+         Root cause: runner.rs clears gen_tps on the same tick as the failure.\n\
+         Baseline was {baseline:.2} tok/s; post-failure was None.\n\
+         This assertion must FAIL (RED) until the EAI-7960 fix is applied."
+    );
+
+    // Assert BOUNDARY 2 (reachable only after boundary-1 is fixed).
+    assert!(
+        boundary2_gen_tps.is_none(),
+        "EAI-7960 BOUNDARY-2 FAILED: gen_tps is still Some({:?}) after the \
+         validity window ({validity_window:?}) elapsed.\n\
+         Contract: held value must expire to None after the window.",
+        boundary2_gen_tps
+    );
+}

--- a/crates/rocm-dash-daemon/tests/telemetry_contract.rs
+++ b/crates/rocm-dash-daemon/tests/telemetry_contract.rs
@@ -342,6 +342,11 @@ fn fast_opts(services_dir: std::path::PathBuf) -> RunnerOptions {
     }
 }
 
+// `spawn_runner` is called with `.await` at every call-site (awaiting the
+// returned JoinHandle would block forever); keep `async` so the call-sites
+// read `spawn_runner(...).await` consistently and the JoinHandle is obtained
+// without needing a separate let-binding.
+#[allow(clippy::unused_async)]
 async fn spawn_runner(
     tx: broadcast::Sender<Event>,
     opts: RunnerOptions,
@@ -375,7 +380,7 @@ async fn wait_for_snapshot<T>(
                     return Ok(v);
                 }
             }
-            Ok(Ok(_)) | Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Ok(_) | Err(broadcast::error::RecvError::Lagged(_))) => {}
             Ok(Err(broadcast::error::RecvError::Closed)) => {
                 return Err("broadcast channel closed".into());
             }
@@ -385,6 +390,10 @@ async fn wait_for_snapshot<T>(
 }
 
 /// Extract the `contract-svc` instance's `gen_tps` from a snapshot.
+/// `Some(None)` = instance present with `gen_tps` not yet computed;
+/// `Some(Some(v))` = instance present with rate `v`; `None` = instance absent.
+// The double Option is intentional: outer = found-instance, inner = gen_tps.
+#[allow(clippy::option_option)]
 fn svc_gen_tps(snap: &rocm_dash_core::metrics::Snapshot) -> Option<Option<f64>> {
     snap.instances
         .iter()
@@ -550,9 +559,9 @@ async fn service_removal_fires_instance_gone() {
         );
         match timeout(remaining, rx.recv()).await {
             Ok(Ok(Event::InstanceGone { container_id })) if container_id == SVC_ID => break,
-            Ok(Ok(_)) | Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Ok(_) | Err(broadcast::error::RecvError::Lagged(_))) => {}
             Ok(Err(broadcast::error::RecvError::Closed)) => panic!("broadcast closed"),
-            Err(_) => panic!("timed out waiting for InstanceGone"),
+            Err(e) => panic!("timed out waiting for InstanceGone: {e}"),
         }
     }
 
@@ -680,16 +689,16 @@ async fn omitted_counter_yields_none_not_zero() {
         if remaining.is_zero() {
             break;
         }
-        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await {
-            if let Some(gen_tps_opt) = svc_gen_tps(&snap) {
-                match gen_tps_opt {
-                    None => got_none = true,
-                    Some(v) if v < 0.01 => got_zero = true,
-                    _ => {}
-                }
-                if got_none {
-                    break; // contract satisfied
-                }
+        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await
+            && let Some(gen_tps_opt) = svc_gen_tps(&snap)
+        {
+            match gen_tps_opt {
+                None => got_none = true,
+                Some(v) if v < 0.01 => got_zero = true,
+                _ => {}
+            }
+            if got_none {
+                break; // contract satisfied
             }
         }
     }
@@ -820,16 +829,16 @@ async fn malformed_payload_yields_none_not_zero() {
         if remaining.is_zero() {
             break;
         }
-        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await {
-            if let Some(gen_tps_opt) = svc_gen_tps(&snap) {
-                match gen_tps_opt {
-                    None => {
-                        saw_none = true;
-                        break;
-                    }
-                    Some(v) if v < 0.01 => saw_zero = true,
-                    _ => {}
+        if let Ok(Ok(Event::Snapshot(snap))) = timeout(remaining, rx.recv()).await
+            && let Some(gen_tps_opt) = svc_gen_tps(&snap)
+        {
+            match gen_tps_opt {
+                None => {
+                    saw_none = true;
+                    break;
                 }
+                Some(v) if v < 0.01 => saw_zero = true,
+                _ => {}
             }
         }
     }
@@ -883,7 +892,7 @@ async fn running_idle_yields_gen_tps_and_zero_running_reqs() {
             .find(|i| i.container_id == SVC_ID)
             .and_then(|i| {
                 // Both conditions must hold: counter-derived rate AND idle reqs.
-                let has_gen_tps = i.gen_tps.map_or(false, |v| v > 0.0);
+                let has_gen_tps = i.gen_tps.is_some_and(|v| v > 0.0);
                 let is_idle = i.running_reqs == Some(0);
                 if has_gen_tps && is_idle {
                     Some((i.gen_tps.unwrap(), i.running_reqs.unwrap()))
@@ -1002,9 +1011,8 @@ async fn gen_tps_expiry_boundary_held_then_unavailable() {
     // Assert BOUNDARY 2 (reachable only after boundary-1 is fixed).
     assert!(
         boundary2_gen_tps.is_none(),
-        "EAI-7960 BOUNDARY-2 FAILED: gen_tps is still Some({:?}) after the \
+        "EAI-7960 BOUNDARY-2 FAILED: gen_tps is still Some({boundary2_gen_tps:?}) after the \
          validity window ({validity_window:?}) elapsed.\n\
-         Contract: held value must expire to None after the window.",
-        boundary2_gen_tps
+         Contract: held value must expire to None after the window."
     );
 }

--- a/crates/rocm-dash-daemon/tests/telemetry_contract.rs
+++ b/crates/rocm-dash-daemon/tests/telemetry_contract.rs
@@ -17,15 +17,15 @@
 //! | 1  | Frozen counter → zero rate                        | `gen_tps ≈ 0.0`    | `≈ 0.0`     | GREEN |
 //! | 2  | Counter reset → invalidation + re-baseline        | None then positive | same        | GREEN |
 //! | 3  | Service removal → `InstanceGone` event            | fired next disc    | same        | GREEN |
-//! | 4  | Single failure → gen_tps held for validity window | Some(…) held       | None immed. | RED   |
+//! | 4  | Single failure → gen_tps held for validity window | Some(…) held       | same        | GREEN |
 //! | 5  | Omitted counter → None (not zero, not panic)      | None, baseline kept| None, kept  | GREEN |
 //! | 6  | Omitted → success path preserves baseline (≠ Fail)| immediate recovery | same        | GREEN |
 //! | 7  | Malformed payload → None (not zero, not panic)    | None               | None        | GREEN |
 //! | 8  | RunningIdle → gen_tps present + running_reqs = 0  | Some(+), req=0     | same        | GREEN |
-//! | 9  | Expiry boundary: held inside window, gone after   | B1 held, B2 none   | B1 RED      | RED   |
+//! | 9  | Expiry boundary: held inside window, gone after   | B1 held, B2 none   | same        | GREEN |
 //!
 //! Scenarios 1–3, 5–8 verify already-correct or distinguishably-observable
-//! behaviour.  Scenarios 4 and 9 reproduce the EAI-7960 root cause.
+//! behaviour.  All scenarios now serve as regression guards.
 //!
 //! Timing: `tick_override = 200 ms`, `discovery_tick = 200 ms`,
 //! `instance_tick = 400 ms` (scrape every 2nd base tick).
@@ -77,11 +77,11 @@
 //!   `clamp(3 × instance_tick, 6 s, 30 s)`.
 //! - Successful scrape: `gen_tps` is recomputed (Fresh), validity clock resets.
 //! - Missing / unparseable counter (HTTP 200, field absent): gen_tps holds,
-//!   validity clock NOT reset, `prev_gen_tokens` preserved.
+//!   validity clock NOT reset, tracker baseline preserved.
 //! - Unchanged valid counter after full rate window: `gen_tps = Some(0.0)`
 //!   (Fresh — idle is not unknown).
 //! - Scrape failure (HTTP non-200): gen_tps holds (Held) until validity expires,
-//!   then `None`.  `prev_gen_tokens` cleared on failure so recovery re-baselines.
+//!   then `None`.  Tracker baseline cleared on failure so recovery re-baselines.
 //! - Counter reset (`cur < prev_val`): immediate `None`, new baseline set.
 //! - Identity change (host:port reassigned): treated as reset.
 //! - Service removal / non-serving terminal state: immediate `None`, no hold.
@@ -407,7 +407,8 @@ fn svc_gen_tps(snap: &rocm_dash_core::metrics::Snapshot) -> Option<Option<f64>> 
 /// distinct from `None` ("no data").  An idle engine is not the same as an
 /// unknown engine.
 ///
-/// GREEN: `gen_tps_from_delta` computes `0 / dt = 0.0` (runner.rs:704).
+/// GREEN: `GenerationObservationTracker` yields `Some(0.0)` when the counter is
+/// unchanged after the full rate window.
 #[tokio::test]
 async fn zero_gen_tps_after_frozen_counter() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -449,8 +450,8 @@ async fn zero_gen_tps_after_frozen_counter() {
 /// immediately yields `gen_tps = None` for that tick, and the new lower value
 /// becomes the baseline so recovery to a positive rate is possible.
 ///
-/// GREEN: `gen_tps_from_delta` has an explicit guard `cur < prev_val → None`
-/// (runner.rs:701), and re-inserts the new value as the baseline.
+/// GREEN: `GenerationObservationTracker` detects `cur < prev_val` and immediately
+/// yields `None`, re-inserting the new lower value as the baseline.
 #[tokio::test]
 async fn counter_reset_invalidates_baseline_immediately() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -512,7 +513,7 @@ async fn counter_reset_invalidates_baseline_immediately() {
 /// event on the next discovery tick and the instance is absent from subsequent
 /// Snapshots.
 ///
-/// GREEN: runner.rs:362-377 computes `known_services.difference(&disc.seen)`
+/// GREEN: runner.rs:446-460 computes `known_services.difference(&disc.seen)`
 /// and fires `InstanceGone` for each absent id.
 #[tokio::test]
 async fn service_removal_fires_instance_gone() {
@@ -579,18 +580,17 @@ async fn service_removal_fires_instance_gone() {
     stop.store(true, Ordering::Relaxed);
 }
 
-// ── Scenario 4: Single failure → gen_tps held for validity window (RED) ────
+// ── Scenario 4: Single failure → gen_tps held for validity window ───────────
 
 /// Contract: after a single failed `/metrics` scrape, `gen_tps` must remain
 /// held at its last positive value for the validity window
 /// `clamp(3 × instance_tick, 6 s, 30 s)` before clearing.
 ///
-/// **Current behaviour — RED:** `runner.rs:462-477` clears `gen_tps` to `None`
-/// and removes `prev_gen_tokens` on the very tick of the failure.  The first
-/// Snapshot after the failure already shows `gen_tps = None`.
+/// This is now a GREEN regression guard: the fix in `GenerationObservationTracker`
+/// holds the last observed value for `clamp(3 × instance_tick, 6 s, 30 s)` before
+/// clearing.  The assertion below will FAIL if the hold-window is regressed.
 ///
-/// This reproduces the same root cause as cucumber Scenario 8 at the daemon
-/// broadcast seam (no PTY / TUI layer).
+/// Complements cucumber Scenario 8 at the daemon broadcast seam (no PTY / TUI).
 #[tokio::test]
 async fn gen_tps_held_for_validity_window_after_single_failure() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -637,16 +637,15 @@ async fn gen_tps_held_for_validity_window_after_single_failure() {
 
     stop.store(true, Ordering::Relaxed);
 
-    // CONTRACT: the held value must still be present.
-    // CURRENT: None — immediate clear.  This assertion FAILS (RED).
+    // CONTRACT: the held value must still be present (regression guard).
+    // If this fails, GenerationObservationTracker no longer holds gen_tps on failure.
     assert!(
         post_failure_gen_tps.is_some(),
         "EAI-7960 REGRESSION (daemon broadcast seam): gen_tps was cleared to None \
-         immediately after the first failed /metrics scrape.\n\
+         immediately after the first failed /metrics scrape — regression detected.\n\
          Contract: hold for clamp(3 × {INSTANCE_TICK:?}, 6 s, 30 s).\n\
-         Root cause: runner.rs:462-477 clears gen_tps on the same tick as the failure.\n\
          Baseline was {baseline:.2} tok/s; post-failure was None.\n\
-         This test must FAIL (RED) until the EAI-7960 fix is applied."
+         This is a GREEN regression guard: if it fires, the EAI-7960 fix was reverted."
     );
 }
 
@@ -654,10 +653,11 @@ async fn gen_tps_held_for_validity_window_after_single_failure() {
 
 /// Contract: when the `/metrics` endpoint returns HTTP 200 but the body omits
 /// `vllm:generation_tokens_total`, `gen_tps` is `None` — not `Some(0.0)`.
-/// `prev_gen_tokens` must NOT be removed (success path, not failure path).
+/// The tracker baseline must NOT be reset (success path, not failure path).
 ///
-/// GREEN: `gen_tps_from_delta` is only reached when `gen_tokens_total.is_some()`;
-/// an absent counter falls straight to `None` without touching `prev_gen_tokens`.
+/// GREEN: `GenerationObservationTracker::observe()` is only called when
+/// `gen_tokens_total` is `Some`; an absent counter is not forwarded and leaves
+/// the tracker baseline untouched.
 #[tokio::test]
 async fn omitted_counter_yields_none_not_zero() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -720,12 +720,12 @@ async fn omitted_counter_yields_none_not_zero() {
 
 /// Contract: after an omitted-counter scrape (HTTP 200, counter absent),
 /// switching back to Growing gives an immediate positive `gen_tps` on the
-/// very next scrape — because `prev_gen_tokens` was preserved on the success
-/// path. This distinguishes `Omitted` from `Failure`, which removes the baseline.
+/// very next scrape — because the tracker baseline was preserved on the success
+/// path. This distinguishes `Omitted` from `Failure`, which resets the baseline.
 ///
-/// GREEN: the success path in runner.rs only calls
-/// `prev_gen_tokens.insert(id, (cur, now))` inside `and_then`, so an absent
-/// counter leaves `prev_gen_tokens` untouched.
+/// GREEN: the success path only forwards `gen_tokens_total` to the tracker when
+/// it is `Some`; an absent counter is not forwarded and leaves the tracker
+/// baseline untouched.
 #[tokio::test]
 async fn omitted_preserves_baseline_so_recovery_is_immediate() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -754,7 +754,7 @@ async fn omitted_preserves_baseline_so_recovery_is_immediate() {
     .await
     .unwrap_or_else(|e| panic!("positive gen_tps never established: {e}"));
 
-    // Step 2: one omitted-counter scrape (success path, prev_gen_tokens preserved).
+    // Step 2: one omitted-counter scrape (success path, tracker baseline preserved).
     // Drain buffered pre-step snapshots, record ticks baseline, then switch to Omitted.
     drain_snapshots(&mut rx);
     let omit_baseline = ticks.load(Ordering::Relaxed);
@@ -769,7 +769,7 @@ async fn omitted_preserves_baseline_so_recovery_is_immediate() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    // Step 3: recover immediately — Growing again with preserved prev_gen_tokens.
+    // Step 3: recover immediately — Growing again with preserved tracker baseline.
     // A single successful scrape with a counter > prev_val should yield positive rate.
     *mode
         .lock()
@@ -921,17 +921,17 @@ async fn running_idle_yields_gen_tps_and_zero_running_reqs() {
 /// Pins both boundaries of the EAI-7960 validity-window contract at the daemon
 /// broadcast seam.
 ///
-/// **BOUNDARY 1 (held assertion — RED today):** immediately after the first
+/// **BOUNDARY 1 (held assertion — regression guard):** immediately after the first
 /// failed scrape, `gen_tps` must still be `Some(_)` (held at its last observed
-/// value).  Current code clears it to `None` immediately — this assertion FAILS.
+/// value).  If this fails, `GenerationObservationTracker` no longer holds on
+/// failure — the EAI-7960 fix was regressed.
 ///
-/// **BOUNDARY 2 (expired assertion — unreachable today):** after the full
-/// validity window `clamp(3 × instance_tick, 6 s, 30 s)` = 6 s elapses, the
-/// held value must be cleared and `gen_tps` must be `None`.
+/// **BOUNDARY 2 (expiry assertion):** after the full validity window
+/// `clamp(3 × instance_tick, 6 s, 30 s)` = 6 s elapses, the held value must be
+/// cleared and `gen_tps` must be `None`.
 ///
-/// Both snapshots are captured before any assertion runs, so the test documents
-/// both boundaries even though only boundary 1 is checked by the final
-/// `assert!`. The boundary 2 assertion becomes GREEN once the fix is applied.
+/// Both snapshots are captured before any assertion runs so both boundaries are
+/// documented.  Both assertions are GREEN regression guards.
 #[tokio::test]
 async fn gen_tps_expiry_boundary_held_then_unavailable() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -1000,12 +1000,11 @@ async fn gen_tps_expiry_boundary_held_then_unavailable() {
     // Assert BOUNDARY 1 first; failure here prevents boundary-2 from running.
     assert!(
         boundary1_gen_tps.is_some(),
-        "EAI-7960 BOUNDARY-1 FAILED (daemon broadcast seam): gen_tps cleared to None \
-         immediately after first failure instead of being held.\n\
+        "EAI-7960 BOUNDARY-1 REGRESSION (daemon broadcast seam): gen_tps cleared to None \
+         immediately after first failure — regression detected.\n\
          Contract: hold for clamp(3 × {INSTANCE_TICK:?}, 6 s, 30 s).\n\
-         Root cause: runner.rs clears gen_tps on the same tick as the failure.\n\
          Baseline was {baseline:.2} tok/s; post-failure was None.\n\
-         This assertion must FAIL (RED) until the EAI-7960 fix is applied."
+         This is a GREEN regression guard: if it fires, the EAI-7960 fix was reverted."
     );
 
     // Assert BOUNDARY 2 (reachable only after boundary-1 is fixed).

--- a/crates/rocm-dash-daemon/tests/telemetry_contract.rs
+++ b/crates/rocm-dash-daemon/tests/telemetry_contract.rs
@@ -972,10 +972,16 @@ async fn gen_tps_expiry_boundary_held_then_unavailable() {
     // Wait for the full validity window + two instance-tick buffer to elapse.
     // Contract: gen_tps must then be None (expired/unavailable).
     // NOTE: this sleep is necessary — the validity window is a real wall-clock
-    // duration that cannot be shortened without touching production code (non-goal).
-    // This code is unreachable today because boundary-1 fails first.
+    // duration that cannot be shortened without touching production code.
+    // After the sleep, drain the broadcast backlog: the channel has accumulated
+    // held-gen_tps snapshots from the sleep period; we want the NEXT snapshot
+    // (from after the drain) which must be from after the validity window.
     let validity_window = observation_validity_window(); // clamp(3×INSTANCE_TICK, 6s, 30s)
     tokio::time::sleep(validity_window + 2 * INSTANCE_TICK + Duration::from_millis(500)).await;
+    // Discard held-period snapshots buffered during the sleep; the immediately
+    // following wait_for_snapshot will read the first post-drain tick, which
+    // is by construction past the validity deadline.
+    drain_snapshots(&mut rx);
     let boundary2_gen_tps = wait_for_snapshot(&mut rx, svc_gen_tps)
         .await
         .unwrap_or_else(|e| panic!("no snapshot for boundary-2 check: {e}"));

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -28,7 +28,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use rocm_dash_core::bench_schema::BenchmarkRow;
-use rocm_dash_core::metrics::{GpuMetrics, Instance, Snapshot};
+use rocm_dash_core::metrics::{GpuMetrics, Instance, ObservationFreshness, Snapshot};
 
 use crate::app::{ChatRole, ChatTurn};
 use crate::client::ClientMsg;
@@ -216,12 +216,32 @@ pub fn gpu_status_json(snap: &StateSnapshot, gpu_index: Option<usize>) -> Value 
     }
 }
 
-/// Discovered serving instances: name, model, status, KV-cache %, req counts.
+/// Discovered serving instances with gen_tps, daemon-provided tok/W,
+/// freshness metadata, and observed_at timestamp.
+///
+/// Fields added by EAI-7960:
+/// - `gen_tps`: live generation throughput from the Instance (same as daemon)
+/// - `tokens_per_watt`: daemon-provided efficiency (never recomputed here)
+/// - `freshness`: `"fresh"` | `"held"` | `null` (null for legacy/unknown)
+/// - `observed_at`: ISO-8601 UTC string when present, `null` when absent
 pub fn list_instances_json(snap: &StateSnapshot) -> Value {
     let arr: Vec<Value> = snap
         .instances
         .iter()
         .map(|i| {
+            let (freshness, observed_at) = match &i.gen_tps_observation {
+                Some(m) => {
+                    let f = match m.freshness {
+                        ObservationFreshness::Fresh => "fresh",
+                        ObservationFreshness::Held => "held",
+                    };
+                    (
+                        serde_json::Value::String(f.into()),
+                        serde_json::Value::String(m.observed_at.to_rfc3339()),
+                    )
+                }
+                None => (serde_json::Value::Null, serde_json::Value::Null),
+            };
             json!({
                 "name": i.container_name,
                 "model": i.model_name,
@@ -229,25 +249,45 @@ pub fn list_instances_json(snap: &StateSnapshot) -> Value {
                 "kv_cache_usage_pct": i.kv_cache_usage_pct,
                 "running_reqs": i.running_reqs,
                 "waiting_reqs": i.waiting_reqs,
+                "gen_tps": i.gen_tps,
+                "tokens_per_watt": i.tokens_per_watt,
+                "freshness": freshness,
+                "observed_at": observed_at,
             })
         })
         .collect();
     json!({ "instances": arr, "instance_count": arr.len() })
 }
 
-/// Per-instance tokens-per-watt: gen tok/s ÷ summed power of its GPUs. Reuses
-/// the core efficiency derivation so it matches the reducer exactly.
+/// Per-instance tokens-per-watt from the daemon-provided field.
+///
+/// Uses `Instance::tokens_per_watt` directly so this tool matches the screen
+/// truth exactly (the daemon computes the same value the TUI displays). Also
+/// includes gen_tps, freshness, and observed_at for completeness.
 pub fn tokens_per_watt_json(snap: &StateSnapshot) -> Value {
-    let gpus = gpus_of(snap);
     let arr: Vec<Value> = snap
         .instances
         .iter()
         .map(|i| {
-            let tpw = rocm_dash_core::efficiency::tokens_per_watt(i.gen_tps, &i.gpu_ids, gpus);
+            let (freshness, observed_at) = match &i.gen_tps_observation {
+                Some(m) => {
+                    let f = match m.freshness {
+                        ObservationFreshness::Fresh => "fresh",
+                        ObservationFreshness::Held => "held",
+                    };
+                    (
+                        serde_json::Value::String(f.into()),
+                        serde_json::Value::String(m.observed_at.to_rfc3339()),
+                    )
+                }
+                None => (serde_json::Value::Null, serde_json::Value::Null),
+            };
             json!({
                 "name": i.container_name,
                 "gen_tps": i.gen_tps,
-                "tokens_per_watt": tpw,
+                "tokens_per_watt": i.tokens_per_watt,
+                "freshness": freshness,
+                "observed_at": observed_at,
             })
         })
         .collect();
@@ -1512,6 +1552,9 @@ mod tests {
             running_reqs: Some(3),
             waiting_reqs: Some(1),
             gen_tps: Some(500.0),
+            // Daemon-computed value: 500 tok/s ÷ 250 W (gpu-2) = 2.0 tok/W.
+            // Set explicitly so tokens_per_watt_json reads the daemon field.
+            tokens_per_watt: Some(2.0),
             ..Default::default()
         };
         let row = BenchmarkRow {
@@ -2225,5 +2268,99 @@ mod tests {
             .expect("oauth reply");
         eprintln!("ChatGPT OAuth reply: {reply}");
         assert!(!reply.is_empty());
+    }
+
+    // ── EAI-7960: agent tool freshness tests ────────────────────────────────
+    // RED: list_instances_json / tokens_per_watt_json must include gen_tps,
+    // tokens_per_watt (daemon-provided), freshness, and observed_at fields.
+
+    fn fixture_with_observation(
+        freshness: rocm_dash_core::metrics::ObservationFreshness,
+    ) -> StateSnapshot {
+        use chrono::Utc;
+        use rocm_dash_core::metrics::{ObservationMetadata, Snapshot};
+        let observed_at = Utc::now();
+        let inst = Instance {
+            container_name: "vllm-obs".into(),
+            model_name: "llama3".into(),
+            gpu_ids: vec!["0".into()],
+            gen_tps: Some(300.0),
+            tokens_per_watt: Some(1.5),
+            gen_tps_observation: Some(ObservationMetadata {
+                observed_at,
+                freshness,
+            }),
+            ..Default::default()
+        };
+        StateSnapshot {
+            latest: Some(Snapshot::default()),
+            instances: vec![inst],
+            bench_rows: vec![],
+        }
+    }
+
+    #[test]
+    fn list_instances_json_includes_gen_tps_and_daemon_tpw() {
+        let snap = fixture_with_observation(rocm_dash_core::metrics::ObservationFreshness::Fresh);
+        let v = list_instances_json(&snap);
+        let i = &v["instances"][0];
+        // Must include gen_tps from Instance.
+        assert_eq!(i["gen_tps"], 300.0, "gen_tps must appear in list_instances");
+        // Must use daemon-provided tokens_per_watt, not recomputed.
+        assert_eq!(i["tokens_per_watt"], 1.5, "daemon tpw must appear");
+        // Must include freshness for non-None metadata.
+        assert!(i["freshness"].is_string(), "freshness must be a string");
+        assert_eq!(i["freshness"], "fresh");
+        // Must include observed_at.
+        assert!(
+            i["observed_at"].is_string(),
+            "observed_at must be an ISO string"
+        );
+    }
+
+    #[test]
+    fn list_instances_json_held_freshness_field() {
+        let snap = fixture_with_observation(rocm_dash_core::metrics::ObservationFreshness::Held);
+        let v = list_instances_json(&snap);
+        let i = &v["instances"][0];
+        assert_eq!(i["freshness"], "held");
+    }
+
+    #[test]
+    fn list_instances_json_legacy_meta_none_freshness_is_null() {
+        // Legacy instance without metadata: freshness must not be fabricated.
+        let inst = Instance {
+            container_name: "vllm-legacy".into(),
+            model_name: "m".into(),
+            gen_tps: Some(100.0),
+            tokens_per_watt: Some(0.5),
+            gen_tps_observation: None,
+            ..Default::default()
+        };
+        let snap = StateSnapshot {
+            latest: Some(rocm_dash_core::metrics::Snapshot::default()),
+            instances: vec![inst],
+            bench_rows: vec![],
+        };
+        let v = list_instances_json(&snap);
+        let i = &v["instances"][0];
+        // freshness must be null (not "fresh" fabricated).
+        assert!(
+            i["freshness"].is_null(),
+            "legacy metadata must yield null freshness, got: {:?}",
+            i["freshness"]
+        );
+    }
+
+    #[test]
+    fn tokens_per_watt_json_uses_daemon_value_not_recomputed() {
+        // Daemon tokens_per_watt=1.5; if re-computed via gen_tps/power it would differ.
+        // The tool must report 1.5, not a recomputed value.
+        let snap = fixture_with_observation(rocm_dash_core::metrics::ObservationFreshness::Fresh);
+        let v = tokens_per_watt_json(&snap);
+        let i = &v["instances"][0];
+        assert_eq!(i["tokens_per_watt"], 1.5, "must use daemon-provided tpw");
+        // freshness also present.
+        assert_eq!(i["freshness"], "fresh");
     }
 }

--- a/crates/rocm-dash-tui/src/replay.rs
+++ b/crates/rocm-dash-tui/src/replay.rs
@@ -626,4 +626,189 @@ mod tests {
 
         let _ = std::fs::remove_file(&path);
     }
+
+    // ── EAI-7960: NDJSON backward-compat / round-trip tests ─────────────────
+    //
+    // Issue 3: use a genuinely hardcoded legacy NDJSON line (no gen_tps_observation
+    // field) and parse it through the actual read_entries → spawn playback path.
+    //
+    // Issue 4: write new NDJSON with Held metadata to a temp file and run it
+    // through spawn; receive ClientMsg::Event and assert gen_tps, observed_at,
+    // and Held freshness survive the full read+playback chain.
+
+    /// A real-world-shaped legacy NDJSON snapshot line produced by a daemon that
+    /// pre-dates EAI-7960. Contains gen_tps=88.5 but has NO gen_tps_observation
+    /// field. Freshness must never be fabricated when this is replayed.
+    const LEGACY_SNAPSHOT_LINE: &str = concat!(
+        r#"{"ts_us":1700000000000000,"event":{"kind":"snapshot","#,
+        r#""timestamp":"2023-11-15T00:00:00Z","#,
+        r#""host":{"cpu_overall_pct":0.0,"cpu_per_core_pct":[],"memory_used_mb":0,"#,
+        r#""memory_total_mb":0,"swap_used_mb":0,"swap_total_mb":0,"#,
+        r#""disk_read_bps":0,"disk_write_bps":0,"net_rx_bps":0,"net_tx_bps":0},"#,
+        r#""gpus":[],"gpu_system_info":null,"#,
+        r#""instances":[{"container_id":"c1","container_name":"vllm-legacy","#,
+        r#""status":"running","model_name":"llama3","gpu_ids":["0"],"#,
+        r#""tensor_parallel_size":1,"vram_used_mb":0,"vram_total_mb":0,"#,
+        r#""gen_tps":88.5,"launch_args":[],"env_vars":{}}],"#,
+        r#""warnings":[]}}"#,
+    );
+
+    #[tokio::test]
+    async fn legacy_ndjson_line_parses_via_playback_no_panic_no_fabricated_freshness() {
+        // Write the hardcoded legacy line to a real file and run it through the
+        // full spawn → read_entries → emit path so we exercise the production
+        // code path, not just serde_json::from_str.
+        let path = tmp_file("legacy-ndjson");
+        {
+            use std::io::Write;
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(LEGACY_SNAPSHOT_LINE.as_bytes()).unwrap();
+            f.write_all(b"\n").unwrap();
+            f.flush().unwrap();
+        }
+
+        let (tx, mut rx) = unbounded_channel::<ClientMsg>();
+        let _ctl = spawn(path.clone(), tx);
+
+        // Drain Connecting + Connected, then collect until we get a Snapshot event.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut found_snapshot = false;
+        loop {
+            let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await else {
+                break;
+            };
+            if let ClientMsg::Event(ev) = &msg
+                && let Event::Snapshot(snap) = ev.as_ref()
+            {
+                found_snapshot = true;
+                let inst = &snap.instances[0];
+                assert!(
+                    (inst.gen_tps.expect("gen_tps must be present") - 88.5).abs() < 1e-9,
+                    "gen_tps must be preserved from legacy NDJSON: got {:?}",
+                    inst.gen_tps
+                );
+                assert!(
+                    inst.gen_tps_observation.is_none(),
+                    "gen_tps_observation must be None for legacy NDJSON; \
+                     freshness must never be fabricated: got {:?}",
+                    inst.gen_tps_observation
+                );
+                break;
+            }
+        }
+        assert!(
+            found_snapshot,
+            "no Snapshot event received from legacy NDJSON replay"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn held_metadata_survives_full_ndjson_write_then_spawn_playback() {
+        // Write NDJSON to a real file via write_lines, then spawn the replay,
+        // receive the ClientMsg::Event, and assert that gen_tps, observed_at,
+        // and Held freshness all survive the full read+playback chain.
+        use chrono::{DateTime, Utc};
+        use rocm_dash_core::metrics::{
+            Instance, InstanceStatus, ObservationFreshness, ObservationMetadata, Snapshot,
+        };
+
+        let observed_at: DateTime<Utc> = "2023-11-15T12:34:56Z".parse().unwrap();
+        let meta = ObservationMetadata {
+            observed_at,
+            freshness: ObservationFreshness::Held,
+        };
+        let inst = Instance {
+            container_id: "c1".into(),
+            container_name: "vllm-held".into(),
+            status: InstanceStatus::Running,
+            model_name: "llama3".into(),
+            gpu_ids: vec!["0".into()],
+            tensor_parallel_size: 1,
+            gen_tps: Some(456.7),
+            gen_tps_observation: Some(meta),
+            ..Default::default()
+        };
+        let mut snap = Snapshot::default();
+        snap.instances.push(inst);
+        let entries = vec![PersistedEntry {
+            ts_us: 1_700_000_000_000_000,
+            event: Event::Snapshot(snap),
+        }];
+
+        let path = tmp_file("held-ndjson");
+        write_lines(&path, &entries);
+
+        // Verify the wire contains the observation field (non-None must appear).
+        let wire = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            wire.contains("gen_tps_observation"),
+            "Held metadata must appear in NDJSON wire: {wire}"
+        );
+
+        let (tx, mut rx) = unbounded_channel::<ClientMsg>();
+        let _ctl = spawn(path.clone(), tx);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut found = false;
+        loop {
+            let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await else {
+                break;
+            };
+            if let ClientMsg::Event(ev) = &msg
+                && let Event::Snapshot(snap_back) = ev.as_ref()
+            {
+                found = true;
+                let i = &snap_back.instances[0];
+                assert!(
+                    (i.gen_tps.expect("gen_tps must survive") - 456.7).abs() < 1e-9,
+                    "gen_tps must survive full playback chain: got {:?}",
+                    i.gen_tps
+                );
+                let obs = i
+                    .gen_tps_observation
+                    .as_ref()
+                    .expect("Held metadata must survive full playback chain");
+                assert_eq!(
+                    obs.freshness,
+                    ObservationFreshness::Held,
+                    "freshness must be Held after full playback"
+                );
+                assert_eq!(
+                    obs.observed_at,
+                    "2023-11-15T12:34:56Z".parse::<DateTime<Utc>>().unwrap(),
+                    "observed_at must survive full playback chain"
+                );
+                break;
+            }
+        }
+        assert!(
+            found,
+            "no Snapshot event received from held-metadata NDJSON replay"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn fresh_metadata_is_absent_from_wire_when_none() {
+        // Instance with gen_tps_observation = None must NOT emit the field in JSON
+        // (skip_serializing_if = None keeps wire back-compat with legacy consumers).
+        use rocm_dash_core::metrics::{Instance, Snapshot};
+        let mut snap = Snapshot::default();
+        snap.instances.push(Instance {
+            container_id: "c2".into(),
+            gen_tps: Some(100.0),
+            gen_tps_observation: None,
+            ..Default::default()
+        });
+        let entry = PersistedEntry {
+            ts_us: 0,
+            event: rocm_dash_core::protocol::Event::Snapshot(snap),
+        };
+        let s = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !s.contains("gen_tps_observation"),
+            "None metadata must be omitted from wire (legacy back-compat); got: {s}"
+        );
+    }
 }

--- a/crates/rocm-dash-tui/src/ui/format.rs
+++ b/crates/rocm-dash-tui/src/ui/format.rs
@@ -15,6 +15,9 @@
 //! - Percentages always with 1 decimal unless < 0.1, then 2 decimals.
 //! - Optional values render `-`.
 
+use chrono::{DateTime, Utc};
+use rocm_dash_core::metrics::{ObservationFreshness, ObservationMetadata};
+
 /// Format a byte count that's already in mebibytes (e.g. amd-smi `vram_used_mb`).
 /// Promotes to GiB at 1024, TiB at 1024², with one decimal.
 pub fn mib(value: u64) -> String {
@@ -164,6 +167,114 @@ pub fn mhz(value: u64) -> String {
     }
 }
 
+// ── EAI-7960: observation-aware formatters ───────────────────────────────────
+
+/// Held-observation marker. Appended to compact values when freshness is Held.
+/// Every surface that shows a held indicator MUST use this constant so the
+/// rendered character and the legend text stay in sync.
+pub const HELD_MARKER: &str = "*";
+
+/// Legend text for [`HELD_MARKER`]. Re-use in tab footers, tooltips, and help
+/// panels rather than inventing view-specific descriptions.
+pub const HELD_LEGEND: &str = "* = held (prior scrape window)";
+
+/// Compact gen_tps for narrow table cells (matches the existing bare-number format).
+///
+/// - `None` → `"—"` (unavailable; em-dash matches the rest of the table)
+/// - Non-finite → `"—"` (NaN/Inf never rendered)
+/// - `Some(v)`, Held → `"{v:.0}*"`
+/// - `Some(v)`, Fresh or unknown metadata → `"{v:.0}"`
+/// - Real `0.0` → `"0"` (zero is a real measurement, never dash)
+pub fn gen_tps_cell(tps: Option<f64>, obs: Option<&ObservationMetadata>) -> String {
+    match tps {
+        None => "—".to_string(),
+        Some(v) if !v.is_finite() => "—".to_string(),
+        Some(v) => {
+            let base = format!("{v:.0}");
+            if obs.is_some_and(|m| m.freshness == ObservationFreshness::Held) {
+                format!("{base}{HELD_MARKER}")
+            } else {
+                base
+            }
+        }
+    }
+}
+
+/// Full-unit gen_tps for cards, pane rows, and services views.
+/// Mirrors [`tps_opt`] format and appends [`HELD_MARKER`] when metadata is Held.
+///
+/// - `None` → `"-"`
+/// - Non-finite → `"-"` (NaN/Inf never rendered)
+/// - `Some(v)`, Held → `"N.N tok/s*"` (or SI-scaled)
+/// - `Some(v)`, Fresh or unknown → `"N.N tok/s"`
+/// - Real `0.0` → `"0.0 tok/s"` — never `"-"`
+pub fn gen_tps_compact(tps: Option<f64>, obs: Option<&ObservationMetadata>) -> String {
+    match tps {
+        None => "-".to_string(),
+        Some(v) if !v.is_finite() => "-".to_string(),
+        Some(v) => {
+            let base = if v >= 1_000.0 {
+                format!("{} tok/s", si(v))
+            } else {
+                format!("{v:.1} tok/s")
+            };
+            if obs.is_some_and(|m| m.freshness == ObservationFreshness::Held) {
+                format!("{base}{HELD_MARKER}")
+            } else {
+                base
+            }
+        }
+    }
+}
+
+/// Freshness label for the detail pane. Age is computed from the snapshot
+/// timestamp minus `observed_at` — **never** from the local wall-clock.
+///
+/// - `None` metadata → `"unknown"` (legacy; freshness never fabricated)
+/// - `Fresh` → `"fresh"`
+/// - `Held`, snap known → `"held · {age}s ago"` (age clamped ≥ 0)
+/// - `Held`, snap unknown → `"held"`
+pub fn gen_tps_detail_freshness(
+    obs: Option<&ObservationMetadata>,
+    snap_ts: Option<DateTime<Utc>>,
+) -> String {
+    match obs {
+        None => "unknown".to_string(),
+        Some(m) => match m.freshness {
+            ObservationFreshness::Fresh => "fresh".to_string(),
+            ObservationFreshness::Held => match snap_ts {
+                Some(ts) => {
+                    let age_s = (ts - m.observed_at).num_seconds().max(0);
+                    format!("held · {age_s}s ago")
+                }
+                None => "held".to_string(),
+            },
+        },
+    }
+}
+
+/// Aggregate gen_tps display for hero panels: formats a sum of instance
+/// throughputs and appends [`HELD_MARKER`] when any contributing instance is Held.
+///
+/// - `None` → `"—"` (no contributing instances with valid gen_tps)
+/// - Non-finite → `"—"` (guards the same sentinel as the per-instance formatters)
+/// - `Some(v)`, `any_held` → `"N.N tok/s*"` (SI-scaled via [`tps_opt`])
+/// - `Some(v)`, fresh/unknown → `"N.N tok/s"`
+pub fn gen_tps_aggregate(tps: Option<f64>, any_held: bool) -> String {
+    match tps {
+        None => "—".to_string(),
+        Some(v) if !v.is_finite() => "—".to_string(),
+        Some(v) => {
+            let base = tps_opt(Some(v));
+            if any_held {
+                format!("{base}{HELD_MARKER}")
+            } else {
+                base
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +368,211 @@ mod tests {
         assert_eq!(celsius(67.0), "67.0°C");
         assert_eq!(mhz(2400), "2.40 GHz");
         assert_eq!(mhz(800), "800 MHz");
+    }
+
+    // ── EAI-7960: observation-aware formatter tests (RED until impl added) ──
+    use chrono::{DateTime, Utc};
+    use rocm_dash_core::metrics::{ObservationFreshness, ObservationMetadata};
+
+    fn fresh_obs() -> ObservationMetadata {
+        ObservationMetadata {
+            observed_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            freshness: ObservationFreshness::Fresh,
+        }
+    }
+
+    fn held_obs() -> ObservationMetadata {
+        ObservationMetadata {
+            observed_at: DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            freshness: ObservationFreshness::Held,
+        }
+    }
+
+    #[test]
+    fn held_marker_and_legend_are_non_empty_and_consistent() {
+        assert!(!HELD_MARKER.is_empty());
+        assert!(!HELD_LEGEND.is_empty());
+        assert!(
+            HELD_LEGEND.contains(HELD_MARKER),
+            "legend must contain the marker"
+        );
+    }
+
+    #[test]
+    fn gen_tps_cell_none_is_em_dash() {
+        assert_eq!(gen_tps_cell(None, None), "—");
+    }
+
+    #[test]
+    fn gen_tps_cell_fresh_has_no_marker() {
+        let obs = fresh_obs();
+        let out = gen_tps_cell(Some(100.0), Some(&obs));
+        assert_eq!(out, "100");
+        assert!(!out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_cell_held_appends_marker() {
+        let obs = held_obs();
+        let out = gen_tps_cell(Some(100.0), Some(&obs));
+        assert!(
+            out.ends_with(HELD_MARKER),
+            "held cell must end with HELD_MARKER: {out:?}"
+        );
+        assert!(out.starts_with("100"));
+    }
+
+    #[test]
+    fn gen_tps_cell_legacy_none_meta_no_marker() {
+        let out = gen_tps_cell(Some(100.0), None);
+        assert_eq!(out, "100");
+        assert!(!out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_cell_real_zero_is_not_dash() {
+        assert_eq!(gen_tps_cell(Some(0.0), None), "0");
+        let obs = held_obs();
+        let out = gen_tps_cell(Some(0.0), Some(&obs));
+        assert!(out.starts_with('0') && out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_compact_none_is_dash() {
+        assert_eq!(gen_tps_compact(None, None), "-");
+    }
+
+    #[test]
+    fn gen_tps_compact_fresh_has_unit_no_marker() {
+        let obs = fresh_obs();
+        let out = gen_tps_compact(Some(45.6), Some(&obs));
+        assert!(out.contains("tok/s") && !out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_compact_held_appends_marker_with_unit() {
+        let obs = held_obs();
+        let out = gen_tps_compact(Some(45.6), Some(&obs));
+        assert!(out.contains("tok/s") && out.ends_with(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_compact_legacy_no_marker() {
+        let out = gen_tps_compact(Some(45.6), None);
+        assert!(out.contains("tok/s") && !out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_compact_zero_renders_as_zero_not_dash() {
+        let out = gen_tps_compact(Some(0.0), None);
+        assert_ne!(out, "-");
+        assert!(out.contains("0.0 tok/s"), "zero with unit: {out:?}");
+    }
+
+    #[test]
+    fn gen_tps_cell_nonfinite_is_em_dash() {
+        assert_eq!(
+            gen_tps_cell(Some(f64::NAN), None),
+            "—",
+            "NaN must render as em-dash"
+        );
+        assert_eq!(
+            gen_tps_cell(Some(f64::INFINITY), None),
+            "—",
+            "+Inf must render as em-dash"
+        );
+        assert_eq!(
+            gen_tps_cell(Some(f64::NEG_INFINITY), None),
+            "—",
+            "-Inf must render as em-dash"
+        );
+        // Held marker must not be appended to a non-finite sentinel.
+        let obs = held_obs();
+        assert_eq!(gen_tps_cell(Some(f64::NAN), Some(&obs)), "—");
+    }
+
+    #[test]
+    fn gen_tps_compact_nonfinite_is_dash() {
+        assert_eq!(
+            gen_tps_compact(Some(f64::NAN), None),
+            "-",
+            "NaN must render as dash"
+        );
+        assert_eq!(
+            gen_tps_compact(Some(f64::INFINITY), None),
+            "-",
+            "+Inf must render as dash"
+        );
+        assert_eq!(
+            gen_tps_compact(Some(f64::NEG_INFINITY), None),
+            "-",
+            "-Inf must render as dash"
+        );
+        let obs = held_obs();
+        assert_eq!(gen_tps_compact(Some(f64::NAN), Some(&obs)), "-");
+    }
+
+    #[test]
+    fn gen_tps_aggregate_none_is_em_dash() {
+        assert_eq!(gen_tps_aggregate(None, false), "—");
+        assert_eq!(gen_tps_aggregate(None, true), "—");
+    }
+
+    #[test]
+    fn gen_tps_aggregate_fresh_has_no_marker() {
+        let out = gen_tps_aggregate(Some(200.0), false);
+        assert!(out.contains("tok/s") && !out.contains(HELD_MARKER));
+    }
+
+    #[test]
+    fn gen_tps_aggregate_held_appends_marker() {
+        let out = gen_tps_aggregate(Some(200.0), true);
+        assert!(
+            out.contains("tok/s") && out.ends_with(HELD_MARKER),
+            "aggregate held must end with HELD_MARKER: {out:?}"
+        );
+    }
+
+    #[test]
+    fn gen_tps_aggregate_nonfinite_is_em_dash() {
+        assert_eq!(gen_tps_aggregate(Some(f64::NAN), false), "—");
+        assert_eq!(gen_tps_aggregate(Some(f64::INFINITY), true), "—");
+    }
+
+    #[test]
+    fn gen_tps_aggregate_zero_is_not_dash() {
+        let out = gen_tps_aggregate(Some(0.0), false);
+        assert_ne!(out, "—", "zero is a real value, not unavailable");
+    }
+
+    #[test]
+    fn gen_tps_detail_freshness_fresh() {
+        let obs = fresh_obs();
+        let ts: Option<DateTime<Utc>> = Some(DateTime::from_timestamp(1_700_000_060, 0).unwrap());
+        assert_eq!(gen_tps_detail_freshness(Some(&obs), ts), "fresh");
+    }
+
+    #[test]
+    fn gen_tps_detail_freshness_held_with_age() {
+        let obs = held_obs();
+        let ts = Some(DateTime::from_timestamp(1_700_000_060, 0).unwrap());
+        let out = gen_tps_detail_freshness(Some(&obs), ts);
+        assert!(
+            out.starts_with("held") && out.contains("60"),
+            "age in output: {out:?}"
+        );
+    }
+
+    #[test]
+    fn gen_tps_detail_freshness_held_no_snapshot_ts() {
+        let obs = held_obs();
+        let out = gen_tps_detail_freshness(Some(&obs), None);
+        assert_eq!(out, "held");
+    }
+
+    #[test]
+    fn gen_tps_detail_freshness_legacy_says_unknown() {
+        let out = gen_tps_detail_freshness(None, None);
+        assert_eq!(out, "unknown");
     }
 }

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -24,7 +24,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
-use rocm_dash_core::metrics::Instance;
+use rocm_dash_core::metrics::{Instance, ObservationMetadata};
 use rocm_dash_core::state::{SideEffect, State, StateEvent};
 
 use crate::ui::approval::{
@@ -74,7 +74,10 @@ pub struct ServicesManagerState {
     pub active_job: Option<String>,
 }
 
-/// A render-ready row derived from an `Instance`.
+/// A render-ready row derived from an [`Instance`].
+///
+/// `gen_tps_observation` carries the freshness metadata alongside the numeric
+/// value so the renderer can mark held observations — no value duplication.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ServiceRow {
     pub id: String,
@@ -82,6 +85,8 @@ pub struct ServiceRow {
     pub port: Option<u16>,
     pub status: String,
     pub gen_tps: Option<f64>,
+    /// Freshness metadata for `gen_tps`; `None` for legacy snapshots.
+    pub gen_tps_observation: Option<ObservationMetadata>,
 }
 
 /// Build the sorted service list from the daemon-surfaced instances.
@@ -98,6 +103,7 @@ pub fn service_rows<S: ::std::hash::BuildHasher>(
             // when the instance is `Starting`; never a raw `{:?}` debug string.
             status: i.status.label().to_owned(),
             gen_tps: i.gen_tps,
+            gen_tps_observation: i.gen_tps_observation.clone(),
         })
         .collect();
     rows.sort_by(|a, b| a.id.cmp(&b.id));
@@ -281,7 +287,10 @@ pub fn draw_services_manager<S: ::std::hash::BuildHasher>(
                     ),
                     Span::styled(format!("{:<10}", r.status), Style::default().fg(theme.ok)),
                     Span::styled(
-                        format!("gen {}", format::tps_opt(r.gen_tps)),
+                        format!(
+                            "gen {}",
+                            format::gen_tps_compact(r.gen_tps, r.gen_tps_observation.as_ref())
+                        ),
                         Style::default().fg(theme.fg),
                     ),
                 ]))

--- a/crates/rocm-dash-tui/src/ui/tabs/home.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/home.rs
@@ -256,13 +256,26 @@ fn draw_hero_left(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         lh[2],
     );
     // Tokens/watt: summed across running instances when available.
+    // Mark held if any contributing instance has a held gen_tps observation
+    // (tok/W derives from gen_tps; aggregate inherits held status).
     let tpw: f64 = state
         .instances
         .values()
         .filter_map(|i| i.tokens_per_watt)
         .sum();
+    let any_tpw_held = state.instances.values().any(|i| {
+        i.tokens_per_watt.is_some()
+            && i.gen_tps_observation
+                .as_ref()
+                .is_some_and(|m| m.freshness == rocm_dash_core::metrics::ObservationFreshness::Held)
+    });
     let tpw_label = if tpw > 0.0 {
-        format!("⎓ {tpw:.1} tokens / watt")
+        let marker = if any_tpw_held {
+            crate::ui::format::HELD_MARKER
+        } else {
+            ""
+        };
+        format!("⎓ {tpw:.1} tokens / watt{marker}")
     } else {
         "⎓ tokens / watt —".to_string()
     };
@@ -350,7 +363,18 @@ fn draw_hero_right(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         theme,
     );
     let tps: f64 = state.instances.values().filter_map(|i| i.gen_tps).sum();
-    mini_spark(f, rh[4], "T/S  ", &format!("{tps:.0}"), &[], true, theme);
+    let any_tps_held = state.instances.values().any(|i| {
+        i.gen_tps.is_some()
+            && i.gen_tps_observation
+                .as_ref()
+                .is_some_and(|m| m.freshness == rocm_dash_core::metrics::ObservationFreshness::Held)
+    });
+    let tps_str = if any_tps_held {
+        format!("{:.0}{}", tps, crate::ui::format::HELD_MARKER)
+    } else {
+        format!("{tps:.0}")
+    };
+    mini_spark(f, rh[4], "T/S  ", &tps_str, &[], true, theme);
 }
 
 fn draw_tiles(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -768,6 +768,7 @@ mod tests {
             running_reqs: None,
             waiting_reqs: None,
             gen_tps: None,
+            gen_tps_observation: None,
             tokens_per_watt: None,
             ttft_ms: None,
             tpot_ms: None,

--- a/crates/rocm-dash-tui/src/ui/tabs/instances.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/instances.rs
@@ -5,6 +5,7 @@
 //! Instances Observe sub-panel — full-screen instance grid with kv-cache / requests / args,
 //! plus a detail modal showing model / partition / launch_args / env / log.
 
+use chrono::{DateTime, Utc};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -91,9 +92,7 @@ pub fn draw_table(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let dash = "—";
     let rows = instances.iter().enumerate().map(|(i, inst)| {
         let model = trunc(&inst.model_name, 22);
-        let tps = inst
-            .gen_tps
-            .map_or_else(|| dash.to_string(), |v| format!("{v:.0}"));
+        let tps = format::gen_tps_cell(inst.gen_tps, inst.gen_tps_observation.as_ref());
         let tpw = inst
             .tokens_per_watt
             .filter(|v| v.is_finite())
@@ -420,7 +419,10 @@ fn draw_card(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme, selected
             Style::default().fg(theme.accent),
         ),
         Span::styled(" · gen ", Style::default().fg(theme.muted)),
-        Span::styled(format::tps_opt(inst.gen_tps), Style::default().fg(theme.fg)),
+        Span::styled(
+            format::gen_tps_compact(inst.gen_tps, inst.gen_tps_observation.as_ref()),
+            Style::default().fg(theme.fg),
+        ),
     ]));
 
     // 5. vram (only if total > 0)
@@ -590,22 +592,30 @@ pub fn draw_detail(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
         return;
     }
 
-    // Vertical: summary (3) | body (min) | footer (1)
+    // Vertical: summary (4 lines: status/id/port/tp · model/gpus/tpw/gen · partition/quant/vram · freshness)
+    // | body (min) | footer (1)
+    let snap_ts = state.latest.as_ref().map(|s| s.timestamp);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            Constraint::Length(4),
             Constraint::Min(0),
             Constraint::Length(1),
         ])
         .split(inner);
 
-    render_summary(f, chunks[0], inst, theme);
+    render_summary(f, chunks[0], inst, snap_ts, theme);
     render_body(f, chunks[1], inst, theme);
     render_footer(f, chunks[2], inst, theme);
 }
 
-fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
+fn render_summary(
+    f: &mut Frame,
+    area: Rect,
+    inst: &Instance,
+    snap_ts: Option<DateTime<Utc>>,
+    theme: &Theme,
+) {
     let (status_color, status_text) = status_meta(inst.status, theme);
     let muted = Style::default().fg(theme.muted);
     let fg = Style::default().fg(theme.fg);
@@ -620,6 +630,14 @@ fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
     } else {
         inst.gpu_ids.join(",")
     };
+
+    // Freshness label: age = snapshot_ts − observed_at (never wall-clock).
+    let freshness_str =
+        format::gen_tps_detail_freshness(inst.gen_tps_observation.as_ref(), snap_ts);
+    let observed_str = inst.gen_tps_observation.as_ref().map_or_else(
+        || "-".to_string(),
+        |m| m.observed_at.format("%H:%M:%S UTC").to_string(),
+    );
 
     let lines = vec![
         Line::from(vec![
@@ -654,7 +672,10 @@ fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
             ),
             Span::raw("  "),
             Span::styled("gen: ", muted),
-            Span::styled(format::tps_opt(inst.gen_tps), fg),
+            Span::styled(
+                format::gen_tps_compact(inst.gen_tps, inst.gen_tps_observation.as_ref()),
+                fg,
+            ),
         ]),
         Line::from(vec![
             Span::styled("partition: ", muted),
@@ -665,6 +686,14 @@ fn render_summary(f: &mut Frame, area: Rect, inst: &Instance, theme: &Theme) {
             Span::raw("  "),
             Span::styled("vram: ", muted),
             Span::styled(format::mib_pair(inst.vram_used_mb, inst.vram_total_mb), fg),
+        ]),
+        // 4th line: gen_tps freshness and deterministic age (snapshot-time, never wall-clock).
+        Line::from(vec![
+            Span::styled("gen freshness: ", muted),
+            Span::styled(freshness_str, fg),
+            Span::raw("  "),
+            Span::styled("observed: ", muted),
+            Span::styled(observed_str, Style::default().fg(theme.muted)),
         ]),
     ];
 
@@ -1190,6 +1219,204 @@ mod tests {
         assert!(
             out.contains('—'),
             "non-finite metrics must render the em-dash placeholder:\n{out}"
+        );
+    }
+
+    // ── EAI-7960: observation-aware renderer tests ───────────────────────────
+    // RED: assert held marker "*" in table/card output, freshness in detail.
+    // These fail until draw_table / draw_card / render_summary use the new
+    // gen_tps_cell / gen_tps_compact / gen_tps_detail_freshness formatters.
+
+    use chrono::{TimeZone, Utc};
+    use rocm_dash_core::metrics::{ObservationFreshness, ObservationMetadata};
+
+    fn mk_inst_obs(name: &str, gen_tps: Option<f64>, obs: Option<ObservationMetadata>) -> Instance {
+        let mut i = mk_inst(name);
+        i.gen_tps = gen_tps;
+        i.gen_tps_observation = obs;
+        i
+    }
+
+    fn obs(freshness: ObservationFreshness, secs_before_snap: i64) -> ObservationMetadata {
+        // snap_ts will be SNAP_TS; this obs was secs_before_snap seconds earlier.
+        let snap_secs = 1_700_000_060_i64;
+        ObservationMetadata {
+            observed_at: Utc.timestamp_opt(snap_secs - secs_before_snap, 0).unwrap(),
+            freshness,
+        }
+    }
+
+    const SNAP_SECS: i64 = 1_700_000_060;
+
+    fn state_with_snap(inst: Instance) -> AppState {
+        let mut m = HashMap::new();
+        m.insert(inst.container_id.clone(), inst.clone());
+        let mut state = mk_state(m, 0);
+        let snap = rocm_dash_core::metrics::Snapshot {
+            timestamp: Utc.timestamp_opt(SNAP_SECS, 0).unwrap(),
+            instances: vec![inst],
+            ..Default::default()
+        };
+        state.latest = Some(snap);
+        state
+    }
+
+    #[test]
+    fn table_held_gen_tps_shows_held_marker() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs(
+            "held",
+            Some(123.0),
+            Some(obs(ObservationFreshness::Held, 30)),
+        );
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 20)).unwrap();
+        term.draw(|f| draw_table(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("123*"),
+            "held gen_tps must show '123*' in table; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn table_fresh_gen_tps_has_no_held_marker() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs(
+            "fresh",
+            Some(456.0),
+            Some(obs(ObservationFreshness::Fresh, 5)),
+        );
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 20)).unwrap();
+        term.draw(|f| draw_table(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("456"),
+            "fresh gen_tps value must appear; got:\n{out}"
+        );
+        assert!(
+            !out.contains("456*"),
+            "fresh must NOT have held marker; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn table_legacy_meta_none_has_no_held_marker() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs("legacy", Some(789.0), None);
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 20)).unwrap();
+        term.draw(|f| draw_table(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("789") && !out.contains("789*"),
+            "legacy (no metadata) must NOT show held marker; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn table_none_gen_tps_shows_em_dash() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs("none-tps", None, None);
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 20)).unwrap();
+        term.draw(|f| draw_table(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains('—'),
+            "missing gen_tps must render em-dash; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn table_zero_gen_tps_is_not_dash() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // Real zero gen_tps (counter is active but rate is zero) must NOT collapse to dash.
+        let inst = mk_inst_obs("zero-tps", Some(0.0), None);
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 20)).unwrap();
+        term.draw(|f| draw_table(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        // "0" appears in the TOK/S column; the em-dash should NOT appear in that slot.
+        // (em-dash may appear for other missing cols, so we check the tok/s specific cell)
+        assert!(
+            out.contains("0 ") || out.contains("0\n") || out.contains("0*"),
+            "zero gen_tps must render as '0', not '—'; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn detail_held_shows_held_freshness_label() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs(
+            "held-detail",
+            Some(100.0),
+            Some(obs(ObservationFreshness::Held, 30)),
+        );
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 48)).unwrap();
+        term.draw(|f| draw_detail(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("held"),
+            "detail for held instance must show 'held' freshness; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn detail_fresh_shows_fresh_label() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs(
+            "fresh-detail",
+            Some(100.0),
+            Some(obs(ObservationFreshness::Fresh, 0)),
+        );
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 48)).unwrap();
+        term.draw(|f| draw_detail(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("fresh"),
+            "detail for fresh instance must show 'fresh'; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn detail_legacy_meta_none_shows_unknown() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let inst = mk_inst_obs("legacy-detail", Some(100.0), None);
+        let state = state_with_snap(inst);
+        let mut term = Terminal::new(TestBackend::new(160, 48)).unwrap();
+        term.draw(|f| draw_detail(f, f.area(), &state, &state.theme))
+            .unwrap();
+        let out = buffer_text(&term);
+        assert!(
+            out.contains("unknown"),
+            "detail for legacy (None metadata) must say 'unknown'; got:\n{out}"
         );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/tabs/observe.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/observe.rs
@@ -93,8 +93,23 @@ fn draw_efficiency_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
     if inner.height == 0 {
         return;
     }
+    // Track aggregate held: an instance contributes if it has gen_tps AND its
+    // observation metadata says Held. Any contributing Held → whole aggregate is held.
+    let any_held = state.latest.as_ref().is_some_and(|snap| {
+        snap.instances.iter().any(|i| {
+            i.gen_tps.is_some()
+                && i.gen_tps_observation.as_ref().is_some_and(|m| {
+                    m.freshness == rocm_dash_core::metrics::ObservationFreshness::Held
+                })
+        })
+    });
     let eff = state.latest.as_ref().and_then(widgets::node_efficiency);
-    let value = eff.map_or_else(|| "—".to_string(), |v| format!("{v:.2} tok/W"));
+    let value_base = eff.map_or_else(|| "—".to_string(), |v| format!("{v:.2} tok/W"));
+    let value = if any_held && eff.is_some() {
+        format!("{value_base}{}", format::HELD_MARKER)
+    } else {
+        value_base
+    };
     // Trend: node efficiency across recent snapshots (scaled to milli-tok/W so
     // the integer sparkline keeps resolution); empty when no history yet.
     let trend: Vec<u64> = state
@@ -104,6 +119,7 @@ fn draw_efficiency_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
         .map(|v| (v * 1000.0).round().max(0.0) as u64)
         .collect();
 
+    // Layout: value | sparkline (min) | label/legend.
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -128,9 +144,15 @@ fn draw_efficiency_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
             rows[1],
         );
     }
+    // Show HELD_LEGEND when any contributing instance is held; otherwise label.
+    let label = if any_held {
+        format::HELD_LEGEND
+    } else {
+        "tokens per watt · whole node"
+    };
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "tokens per watt · whole node",
+            label,
             Style::default().fg(theme.muted),
         ))),
         rows[2],
@@ -151,33 +173,36 @@ fn draw_throughput_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
     if inner.height == 0 {
         return;
     }
-    let (tps, has_tps, power, has_power) =
+    let (tps, has_tps, power, has_power, any_held) =
         state
             .latest
             .as_ref()
-            .map_or((0.0, false, 0.0_f32, false), |snap| {
+            .map_or((0.0, false, 0.0_f32, false, false), |snap| {
                 let mut tps = 0.0;
                 let mut has_tps = false;
+                let mut any_held = false;
                 for inst in &snap.instances {
                     if let Some(v) = inst.gen_tps {
                         tps += v;
                         has_tps = true;
+                        if inst.gen_tps_observation.as_ref().is_some_and(|m| {
+                            m.freshness == rocm_dash_core::metrics::ObservationFreshness::Held
+                        }) {
+                            any_held = true;
+                        }
                     }
                 }
                 let power: f32 = snap.gpus.iter().map(|g| g.power_w).sum();
-                (tps, has_tps, power, !snap.gpus.is_empty())
+                (tps, has_tps, power, !snap.gpus.is_empty(), any_held)
             });
-    let tps_str = if has_tps {
-        format::tps_opt(Some(tps))
-    } else {
-        "—".to_string()
-    };
+    // Aggregate formatted via shared formatter: NaN/Inf guard + held marker.
+    let tps_str = format::gen_tps_aggregate(has_tps.then_some(tps), any_held);
     let power_str = if has_power {
         format::watts(power)
     } else {
         "—".to_string()
     };
-    let lines = vec![
+    let mut lines = vec![
         Line::from(Span::styled(
             tps_str,
             Style::default()
@@ -193,6 +218,14 @@ fn draw_throughput_hero(f: &mut Frame, area: Rect, state: &AppState, theme: &The
             Style::default().fg(theme.muted),
         )),
     ];
+    // Show the shared HELD_LEGEND only when at least one contributing instance
+    // is held — keeps the surface quiet when data is fully fresh.
+    if any_held {
+        lines.push(Line::from(Span::styled(
+            format::HELD_LEGEND,
+            Style::default().fg(theme.muted),
+        )));
+    }
     f.render_widget(Paragraph::new(lines), inner);
 }
 
@@ -219,7 +252,10 @@ mod tests {
     use crate::app::ActiveTab;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
-    use rocm_dash_core::metrics::{GpuMetrics, Instance, InstanceStatus, Snapshot, SystemMetrics};
+    use rocm_dash_core::metrics::{
+        GpuMetrics, Instance, InstanceStatus, ObservationFreshness, ObservationMetadata, Snapshot,
+        SystemMetrics,
+    };
 
     fn render(state: &AppState, cols: u16, rows: u16) -> String {
         let backend = TestBackend::new(cols, rows);
@@ -386,5 +422,99 @@ mod tests {
         for h in [1u16, 2, 3, 5, 8, 12] {
             let _ = render(&s, 80, h);
         }
+    }
+
+    fn instance_with_obs(model: &str, gen_tps: f64, obs: Option<ObservationMetadata>) -> Instance {
+        Instance {
+            container_id: model.into(),
+            container_name: model.into(),
+            status: InstanceStatus::Running,
+            model_name: model.into(),
+            gpu_ids: vec!["0".into()],
+            gen_tps: Some(gen_tps),
+            tokens_per_watt: Some(gen_tps / 300.0),
+            gen_tps_observation: obs,
+            ..Default::default()
+        }
+    }
+
+    fn held_obs() -> ObservationMetadata {
+        ObservationMetadata {
+            observed_at: "2023-11-15T12:00:00Z".parse().unwrap(),
+            freshness: ObservationFreshness::Held,
+        }
+    }
+
+    fn fresh_obs() -> ObservationMetadata {
+        ObservationMetadata {
+            observed_at: "2023-11-15T12:00:00Z".parse().unwrap(),
+            freshness: ObservationFreshness::Fresh,
+        }
+    }
+
+    // ── EAI-7960: HELD_LEGEND rendering and efficiency hero held marker ───────
+
+    #[test]
+    fn observe_held_legend_visible_in_throughput_hero_when_held() {
+        use crate::ui::format;
+        let inst = instance_with_obs("m", 200.0, Some(held_obs()));
+        let state = connected_with_instances(vec![inst]);
+        let out = render(&state, 160, 50);
+        assert!(
+            out.contains(format::HELD_LEGEND),
+            "HELD_LEGEND must be visible when data is held; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn observe_held_legend_absent_when_all_fresh() {
+        use crate::ui::format;
+        let inst = instance_with_obs("m", 200.0, Some(fresh_obs()));
+        let state = connected_with_instances(vec![inst]);
+        let out = render(&state, 160, 50);
+        assert!(
+            !out.contains(format::HELD_LEGEND),
+            "HELD_LEGEND must not appear when all fresh; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn observe_efficiency_hero_appends_held_marker_when_any_held() {
+        use crate::ui::format;
+        let inst = instance_with_obs("m", 300.0, Some(held_obs()));
+        let state = connected_with_instances(vec![inst]);
+        let out = render(&state, 160, 50);
+        assert!(
+            out.contains(format::HELD_MARKER),
+            "HELD_MARKER must appear in efficiency hero when any instance is held; got:\n{out}"
+        );
+        assert!(
+            out.contains(format::HELD_LEGEND),
+            "HELD_LEGEND must appear in a hero when held; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn observe_efficiency_hero_no_held_marker_for_fresh_instances() {
+        use crate::ui::format;
+        let inst = instance_with_obs("m", 300.0, Some(fresh_obs()));
+        let state = connected_with_instances(vec![inst]);
+        let out = render(&state, 160, 50);
+        assert!(
+            !out.contains(format::HELD_LEGEND),
+            "HELD_LEGEND must be absent when all fresh; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn observe_efficiency_hero_no_held_marker_for_legacy_none_metadata() {
+        use crate::ui::format;
+        let inst = instance_with_obs("m", 300.0, None);
+        let state = connected_with_instances(vec![inst]);
+        let out = render(&state, 160, 50);
+        assert!(
+            !out.contains(format::HELD_LEGEND),
+            "HELD_LEGEND must not appear for legacy None metadata; got:\n{out}"
+        );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/tabs/pane.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/pane.rs
@@ -422,7 +422,10 @@ fn live_lines(action: KeyAction, state: &AppState, theme: &Theme) -> Vec<Line<'s
                         Span::styled(i.model_name.clone(), Style::default().fg(theme.fg)),
                         Span::styled(port, Style::default().fg(theme.muted)),
                         Span::styled(
-                            format!("  gen {}", format::tps_opt(i.gen_tps)),
+                            format!(
+                                "  gen {}",
+                                format::gen_tps_compact(i.gen_tps, i.gen_tps_observation.as_ref())
+                            ),
                             Style::default().fg(theme.muted),
                         ),
                     ]));

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -68,3 +68,45 @@ Feature: Interactive dashboard
     Then the managed model is displayed
     When the user quits the dashboard
     Then the dashboard exits successfully
+
+
+  @id:eai-7960-gen-tps-held-after-scrape-failure @requires-os:linux
+  Scenario: 8 - Gen throughput stays visible for the validity window after a scrape failure
+    # EAI-7960 principal regression: after establishing a positive gen_tps
+    # baseline through the scripted mock, a single /metrics transport failure
+    # must NOT immediately clear the displayed "tok/s" value.  The contract
+    # requires the held value to remain visible for the validity window
+    # clamp(3 x instance_tick, 6 s, 30 s).  Current code has no such window
+    # (runner.rs clears gen_tps on the same tick as the failure), so the
+    # "generation throughput remains visible" step is the RED assertion.
+    Given a managed model exposes scripted serving metrics
+    When the user opens the dashboard
+    And the user opens the Observe view
+    Then positive generation throughput is displayed for the managed model
+    When the metrics endpoint fails transiently
+    Then generation throughput remains visible within the validity window
+    When the user quits the dashboard
+    Then the dashboard exits successfully
+
+  @id:eai-7960-gen-tps-expiry-boundary @requires-os:linux
+  Scenario: 9 - Gen throughput expires after the validity window following sustained failure
+    # EAI-7960 expiry-boundary scenario: two contract boundaries are pinned.
+    #
+    # BOUNDARY 1 (held assertion) — immediately after the first failed scrape,
+    # gen_tps must still be visible (Held).  With current code this FAILS (RED)
+    # because runner.rs clears gen_tps immediately.
+    #
+    # BOUNDARY 2 (expired assertion) — after the validity window elapses
+    # (clamp(3 × instance_tick, 6 s, 30 s) = 6 s for the production 2 s tick),
+    # gen_tps must be gone from the screen.  This step is unreachable today
+    # because BOUNDARY 1 fails first; it becomes GREEN once the fix is applied.
+    Given a managed model exposes scripted serving metrics
+    When the user opens the dashboard
+    And the user opens the Observe view
+    Then positive generation throughput is displayed for the managed model
+    When the metrics endpoint fails transiently
+    Then generation throughput remains visible within the validity window
+    When the validity window has elapsed
+    Then generation throughput is no longer displayed
+    When the user quits the dashboard
+    Then the dashboard exits successfully

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::Json;
 use axum::routing::{get, post};
 use serde_json::{Value, json};
@@ -19,6 +20,327 @@ use crate::http_server::{self, ServerHandle};
 /// request while waiting for the client to POST.
 const CHAT_REQUEST_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
+/// Controls what each `/metrics` scrape returns in a [`ScriptedMetrics`]-backed
+/// mock. Every variant is a deterministic primitive that tests can switch to at
+/// runtime without restarting the server, covering all EAI-7960 contract states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricsMode {
+    /// Every scrape increments the cumulative counter by 20 tok/scrape; yields a
+    /// positive `gen_tps` from the second scrape onward (busy/running instance).
+    Growing,
+    /// Counter frozen at the given cumulative value; `gen_tps` approaches 0.0
+    /// after the rate window (idle instance still reporting a counter).
+    Unchanged(u64),
+    /// HTTP 200 with a valid Prometheus body that omits
+    /// `vllm:generation_tokens_total` entirely. The runner's parser returns
+    /// `sample.gen_tokens_total = None`; `gen_tps` stays `None` and the
+    /// validity timer is NOT refreshed (missing ≠ failure, ≠ zero).
+    Omitted,
+    /// HTTP 200 with a structurally invalid (unparseable) body. All sample
+    /// fields come back `None`; semantically equivalent to `Omitted` at the
+    /// runner level but triggered by a parse failure rather than a missing key.
+    Malformed,
+    /// HTTP 503 transport failure. The runner's failure path clears
+    /// `prev_gen_tokens` and sets `gen_tps = None` immediately (EAI-7960 bug).
+    ///
+    /// Under the EAI-7960 contract, `gen_tps` **must** remain held at its last
+    /// observed value for `clamp(3 × instance_tick, 6 s, 30 s)` before clearing.
+    Failure,
+    /// Counter resets to the given value, which must be below the accumulated
+    /// Growing total. `gen_tps_from_delta` returns `None` (cur < prev_val guard)
+    /// and re-baselines to the new lower value for recovery.
+    Reset(u64),
+    /// Growing counter but `running_reqs = 0` — engine is alive but idle,
+    /// no in-flight requests. Distinct from `Unchanged` (counter still grows)
+    /// and `Omitted` (counter is present but running_reqs shows idle load).
+    RunningIdle,
+}
+
+/// Scriptable state for a mock `/metrics` endpoint. Unlike [`MetricsCounter`],
+/// the mode can be switched at runtime so a single test can drive the full
+/// Growing → Failure → Growing lifecycle without restarting the server.
+#[derive(Debug)]
+struct ScriptedMetrics {
+    /// Monotonically-advancing tick for Growing mode; mirrors [`MetricsCounter`].
+    ticks: AtomicU64,
+    /// Current mode; swapped by the test thread, read by the Axum handler thread.
+    mode: Mutex<MetricsMode>,
+    /// How many HTTP 503 failure responses have been served. Used by
+    /// `MockServer::metrics_failure_count` so tests can poll deterministically
+    /// (confirm the failure actually landed) instead of sleeping a fixed wall time.
+    failure_count: AtomicU64,
+}
+
+impl ScriptedMetrics {
+    fn new() -> Self {
+        Self {
+            ticks: AtomicU64::new(0),
+            mode: Mutex::new(MetricsMode::Growing),
+            failure_count: AtomicU64::new(0),
+        }
+    }
+
+    fn set_mode(&self, mode: MetricsMode) {
+        *self
+            .mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = mode;
+    }
+
+    fn failure_count(&self) -> u64 {
+        self.failure_count.load(Ordering::Relaxed)
+    }
+
+    /// Advance one scrape. Returns `Some(body)` for 200-OK modes,
+    /// `None` for `Failure` (the handler maps `None` → HTTP 503).
+    fn scrape(&self) -> Option<String> {
+        let mode = *self
+            .mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match mode {
+            MetricsMode::Growing | MetricsMode::RunningIdle => {
+                let tick = self.ticks.fetch_add(1, Ordering::Relaxed) + 1;
+                let gen_tokens_total = tick * 20;
+                let running = if mode == MetricsMode::RunningIdle {
+                    0
+                } else {
+                    1
+                };
+                let ttft_sum_s = tick as f64 * 0.050;
+                let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+                let tpot_count = gen_tokens_total;
+                Some(format!(
+                    "\
+# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} {running}
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{{model=\"mock\"}} 0
+# HELP vllm:gpu_cache_usage_perc GPU KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc{{model=\"mock\"}} 0.25
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {gen_tokens_total}
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}
+# HELP vllm:time_per_output_token_seconds Histogram of time per output token.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tpot_count}
+"
+                ))
+            }
+            MetricsMode::Unchanged(n) => {
+                let tick = n.max(1);
+                let ttft_sum_s = tick as f64 * 0.050;
+                let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+                let tpot_count = n;
+                Some(format!(
+                    "\
+# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{{model=\"mock\"}} 1
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {n}
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}
+# HELP vllm:time_per_output_token_seconds Histogram of time per output token.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tpot_count}
+"
+                ))
+            }
+            MetricsMode::Omitted => {
+                // Valid Prometheus body with no generation_tokens_total line.
+                // runner: sample.gen_tokens_total = None → gen_tps stays None,
+                // prev_gen_tokens is NOT cleared (success path, not failure path).
+                Some(
+                    "\
+# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model=\"mock\"} 1
+# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model=\"mock\"} 0
+# HELP vllm:gpu_cache_usage_perc GPU KV-cache usage. 1 means 100 percent usage.
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc{model=\"mock\"} 0.25
+"
+                    .to_string(),
+                )
+            }
+            MetricsMode::Malformed => {
+                // HTTP 200 with structurally invalid body; parser returns all-None.
+                Some(
+                    "# malformed: not valid prometheus exposition format\n!!!invalid!!!\n"
+                        .to_string(),
+                )
+            }
+            MetricsMode::Failure => {
+                self.failure_count.fetch_add(1, Ordering::Relaxed);
+                None // handler maps None → HTTP 503
+            }
+            MetricsMode::Reset(n) => {
+                // Counter explicitly lower than any Growing accumulation.
+                let tick = n.max(1);
+                let ttft_sum_s = tick as f64 * 0.050;
+                let tpot_sum_s = tick as f64 * 20.0 * 0.020;
+                Some(format!(
+                    "\
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{{model=\"mock\"}} {n}
+# HELP vllm:time_to_first_token_seconds Histogram of time to first token.
+# TYPE vllm:time_to_first_token_seconds histogram
+vllm:time_to_first_token_seconds_sum{{model=\"mock\"}} {ttft_sum_s}
+vllm:time_to_first_token_seconds_count{{model=\"mock\"}} {tick}
+# HELP vllm:time_per_output_token_seconds Histogram of time per output token.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_sum{{model=\"mock\"}} {tpot_sum_s}
+vllm:time_per_output_token_seconds_count{{model=\"mock\"}} {tick}
+"
+                ))
+            }
+        }
+    }
+}
+
+/// Unit tests for [`ScriptedMetrics`] body generation — verify the raw payload
+/// each mode produces matches the contract before the runner even sees it.
+#[cfg(test)]
+mod scripted_metrics_tests {
+    use super::{MetricsMode, ScriptedMetrics};
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn growing_increments_counter_and_running_reqs_is_1() {
+        let s = ScriptedMetrics::new();
+        let body = s.scrape().expect("Growing must return Some");
+        assert!(
+            body.contains("generation_tokens_total"),
+            "counter line absent"
+        );
+        assert!(body.contains("} 20"), "first tick should be 20 tokens");
+        assert!(
+            body.contains("num_requests_running") && body.contains("} 1"),
+            "running_reqs must be 1 for Growing"
+        );
+        assert_eq!(s.ticks.load(Ordering::Relaxed), 1, "tick counter advanced");
+    }
+
+    #[test]
+    fn running_idle_counter_grows_but_running_reqs_is_0() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::RunningIdle);
+        let body = s.scrape().expect("RunningIdle must return Some");
+        assert!(
+            body.contains("generation_tokens_total"),
+            "counter line absent"
+        );
+        // running_reqs = 0 distinguishes idle from busy
+        let running_line = body
+            .lines()
+            .find(|l| l.starts_with("vllm:num_requests_running"))
+            .unwrap_or("");
+        assert!(
+            running_line.ends_with("} 0"),
+            "running_reqs must be 0 for RunningIdle, got: {running_line}"
+        );
+    }
+
+    #[test]
+    fn unchanged_always_returns_same_counter() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::Unchanged(1_000));
+        let b1 = s.scrape().expect("Unchanged must return Some");
+        let b2 = s.scrape().expect("Unchanged must return Some on 2nd call");
+        // Both should reference the same fixed value
+        assert!(b1.contains("} 1000"), "first scrape counter mismatch");
+        assert!(b2.contains("} 1000"), "second scrape counter mismatch");
+        assert_eq!(
+            s.ticks.load(Ordering::Relaxed),
+            0,
+            "ticks must not advance for Unchanged"
+        );
+    }
+
+    #[test]
+    fn omitted_body_has_no_generation_tokens_total_line() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::Omitted);
+        let body = s.scrape().expect("Omitted returns HTTP 200");
+        assert!(
+            !body.contains("generation_tokens_total"),
+            "Omitted body must not contain the counter key"
+        );
+        // But other gauge lines are present (valid subset of a Prometheus payload).
+        assert!(
+            body.contains("num_requests_running"),
+            "gauge lines must be present"
+        );
+    }
+
+    #[test]
+    fn malformed_body_is_returned_with_some_not_none() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::Malformed);
+        // Malformed is HTTP 200 — scrape() must return Some, not None.
+        let body = s.scrape().expect("Malformed returns HTTP 200 (Some)");
+        assert!(!body.is_empty(), "Malformed body must be non-empty");
+        assert!(
+            !body.contains("generation_tokens_total"),
+            "Malformed body must not accidentally contain the counter key"
+        );
+    }
+
+    #[test]
+    fn failure_returns_none_and_increments_failure_count() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::Failure);
+        assert!(s.scrape().is_none(), "Failure must return None → HTTP 503");
+        assert_eq!(s.failure_count(), 1, "failure_count must increment");
+        let _ = s.scrape();
+        assert_eq!(s.failure_count(), 2, "failure_count accumulates");
+    }
+
+    #[test]
+    fn reset_returns_specified_low_counter() {
+        let s = ScriptedMetrics::new();
+        s.set_mode(MetricsMode::Reset(3));
+        let body = s.scrape().expect("Reset returns HTTP 200");
+        assert!(
+            body.contains("} 3"),
+            "Reset body must carry the specified low counter value"
+        );
+    }
+
+    #[test]
+    fn mode_switch_growing_to_failure_to_growing() {
+        let s = ScriptedMetrics::new();
+        // Growing → positive counter
+        assert!(s.scrape().is_some());
+        // Failure → HTTP 503
+        s.set_mode(MetricsMode::Failure);
+        assert!(s.scrape().is_none());
+        assert_eq!(s.failure_count(), 1);
+        // Recovery (back to Growing) → resumes ticking
+        s.set_mode(MetricsMode::Growing);
+        let body = s.scrape().expect("recovery scrape must succeed");
+        assert!(
+            body.contains("generation_tokens_total"),
+            "counter resumes after recovery"
+        );
+    }
+}
 #[derive(Clone)]
 struct ServerState {
     model_name: String,
@@ -29,6 +351,9 @@ struct ServerState {
     /// dashboard metrics — gets a 404 for `/metrics`, matching a vLLM instance
     /// that scenario never asked to simulate.
     metrics: Option<Arc<MetricsCounter>>,
+    /// `Some` only when started via [`MockServer::start_with_scripted_metrics`];
+    /// drives the scriptable `/metrics` route. Mutually exclusive with `metrics`.
+    scripted_metrics: Option<Arc<ScriptedMetrics>>,
     /// The most recently received `/v1/chat/completions` request body, shared
     /// with the `MockServer` handle so scenarios can assert on exactly what the
     /// CLI sent — not just on the (fixed) canned reply, which would silently
@@ -118,6 +443,8 @@ pub struct MockServer {
     last_chat_request: Arc<Mutex<Option<Value>>>,
     /// Shared with the running server's `ServerState`; see the field doc there.
     chat_paths: Arc<Mutex<Vec<String>>>,
+    /// `Some` only when started with [`MockServer::start_with_scripted_metrics`].
+    scripted: Option<Arc<ScriptedMetrics>>,
 }
 
 impl MockServer {
@@ -135,12 +462,70 @@ impl MockServer {
         Self::spawn(model_name, true).await
     }
 
+    /// Like [`Self::start_with_metrics`] but the `/metrics` endpoint starts in
+    /// [`MetricsMode::Growing`] and can be switched to [`MetricsMode::Failure`]
+    /// (and back) at runtime via [`Self::set_metrics_mode`] while the server is
+    /// live. Use this for EAI-7960 scenarios that need to exercise the
+    /// validity-window holding behaviour or the recovery path.
+    pub async fn start_with_scripted_metrics(model_name: &str) -> Self {
+        let last_chat_request = Arc::new(Mutex::new(None));
+        let chat_paths = Arc::new(Mutex::new(Vec::new()));
+        let scripted = Arc::new(ScriptedMetrics::new());
+        let state = ServerState {
+            model_name: model_name.to_string(),
+            metrics: None,
+            scripted_metrics: Some(Arc::clone(&scripted)),
+            last_chat_request: Arc::clone(&last_chat_request),
+            chat_paths: Arc::clone(&chat_paths),
+        };
+        let app = Router::new()
+            .route("/v1/models", get(handle_models))
+            .route("/models", get(handle_models))
+            .route("/v1/chat/completions", post(handle_chat))
+            .route("/chat/completions", post(handle_chat))
+            .route("/metrics", get(handle_scripted_metrics))
+            .with_state(state);
+        Self {
+            server: http_server::spawn(app).await,
+            last_chat_request,
+            scripted: Some(scripted),
+            chat_paths,
+        }
+    }
+
+    /// Switch the scripted `/metrics` endpoint mode while the server is running.
+    ///
+    /// # Panics
+    /// Panics when the server was not started with
+    /// [`Self::start_with_scripted_metrics`].
+    pub fn set_metrics_mode(&self, mode: MetricsMode) {
+        self.scripted
+            .as_ref()
+            .expect("set_metrics_mode requires start_with_scripted_metrics")
+            .set_mode(mode);
+    }
+
+    /// How many HTTP 503 failure responses the scripted endpoint has served.
+    /// Lets tests poll deterministically — confirm the failure landed — without
+    /// relying on a fixed wall-time sleep.
+    ///
+    /// # Panics
+    /// Panics when the server was not started with
+    /// [`Self::start_with_scripted_metrics`].
+    pub fn metrics_failure_count(&self) -> u64 {
+        self.scripted
+            .as_ref()
+            .expect("metrics_failure_count requires start_with_scripted_metrics")
+            .failure_count()
+    }
+
     async fn spawn(model_name: &str, with_metrics: bool) -> Self {
         let last_chat_request = Arc::new(Mutex::new(None));
         let chat_paths = Arc::new(Mutex::new(Vec::new()));
         let state = ServerState {
             model_name: model_name.to_string(),
             metrics: with_metrics.then(|| Arc::new(MetricsCounter::new())),
+            scripted_metrics: None,
             last_chat_request: Arc::clone(&last_chat_request),
             chat_paths: Arc::clone(&chat_paths),
         };
@@ -157,6 +542,7 @@ impl MockServer {
 
         Self {
             server: http_server::spawn(app).await,
+            scripted: None,
             last_chat_request,
             chat_paths,
         }
@@ -196,6 +582,7 @@ impl MockServer {
             server: http_server::spawn(app).await,
             last_chat_request: Arc::new(Mutex::new(None)),
             chat_paths: Arc::new(Mutex::new(Vec::new())),
+            scripted: None,
         }
     }
 
@@ -354,6 +741,18 @@ async fn handle_metrics(State(state): State<ServerState>) -> String {
         .scrape()
 }
 
+async fn handle_scripted_metrics(State(state): State<ServerState>) -> (StatusCode, String) {
+    match state
+        .scripted_metrics
+        .as_ref()
+        .expect("scripted_metrics route requires scripted_metrics state")
+        .scrape()
+    {
+        Some(body) => (StatusCode::OK, body),
+        None => (StatusCode::SERVICE_UNAVAILABLE, String::new()),
+    }
+}
+
 async fn handle_chat(
     State(state): State<ServerState>,
     uri: axum::http::Uri,
@@ -366,7 +765,6 @@ async fn handle_chat(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .push(uri.path().to_string());
-
     let model = body
         .get("model")
         .and_then(Value::as_str)

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -20,8 +20,9 @@ use crate::http_server::{self, ServerHandle};
 /// request while waiting for the client to POST.
 const CHAT_REQUEST_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Controls what each `/metrics` scrape returns in a [`ScriptedMetrics`]-backed
-/// mock. Every variant is a deterministic primitive that tests can switch to at
+/// Controls what each `/metrics` scrape returns in a [`ScriptedMetrics`]-backed mock.
+///
+/// Every variant is a deterministic primitive that tests can switch to at
 /// runtime without restarting the server, covering all EAI-7960 contract states.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricsMode {
@@ -72,7 +73,7 @@ struct ScriptedMetrics {
 }
 
 impl ScriptedMetrics {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             ticks: AtomicU64::new(0),
             mode: Mutex::new(MetricsMode::Growing),
@@ -102,11 +103,7 @@ impl ScriptedMetrics {
             MetricsMode::Growing | MetricsMode::RunningIdle => {
                 let tick = self.ticks.fetch_add(1, Ordering::Relaxed) + 1;
                 let gen_tokens_total = tick * 20;
-                let running = if mode == MetricsMode::RunningIdle {
-                    0
-                } else {
-                    1
-                };
+                let running = i32::from(mode != MetricsMode::RunningIdle);
                 let ttft_sum_s = tick as f64 * 0.050;
                 let tpot_sum_s = tick as f64 * 20.0 * 0.020;
                 let tpot_count = gen_tokens_total;

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -8,7 +8,8 @@
 //! screen, and clean exit — which the piped-`Command` steps structurally cannot.
 
 use cucumber::{given, then, when};
-use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions};
+use e2e_cucumber::mock_server::{MetricsMode, MockServer, ServiceRecordOptions};
+use std::time::{Duration, Instant};
 
 use crate::E2eWorld;
 use crate::e2e::tui_driver::{DEFAULT_TIMEOUT, TuiSession};
@@ -434,4 +435,126 @@ async fn privacy_notice_shown(world: &mut E2eWorld) {
         )
         .await
         .unwrap_or_else(|e| panic!("the privacy notice was not shown: {e}"));
+}
+
+// ── EAI-7960: scripted metrics / validity-window regression ────────────────
+
+/// Start the mock in Growing mode so the daemon builds a positive gen_tps
+/// baseline before the scenario injects the Failure transition.
+#[given("a managed model exposes scripted serving metrics")]
+async fn managed_model_scripted_metrics(world: &mut E2eWorld) {
+    let model = "TestModel/E2E-1B";
+    let mock = MockServer::start_with_scripted_metrics(model).await;
+    world.endpoint = Some(mock.base_url());
+    world.model_name = Some(model.to_string());
+    world.mock = Some(mock);
+    world.register_mock_service_with(ServiceRecordOptions::default());
+}
+
+/// The Observe tab's node-throughput hero shows the "tok/s" unit whenever
+/// `gen_tps` is `Some(_)`. Wait for it to confirm a positive baseline was
+/// established through at least two successful Growing-mode scrapes.
+#[then("positive generation throughput is displayed for the managed model")]
+async fn positive_gen_tps_displayed(world: &mut E2eWorld) {
+    session(world)
+        .wait_for_screen("tok/s", DEFAULT_TIMEOUT)
+        .await
+        .unwrap_or_else(|e| {
+            panic!("positive gen_tps (\"tok/s\") never appeared after Growing-mode scrapes: {e}")
+        });
+}
+
+/// Switch the scripted mock to Failure mode, then poll the mock's own failure
+/// counter until the daemon delivers at least one 503 — confirming the failure
+/// scrape actually landed before the assertion checks the TUI. This avoids a
+/// fixed wall-time sleep while remaining deterministic.
+#[when("the metrics endpoint fails transiently")]
+async fn metrics_endpoint_fails(world: &mut E2eWorld) {
+    let mock = world.mock.as_ref().expect("no mock server running");
+    mock.set_metrics_mode(MetricsMode::Failure);
+
+    // Poll until the daemon delivers at least one 503 to the mock endpoint.
+    // The production instance_tick is 2 s, so this converges in 2–3 s.
+    let deadline = Instant::now() + DEFAULT_TIMEOUT;
+    loop {
+        if mock.metrics_failure_count() >= 1 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "scripted failure was never served within {DEFAULT_TIMEOUT:?}; \
+             check instance_tick and scrape cadence"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Allow one TUI render cycle (50 ms >> 20 ms poll) so the failure
+    // snapshot is painted before the assertion reads the screen.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+/// EAI-7960 principal regression assertion (must be RED with current code).
+///
+/// Contract: the Observe tab must still show "tok/s" immediately after the
+/// first failed scrape — the held value must persist for the validity window
+/// `clamp(3 × instance_tick, 6 s, 30 s)` before clearing.
+///
+/// **Current behaviour:** `runner.rs` lines 464-476 clear `gen_tps` on the
+/// very tick that the `/metrics` fetch fails — no holding logic exists. The
+/// TUI therefore renders "—" the moment the failure propagates, and this
+/// assertion **FAILS**, confirming EAI-7960 is reproduced at the PTY seam.
+#[then("generation throughput remains visible within the validity window")]
+async fn gen_tps_held_after_failure(world: &mut E2eWorld) {
+    let screen = session(world).screen_text();
+    assert!(
+        screen.contains("tok/s"),
+        "EAI-7960 REGRESSION: gen throughput (\"tok/s\") was cleared immediately \
+         after the first failed scrape instead of being held for the validity \
+         window (clamp(3 × instance_tick, 6 s, 30 s)).\n\
+         Root cause: runner.rs clears gen_tps on the same tick as the failure; \
+         no held-value / validity-window logic exists yet.\n\
+         This assertion must FAIL (RED) until the fix is applied.\n\n\
+         Last screen:\n{screen}"
+    );
+}
+
+// ── EAI-7960: expiry boundary helpers ───────────────────────────────────────
+
+/// Production validity window: clamp(3 × instance_tick, 6 s, 30 s).
+///
+/// With the daemon's 2 s `instance_tick` the lower bound clamp(6 s, 6 s) = 6 s
+/// is always reached. An additional buffer of two instance-ticks (4 s) ensures
+/// the runner has had enough cycles to propagate the expiry to the TUI.
+const VALIDITY_WINDOW: Duration = Duration::from_secs(6);
+const VALIDITY_WINDOW_BUFFER: Duration = Duration::from_secs(5); // 2 × instance_tick + render
+
+/// Sleep for the full observation validity window so the caller can then assert
+/// that the held gen_tps has expired. Designed to follow
+/// "When the metrics endpoint fails transiently" — at that step's exit at least
+/// one 503 has been served, meaning the validity clock has started.
+#[when("the validity window has elapsed")]
+async fn validity_window_elapsed(_world: &mut E2eWorld) {
+    // Sleep the full window + buffer so the daemon has had enough cycles
+    // after expiry to deliver the snapshot change to the TUI.
+    tokio::time::sleep(VALIDITY_WINDOW + VALIDITY_WINDOW_BUFFER).await;
+}
+
+/// Assert that gen_tps is no longer rendered on screen (BOUNDARY 2 of the
+/// EAI-7960 expiry contract). After the validity window the daemon must clear
+/// the held value and the TUI must show "—" in place of the "tok/s" unit.
+///
+/// With current code this step is unreachable because BOUNDARY 1 (the "remains
+/// visible" assertion) fails first. This step becomes GREEN once the hold/expiry
+/// logic is implemented.
+#[then("generation throughput is no longer displayed")]
+async fn gen_tps_no_longer_displayed(world: &mut E2eWorld) {
+    let screen = session(world).screen_text();
+    assert!(
+        !screen.contains("tok/s"),
+        "EAI-7960 BOUNDARY-2: gen_tps (\"tok/s\") is still visible after the \
+         validity window clamp(3 × instance_tick, 6 s, 30 s) elapsed.\n\
+         Expected the daemon to have cleared the held value and the TUI to \
+         show the unavailable placeholder.\n\n\
+         Last screen:\n{screen}"
+    );
 }


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No EAI-7960 entry exists.)

## Problem

The dashboard cleared generation throughput on the first missed metrics scrape, and discovery refreshes replaced live collector fields. A serving model could therefore show Gen briefly and then fall back to an unavailable value while generation continued.

## Change

- Add daemon-owned, cadence-derived generation observation state with bounded counter rates and Fresh/Held metadata.
- Preserve collector observations across same-identity discovery refreshes; invalidate on endpoint changes, resets, removal, or expiry.
- Apply the same policy to vLLM counters and Lemonade direct rates, with tokens-per-watt derived only from the valid observation.
- Reuse one held marker and deterministic observation age across Observe, services, assistant tools, and replay.
- Add scripted counter/failure/reset/removal coverage and PTY-driven dashboard regressions spanning consecutive snapshots.

The wire change is additive: legacy recordings without observation metadata continue to load with unknown freshness. This does not change serving policy, platform gates, or GPU-required behavior, and it does not add CPU fallback.

## Verification

- `cargo test --workspace --all-targets -- --test-threads=1` with isolated `ROCM_CLI_*` roots: 1,982 passed, 6 ignored
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python3 scripts/smoke_local.py --skip-build`
- Dashboard black-box journey: 2 scenarios, 18/18 steps passed
- Telemetry contract: 9/9 passed
- All commits signed and DCO-signed

## Verification gaps

- Live 2+ minute GPU generation was unavailable on this WSL host: gfx1103 was detected, but ROCm WSL driver plumbing (`librocdxg.so`) was missing and no model service was ready.
- The default parallel workspace test invocation has a pre-existing PATH-mutating test race that can temporarily hide `tar`; the isolated serialized full run above passed. The push hook was run with isolated state and `RUST_TEST_THREADS=1`.

EAI-7960