### PR TITLE
feat: add sampling controls for chat and serve commands (eai-7538)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,17 @@ rocm serve <model> [--engine lemonade|vllm]
                    [--verbose] [--foreground | --managed]
                    [--no-smoke-test]
                    [--allow-public-bind]
+                   [--temperature TEMP] [--top-p PROB] [--max-tokens N]
 ```
+
+`--temperature` (>= 0.0), `--top-p` (0.0-1.0), and `--max-tokens` (> 0) set
+server-wide sampling defaults for the launched engine. They apply only to
+`vllm` and `lemonade`; other engines reject them. For vLLM they are folded
+into a single `--override-generation-config` JSON object (`--max-tokens` maps
+to vLLM's `max_new_tokens`); for Lemonade they pass straight through as
+llama.cpp's `--temperature`, `--top-p`, and `--n-predict` flags. Each control
+is optional and independent — omit any of them to keep the engine's own
+default.
 
 By default the server runs in the background under rocm-cli's supervision and
 prints a deployment summary — a progress indicator while it starts, then a table
@@ -392,10 +402,13 @@ and a chat tab backed by any configured provider. See
 
 ```
 rocm chat [--provider anthropic|openai|...] [--model NAME] [--prompt TEXT] [--tools]
+          [--temperature TEMP] [--top-p PROB] [--max-tokens N]
 ```
 
 Chat with an AI provider from the terminal. Reads from stdin when `--prompt` is
-omitted.
+omitted. `--temperature`, `--top-p`, and `--max-tokens` are optional sampling
+controls forwarded to the request; each is independent, so omit any of them to
+use the provider's default.
 
 ### ComfyUI
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ llama.cpp's `--temperature`, `--top-p`, and `--n-predict` flags. Each control
 is optional and independent — omit any of them to keep the engine's own
 default.
 
+`rocm serve` only reuses an already-running service for the same engine and
+model if its sampling controls (and other recipe settings) match the ones
+requested this time; otherwise it errors out instead of silently serving with
+different settings. If you previously started a service with `--temperature`
+(or another sampling flag) and now run `rocm serve` for the same model without
+flags — or with different ones — stop the existing service first (`rocm
+services stop`) or match the original flags.
+
 By default the server runs in the background under rocm-cli's supervision and
 prints a deployment summary — a progress indicator while it starts, then a table
 with the status, the full inference endpoint, the API-qualified model name, and a

--- a/apps/rocm/build.rs
+++ b/apps/rocm/build.rs
@@ -2,4 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-fn main() {}
+fn main() {
+    // The generated clap parser for the unified CLI has a large command graph.
+    // Windows reserves a much smaller main-thread stack than our Unix targets,
+    // and parsing can otherwise overflow before dispatch reaches the selected
+    // command. This affects the executable only; test-harness worker threads
+    // already receive Rust's independently configured stack size.
+    if std::env::var_os("CARGO_CFG_TARGET_OS").as_deref() == Some("windows".as_ref())
+        && std::env::var_os("CARGO_CFG_TARGET_ENV").as_deref() == Some("msvc".as_ref())
+    {
+        println!("cargo:rustc-link-arg-bin=rocm=/STACK:8388608");
+    }
+}

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -26,6 +26,7 @@ use rocm_dash_tui::ui::launcher::LauncherChoice;
 use rocm_dash_tui::ui::model_picker::ModelRecipeSummary;
 use rocm_dash_tui::ui::runtime_manager::RuntimeSummary;
 
+use crate::ChatInferenceParams;
 use crate::therock;
 
 /// Build the telemetry-daemon options from the unified dashboard config.
@@ -192,6 +193,9 @@ pub fn resolved_args(
         chat_url: t.chat_url.clone(),
         chat_model: t.chat_model.clone(),
         chat_auth_header: t.chat_auth_header.clone(),
+        chat_temperature: t.chat_temperature,
+        chat_top_p: t.chat_top_p,
+        chat_max_tokens: t.chat_max_tokens,
         chat_env_url: std::env::var("OPENAI_BASE_URL")
             .ok()
             .filter(|v| !v.is_empty()),
@@ -358,7 +362,7 @@ pub fn run_launcher(chat_mock: bool) -> Result<()> {
             None => return Ok(()),
             Some(choice) => match launcher_route(choice) {
                 LauncherRoute::Focused(focus) => run_focused(focus)?,
-                LauncherRoute::Chat => run_chat(chat_mock)?,
+                LauncherRoute::Chat => run_chat(chat_mock, ChatInferenceParams::default())?,
                 LauncherRoute::Dashboard => run(None, false, chat_mock)?,
             },
         }
@@ -383,13 +387,25 @@ pub fn run_focused(focus: Focus) -> Result<()> {
 
 /// Entry point for interactive `rocm chat`. Opens the unified dashboard with the
 /// Chat tab focused. Thin wrapper over the same runtime/`run_async` path as
-/// [`run`]; no replay/demo, embedded daemon as usual.
-pub fn run_chat(chat_mock: bool) -> Result<()> {
+/// [`run`]; no replay/demo, embedded daemon as usual. `inference` carries the
+/// `--temperature`/`--top-p`/`--max-tokens` CLI flags, which override any
+/// values configured under `[dashboard.tui]`.
+pub fn run_chat(chat_mock: bool, inference: ChatInferenceParams) -> Result<()> {
     let paths = AppPaths::discover()?;
     let config = RocmCliConfig::load(&paths)?;
     // See `run`: resolve args (incl. the keyring lookup) before the runtime so the
     // secure-store `zbus::blocking` path never runs on a runtime worker thread.
-    let args = resolved_args(&config, &paths, ActiveTab::Chat);
+    let mut args = resolved_args(&config, &paths, ActiveTab::Chat);
+    // CLI flags win over the persisted `[dashboard.tui]` chat_* values.
+    if let Some(t) = inference.temperature {
+        args.chat_temperature = Some(t);
+    }
+    if let Some(p) = inference.top_p {
+        args.chat_top_p = Some(p);
+    }
+    if let Some(m) = inference.max_tokens {
+        args.chat_max_tokens = Some(m);
+    }
     let rt = build_dashboard_runtime()?;
     rt.block_on(run_async(config, paths, args, None, chat_mock))
 }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -256,6 +256,15 @@ echo \"Summarize this\" | rocm chat --provider anthropic")]
         /// Prompt to send. If omitted, rocm-cli reads from standard input when possible.
         #[arg(long)]
         prompt: Option<String>,
+        /// Sampling temperature to send with the request (>= 0.0). Higher is more random.
+        #[arg(long, value_parser = parse_non_negative_temperature)]
+        temperature: Option<f32>,
+        /// Nucleus sampling probability to send with the request (0.0-1.0).
+        #[arg(long = "top-p", value_parser = parse_unit_interval)]
+        top_p: Option<f32>,
+        /// Maximum number of tokens to generate in the response.
+        #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
+        max_tokens: Option<u32>,
         #[arg(
             long,
             help = "Allow an OpenAI-compatible provider to request ROCm tool calls."
@@ -388,6 +397,15 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         // (`--gpu-memory-utilization --verbose`), which then fails loudly on parse.
         #[arg(long, value_name = "FRACTION", allow_hyphen_values = true)]
         gpu_memory_utilization: Option<String>,
+        /// Default sampling temperature for generation (>= 0.0).
+        #[arg(long, value_parser = parse_non_negative_temperature)]
+        temperature: Option<f32>,
+        /// Default nucleus sampling probability for generation (0.0-1.0).
+        #[arg(long = "top-p", value_parser = parse_unit_interval)]
+        top_p: Option<f32>,
+        /// Default maximum number of tokens to generate per response.
+        #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
+        max_tokens: Option<u32>,
         /// API key that clients must present to a public (non-loopback) endpoint.
         /// When binding a public interface and this is omitted, a strong key is
         /// generated automatically. Prefer the `ROCM_SERVE_API_KEY` environment
@@ -1679,6 +1697,9 @@ fn dispatch(cli: Cli) -> Result<()> {
             provider,
             model,
             prompt,
+            temperature,
+            top_p,
+            max_tokens,
             tools,
             chat_mock,
         }) => {
@@ -1706,7 +1727,12 @@ fn dispatch(cli: Cli) -> Result<()> {
                         provider.map_or("local", provider_name),
                         model.as_deref(),
                         &prompt,
-                        tools
+                        tools,
+                        ChatInferenceParams {
+                            temperature,
+                            top_p,
+                            max_tokens,
+                        },
                     )?
                 ),
                 None => print!(
@@ -1832,6 +1858,9 @@ fn dispatch(cli: Cli) -> Result<()> {
             allow_public_bind,
             tool_call_parser,
             gpu_memory_utilization,
+            temperature,
+            top_p,
+            max_tokens,
             api_key,
         }) => serve(ServeArgs {
             model,
@@ -1849,6 +1878,9 @@ fn dispatch(cli: Cli) -> Result<()> {
             allow_public_bind,
             tool_call_parser,
             gpu_memory_utilization,
+            temperature,
+            top_p,
+            max_tokens,
             api_key,
         }),
         Some(Command::Comfyui { command }) => comfyui(command),
@@ -4405,6 +4437,142 @@ fn engine_recipe_with_tool_call_override(
     Some(hint)
 }
 
+/// Sampling defaults a `rocm serve` invocation can push into a vLLM launch.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+struct ServeGenerationDefaults {
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    max_tokens: Option<u32>,
+}
+
+impl ServeGenerationDefaults {
+    const fn is_empty(&self) -> bool {
+        self.temperature.is_none() && self.top_p.is_none() && self.max_tokens.is_none()
+    }
+}
+
+/// Applies `rocm serve` generation defaults (`--temperature`/`--top-p`/`--max-tokens`)
+/// to the selected engine's launch recipe.
+///
+/// vLLM `serve` has no raw `--temperature`/`--top-p` flags; `--override-generation-config`
+/// is the supported way to set server-wide sampling defaults, so `--max-tokens` is
+/// mapped onto vLLM's `max_new_tokens` output cap. Only supplied values are written,
+/// and any values already carried by an authored recipe's
+/// `--override-generation-config` are preserved (the CLI-supplied keys win).
+///
+/// Lemonade's llama.cpp backend accepts the equivalent `--temperature`, `--top-p`,
+/// and `--n-predict` launch flags. A minimal hint is synthesized when none exists.
+/// With no defaults supplied the hint passes through unchanged.
+fn engine_recipe_with_generation_defaults(
+    engine: &str,
+    hint: Option<EngineRecipeHint>,
+    defaults: ServeGenerationDefaults,
+) -> Result<Option<EngineRecipeHint>> {
+    if defaults.is_empty() {
+        return Ok(hint);
+    }
+    let mut hint = hint.unwrap_or_else(|| EngineRecipeHint {
+        contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+        engine: engine.to_owned(),
+        ..EngineRecipeHint::default()
+    });
+    if engine.eq_ignore_ascii_case("vllm") {
+        let mut overrides = serde_json::Map::new();
+        if let Some(temperature) = defaults.temperature {
+            overrides.insert("temperature".to_owned(), serde_json::json!(temperature));
+        }
+        if let Some(top_p) = defaults.top_p {
+            overrides.insert("top_p".to_owned(), serde_json::json!(top_p));
+        }
+        if let Some(max_tokens) = defaults.max_tokens {
+            overrides.insert("max_new_tokens".to_owned(), serde_json::json!(max_tokens));
+        }
+        set_vllm_override_generation_config(&mut hint.required_flags, &overrides);
+    } else if engine.eq_ignore_ascii_case("lemonade") {
+        set_lemonade_generation_defaults(&mut hint.required_flags, defaults);
+    } else {
+        bail!(
+            "generation defaults are not supported by engine `{engine}`; omit --temperature/--top-p/--max-tokens or select vllm/lemonade"
+        );
+    }
+    Ok(Some(hint))
+}
+
+fn set_lemonade_generation_defaults(flags: &mut Vec<String>, defaults: ServeGenerationDefaults) {
+    // Only touch a flag pair when the caller actually supplied that control —
+    // an unset field must leave any authored recipe value in place rather than
+    // deleting it, mirroring the vLLM merge semantics in
+    // `set_vllm_override_generation_config`.
+    for (name, value) in [
+        (
+            "--temperature",
+            defaults.temperature.map(|value| value.to_string()),
+        ),
+        ("--top-p", defaults.top_p.map(|value| value.to_string())),
+        (
+            "--n-predict",
+            defaults.max_tokens.map(|value| value.to_string()),
+        ),
+    ] {
+        let Some(value) = value else {
+            continue;
+        };
+        let mut rewritten = Vec::with_capacity(flags.len() + 2);
+        let mut skip_value = false;
+        for flag in std::mem::take(flags) {
+            if skip_value {
+                skip_value = false;
+                continue;
+            }
+            if flag == name {
+                skip_value = true;
+            } else {
+                rewritten.push(flag);
+            }
+        }
+        rewritten.extend([name.to_owned(), value]);
+        *flags = rewritten;
+    }
+}
+
+/// Rewrites `flags` so vLLM's `--override-generation-config` carries exactly one
+/// merged JSON object: any existing `--override-generation-config <value>` pair is
+/// removed, its keys are used as a base, and `overrides` are layered on top (CLI
+/// values win). Emits a single flag pair with the merged, stably-ordered config.
+fn set_vllm_override_generation_config(
+    flags: &mut Vec<String>,
+    overrides: &serde_json::Map<String, serde_json::Value>,
+) {
+    let existing = std::mem::take(flags);
+    let mut rewritten: Vec<String> = Vec::with_capacity(existing.len() + 2);
+    let mut merged = serde_json::Map::new();
+    let mut take_value = false;
+    for flag in existing {
+        if take_value {
+            take_value = false;
+            if let Ok(serde_json::Value::Object(existing_config)) =
+                serde_json::from_str::<serde_json::Value>(&flag)
+            {
+                for (key, value) in existing_config {
+                    merged.insert(key, value);
+                }
+            }
+            continue;
+        }
+        if flag == "--override-generation-config" {
+            take_value = true;
+            continue;
+        }
+        rewritten.push(flag);
+    }
+    for (key, value) in overrides {
+        merged.insert(key.clone(), value.clone());
+    }
+    rewritten.push("--override-generation-config".to_owned());
+    rewritten.push(serde_json::Value::Object(merged).to_string());
+    *flags = rewritten;
+}
+
 /// Rewrites `flags` so vLLM tool calling uses exactly `parser`: drops any existing
 /// `--tool-call-parser <value>` pair, ensures `--enable-auto-tool-choice` is
 /// present, then appends the new parser flag.
@@ -4538,6 +4706,9 @@ struct ServeArgs {
     allow_public_bind: bool,
     tool_call_parser: Option<String>,
     gpu_memory_utilization: Option<String>,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    max_tokens: Option<u32>,
     api_key: Option<String>,
 }
 
@@ -4558,6 +4729,9 @@ fn serve(args: ServeArgs) -> Result<()> {
         allow_public_bind,
         tool_call_parser,
         gpu_memory_utilization,
+        temperature,
+        top_p,
+        max_tokens,
         api_key,
     } = args;
     let _ = managed; // background is now the default; --managed is accepted as an explicit synonym.
@@ -4635,6 +4809,18 @@ fn serve(args: ServeArgs) -> Result<()> {
                 "--gpu-memory-utilization applies only to vLLM; ignored for engine '{selected_engine}'"
             )
         });
+    // Translate the engine-neutral CLI controls into each adapter's server-wide
+    // defaults: vLLM generation config or Lemonade llama.cpp launch flags.
+    let generation_defaults = ServeGenerationDefaults {
+        temperature,
+        top_p,
+        max_tokens,
+    };
+    let engine_recipe = engine_recipe_with_generation_defaults(
+        &selected_engine,
+        engine_recipe,
+        generation_defaults,
+    )?;
     let tool_call_note = if tool_call_parser.is_some() && !engine_serves_vllm {
         Some(format!(
             "note: --tool-call-parser applies only to vLLM; ignored for engine '{selected_engine}'"
@@ -5205,9 +5391,20 @@ fn spawn_managed_engine_child(
     // an error. Keyed on engine+canonical model — the freshly generated
     // `service_id` is timestamp-unique and would never match an existing one.
     // Stale/dead services fall through and relaunch normally.
+    let requested_recipe_json = engine_recipe
+        .map(serde_json::to_string)
+        .transpose()
+        .context("failed to encode engine recipe hint")?;
     if let Some(existing) =
         existing_live_managed_service(paths, engine, &resolve.canonical_model_id)
     {
+        if existing.engine_recipe_json != requested_recipe_json {
+            bail!(
+                "managed service `{}` is already running for engine `{engine}` and model `{}` with different serve options (recipe hint, tool-call parser, or generation defaults); stop it and run `rocm serve` again to apply the requested options",
+                existing.service_id,
+                resolve.canonical_model_id
+            );
+        }
         record_cli_audit_event(
             paths,
             "service",
@@ -5245,10 +5442,7 @@ fn spawn_managed_engine_child(
         Some(device_policy_name(device_policy).to_owned()),
     );
     record.gpu_indices = gpu_indices.to_vec();
-    record.engine_recipe_json = engine_recipe
-        .map(serde_json::to_string)
-        .transpose()
-        .context("failed to encode engine recipe hint")?;
+    record.engine_recipe_json = requested_recipe_json;
     record.write()?;
 
     if let Some(parent) = record.engine_state_path.parent() {
@@ -7914,8 +8108,52 @@ pub(crate) fn render_chat_prompt_text(
     model: Option<&str>,
     prompt: &str,
     rocm_tools: bool,
+    params: ChatInferenceParams,
 ) -> Result<String> {
-    Ok(render_chat_prompt_result(paths, provider, model, prompt, rocm_tools)?.rendered)
+    Ok(render_chat_prompt_result_with_progress(
+        paths, provider, model, prompt, rocm_tools, params, None,
+    )?
+    .rendered)
+}
+
+/// Sampling controls a caller can pass through to the underlying chat request.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ChatInferenceParams {
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_tokens: Option<u32>,
+}
+
+/// Parse a `--temperature` value: a finite number greater than or equal to 0.
+fn parse_non_negative_temperature(value: &str) -> Result<f32, String> {
+    let parsed: f32 = value
+        .parse()
+        .map_err(|_| format!("`{value}` is not a valid number"))?;
+    if !parsed.is_finite() || parsed < 0.0 {
+        return Err("temperature must be a finite value >= 0.0".to_owned());
+    }
+    Ok(parsed)
+}
+
+/// Parse a `--top-p` value: a finite number in the inclusive range 0.0..=1.0.
+fn parse_unit_interval(value: &str) -> Result<f32, String> {
+    let parsed: f32 = value
+        .parse()
+        .map_err(|_| format!("`{value}` is not a valid number"))?;
+    if !parsed.is_finite() || !(0.0..=1.0).contains(&parsed) {
+        return Err("top-p must be between 0.0 and 1.0".to_owned());
+    }
+    Ok(parsed)
+}
+
+fn parse_positive_u32(value: &str) -> Result<u32, String> {
+    let parsed: u32 = value
+        .parse()
+        .map_err(|_| format!("`{value}` is not a valid positive integer"))?;
+    if parsed == 0 {
+        return Err("max-tokens must be greater than 0".to_owned());
+    }
+    Ok(parsed)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -7941,6 +8179,8 @@ struct ChatToolRunResult {
     needs_install_folder: bool,
 }
 
+/// Convenience wrapper used by tests that do not exercise sampling controls.
+#[cfg(test)]
 pub(crate) fn render_chat_prompt_result(
     paths: &AppPaths,
     provider: &str,
@@ -7948,7 +8188,15 @@ pub(crate) fn render_chat_prompt_result(
     prompt: &str,
     rocm_tools: bool,
 ) -> Result<ChatPromptResult> {
-    render_chat_prompt_result_with_progress(paths, provider, model, prompt, rocm_tools, None)
+    render_chat_prompt_result_with_progress(
+        paths,
+        provider,
+        model,
+        prompt,
+        rocm_tools,
+        ChatInferenceParams::default(),
+        None,
+    )
 }
 
 pub(crate) fn render_chat_prompt_result_with_progress(
@@ -7957,6 +8205,7 @@ pub(crate) fn render_chat_prompt_result_with_progress(
     model: Option<&str>,
     prompt: &str,
     rocm_tools: bool,
+    params: ChatInferenceParams,
     progress: Option<&mut dyn FnMut(String)>,
 ) -> Result<ChatPromptResult> {
     let mut progress = progress;
@@ -8010,7 +8259,9 @@ pub(crate) fn render_chat_prompt_result_with_progress(
                 &providers::ChatRequest {
                     model: assistant_model.map(str::to_owned),
                     messages: messages.clone(),
-                    max_tokens: None,
+                    max_tokens: params.max_tokens,
+                    temperature: params.temperature,
+                    top_p: params.top_p,
                     rocm_tools,
                 },
             ) {
@@ -8047,7 +8298,9 @@ pub(crate) fn render_chat_prompt_result_with_progress(
             &providers::ChatRequest {
                 model: assistant_model.map(str::to_owned),
                 messages: messages.clone(),
-                max_tokens: None,
+                max_tokens: params.max_tokens,
+                temperature: params.temperature,
+                top_p: params.top_p,
                 rocm_tools,
             },
         ) {
@@ -8141,7 +8394,9 @@ pub(crate) fn render_chat_prompt_result_with_progress(
             &providers::ChatRequest {
                 model: assistant_model.map(str::to_owned),
                 messages: follow_up_messages,
-                max_tokens: Some(256),
+                max_tokens: params.max_tokens.or(Some(256)),
+                temperature: params.temperature,
+                top_p: params.top_p,
                 rocm_tools: false,
             },
         )?;
@@ -14405,7 +14660,8 @@ pub(crate) fn managed_service_is_live(record: &ManagedServiceRecord) -> bool {
 }
 
 /// Idempotency guard for managed launches: returns an already-live managed
-/// service for this engine+model, if any.
+/// service for this engine+model, if any. The caller compares its effective
+/// launch recipe before deciding whether reuse is safe.
 ///
 /// Keyed on `(engine, canonical_model_id)` — NOT `service_id`. `generate_service_id`
 /// embeds `unix_time_millis()`, so every launch mints a unique id; matching on it
@@ -15307,6 +15563,8 @@ fn resolve_freeform_plan_with_provider(
                 content: prompt,
             }],
             max_tokens: Some(512),
+            temperature: None,
+            top_p: None,
             rocm_tools: false,
         },
     )?;
@@ -17866,6 +18124,93 @@ mod tests {
             }
             other => panic!("expected Serve, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn serve_parses_generation_flags() {
+        let cli = parse_serve(&[
+            "--temperature",
+            "0.5",
+            "--top-p",
+            "0.25",
+            "--max-tokens",
+            "128",
+        ])
+        .expect("generation flags parse");
+        match cli.command {
+            Some(Command::Serve {
+                temperature,
+                top_p,
+                max_tokens,
+                ..
+            }) => {
+                assert_eq!(temperature, Some(0.5));
+                assert_eq!(top_p, Some(0.25));
+                assert_eq!(max_tokens, Some(128));
+            }
+            other => panic!("expected Serve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serve_rejects_out_of_range_sampling() {
+        // top-p is a probability; temperature must be non-negative. Both are
+        // validated at the CLI boundary so a bad value never reaches the engine.
+        assert_eq!(
+            parse_serve(&["--top-p=1.5"])
+                .expect_err("top-p above 1.0 is rejected")
+                .kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+        assert_eq!(
+            parse_serve(&["--temperature=-0.1"])
+                .expect_err("negative temperature is rejected")
+                .kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+        assert_eq!(
+            parse_serve(&["--max-tokens=0"])
+                .expect_err("zero max-tokens is rejected")
+                .kind(),
+            clap::error::ErrorKind::ValueValidation
+        );
+    }
+
+    #[test]
+    fn chat_parses_generation_flags() {
+        let cli = Cli::try_parse_from([
+            "rocm",
+            "chat",
+            "--prompt",
+            "hello",
+            "--temperature",
+            "0.5",
+            "--top-p",
+            "0.25",
+            "--max-tokens",
+            "64",
+        ])
+        .expect("chat generation flags parse");
+        match cli.command {
+            Some(Command::Chat {
+                temperature,
+                top_p,
+                max_tokens,
+                ..
+            }) => {
+                assert_eq!(temperature, Some(0.5));
+                assert_eq!(top_p, Some(0.25));
+                assert_eq!(max_tokens, Some(64));
+            }
+            other => panic!("expected Chat, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chat_rejects_zero_max_tokens() {
+        let error = Cli::try_parse_from(["rocm", "chat", "--prompt", "hello", "--max-tokens", "0"])
+            .expect_err("zero max-tokens is rejected");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]
@@ -21958,6 +22303,93 @@ install therock";
     }
 
     #[test]
+    fn spawn_managed_engine_child_blocks_reuse_with_mismatched_recipe() -> Result<()> {
+        // A live service recorded with one recipe (e.g. a tool-call parser flag)
+        // must reject a relaunch requesting a different recipe rather than
+        // silently reusing the old server, and the error must not claim the
+        // mismatch is specifically about generation defaults when it could stem
+        // from any recipe field.
+        let (root, paths) = test_paths("dup-managed-recipe-mismatch");
+        paths.ensure()?;
+        let mut existing = ManagedServiceRecord::new(
+            &paths,
+            "lemonade-qwen-1000",
+            "lemonade",
+            "qwen",
+            "qwen-canonical",
+            "127.0.0.1",
+            11510,
+            "managed",
+            std::process::id(),
+            None,
+            None,
+            None,
+        );
+        existing.status = "ready".to_owned();
+        existing.engine_pid = Some(std::process::id());
+        existing.engine_recipe_json = Some(serde_json::to_string(&EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "lemonade".to_owned(),
+            required_flags: vec!["--tool-call-parser".to_owned(), "hermes".to_owned()],
+            ..EngineRecipeHint::default()
+        })?);
+        existing.write()?;
+
+        let resolve = ResolveModelResponse {
+            canonical_model_id: "qwen-canonical".to_owned(),
+            task: "chat".to_owned(),
+            source: "hf".to_owned(),
+            revision: "main".to_owned(),
+            loader: "llama.cpp".to_owned(),
+            trust_remote_code: false,
+            chat_template_mode: "auto".to_owned(),
+            dtype: "auto".to_owned(),
+            device_policy: DevicePolicy::GpuPreferred,
+            estimated_memory: "unknown".to_owned(),
+            launch_defaults: serde_json::json!({}),
+            engine_recipe: None,
+            warnings: Vec::new(),
+        };
+        let requested_recipe = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "lemonade".to_owned(),
+            required_flags: vec!["--temperature".to_owned(), "0.5".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+
+        let result = spawn_managed_engine_child(
+            &paths,
+            "lemonade",
+            "lemonade-qwen-2000",
+            "qwen",
+            &resolve,
+            "127.0.0.1",
+            11511,
+            &resolve.device_policy,
+            &[],
+            None,
+            None,
+            Some(&requested_recipe),
+        );
+        let _ = fs::remove_dir_all(root);
+
+        let error = match result {
+            Ok(_) => panic!("mismatched recipe on a live service must be rejected"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("different serve options"),
+            "message should describe the mismatch generically: {message}"
+        );
+        assert!(
+            message.contains("recipe hint, tool-call parser, or generation defaults"),
+            "message should not single out generation defaults as the sole cause: {message}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn services_tool_result_text_includes_running_interpretation() {
         let (_root, paths) = test_paths("services-tool-text");
         let mut record = ManagedServiceRecord::new(
@@ -22955,6 +23387,173 @@ install therock";
                 .iter()
                 .any(|entry| entry.contains("--gpu-memory-utilization")),
             "nothing to report when the flag was honored: {quiet:?}"
+        );
+    }
+
+    #[test]
+    fn generation_defaults_inject_override_generation_config_for_vllm() {
+        // vLLM has no raw sampling flags: all three controls collapse into a single
+        // `--override-generation-config` JSON with `--max-tokens` mapped to the
+        // engine's `max_new_tokens` output cap.
+        let hint = engine_recipe_with_generation_defaults(
+            "vllm",
+            None,
+            ServeGenerationDefaults {
+                temperature: Some(0.5),
+                top_p: Some(0.25),
+                max_tokens: Some(128),
+            },
+        )
+        .expect("vllm defaults are supported")
+        .expect("supplied defaults should synthesize a vllm hint");
+        assert_eq!(hint.engine, "vllm");
+        assert_eq!(hint.required_flags.len(), 2);
+        assert_eq!(hint.required_flags[0], "--override-generation-config");
+        let config: serde_json::Value =
+            serde_json::from_str(&hint.required_flags[1]).expect("config is valid JSON");
+        assert_eq!(config["temperature"], 0.5);
+        assert_eq!(config["top_p"], 0.25);
+        assert_eq!(config["max_new_tokens"], 128);
+    }
+
+    #[test]
+    fn generation_defaults_include_only_supplied_values() {
+        // Unset controls are omitted so the engine keeps its own defaults.
+        let hint = engine_recipe_with_generation_defaults(
+            "vllm",
+            None,
+            ServeGenerationDefaults {
+                temperature: Some(0.25),
+                top_p: None,
+                max_tokens: None,
+            },
+        )
+        .expect("vllm defaults are supported")
+        .expect("a single supplied default still synthesizes a hint");
+        let config: serde_json::Value =
+            serde_json::from_str(&hint.required_flags[1]).expect("config is valid JSON");
+        assert_eq!(config["temperature"], 0.25);
+        assert!(config.get("top_p").is_none());
+        assert!(config.get("max_new_tokens").is_none());
+    }
+
+    #[test]
+    fn generation_defaults_merge_with_recipe_authored_config() {
+        // CLI values win, but authored keys the CLI does not set are preserved and
+        // exactly one `--override-generation-config` pair remains.
+        let authored = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "vllm".to_owned(),
+            required_flags: vec![
+                "--enable-auto-tool-choice".to_owned(),
+                "--override-generation-config".to_owned(),
+                "{\"temperature\":0.9,\"repetition_penalty\":1.1}".to_owned(),
+            ],
+            ..EngineRecipeHint::default()
+        };
+        let hint = engine_recipe_with_generation_defaults(
+            "vllm",
+            Some(authored),
+            ServeGenerationDefaults {
+                temperature: Some(0.25),
+                top_p: Some(0.5),
+                max_tokens: None,
+            },
+        )
+        .expect("vllm defaults are supported")
+        .unwrap();
+        assert_eq!(
+            hint.required_flags
+                .iter()
+                .filter(|flag| *flag == "--override-generation-config")
+                .count(),
+            1
+        );
+        assert_eq!(hint.required_flags[0], "--enable-auto-tool-choice");
+        let config: serde_json::Value =
+            serde_json::from_str(hint.required_flags.last().unwrap()).unwrap();
+        assert_eq!(config["temperature"], 0.25);
+        assert_eq!(config["top_p"], 0.5);
+        assert_eq!(config["repetition_penalty"], 1.1);
+    }
+
+    #[test]
+    fn generation_defaults_absent_or_non_vllm_pass_through() {
+        // No controls supplied: the hint flows through unchanged.
+        assert!(
+            engine_recipe_with_generation_defaults(
+                "vllm",
+                None,
+                ServeGenerationDefaults::default()
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            engine_recipe_with_generation_defaults(
+                "unknown",
+                None,
+                ServeGenerationDefaults {
+                    temperature: Some(0.5),
+                    top_p: Some(0.5),
+                    max_tokens: Some(64),
+                },
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn generation_defaults_translate_to_lemonade_llama_server_flags() {
+        let hint = engine_recipe_with_generation_defaults(
+            "lemonade",
+            None,
+            ServeGenerationDefaults {
+                temperature: Some(0.5),
+                top_p: Some(0.25),
+                max_tokens: Some(128),
+            },
+        )
+        .expect("lemonade defaults are supported")
+        .expect("defaults synthesize a recipe");
+        assert_eq!(
+            hint.required_flags,
+            [
+                "--temperature",
+                "0.5",
+                "--top-p",
+                "0.25",
+                "--n-predict",
+                "128"
+            ]
+        );
+    }
+
+    #[test]
+    fn generation_defaults_preserve_unset_lemonade_recipe_flags() {
+        // Only --temperature is supplied via CLI; an authored --top-p already
+        // present in the recipe must survive untouched, mirroring the vLLM
+        // merge behavior instead of being deleted.
+        let authored = EngineRecipeHint {
+            contract_version: ENGINE_RECIPE_CONTRACT_VERSION.to_owned(),
+            engine: "lemonade".to_owned(),
+            required_flags: vec!["--top-p".to_owned(), "0.9".to_owned()],
+            ..EngineRecipeHint::default()
+        };
+        let hint = engine_recipe_with_generation_defaults(
+            "lemonade",
+            Some(authored),
+            ServeGenerationDefaults {
+                temperature: Some(0.5),
+                top_p: None,
+                max_tokens: None,
+            },
+        )
+        .expect("lemonade defaults are supported")
+        .expect("supplied defaults should synthesize a hint");
+        assert_eq!(
+            hint.required_flags,
+            ["--top-p", "0.9", "--temperature", "0.5"]
         );
     }
 

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1717,7 +1717,14 @@ fn dispatch(cli: Cli) -> Result<()> {
                         "note: launching the dash chat; switch providers with /provider <name>"
                     );
                 }
-                return dash::run_chat(chat_mock);
+                return dash::run_chat(
+                    chat_mock,
+                    ChatInferenceParams {
+                        temperature,
+                        top_p,
+                        max_tokens,
+                    },
+                );
             }
             match prompt {
                 Some(prompt) => print!(
@@ -26805,7 +26812,7 @@ ID_LIKE="suse opensuse"
         // interactive target). Coercing to the fn pointer fails to compile if
         // the entrypoint is removed or its signature drifts; casting the pointer
         // to an address gives the binding a real effect (no underscore-bind).
-        let target: fn(bool) -> Result<()> = dash::run_chat;
+        let target: fn(bool, ChatInferenceParams) -> Result<()> = dash::run_chat;
         assert_ne!(target as usize, 0);
     }
 
@@ -26828,8 +26835,8 @@ ID_LIKE="suse opensuse"
         let src = main_rs_source();
         let body = strip_line_comments(&command_chat_handler_body(&src));
         assert!(
-            body.contains("dash::run_chat(chat_mock)"),
-            "interactive `rocm chat` must route to dash::run_chat(chat_mock); body:\n{body}"
+            body.contains("dash::run_chat("),
+            "interactive `rocm chat` must route to dash::run_chat(...); body:\n{body}"
         );
         assert!(
             !body.contains("tui::run"),
@@ -26865,8 +26872,15 @@ ID_LIKE="suse opensuse"
             "Command::Chat must destructure the --chat-mock field; body:\n{body}"
         );
         assert!(
-            body.contains("dash::run_chat(chat_mock)"),
-            "--chat-mock must drive run_chat(chat_mock); body:\n{body}"
+            body.contains("dash::run_chat(") && body.contains("chat_mock,"),
+            "--chat-mock must be forwarded to run_chat; body:\n{body}"
+        );
+        assert!(
+            body.contains("ChatInferenceParams")
+                && body.contains("temperature,")
+                && body.contains("top_p,")
+                && body.contains("max_tokens,"),
+            "sampling controls must be forwarded to interactive dash chat; body:\n{body}"
         );
         // The scriptable prompt passthrough stays on the text render path,
         // NOT the dash/TUI.

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -22380,9 +22380,8 @@ install therock";
         );
         let _ = fs::remove_dir_all(root);
 
-        let error = match result {
-            Ok(_) => panic!("mismatched recipe on a live service must be rejected"),
-            Err(error) => error,
+        let Err(error) = result else {
+            panic!("mismatched recipe on a live service must be rejected")
         };
         let message = error.to_string();
         assert!(

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4563,6 +4563,10 @@ fn set_vllm_override_generation_config(
                 for (key, value) in existing_config {
                     merged.insert(key, value);
                 }
+            } else {
+                eprintln!(
+                    "warning: existing --override-generation-config value is not valid JSON; discarding it"
+                );
             }
             continue;
         }

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -35,11 +35,13 @@ pub(crate) struct ChatMessage {
     pub content: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct ChatRequest {
     pub model: Option<String>,
     pub messages: Vec<ChatMessage>,
     pub max_tokens: Option<u32>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
     pub rocm_tools: bool,
 }
 
@@ -985,6 +987,8 @@ fn local_openai_compatible_request(request: &ChatRequest) -> ChatRequest {
         model: request.model.clone(),
         messages,
         max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
         rocm_tools: request.rocm_tools,
     }
 }
@@ -1005,6 +1009,12 @@ fn openai_chat_request_body_with_stream(
         "stream": stream,
         "max_tokens": request.max_tokens.unwrap_or(512),
     });
+    if let Some(temperature) = request.temperature {
+        body["temperature"] = serde_json::json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        body["top_p"] = serde_json::json!(top_p);
+    }
     if request.rocm_tools && !stream {
         body["tools"] = serde_json::Value::Array(rocm_openai_tool_definitions());
         body["tool_choice"] = serde_json::json!("auto");
@@ -1228,6 +1238,12 @@ fn anthropic_chat_request_body_with_stream(
         .join("\n\n");
     if !system.is_empty() {
         body["system"] = serde_json::Value::String(system);
+    }
+    if let Some(temperature) = request.temperature {
+        body["temperature"] = serde_json::json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        body["top_p"] = serde_json::json!(top_p);
     }
     if request.rocm_tools && !stream {
         body["tools"] = serde_json::Value::Array(rocm_anthropic_tool_definitions());
@@ -1746,6 +1762,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(1),
+                temperature: None,
+                top_p: None,
                 rocm_tools: false,
             },
         )
@@ -1880,6 +1898,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(42),
+            temperature: None,
+            top_p: None,
             rocm_tools: false,
         };
         let openai = openai_chat_request_body("model-a", &request);
@@ -1894,6 +1914,41 @@ mod tests {
     }
 
     #[test]
+    fn request_bodies_include_temperature_and_top_p_only_when_set() {
+        let base = ChatRequest {
+            model: Some("model-a".to_owned()),
+            messages: vec![ChatMessage {
+                role: "user".to_owned(),
+                content: "hello".to_owned(),
+            }],
+            max_tokens: Some(42),
+            temperature: None,
+            top_p: None,
+            rocm_tools: false,
+        };
+
+        // Omitted by default so provider/server defaults are preserved.
+        let openai_default = openai_chat_request_body("model-a", &base);
+        assert!(openai_default.get("temperature").is_none());
+        assert!(openai_default.get("top_p").is_none());
+        let anthropic_default = anthropic_chat_request_body("claude-test", &base);
+        assert!(anthropic_default.get("temperature").is_none());
+        assert!(anthropic_default.get("top_p").is_none());
+
+        let tuned = ChatRequest {
+            temperature: Some(0.25),
+            top_p: Some(0.5),
+            ..base
+        };
+        let openai = openai_chat_request_body("model-a", &tuned);
+        assert_eq!(openai["temperature"], 0.25);
+        assert_eq!(openai["top_p"], 0.5);
+        let anthropic = anthropic_chat_request_body("claude-test", &tuned);
+        assert_eq!(anthropic["temperature"], 0.25);
+        assert_eq!(anthropic["top_p"], 0.5);
+    }
+
+    #[test]
     fn openai_local_qwen3_request_disables_thinking_for_visible_answers() {
         let request = ChatRequest {
             model: Some("Qwen3-0.6B-GGUF".to_owned()),
@@ -1902,6 +1957,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
+            temperature: None,
+            top_p: None,
             rocm_tools: false,
         };
 
@@ -1919,6 +1976,8 @@ mod tests {
                 content: "check this host".to_owned(),
             }],
             max_tokens: Some(42),
+            temperature: None,
+            top_p: None,
             rocm_tools: true,
         };
         let non_streaming = openai_chat_request_body("model-a", &request);
@@ -1983,6 +2042,8 @@ mod tests {
                 },
             ],
             max_tokens: Some(42),
+            temperature: None,
+            top_p: None,
             rocm_tools: true,
         };
 
@@ -2115,6 +2176,8 @@ mod tests {
                     },
                 ],
                 max_tokens: Some(16),
+                temperature: None,
+                top_p: None,
                 rocm_tools: false,
             },
         )?;
@@ -2346,6 +2409,8 @@ mod tests {
                     content: "check this host".to_owned(),
                 }],
                 max_tokens: Some(16),
+                temperature: None,
+                top_p: None,
                 rocm_tools: true,
             },
         )?;
@@ -2418,6 +2483,8 @@ mod tests {
                     },
                 ],
                 max_tokens: Some(16),
+                temperature: None,
+                top_p: None,
                 rocm_tools: false,
             },
         )?;
@@ -2519,6 +2586,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(16),
+                temperature: None,
+                top_p: None,
                 rocm_tools: false,
             },
             &mut |event| {
@@ -2606,6 +2675,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(16),
+                temperature: None,
+                top_p: None,
                 rocm_tools: false,
             },
         )?;
@@ -2679,6 +2750,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
+            temperature: None,
+            top_p: None,
             rocm_tools: false,
         };
         let body = openai_stream_chat_request_body("gpt-test", &chat_request);
@@ -2780,6 +2853,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
+            temperature: None,
+            top_p: None,
             rocm_tools: false,
         };
         let body = anthropic_stream_chat_request_body("claude-test", &chat_request);

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -1762,9 +1762,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(1),
-                temperature: None,
-                top_p: None,
                 rocm_tools: false,
+                ..Default::default()
             },
         )
         .unwrap_err()
@@ -1898,9 +1897,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(42),
-            temperature: None,
-            top_p: None,
             rocm_tools: false,
+            ..Default::default()
         };
         let openai = openai_chat_request_body("model-a", &request);
         assert_eq!(openai["model"], "model-a");
@@ -1922,9 +1920,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(42),
-            temperature: None,
-            top_p: None,
             rocm_tools: false,
+            ..Default::default()
         };
 
         // Omitted by default so provider/server defaults are preserved.
@@ -1957,9 +1954,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
-            temperature: None,
-            top_p: None,
             rocm_tools: false,
+            ..Default::default()
         };
 
         let body = openai_local_chat_request_body("Qwen3-0.6B-GGUF", &request);
@@ -1976,9 +1972,8 @@ mod tests {
                 content: "check this host".to_owned(),
             }],
             max_tokens: Some(42),
-            temperature: None,
-            top_p: None,
             rocm_tools: true,
+            ..Default::default()
         };
         let non_streaming = openai_chat_request_body("model-a", &request);
         assert_eq!(non_streaming["tool_choice"], "auto");
@@ -2042,9 +2037,8 @@ mod tests {
                 },
             ],
             max_tokens: Some(42),
-            temperature: None,
-            top_p: None,
             rocm_tools: true,
+            ..Default::default()
         };
 
         let non_streaming = anthropic_chat_request_body("claude-test", &request);
@@ -2176,9 +2170,8 @@ mod tests {
                     },
                 ],
                 max_tokens: Some(16),
-                temperature: None,
-                top_p: None,
                 rocm_tools: false,
+                ..Default::default()
             },
         )?;
         let request = server.join().expect("server thread should not panic")?;
@@ -2409,9 +2402,8 @@ mod tests {
                     content: "check this host".to_owned(),
                 }],
                 max_tokens: Some(16),
-                temperature: None,
-                top_p: None,
                 rocm_tools: true,
+                ..Default::default()
             },
         )?;
         let request = server.join().expect("server thread should not panic")?;
@@ -2483,9 +2475,8 @@ mod tests {
                     },
                 ],
                 max_tokens: Some(16),
-                temperature: None,
-                top_p: None,
                 rocm_tools: false,
+                ..Default::default()
             },
         )?;
         let request = server.join().expect("server thread should not panic")?;
@@ -2586,9 +2577,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(16),
-                temperature: None,
-                top_p: None,
                 rocm_tools: false,
+                ..Default::default()
             },
             &mut |event| {
                 if event.content == "hel" {
@@ -2675,9 +2665,8 @@ mod tests {
                     content: "hello".to_owned(),
                 }],
                 max_tokens: Some(16),
-                temperature: None,
-                top_p: None,
                 rocm_tools: false,
+                ..Default::default()
             },
         )?;
         let request = server.join().expect("server thread should not panic")?;
@@ -2750,9 +2739,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
-            temperature: None,
-            top_p: None,
             rocm_tools: false,
+            ..Default::default()
         };
         let body = openai_stream_chat_request_body("gpt-test", &chat_request);
         let mut events = Vec::new();
@@ -2853,9 +2841,8 @@ mod tests {
                 content: "hello".to_owned(),
             }],
             max_tokens: Some(16),
-            temperature: None,
-            top_p: None,
             rocm_tools: false,
+            ..Default::default()
         };
         let body = anthropic_stream_chat_request_body("claude-test", &chat_request);
         let mut events = Vec::new();

--- a/apps/rocm/src/serve_summary.rs
+++ b/apps/rocm/src/serve_summary.rs
@@ -200,6 +200,8 @@ pub(crate) fn run_smoke_test(paths: &AppPaths, api_model: &str) -> SmokeMetrics 
             content: SMOKE_PROMPT.to_owned(),
         }],
         max_tokens: Some(SMOKE_MAX_TOKENS),
+        temperature: None,
+        top_p: None,
         rocm_tools: false,
     };
 

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -3564,7 +3564,11 @@ fn slugify(value: &str) -> String {
 mod tests {
     use super::*;
 
-    static PYTHON_RESOLVER_TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Serializes tests that replace process-global `PATH` (or other env vars) while
+    // they run. Because env is shared across all test threads, any test that spawns a
+    // bare-name binary (e.g. `tar`) via `PATH` lookup must also hold this lock, or it
+    // can fail with ENOENT while another test has temporarily narrowed `PATH`.
+    static PROCESS_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn tarball_space_preflight_skips_when_the_download_size_is_unknown() {
@@ -4051,6 +4055,9 @@ mod tests {
     /// would double the disk cost of every installed SDK version.
     #[test]
     fn extracting_the_sdk_archive_removes_it() -> Result<()> {
+        // Extraction spawns bare-name `tar` via `PATH`; hold the shared env lock so a
+        // concurrent test that temporarily narrows `PATH` cannot make it fail to launch.
+        let _guard = PROCESS_ENV_TEST_LOCK.lock().unwrap();
         let (root, _paths) = test_paths("discard-archive");
         let cache = root.join("cache");
         let payload_dir = root.join("payload");
@@ -4306,6 +4313,7 @@ mod tests {
             // the managed/uv path regardless of PATH. Nothing to assert here.
             return Ok(());
         }
+        let _guard = PROCESS_ENV_TEST_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-prefers-path");
         let bin_dir = root.join("bin");
         fs::create_dir_all(&bin_dir)?;
@@ -4356,7 +4364,7 @@ mod tests {
         if !runtime_is_windows() {
             return Ok(());
         }
-        let _guard = PYTHON_RESOLVER_TEST_ENV_LOCK.lock().unwrap();
+        let _guard = PROCESS_ENV_TEST_LOCK.lock().unwrap();
         let (root, _paths) = test_paths("python-probe-temp-root");
         let temp_root = root.join("Temp");
         fs::create_dir_all(&temp_root)?;
@@ -4409,6 +4417,7 @@ mod tests {
             // the managed/uv path regardless of PATH. Nothing to assert here.
             return Ok(());
         }
+        let _guard = PROCESS_ENV_TEST_LOCK.lock().unwrap();
         let (root, paths) = test_paths("python-path-over-managed");
         let bin_dir = root.join("bin");
         fs::create_dir_all(&bin_dir)?;

--- a/apps/rocm/tests/daemon_run.rs
+++ b/apps/rocm/tests/daemon_run.rs
@@ -9,7 +9,7 @@
 //! spawn the built binary, read stdout until the banner appears (or a short
 //! timeout elapses), then kill the process.
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
@@ -47,12 +47,13 @@ fn daemon_runs_real_foreground_loop() {
         .env("ROCM_CLI_DATA_DIR", &data_dir)
         .env("ROCM_CLI_CACHE_DIR", &cache_dir)
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .stdin(Stdio::null())
         .spawn()
         .expect("spawn rocm daemon");
 
     let stdout = child.stdout.take().expect("capture daemon stdout");
+    let mut stderr = child.stderr.take().expect("capture daemon stderr");
     let (tx, rx) = mpsc::channel::<bool>();
     let reader = thread::spawn(move || {
         let mut reader = BufReader::new(stdout);
@@ -77,13 +78,17 @@ fn daemon_runs_real_foreground_loop() {
 
     // The foreground loop blocks; terminate it regardless of outcome.
     let _ = child.kill();
-    let _ = child.wait();
+    let status = child.wait().expect("wait for rocm daemon");
     let _ = reader.join();
+    let mut stderr_text = String::new();
+    stderr
+        .read_to_string(&mut stderr_text)
+        .expect("read daemon stderr");
     let _ = std::fs::remove_dir_all(&state_dir);
 
     assert!(
         saw_banner,
         "expected `rocm daemon` to print the rocmd run banner (real foreground loop), \
-         but it did not appear before timeout"
+         but it did not appear before timeout; exit status: {status}; stderr: {stderr_text}"
     );
 }

--- a/apps/rocmd/src/lib.rs
+++ b/apps/rocmd/src/lib.rs
@@ -2985,6 +2985,12 @@ async fn run_daemon(
         .filter(|watcher| watcher.enabled)
         .count();
     println!("  enabled watchers: {enabled_count}");
+    // This banner is the foreground-loop readiness contract used by callers and
+    // integration tests. Flush it before any persistent work so piped stdout on
+    // Windows cannot retain the line in a userspace buffer indefinitely.
+    io::stdout()
+        .flush()
+        .context("failed to flush rocmd run banner")?;
 
     if !automations_enabled {
         println!(

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -5370,10 +5370,49 @@ impl DashboardDaemonConfig {
     }
 }
 
+fn deserialize_optional_chat_temperature<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f32>::deserialize(deserializer)?;
+    if value.is_some_and(|value| !value.is_finite() || value < 0.0) {
+        return Err(serde::de::Error::custom(
+            "dashboard.tui.chat_temperature must be a finite value >= 0.0",
+        ));
+    }
+    Ok(value)
+}
+
+fn deserialize_optional_chat_top_p<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f32>::deserialize(deserializer)?;
+    if value.is_some_and(|value| !value.is_finite() || !(0.0..=1.0).contains(&value)) {
+        return Err(serde::de::Error::custom(
+            "dashboard.tui.chat_top_p must be a finite value between 0.0 and 1.0",
+        ));
+    }
+    Ok(value)
+}
+
+fn deserialize_optional_chat_max_tokens<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<u32>::deserialize(deserializer)?;
+    if value == Some(0) {
+        return Err(serde::de::Error::custom(
+            "dashboard.tui.chat_max_tokens must be greater than 0",
+        ));
+    }
+    Ok(value)
+}
+
 /// Dashboard TUI spec. The chat endpoint URL / model / auth-header *name* are
 /// plain data; the auth-header *value* (API key) is always env-only and never
 /// stored here (AMD gateway invariant).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DashboardTuiConfig {
     #[serde(default = "default_dashboard_connect")]
     pub connect: String,
@@ -5385,6 +5424,31 @@ pub struct DashboardTuiConfig {
     pub chat_model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_auth_header: Option<String>,
+    /// Sampling temperature applied to chat requests (parity with the
+    /// `rocm chat` / `rocm serve` `--temperature` flag). `None` leaves the
+    /// endpoint default untouched; a CLI flag overrides this.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_chat_temperature",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chat_temperature: Option<f32>,
+    /// Nucleus-sampling `top_p` applied to chat requests (parity with
+    /// `--top-p`). `None` leaves the endpoint default untouched.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_chat_top_p",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chat_top_p: Option<f32>,
+    /// Upper bound on generated tokens for chat requests (parity with
+    /// `--max-tokens`). `None` uses the built-in dashboard default.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_chat_max_tokens",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub chat_max_tokens: Option<u32>,
 }
 
 impl Default for DashboardTuiConfig {
@@ -5395,6 +5459,9 @@ impl Default for DashboardTuiConfig {
             chat_url: None,
             chat_model: None,
             chat_auth_header: None,
+            chat_temperature: None,
+            chat_top_p: None,
+            chat_max_tokens: None,
         }
     }
 }
@@ -11131,6 +11198,48 @@ Class Name:                Display
             "default listen must use unix scheme"
         );
         assert_eq!(relisten.daemon.listen, "tcp:127.0.0.1:9000");
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn dashboard_tui_inference_params_round_trip_and_default_absent() {
+        // Defaults leave the sampling knobs unset and out of the serialized JSON
+        // (skip_serializing_if), so a stock config carries no sampling override.
+        let default_json = serde_json::to_value(DashboardTuiConfig::default()).unwrap();
+        assert!(default_json.get("chat_temperature").is_none());
+        assert!(default_json.get("chat_top_p").is_none());
+        assert!(default_json.get("chat_max_tokens").is_none());
+
+        // When set, all three round-trip through JSON unchanged.
+        let cfg = DashboardTuiConfig {
+            chat_temperature: Some(0.25),
+            chat_top_p: Some(0.5),
+            chat_max_tokens: Some(512),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: DashboardTuiConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.chat_temperature, Some(0.25));
+        assert_eq!(back.chat_top_p, Some(0.5));
+        assert_eq!(back.chat_max_tokens, Some(512));
+    }
+
+    #[test]
+    fn dashboard_tui_rejects_invalid_inference_params() {
+        for (field, value, expected) in [
+            ("chat_temperature", "-0.1", "chat_temperature"),
+            ("chat_top_p", "1.1", "chat_top_p"),
+            ("chat_max_tokens", "0", "chat_max_tokens"),
+        ] {
+            let json = format!(r#"{{"{field}":{value}}}"#);
+            let error = serde_json::from_str::<DashboardTuiConfig>(&json)
+                .expect_err("invalid inference parameter must be rejected")
+                .to_string();
+            assert!(
+                error.contains(expected),
+                "unexpected error for {field}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -47,7 +47,59 @@ const MAX_TOOL_TURNS: usize = 5;
 /// Max tokens the model may emit in its final answer. Shared by all three
 /// backends (RigAgentClient, ChatGptAgentClient, AnthropicAgentClient) so the
 /// budget is defined once. `u64` to match rig's `AgentBuilder::max_tokens`.
+/// Used as the fallback when no explicit `--max-tokens` is configured.
 const MAX_AGENT_TOKENS: u64 = 1024;
+
+/// Optional sampling controls forwarded to the chat backend.
+///
+/// Parity with the `rocm chat` / `rocm serve` CLI flags. `None` means "leave
+/// the model / endpoint default untouched", so an unset knob never overrides a
+/// server- or recipe-configured value. Applied uniformly across all three live
+/// backends.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct InferenceParams {
+    /// Sampling temperature (already validated `>= 0.0` by the bin).
+    pub temperature: Option<f32>,
+    /// Nucleus-sampling probability mass (already validated in `0.0..=1.0`).
+    pub top_p: Option<f32>,
+    /// Upper bound on generated tokens; overrides [`MAX_AGENT_TOKENS`] when set.
+    pub max_tokens: Option<u32>,
+}
+
+/// Apply the optional sampling controls to a fresh Rig `AgentBuilder`.
+///
+/// `max_tokens` always resolves to a concrete value (the CLI override or the
+/// shared [`MAX_AGENT_TOKENS`] default). `temperature` maps to the builder's
+/// native `.temperature()`; `top_p` has no dedicated builder method in
+/// rig-core, so it rides in `.additional_params({"top_p": ..})`, which the
+/// provider merges into the request body. Both are set only when supplied, so
+/// an unset knob leaves the request untouched.
+fn apply_inference_params<M, P>(
+    builder: rig::agent::AgentBuilder<M, P>,
+    params: &InferenceParams,
+) -> rig::agent::AgentBuilder<M, P>
+where
+    M: rig::completion::CompletionModel,
+    P: rig::agent::PromptHook<M>,
+{
+    let mut builder = builder.max_tokens(params.max_tokens.map_or(MAX_AGENT_TOKENS, u64::from));
+    if let Some(temperature) = params.temperature {
+        builder = builder.temperature(f64::from(temperature));
+    }
+    if let Some(top_p) = params.top_p {
+        builder = builder.additional_params(serde_json::json!({ "top_p": top_p }));
+    }
+    builder
+}
+
+fn validate_chatgpt_inference_params(params: &InferenceParams) -> Result<(), AgentError> {
+    if params.temperature.is_some() && params.top_p.is_some() {
+        return Err(AgentError::Build(
+            "ChatGPT Responses accepts either temperature or top_p, not both".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 /// Default system preamble for the dashboard assistant.
 const DEFAULT_PREAMBLE: &str = "You are the rocm-dash assistant, embedded in a terminal dashboard for AMD \
@@ -982,6 +1034,8 @@ pub struct RigAgentClient {
     client: rig::providers::openai::CompletionsClient,
     model: String,
     preamble: String,
+    /// Optional sampling controls (temperature/top_p/max_tokens).
+    params: InferenceParams,
     /// Bin-injected tool executor (None for tests / no live seam).
     executor: Option<SharedRocmToolExecutor>,
     /// Channel to surface mutating-tool approval intents to the app (None for
@@ -992,6 +1046,7 @@ pub struct RigAgentClient {
 impl RigAgentClient {
     pub fn new(
         cfg: LlmConfig,
+        params: InferenceParams,
         executor: Option<SharedRocmToolExecutor>,
         approval_tx: Option<UnboundedSender<ClientMsg>>,
     ) -> Result<Self, AgentError> {
@@ -1025,6 +1080,7 @@ impl RigAgentClient {
             client,
             model: cfg.model,
             preamble: DEFAULT_PREAMBLE.to_string(),
+            params,
             executor,
             approval_tx,
         })
@@ -1061,11 +1117,8 @@ impl AgentClient for RigAgentClient {
         let snap = Arc::new(snapshot);
         let fired: FiredLog = Arc::new(Mutex::new(Vec::new()));
 
-        let agent = self
-            .client
-            .agent(&self.model)
-            .preamble(&self.preamble)
-            .max_tokens(MAX_AGENT_TOKENS);
+        let agent = self.client.agent(&self.model).preamble(&self.preamble);
+        let agent = apply_inference_params(agent, &self.params);
         // Telemetry + skill registry tools (shared registration site).
         let agent = register_telemetry_tools(agent, &snap, &fired);
         // Read-only ROCm machine-inspection tools (forward across the seam).
@@ -1216,6 +1269,8 @@ pub struct ChatGptAgentClient {
     client: rig::providers::chatgpt::Client,
     model: String,
     preamble: String,
+    /// Optional sampling controls (temperature/top_p/max_tokens).
+    params: InferenceParams,
     /// Bin-injected tool executor (None for tests / no live seam).
     executor: Option<SharedRocmToolExecutor>,
     /// Channel to surface mutating-tool approval intents to the app (None for
@@ -1230,6 +1285,7 @@ impl ChatGptAgentClient {
     /// deferred to the first `complete()`.
     pub fn new<F>(
         model: Option<String>,
+        params: InferenceParams,
         on_device_code: F,
         executor: Option<SharedRocmToolExecutor>,
         approval_tx: Option<UnboundedSender<ClientMsg>>,
@@ -1292,6 +1348,7 @@ impl ChatGptAgentClient {
             client,
             model: model.unwrap_or_else(|| chatgpt::GPT_5_3_CODEX.to_string()),
             preamble: DEFAULT_PREAMBLE.to_string(),
+            params,
             executor,
             approval_tx,
         })
@@ -1313,6 +1370,10 @@ impl AgentClient for ChatGptAgentClient {
             return Err(AgentError::Empty);
         };
 
+        // OpenAI's Responses API defines temperature and top_p as mutually
+        // exclusive. Reject the combination before device login or network I/O.
+        validate_chatgpt_inference_params(&self.params)?;
+
         // Device-code login on first use; the provider caches the token after.
         // A failed/declined sign-in is an Auth error (distinct from a build
         // failure), surfaced as a clear error turn — never leaks the token.
@@ -1324,9 +1385,8 @@ impl AgentClient for ChatGptAgentClient {
         let snap = Arc::new(snapshot);
         let fired: FiredLog = Arc::new(Mutex::new(Vec::new()));
         let model = ResponsesCompletionModel::new(self.client.clone(), self.model.clone());
-        let agent = AgentBuilder::new(model)
-            .preamble(&self.preamble)
-            .max_tokens(MAX_AGENT_TOKENS);
+        let agent = AgentBuilder::new(model).preamble(&self.preamble);
+        let agent = apply_inference_params(agent, &self.params);
         // Telemetry + skill registry tools (shared registration site).
         let agent = register_telemetry_tools(agent, &snap, &fired);
         // Read-only ROCm machine-inspection tools (forward across the seam).
@@ -1360,6 +1420,8 @@ pub struct AnthropicAgentClient {
     client: rig::providers::anthropic::Client,
     model: String,
     preamble: String,
+    /// Optional sampling controls (temperature/top_p/max_tokens).
+    params: InferenceParams,
     /// Bin-injected tool executor (None for tests / no live seam).
     executor: Option<SharedRocmToolExecutor>,
     /// Channel to surface mutating-tool approval intents to the app (None for
@@ -1376,6 +1438,7 @@ impl AnthropicAgentClient {
     /// No network I/O happens here — the request is deferred to `complete()`.
     pub fn new(
         cfg: LlmConfig,
+        params: InferenceParams,
         executor: Option<SharedRocmToolExecutor>,
         approval_tx: Option<UnboundedSender<ClientMsg>>,
     ) -> Result<Self, AgentError> {
@@ -1398,6 +1461,7 @@ impl AnthropicAgentClient {
             client,
             model,
             preamble: DEFAULT_PREAMBLE.to_string(),
+            params,
             executor,
             approval_tx,
         })
@@ -1423,11 +1487,8 @@ impl AgentClient for AnthropicAgentClient {
         // Identical tool registration to RigAgentClient / ChatGptAgentClient:
         // the SAME telemetry/skill tools + every ROCm read + mutating tool, so
         // capability and approval behavior are uniform across backends.
-        let agent = self
-            .client
-            .agent(&self.model)
-            .preamble(&self.preamble)
-            .max_tokens(MAX_AGENT_TOKENS);
+        let agent = self.client.agent(&self.model).preamble(&self.preamble);
+        let agent = apply_inference_params(agent, &self.params);
         // Telemetry + skill registry tools (shared registration site).
         let agent = register_telemetry_tools(agent, &snap, &fired);
         // Read-only ROCm machine-inspection tools (forward across the seam).
@@ -2016,6 +2077,59 @@ mod tests {
         assert!(matches!(err, AgentError::Empty));
     }
 
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn rig_client_stores_inference_params() {
+        // Construction is offline (no network until complete()), so this pins
+        // that the sampling knobs survive into the client that applies them to
+        // every request builder. A default (all-None) client leaves them unset.
+        let cfg = LlmConfig {
+            base_url: "http://127.0.0.1:8000/v1".to_string(),
+            model: "local-model".to_string(),
+            api_key: None,
+            auth_header: None,
+        };
+        let params = InferenceParams {
+            temperature: Some(0.25),
+            top_p: Some(0.5),
+            max_tokens: Some(512),
+        };
+        let client =
+            RigAgentClient::new(cfg.clone(), params, None, None).expect("build rig client");
+        assert_eq!(client.params, params);
+        let client_default =
+            RigAgentClient::new(cfg, InferenceParams::default(), None, None).expect("build");
+        assert_eq!(client_default.params, InferenceParams::default());
+    }
+
+    #[test]
+    fn chatgpt_rejects_temperature_and_top_p_together() {
+        let params = InferenceParams {
+            temperature: Some(0.25),
+            top_p: Some(0.5),
+            max_tokens: None,
+        };
+        let error = validate_chatgpt_inference_params(&params)
+            .expect_err("Responses API must reject mutually exclusive controls");
+        assert!(matches!(error, AgentError::Build(_)));
+        assert!(error.to_string().contains("either temperature or top_p"));
+
+        assert!(
+            validate_chatgpt_inference_params(&InferenceParams {
+                temperature: Some(0.25),
+                ..InferenceParams::default()
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_chatgpt_inference_params(&InferenceParams {
+                top_p: Some(0.5),
+                ..InferenceParams::default()
+            })
+            .is_ok()
+        );
+    }
+
     /// Manual-demo verification of the live Rig path (tool-calling) against a
     /// local OpenAI-compatible endpoint. NOT run in CI (no live LLM). Run with:
     /// `cargo test -p rocm-dash-tui --lib rig_round_trip -- --ignored`
@@ -2029,7 +2143,8 @@ mod tests {
             api_key: None,
             auth_header: None,
         };
-        let client = RigAgentClient::new(cfg, None, None).expect("build rig client");
+        let client = RigAgentClient::new(cfg, InferenceParams::default(), None, None)
+            .expect("build rig client");
         let history = vec![ChatTurn::user("What's GPU-2 doing? Use the tools.")];
         let reply = client
             .complete(&history, fixture_snapshot())
@@ -2060,7 +2175,8 @@ mod tests {
             api_key: Some(key),
             auth_header,
         };
-        let client = RigAgentClient::new(cfg, None, None).expect("build rig client");
+        let client = RigAgentClient::new(cfg, InferenceParams::default(), None, None)
+            .expect("build rig client");
         let history = vec![ChatTurn::user("Reply with exactly: gateway ok")];
         let reply = client
             .complete(&history, fixture_snapshot())
@@ -2079,6 +2195,7 @@ mod tests {
         let sink = fired.clone();
         let client = ChatGptAgentClient::new(
             Some("gpt-5.3-codex".to_string()),
+            InferenceParams::default(),
             move |url, code| {
                 // Would surface in the chat tab during a real device-code login.
                 sink.lock().unwrap().push(format!("{url}|{code}"));
@@ -2094,8 +2211,14 @@ mod tests {
 
     #[test]
     fn chatgpt_oauth_client_defaults_model_when_none() {
-        let client = ChatGptAgentClient::new(None, |_url, _code| {}, None, None)
-            .expect("build chatgpt oauth client");
+        let client = ChatGptAgentClient::new(
+            None,
+            InferenceParams::default(),
+            |_url, _code| {},
+            None,
+            None,
+        )
+        .expect("build chatgpt oauth client");
         assert_eq!(
             client.model,
             rig::providers::chatgpt::GPT_5_3_CODEX,
@@ -2114,6 +2237,7 @@ mod tests {
                 api_key: Some("dummy".to_string()),
                 auth_header: None,
             },
+            InferenceParams::default(),
             None,
             None,
         )
@@ -2138,6 +2262,7 @@ mod tests {
                 api_key: None,
                 auth_header: None,
             },
+            InferenceParams::default(),
             None,
             None,
         ) else {
@@ -2159,6 +2284,7 @@ mod tests {
                 api_key: Some("dummy".to_string()),
                 auth_header: None,
             },
+            InferenceParams::default(),
             None,
             None,
         )
@@ -2233,6 +2359,7 @@ mod tests {
                 api_key: Some(key),
                 auth_header: None,
             },
+            InferenceParams::default(),
             None,
             None,
         )
@@ -2254,6 +2381,7 @@ mod tests {
     async fn chatgpt_oauth_round_trip() {
         let client = ChatGptAgentClient::new(
             None,
+            InferenceParams::default(),
             |url, code| {
                 eprintln!("Sign in: open {url} and enter code {code}");
             },

--- a/crates/rocm-dash-tui/src/app/chat.rs
+++ b/crates/rocm-dash-tui/src/app/chat.rs
@@ -67,9 +67,14 @@ pub(super) fn build_chat_agent(
                 api_key: Some(api_key),
                 auth_header: None,
             };
-            crate::agent::RigAgentClient::new(cfg, executor, Some(approval_tx))
-                .ok()
-                .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
+            crate::agent::RigAgentClient::new(
+                cfg,
+                args.inference_params(),
+                executor,
+                Some(approval_tx),
+            )
+            .ok()
+            .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         }
         ChatProvider::Anthropic => {
             // Leave base_url empty → the Anthropic backend uses rig's default
@@ -80,9 +85,14 @@ pub(super) fn build_chat_agent(
                 api_key: args.anthropic_api_key.clone(),
                 auth_header: None,
             };
-            crate::agent::AnthropicAgentClient::new(cfg, executor, Some(approval_tx))
-                .ok()
-                .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
+            crate::agent::AnthropicAgentClient::new(
+                cfg,
+                args.inference_params(),
+                executor,
+                Some(approval_tx),
+            )
+            .ok()
+            .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         }
     }
 }
@@ -97,10 +107,11 @@ pub(super) fn build_chat_agent(
 /// turn (the rebuild drain).
 pub(super) fn build_local_agent(
     cfg: crate::llm::LlmConfig,
+    params: crate::agent::InferenceParams,
     executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
     approval_tx: mpsc::UnboundedSender<ClientMsg>,
 ) -> Result<std::sync::Arc<dyn crate::agent::AgentClient>, crate::agent::AgentError> {
-    crate::agent::RigAgentClient::new(cfg, executor, Some(approval_tx))
+    crate::agent::RigAgentClient::new(cfg, params, executor, Some(approval_tx))
         .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
 }
 

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -86,6 +86,13 @@ pub struct ResolvedArgs {
     /// Custom auth header NAME (CLI-flag value merged over config), e.g.
     /// `Ocp-Apim-Subscription-Key` for Azure APIM gateways.
     pub chat_auth_header: Option<String>,
+    /// Sampling temperature for chat requests, CLI-flag value merged over
+    /// config. `None` leaves the endpoint default untouched.
+    pub chat_temperature: Option<f32>,
+    /// Nucleus-sampling `top_p` for chat requests, CLI merged over config.
+    pub chat_top_p: Option<f32>,
+    /// Max generated tokens for chat requests, CLI merged over config.
+    pub chat_max_tokens: Option<u32>,
     /// Chat endpoint base URL from the environment (`OPENAI_BASE_URL`).
     /// A separate, lower-precedence tier than `chat_url`.
     pub chat_env_url: Option<String>,
@@ -121,6 +128,19 @@ pub struct ResolvedArgs {
     /// When `Some`, the bench-run form defaults `--out` to this path so appended
     /// rows appear live in the bench tab. Adapted by the bin (owns `rocm-core`).
     pub bench_results_dir: Option<std::path::PathBuf>,
+}
+
+impl ResolvedArgs {
+    /// The optional sampling controls (temperature/top_p/max_tokens) resolved
+    /// for chat, bundled for the agent builders. CLI-over-config merge already
+    /// happened in the bin, so these are the final values.
+    pub(crate) const fn inference_params(&self) -> crate::agent::InferenceParams {
+        crate::agent::InferenceParams {
+            temperature: self.chat_temperature,
+            top_p: self.chat_top_p,
+            max_tokens: self.chat_max_tokens,
+        }
+    }
 }
 
 type Tui = Terminal<CrosstermBackend<io::Stdout>>;
@@ -1790,6 +1810,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             let oauth_tx = chat_tx.clone();
             crate::agent::ChatGptAgentClient::new(
                 args.chat_model.clone(),
+                args.inference_params(),
                 move |url, code| {
                     let _ = oauth_tx.send(ClientMsg::ChatReply {
                         text: format!(
@@ -1805,10 +1826,13 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
         } else {
             // A build failure leaves `agent` None; a submit surfaces an error turn.
             match &state.chat_llm {
-                Some(cfg) => {
-                    build_local_agent(cfg.clone(), state.tool_executor.clone(), chat_tx.clone())
-                        .ok()
-                }
+                Some(cfg) => build_local_agent(
+                    cfg.clone(),
+                    args.inference_params(),
+                    state.tool_executor.clone(),
+                    chat_tx.clone(),
+                )
+                .ok(),
                 None => None,
             }
         }
@@ -2285,7 +2309,12 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
             };
             match state.chat_llm.clone() {
                 Some(cfg) => {
-                    match build_local_agent(cfg, state.tool_executor.clone(), chat_tx.clone()) {
+                    match build_local_agent(
+                        cfg,
+                        args.inference_params(),
+                        state.tool_executor.clone(),
+                        chat_tx.clone(),
+                    ) {
                         Ok(arc) => {
                             agent = Some(arc.clone());
                             // Refresh the restore snapshot so a later `/provider
