### PR TITLE
feat(examine): let the user choose which framework to probe

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -110,6 +110,17 @@ enum Command {
         /// Emit the machine-readable Examination JSON (for diagnosis tooling).
         #[arg(long)]
         json: bool,
+        /// Which machine-learning framework to inspect (affects --json only).
+        ///
+        /// The probe imports the framework to read its ROCm build and the GPU
+        /// architectures it was compiled for, which costs an interpreter start.
+        /// Left alone it tries PyTorch and falls back to llama.cpp; name one to
+        /// go straight there, or `skip` to leave frameworks out entirely.
+        ///
+        /// Only the machine-readable form reports framework state, so this has
+        /// no effect on the human report.
+        #[arg(long, value_enum, default_value_t = FrameworkArg::Auto)]
+        framework: FrameworkArg,
     },
     /// Diagnose known ROCm/PyTorch/llama.cpp failure modes against a closed catalog.
     ///
@@ -838,6 +849,37 @@ enum SetupCommand {
     Reset,
 }
 
+/// Which framework `rocm examine` should probe.
+///
+/// The CLI-facing mirror of [`rocm_core::FrameworkProbe`], which cannot derive
+/// `ValueEnum` itself without pulling clap into `rocm-core`. Every variant of
+/// that enum existed and was reachable in the library, but no caller ever passed
+/// anything but the default, so the choice could not be made from the command
+/// line at all.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum FrameworkArg {
+    /// Try PyTorch first, then llama.cpp (the default).
+    Auto,
+    /// Probe PyTorch only.
+    Pytorch,
+    /// Probe llama.cpp only.
+    #[value(name = "llama-cpp", alias = "llamacpp")]
+    LlamaCpp,
+    /// Probe no framework at all — fastest, and enough for GPU and driver questions.
+    Skip,
+}
+
+impl From<FrameworkArg> for rocm_core::FrameworkProbe {
+    fn from(value: FrameworkArg) -> Self {
+        match value {
+            FrameworkArg::Auto => Self::Auto,
+            FrameworkArg::Pytorch => Self::PyTorch,
+            FrameworkArg::LlamaCpp => Self::LlamaCpp,
+            FrameworkArg::Skip => Self::Skip,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum InstallFormat {
     /// Python wheel packages (recommended; smaller, pip-installable).
@@ -1471,7 +1513,7 @@ fn dispatch(cli: Cli) -> Result<()> {
     }
 
     match cli.command {
-        Some(Command::Examine { json }) => examine(json),
+        Some(Command::Examine { json, framework }) => examine(json, framework.into()),
         Some(Command::Diagnose { symptom, top, json }) => diagnose(symptom, top, json),
         Some(Command::Fix {
             fix_id,
@@ -1996,7 +2038,7 @@ struct ExamineJsonSummary<'a> {
     previous_runtime_key: Option<&'a str>,
 }
 
-fn examine(json: bool) -> Result<()> {
+fn examine(json: bool, framework: rocm_core::FrameworkProbe) -> Result<()> {
     // `rocm examine` is the general system inspector: the exit code reports
     // whether it RAN, not what it found. Any finding (no GPU, WSL, degraded) is
     // surfaced in the output and the `--json` `status` field, and the command
@@ -2004,7 +2046,7 @@ fn examine(json: bool) -> Result<()> {
     let paths = AppPaths::discover()?;
     let config = RocmCliConfig::load(&paths).unwrap_or_default();
     if json {
-        let examination = rocm_core::Examination::probe(rocm_core::FrameworkProbe::Auto);
+        let examination = rocm_core::Examination::probe(framework);
         // `gather` rather than `examine_human_report`: the latter first runs
         // `recover_setup_runtime_registration`, which writes. Asking a machine a
         // question should not change it, and `--json` is the form tooling calls
@@ -17140,6 +17182,47 @@ mod tests {
     #[test]
     fn cli_command_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn every_framework_choice_reaches_the_library() {
+        // The defect this flag fixes was not a missing enum -- the library had
+        // all four variants -- but that no caller could select one. Pin the
+        // mapping so a renamed variant cannot silently fall back to the default.
+        use rocm_core::FrameworkProbe;
+        assert_eq!(
+            FrameworkProbe::from(FrameworkArg::Auto),
+            FrameworkProbe::Auto
+        );
+        assert_eq!(
+            FrameworkProbe::from(FrameworkArg::Pytorch),
+            FrameworkProbe::PyTorch
+        );
+        assert_eq!(
+            FrameworkProbe::from(FrameworkArg::LlamaCpp),
+            FrameworkProbe::LlamaCpp
+        );
+        assert_eq!(
+            FrameworkProbe::from(FrameworkArg::Skip),
+            FrameworkProbe::Skip
+        );
+    }
+
+    #[test]
+    fn the_framework_choice_is_offered_on_the_command_line() {
+        // Guards the actual regression: the variants existed in the library and
+        // were unreachable from here. A user must be able to see and pass them.
+        let help = Cli::command()
+            .find_subcommand_mut("examine")
+            .expect("examine subcommand")
+            .render_long_help()
+            .to_string();
+        for choice in ["auto", "pytorch", "llama-cpp", "skip"] {
+            assert!(
+                help.contains(choice),
+                "`{choice}` must be offered by `rocm examine --help`:\n{help}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -1554,6 +1554,30 @@ mod tests {
     }
 
     #[test]
+    fn asking_to_skip_the_frameworks_is_recorded_as_skipped() {
+        // Host-independent on purpose: every other variant depends on what is
+        // installed, so this is the one the CLI flag can be pinned against
+        // anywhere. "skipped" is a distinct answer from "unknown" -- the latter
+        // means the probe ran and found nothing.
+        let mut e = Examination::default();
+        probe_framework(&mut e, FrameworkProbe::Skip);
+        assert_eq!(e.framework, "skipped");
+    }
+
+    #[test]
+    fn a_skipped_framework_probe_runs_no_interpreter() {
+        // The reason to offer `skip` at all: the other variants start Python to
+        // read the framework's ROCm build. Nothing else on the Examination may
+        // move, or "skip" would be quietly doing work.
+        let mut e = Examination::default();
+        probe_framework(&mut e, FrameworkProbe::Skip);
+        assert!(e.framework_version.is_empty());
+        assert!(e.framework_rocm_version.is_empty());
+        assert!(e.framework_arch_list.is_empty());
+        assert!(e.framework_notes.is_empty());
+    }
+
+    #[test]
     fn the_sysfs_fallback_leaves_a_real_pci_enumeration_alone() {
         // lspci carries the PCI id, the marketing name and the APU/discrete
         // distinction; the topology read carries none of those. So the fallback

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -170,11 +170,3 @@ reason = "Lemonade managed serve reaches ready then shuts down immediately, so t
 serve_timeout_secs = 90
 flaky = true
 
-# --- EAI-7193: the framework probe can be scoped in the library, but no call
-# site passes anything but the default, so `--framework` does not exist on the
-# command line and the choice is unreachable. Platform-independent (pure
-# argument parsing). Remove this row when the flag lands. ---
-[["examine-can-skip-framework-probing"]]
-when = {}
-bug = "EAI-7193"
-reason = "`examine` has no --framework flag, so the framework probe cannot be scoped from the command line."

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -169,4 +169,3 @@ bug = "EAI-7423"
 reason = "Lemonade managed serve reaches ready then shuts down immediately, so the benchmark never reaches a live model."
 serve_timeout_secs = 90
 flaky = true
-

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -86,12 +86,17 @@ Feature: GPU detection and system inspection
     Then the inspection completes successfully
     And it states a verdict for this machine
 
-  # Expected to FAIL until the framework choice is reachable from the command
-  # line. The library can already scope the probe, but every caller passes the
-  # default, so the user cannot. Leaving the frameworks out is the variant worth
-  # pinning here: the outcome is identical on every host, whereas asserting that
-  # a *named* framework was probed would depend on what happens to be installed.
-  @id:examine-can-skip-framework-probing
+  # Leaving the frameworks out is the variant pinned here: the outcome is
+  # identical on every host, whereas asserting that a *named* framework was
+  # probed would depend on what happens to be installed.
+  #
+  # @requires-bare-metal because the probe never reaches its framework step on
+  # WSL2 — it returns as soon as it recognises the platform — so `framework`
+  # stays "unknown" there whatever the flag says. That the probe gives up that
+  # early is its own defect, tracked separately; this scenario is about whether
+  # the choice is reachable, and it cannot answer that where no choice is acted
+  # on at all.
+  @id:examine-can-skip-framework-probing @requires-bare-metal
   Scenario: 10 - The user can leave the frameworks out of the inspection
     When the user inspects the system without probing frameworks
     Then the inspection reports that it skipped the frameworks

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -61,12 +61,18 @@ pub struct ScenarioDecl {
     pub requires_no_gpu: bool,
     /// `@requires-bare-metal`: the scenario's premise is a host running the
     /// in-tree amdgpu driver, so it does not hold under WSL2 — which uses
-    /// `/dev/dxg` and the Windows host driver instead. `rocm diagnose` skips its
-    /// bare-metal catalog there *by design* rather than emitting Linux diagnoses
-    /// that cannot apply, so a scenario needing a catalog match has no premise on
-    /// WSL2. This is a SKIP and not an xfail row: the behaviour is deliberate and
+    /// `/dev/dxg` and the Windows host driver instead.
+    ///
+    /// Two things stop short there. `rocm diagnose` skips its bare-metal catalog
+    /// *by design* rather than emitting Linux diagnoses that cannot apply, so a
+    /// scenario needing a catalog match has no premise. And `examine`'s probe
+    /// returns as soon as it recognises WSL2, before most of its steps run, so a
+    /// scenario asserting anything those steps populate has none either.
+    ///
+    /// This is a SKIP and not an xfail row: the diagnose half is deliberate and
     /// separately unit-tested, and recording it as a known bug would tell every
-    /// later reader the opposite.
+    /// later reader the opposite. (How much the probe gives up on WSL2 is a
+    /// separate question, and a separate ticket.)
     ///
     /// `@requires-os:linux` cannot express this — WSL2 reports an os_family of
     /// `linux`, so it matches.


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. The row for this gap is removed here.

> **Stacked on #217**, which is stacked on #216. Merge in that order; this diff shrinks to just the flag once they land.

## Summary

`FrameworkProbe` has had four variants all along, and the probe acts on all four. No caller ever passed anything but the default, so from the command line there was no choice to make — `rocm examine --framework skip` was an unknown argument. This is wiring, not new capability.

```
$ rocm examine --framework nonsense --json
error: invalid value 'nonsense' for '--framework <FRAMEWORK>'
  [possible values: auto, pytorch, llama-cpp, skip]
```

The flag is a CLI-side mirror of the library enum rather than a `ValueEnum` derived on it, so clap stays out of `rocm-core`.

**It applies to `--json` only, and the help says so.** The human report carries no framework line, so the flag would otherwise be a silent no-op there — worse than one that admits its scope.

## Test plan

Two unit tests cover what this host cannot:

- the mapping is pinned for all four variants, so a renamed one cannot quietly fall back to the default;
- `rocm examine --help` is asserted to offer all four. That they existed in the library but were unreachable *is* the defect, so "the library has them" would be the wrong thing to assert.

Two more in `rocm-core` pin the behaviour the flag selects: `skip` records `"skipped"` — a distinct answer from `"unknown"`, which means the probe ran and found nothing — and touches none of the other framework fields, so it cannot quietly do the work it claims to avoid.

Locally: `cargo xtask e2e` gives 40 scenarios, 3 xfail, 0 XPASS, 0 unexpected. `cargo fmt --all --check`, workspace clippy, `clippy -p e2e-cucumber --test e2e`, and the 62 harness unit tests are all clean.

## A defect found while doing this, and deliberately not fixed here

The scenario becomes `@requires-bare-metal`, and the reason is worth a reviewer's attention rather than being buried in a tag.

On WSL2 the probe returns as soon as it recognises the platform — before its framework step — so `framework` stays `"unknown"` whatever the flag says. Verified on a WSL2 box: all four values yield `unknown`. The scenario therefore has nothing to assert there.

That early return exists because the *driver and kernel* probes do not apply under WSL2, which is true. But it also skips the framework probe, and **PyTorch on WSL2 is a supported, AMD-documented configuration** — so `examine --json` can never tell a WSL user what ROCm build their PyTorch has. That is a real gap, it belongs with the rest of the WSL work rather than smuggled in here, and the tag's doc comment now records it so the next reader does not have to rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)