### PR TITLE
ci(nightly): consolidate the nightly E2E lanes into one report

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -634,6 +634,11 @@ jobs:
     name: E2E consolidated report (nightly)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Narrower than the workflow-level `contents: write`, which exists for the
+    # release-publishing jobs. This one checks out, downloads artifacts, runs an
+    # xtask and uploads; it has no business being able to write to the repo.
+    permissions:
+      contents: read
     needs:
       - e2e-gpu-nightly
       - e2e-gpu-nightly-strix

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -404,11 +404,17 @@ jobs:
 
           cargo xtask e2e
 
+      # Canonical artifact name, matching the per-PR workflow rather than a
+      # `-nightly-` variant. `parse_descriptor` in the e2e-report crate maps
+      # these names to Platform/OS, and an unrecognised one falls back to a
+      # titlecased platform with the OS hardcoded to Linux — which would have
+      # labelled the Windows lane below as Linux. Artifacts are scoped to their
+      # run, so sharing the name with the per-PR workflow collides with nothing.
       - name: Upload E2E report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-gpu-nightly-report
+          name: e2e-gpu-report
           path: tests/e2e-cucumber/results/
 
   # Strix Halo counterpart to e2e-gpu-nightly. The same @nightly large-model
@@ -510,7 +516,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-gpu-nightly-strix-report
+          name: e2e-gpu-strix-ubuntu-report
           path: tests/e2e-cucumber/results/
 
   # Windows counterpart to e2e-gpu-nightly-strix. Keep the PowerShell-native
@@ -616,5 +622,56 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-gpu-nightly-strix-windows-report
+          name: e2e-gpu-strix-windows-report
           path: tests/e2e-cucumber/results/