@@ -5516,6 +5545,9 @@ mod tests {
             chat_url: None,
             chat_model: None,
             chat_auth_header: None,
+            chat_temperature: None,
+            chat_top_p: None,
+            chat_max_tokens: None,
             chat_env_url: None,
             chat_api_key: None,
             anthropic_api_key: key.map(str::to_string),
@@ -5527,6 +5559,29 @@ mod tests {
             tool_executor: None,
             bench_results_dir: None,
         }
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn resolved_args_inference_params_maps_and_defaults() {
+        // Bare args carry no sampling override → all three knobs are None, so an
+        // unset endpoint default is never clobbered.
+        let bare = args_with_anthropic_key(None);
+        assert_eq!(
+            bare.inference_params(),
+            crate::agent::InferenceParams::default()
+        );
+
+        // Populated args copy every knob through unchanged (CLI-over-config merge
+        // already happened in the bin).
+        let mut args = args_with_anthropic_key(None);
+        args.chat_temperature = Some(0.25);
+        args.chat_top_p = Some(0.5);
+        args.chat_max_tokens = Some(512);
+        let params = args.inference_params();
+        assert_eq!(params.temperature, Some(0.25));
+        assert_eq!(params.top_p, Some(0.5));
+        assert_eq!(params.max_tokens, Some(512));
     }
 
     #[test]

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2831,6 +2831,7 @@ fn run_lemonade_pull(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_lemonade_model_load(
     manifest: &LemonadeInstallManifest,
     host: &str,

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -622,6 +622,7 @@ fn serve_http(mut request: ServeHttpRequest) -> Result<()> {
         request.port,
         &request.model_ref,
         &backend,
+        request.engine_recipe.as_ref(),
         log_path,
         &process_env,
     );
@@ -864,6 +865,7 @@ fn ensure_direct_llama_model_available(
             download_port,
             &request.model_ref,
             ROCM_BACKEND_NAME,
+            None,
             log_path,
             process_env,
         );
@@ -2835,12 +2837,19 @@ fn run_lemonade_model_load(
     port: u16,
     model_ref: &str,
     backend: &str,
+    engine_recipe: Option<&EngineRecipeHint>,
     log_path: Option<&Path>,
     process_env: &LemonadeProcessEnvironment,
 ) -> Result<()> {
     let mut command = ProcessCommand::new(&manifest.lemonade);
     command
-        .args(lemonade_model_load_args(host, port, model_ref, backend))
+        .args(lemonade_model_load_args(
+            host,
+            port,
+            model_ref,
+            backend,
+            engine_recipe,
+        ))
         .stdin(Stdio::null());
     if let Some(log_path) = log_path {
         let log = fs::OpenOptions::new()
@@ -2925,6 +2934,9 @@ fn serve_direct_llama_server(
         .arg("--alias")
         .arg(&request.model_ref)
         .stdin(Stdio::null());
+    if let Some(engine_recipe) = request.engine_recipe.as_ref() {
+        command.args(&engine_recipe.required_flags);
+    }
     // Packaged llama-server is raw llama.cpp — it does not read `LEMONADE_API_KEY`.
     // When `rocm serve` protects a public endpoint, hand llama-server the *existing*
     // CLI-managed 0600 key file via `--api-key-file` (a path, not the value, so the
@@ -3368,8 +3380,14 @@ fn model_reports_ready_backend(model: &Value, backend: &str) -> bool {
     }
 }
 
-fn lemonade_model_load_args(host: &str, port: u16, model_ref: &str, backend: &str) -> Vec<String> {
-    vec![
+fn lemonade_model_load_args(
+    host: &str,
+    port: u16,
+    model_ref: &str,
+    backend: &str,
+    engine_recipe: Option<&EngineRecipeHint>,
+) -> Vec<String> {
+    let mut args = vec![
         "--host".to_owned(),
         host.to_owned(),
         "--port".to_owned(),
@@ -3379,7 +3397,14 @@ fn lemonade_model_load_args(host: &str, port: u16, model_ref: &str, backend: &st
         "--llamacpp".to_owned(),
         backend.to_owned(),
         "--save-options".to_owned(),
-    ]
+    ];
+    if let Some(engine_recipe) = engine_recipe.filter(|recipe| !recipe.required_flags.is_empty()) {
+        args.extend([
+            "--llamacpp-args".to_owned(),
+            engine_recipe.required_flags.join(" "),
+        ]);
+    }
+    args
 }
 
 fn query_health_json(host: &str, port: u16) -> Result<Value> {
@@ -4918,7 +4943,7 @@ mod tests {
 
     #[test]
     fn lemonade_model_load_uses_selected_backend() {
-        let args = lemonade_model_load_args("127.0.0.1", 11435, DEFAULT_MODEL, "vulkan");
+        let args = lemonade_model_load_args("127.0.0.1", 11435, DEFAULT_MODEL, "vulkan", None);
         assert_eq!(
             args,
             vec![
@@ -4931,6 +4956,30 @@ mod tests {
                 "--llamacpp",
                 "vulkan",
                 "--save-options",
+            ]
+        );
+    }
+
+    #[test]
+    fn lemonade_model_load_forwards_llamacpp_recipe_flags() {
+        let recipe = EngineRecipeHint {
+            required_flags: vec![
+                "--temperature".to_owned(),
+                "0.5".to_owned(),
+                "--top-p".to_owned(),
+                "0.25".to_owned(),
+                "--n-predict".to_owned(),
+                "128".to_owned(),
+            ],
+            ..EngineRecipeHint::default()
+        };
+        let args =
+            lemonade_model_load_args("127.0.0.1", 11435, DEFAULT_MODEL, "vulkan", Some(&recipe));
+        assert_eq!(
+            args[args.len() - 2..],
+            [
+                "--llamacpp-args",
+                "--temperature 0.5 --top-p 0.25 --n-predict 128"
             ]
         );
     }


### PR DESCRIPTION
This pull request adds support for optional sampling controls (`--temperature`, `--top-p`, and `--max-tokens`) to both the `rocm serve` and `rocm chat` commands, allowing users to customize model generation behavior for supported engines and providers. The changes ensure these parameters are only forwarded when set, preserving provider defaults otherwise. Additionally, the Lemonade engine now correctly passes these controls to llama.cpp via command-line flags, and comprehensive tests have been added to verify the correct propagation of these options.

**Sampling Controls:**

* Added support for `--temperature`, `--top-p`, and `--max-tokens` flags in `rocm serve` and `rocm chat`, updating the documentation to describe their use and behavior for different engines and providers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R279-R290) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R379-R385)
* Updated the `ChatRequest` struct to include optional `temperature` and `top_p` fields, and ensured these are forwarded in requests to OpenAI and Anthropic providers only when set. [[1]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743L38-R44) [[2]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R990-R991) [[3]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1012-R1017) [[4]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1242-R1247)
* Added and updated tests to verify that `temperature` and `top_p` are only included in provider request bodies when explicitly set, preserving default behavior otherwise. [[1]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1765-R1766) [[2]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1901-R1902) [[3]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1916-R1950) [[4]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1960-R1961) [[5]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R1979-R1980) [[6]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2045-R2046) [[7]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2179-R2180) [[8]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2412-R2413) [[9]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2486-R2487) [[10]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2589-R2590) [[11]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2678-R2679) [[12]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2753-R2754) [[13]](diffhunk://#diff-d2a0afb86a448624bd23149a82ff95a1de4c3698fd5faaa6cf5ad0193b0ef743R2856-R2857) [[14]](diffhunk://#diff-6c8990ed4fc72ae13ae54a8a56ece93f04f2700aa76a93f04a818840270d521dR203-R204)

**Lemonade Engine Integration:**

* Modified Lemonade engine startup to accept and forward recipe flags (including sampling controls) to llama.cpp via the `--llamacpp-args` parameter, and updated the relevant function signatures and invocations. [[1]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994R610) [[2]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994R853) [[3]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994R2326-R2338) [[4]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994R2423-R2425) [[5]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994L2836-R2855) [[6]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994L2847-R2872)
* Added tests to ensure Lemonade correctly forwards llama.cpp recipe flags, including sampling parameters. [[1]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994L4353-R4378) [[2]](diffhunk://#diff-192c3a73c51c33f7d28450c95072fcf5beafa517d6550d8c46beb95b54e35994R4395-R4418)