+
+  # The nightly lanes each uploaded a report nobody joined up, so reading a
+  # nightly meant opening three artifacts and comparing them by hand — on the
+  # run that covers the most scenarios, since only nightly sets
+  # E2E_INCLUDE_NIGHTLY. Same consolidation the per-PR self-hosted workflow
+  # already does (e2e-selfhosted.yml), against the three nightly artifacts.
+  e2e-report-nightly:
+    name: E2E consolidated report (nightly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - e2e-gpu-nightly
+      - e2e-gpu-nightly-strix
+      - e2e-gpu-nightly-strix-windows
+    # Unconditional `always()`, unlike the per-PR workflow: there is no paths
+    # filter to consult on a schedule, and the lanes are `continue-on-error`, so
+    # a failed lane must still be reported. A nightly that broke is precisely
+    # when the grid is worth reading.
+    if: always()
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      # `*-report` matches the three artifacts above, and will pick up any
+      # nightly platform added later without a change here — provided it is
+      # named canonically (see the rename note on the upload steps).
+      # Layout note (same as the per-PR job): download-artifact@v8 uses a
+      # per-artifact subdir when several match but flattens into the root when
+      # exactly one does, which is what a partially-failed nightly can produce;
+      # `discover()` handles both, labeling a root-level report from its
+      # platform.json slug.
+      - name: Download all nightly E2E reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: '*-report'
+          path: e2e-artifacts
+
+      - name: Build consolidated report + step summary
+        run: |
+          mkdir -p consolidated
+          cargo xtask e2e-report \
+            --artifacts-dir e2e-artifacts \
+            --html-out consolidated/index.html >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload consolidated report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-consolidated-report-nightly
+          path: consolidated/

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -49,11 +49,19 @@ run on dedicated self-hosted runners with a real AMD GPU attached, so they
 exercise host/GPU detection, engine `detect`/`capabilities`, and live serving
 scenarios that the mock job cannot.
 
-Each workflow has its own consolidated report job (both named `e2e-report`
-internally). `ci.yml`'s `E2E consolidated report` covers the mock platform;
-`e2e-selfhosted.yml`'s `E2E consolidated report (self-hosted)` covers the three
-GPU platforms. Each joins its platforms' reports — including partial or failed
-runs — by scenario id into one HTML report and GitHub step summary.
+Each workflow has its own consolidated report job. `ci.yml`'s `e2e-report`
+covers the mock platform; `e2e-selfhosted.yml`'s `e2e-report` covers the three
+GPU platforms; `nightly.yml`'s `e2e-report-nightly` covers the same three
+platforms with the `@nightly` scenarios included. Each joins its platforms'
+reports — including partial or failed runs — by scenario id into one HTML report
+and GitHub step summary.
+
+The lane artifacts are named canonically (`e2e-report`, `e2e-gpu-report`,
+`e2e-gpu-strix-ubuntu-report`, `e2e-gpu-strix-windows-report`) in every workflow,
+because the report derives each platform's name and OS from the artifact name.
+An unrecognised name renders as a guessed platform on Linux, which would report
+a Windows lane as Linux; `xtask`'s
+`every_uploaded_e2e_artifact_has_a_name_the_report_can_label` guards against it.
 
 ## Triggers
 

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -135,12 +135,14 @@ self-hosted runner can never stall `ci.yml`'s merge-required checks:
 | `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo / Windows (self-hosted) | no |
 
 The blocking mock job passes when every applicable scenario is pass-or-xfail with
-no XPASS or unexpected failure; the GPU jobs are non-blocking. Each workflow has
-its own `e2e-report` job: `ci.yml`'s consolidates the mock platform, and
-`e2e-selfhosted.yml`'s consolidates the self-hosted platforms.
+no XPASS or unexpected failure; the GPU jobs are non-blocking. Each workflow
+consolidates its own platforms: `ci.yml`'s `e2e-report` the mock platform,
+`e2e-selfhosted.yml`'s `e2e-report` the self-hosted platforms, and
+`nightly.yml`'s `e2e-report-nightly` the nightly lanes below.
 
 The nightly workflow runs three non-blocking jobs — the existing MI300X job and
-new Strix Halo jobs on Ubuntu and Windows — with `E2E_INCLUDE_NIGHTLY=1`. The
+new Strix Halo jobs on Ubuntu and Windows — with `E2E_INCLUDE_NIGHTLY=1`, then
+consolidates them into the same cross-platform grid. The
 shared large-model scenario serves `Qwen/Qwen3.6-27B` through vLLM on MI300X and
 the hardware-verified `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` checkpoint
 through Lemonade on Strix Halo.

--- a/xtask/src/e2e_report.rs
+++ b/xtask/src/e2e_report.rs
@@ -143,6 +143,71 @@ fn label_for_root_report(dir: &Path) -> String {
 mod tests {
     use super::*;
 
+    /// Artifact names `label_for_root_report` and the e2e-report crate's
+    /// `parse_descriptor` both recognise. Anything else falls back to a
+    /// titlecased platform with the OS hardcoded to Linux.
+    const CANONICAL_REPORT_ARTIFACTS: &[&str] = &[
+        "e2e-report",
+        "e2e-gpu-report",
+        "e2e-gpu-strix-ubuntu-report",
+        "e2e-gpu-strix-windows-report",
+    ];
+
+    /// Every `name: e2e-…-report` an upload step in `file` publishes.
+    fn uploaded_report_artifacts(file: &str) -> Vec<String> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(".github")
+            .join("workflows")
+            .join(file);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        text.lines()
+            .filter_map(|line| line.trim().strip_prefix("name: "))
+            .map(str::trim)
+            .filter(|name| name.starts_with("e2e-") && name.ends_with("-report"))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn every_uploaded_e2e_artifact_has_a_name_the_report_can_label() {
+        // A misnamed artifact does not fail anything -- it renders under a
+        // titlecased platform with the OS defaulted to Linux, so a Windows lane
+        // silently reports as Linux. That is how the nightly artifacts were
+        // named before they fed a consolidated report, and renaming them is
+        // what makes the nightly grid correct rather than merely present.
+        for file in ["ci.yml", "e2e-selfhosted.yml", "nightly.yml"] {
+            for name in uploaded_report_artifacts(file) {
+                // The consolidated artifacts are outputs, not inputs, and are
+                // never parsed back into a platform.
+                if name.starts_with("e2e-consolidated-report") {
+                    continue;
+                }
+                assert!(
+                    CANONICAL_REPORT_ARTIFACTS.contains(&name.as_str()),
+                    "{file} uploads `{name}`, which the report cannot map to a \
+                     platform; it would render as a guessed name on Linux. Use one \
+                     of {CANONICAL_REPORT_ARTIFACTS:?} or teach parse_descriptor."
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_nightly_lanes_publish_the_same_platforms_as_the_per_pr_lanes() {
+        // The nightly workflow exists to run *more* scenarios on the *same*
+        // three platforms. If the two ever diverge, the nightly grid is
+        // comparing different hardware than the PR grid without saying so.
+        let mut nightly = uploaded_report_artifacts("nightly.yml");
+        let mut per_pr = uploaded_report_artifacts("e2e-selfhosted.yml");
+        nightly.retain(|n| !n.starts_with("e2e-consolidated-report"));
+        per_pr.retain(|n| !n.starts_with("e2e-consolidated-report"));
+        nightly.sort();
+        per_pr.sort();
+        assert_eq!(nightly, per_pr);
+    }
+
     #[test]
     fn discover_missing_dir_is_empty() {
         let got = discover(Path::new("/no/such/dir")).expect("ok");

--- a/xtask/src/e2e_report.rs
+++ b/xtask/src/e2e_report.rs
@@ -143,9 +143,17 @@ fn label_for_root_report(dir: &Path) -> String {
 mod tests {
     use super::*;
 
-    /// Artifact names `label_for_root_report` and the e2e-report crate's
-    /// `parse_descriptor` both recognise. Anything else falls back to a
-    /// titlecased platform with the OS hardcoded to Linux.
+    /// The artifact names a **workflow may statically upload** and have
+    /// `parse_descriptor` resolve to a real platform and OS. Anything outside
+    /// this set falls through to a titlecased platform with the OS hardcoded to
+    /// Linux, which is how a Windows lane comes to be reported as Linux.
+    ///
+    /// `e2e-unknown-report` is deliberately absent despite being recognised.
+    /// It is a runtime-only sentinel: [`label_for_root_report`] emits it for a
+    /// report whose `platform.json` was missing or carried an unknown slug, and
+    /// `parse_descriptor` maps it to Unknown/Unknown precisely so it escapes the
+    /// Linux default. No workflow can name it, so a workflow that did would be
+    /// claiming an identity it has no business asserting.
     const CANONICAL_REPORT_ARTIFACTS: &[&str] = &[
         "e2e-report",
         "e2e-gpu-report",
@@ -153,21 +161,49 @@ mod tests {
         "e2e-gpu-strix-windows-report",
     ];
 
-    /// Every `name: e2e-…-report` an upload step in `file` publishes.
-    fn uploaded_report_artifacts(file: &str) -> Vec<String> {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("..")
-            .join(".github")
-            .join("workflows")
-            .join(file);
-        let text = std::fs::read_to_string(&path)
+    /// Every `e2e-`-prefixed artifact name an upload step in `file` publishes.
+    ///
+    /// Deliberately not filtered to `-report`: that is the shape the caller
+    /// asserts, so filtering on it first would make the population and the
+    /// assertion the same condition, and an artifact named `e2e-gpu-results`
+    /// would be invisible to a test claiming to check every e2e artifact.
+    fn uploaded_e2e_artifacts(path: &Path) -> Vec<String> {
+        let text = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
         text.lines()
             .filter_map(|line| line.trim().strip_prefix("name: "))
             .map(str::trim)
-            .filter(|name| name.starts_with("e2e-") && name.ends_with("-report"))
+            // Job and step display names are titlecased (`E2E tests …`), so the
+            // lowercase prefix picks out artifact names only.
+            .filter(|name| name.starts_with("e2e-"))
             .map(str::to_owned)
             .collect()
+    }
+
+    /// Every workflow in `.github/workflows`, so a new one cannot upload under a
+    /// name nothing checks — the exact hole this guard exists to close.
+    fn workflow_files() -> Vec<PathBuf> {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(".github")
+            .join("workflows");
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e == "yml" || e == "yaml")
+            })
+            .collect();
+        assert!(
+            !files.is_empty(),
+            "no workflows found under {}",
+            dir.display()
+        );
+        files.sort();
+        files
     }
 
     #[test]
@@ -177,10 +213,11 @@ mod tests {
         // silently reports as Linux. That is how the nightly artifacts were
         // named before they fed a consolidated report, and renaming them is
         // what makes the nightly grid correct rather than merely present.
-        for file in ["ci.yml", "e2e-selfhosted.yml", "nightly.yml"] {
-            for name in uploaded_report_artifacts(file) {
-                // The consolidated artifacts are outputs, not inputs, and are
-                // never parsed back into a platform.
+        for path in workflow_files() {
+            let file = path.file_name().unwrap_or_default().to_string_lossy();
+            for name in uploaded_e2e_artifacts(&path) {
+                // The consolidated artifacts are outputs, not inputs: nothing
+                // parses them back into a platform.
                 if name.starts_with("e2e-consolidated-report") {
                     continue;
                 }
@@ -199,13 +236,19 @@ mod tests {
         // The nightly workflow exists to run *more* scenarios on the *same*
         // three platforms. If the two ever diverge, the nightly grid is
         // comparing different hardware than the PR grid without saying so.
-        let mut nightly = uploaded_report_artifacts("nightly.yml");
-        let mut per_pr = uploaded_report_artifacts("e2e-selfhosted.yml");
-        nightly.retain(|n| !n.starts_with("e2e-consolidated-report"));
-        per_pr.retain(|n| !n.starts_with("e2e-consolidated-report"));
-        nightly.sort();
-        per_pr.sort();
-        assert_eq!(nightly, per_pr);
+        let lanes = |file: &str| {
+            let mut names = uploaded_e2e_artifacts(
+                &Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("..")
+                    .join(".github")
+                    .join("workflows")
+                    .join(file),
+            );
+            names.retain(|n| !n.starts_with("e2e-consolidated-report"));
+            names.sort();
+            names
+        };
+        assert_eq!(lanes("nightly.yml"), lanes("e2e-selfhosted.yml"));
     }
 
     #[test]


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. Not applicable — CI-only change.

## Summary

The three nightly E2E lanes each uploaded a report nobody joined up, so reading a nightly meant downloading three artifacts and comparing them by hand. That is the run most worth reading: only nightly sets `E2E_INCLUDE_NIGHTLY`, so it covers scenarios no per-PR run does.

It now produces the same consolidated grid the per-PR self-hosted workflow already has — the one at the bottom of an `E2E self-hosted` run summary.

The job runs unconditionally rather than behind a paths filter: there is none to consult on a schedule, and the lanes are `continue-on-error`, so a failed lane must still be reported. A nightly that broke is exactly when the grid is worth having.

## The rename is the load-bearing part

The three artifacts are renamed to the canonical `e2e-gpu-report` / `e2e-gpu-strix-ubuntu-report` / `e2e-gpu-strix-windows-report`.

This is not tidying. `parse_descriptor` in the e2e-report crate maps the artifact *name* to Platform/OS, and an unrecognised name falls through to `fallback_descriptor`, which titlecases the name and **hardcodes the OS to Linux**. So `e2e-gpu-nightly-strix-windows-report` would have produced a row reading "Gpu Nightly Strix Windows / Linux" — the Windows lane reported as Linux. `lib.rs:418` already warns about exactly this hazard for a different case.

Nothing outside `nightly.yml` referenced the old names (checked), and artifacts are scoped to their run, so sharing names with the per-PR workflow collides with nothing.

## Test plan

Two tests, because the failure mode is a silently wrong label rather than a broken build:

- **every e2e artifact any workflow uploads must carry a name the report can map** — scans `ci.yml`, `e2e-selfhosted.yml` and `nightly.yml`;
- **the nightly lanes must publish the same platforms as the per-PR lanes** — if those diverge, the two grids compare different hardware without saying so.

Both were verified to *fail* against the old name, not merely to pass now:

```
nightly.yml uploads `e2e-gpu-nightly-strix-windows-report`, which the report cannot
map to a platform; it would render as a guessed name on Linux. Use one of
["e2e-report", "e2e-gpu-report", "e2e-gpu-strix-ubuntu-report",
 "e2e-gpu-strix-windows-report"] or teach parse_descriptor.
```

`cargo test -p xtask`: 74 pass. `cargo fmt --all --check`, `clippy -p xtask --all-targets -D warnings`, and the prek hooks including `check-yaml` are clean.

**Verification gap:** the job itself cannot run until this is on `main` and the schedule fires (or someone dispatches the workflow). What is verified here is the naming contract and the YAML; that the consolidated step renders is inherited from the identical per-PR job, which runs on every heavy PR. Worth a `workflow_dispatch` after merge to confirm end to end.

---

## Review follow-up (44076e2)

- **Doc comment on `CANONICAL_REPORT_ARTIFACTS` corrected.** It claimed `e2e-unknown-report` was unrecognised and would take the Linux default; it is recognised, and maps to Unknown/Unknown *precisely so it escapes* that default. Its omission from the const is still right — it is a runtime-only sentinel no workflow can name — and the comment now says that. Also stopped describing `label_for_root_report` as recognising artifact names; it emits one from a platform slug.
- **Both stale docs updated** — `docs/ci-hardware-testing.md` and `tests/e2e-cucumber/README.md` each enumerated two report jobs and asserted both were named `e2e-report`. This PR made both statements false, so it should fix them.
- **Guard test widened on both axes.** It now globs `.github/workflows` rather than listing three files, and collects every `e2e-`-prefixed artifact rather than only `-report` ones — the latter was the same shape it then asserted, so the population was defined by the assertion. Verified by breaking it two ways: a `-nightly-` name and an `e2e-gpu-results` name both now fail, and the second would have passed before. This incidentally makes the consolidated-output filters live; they could not match anything previously.
- **`permissions: contents: read`** added to the job, which was inheriting `contents: write` from the workflow block that exists for the release jobs.
- **AI-generation footer removed**, as requested.

### On the duplication — deferring, deliberately

Declining for this PR, with reasons rather than by omission. Extracting a composite action would mean rewriting the two working report jobs as well as adding the third, so a subtle mistake takes out the per-PR report that runs on every heavy PR — a strictly larger blast radius than the change being asked for. It also introduces the repo's first composite action as a side effect of a nightly-report PR, which is the wrong place to decide that pattern.

The cost you name is real and I am not disputing it: four SHA pins now maintained in twelve places, and a flattening explainer written five ways. Three copies is the usual threshold and this is the third. I would rather see it done as its own change, where the diff is legible as a refactor and a reviewer can judge the composite action on its merits.

### On #141

Confirmed independently. Once both land, `e2e-gpu-strix-wsl-report` fails the naming guard (`gpu-strix-wsl` is not a `parse_descriptor` arm) *and* the set-equality test, since nightly has no matching lane. I read that as the invariants working rather than being too strict — #141 needs a `parse_descriptor` arm regardless, or that lane renders as "Gpu Strix Wsl / Linux" in its own report today. Whoever lands second will need to sequence it.
