### PR TITLE
ci(dependabot): track pre-commit hook versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,24 @@ updates:
         update-types:
           - minor
           - patch
+
+  # The hook pins in `.pre-commit-config.yaml` were bumped by hand, so they
+  # drifted. Dependabot resolves each `rev` against the hook repository's tags
+  # and leaves the `builtin` and `local` blocks alone -- prek's native hooks and
+  # the `cargo xtask` hooks have no upstream release to track. Grouped into one
+  # PR: this is a short list of linters whose individual bumps carry no review
+  # signal worth a PR each.
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: weekly
+    # Same reasoning as the two blocks above, and it lands harder here: a hook is
+    # executable code that runs on every contributor's machine at commit time and
+    # in the `prek` CI job, so a compromised release executes before anyone has
+    # read the bump. Cooldown delays only version updates, never security updates.
+    cooldown:
+      default-days: 7
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a `pre-commit` entry to `.github/dependabot.yml` so the hook pins in
`.pre-commit-config.yaml` stop drifting.

Those `rev`s (currently `ruff-pre-commit` and `shellcheck-py`) have only ever
been bumped by hand, which means the linters CI enforces are whatever version
someone last remembered to update. Dependabot [added a `pre-commit`
ecosystem](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/)
that parses the config, resolves each `rev` against the hook repository's tags,
and opens a PR when one moves.

Notably it skips the `repo: builtin` and `repo: local` blocks, so prek's native
hooks and the `cargo xtask` hooks are untouched — they have no upstream release
to track.

Weekly, grouped into a single PR, with the same `cooldown: 7` as the other two
ecosystems. The cooldown reasoning is a bit sharper here than for actions or
crates: a hook is executable code that runs on every contributor's machine at
commit time and in the `prek` CI job, so a compromised release executes before
anyone has read the bump. Cooldown never delays security updates.

Risk: low. Config-only; the worst case is that no PRs are opened.

## Test plan

- `prek run --all-files --no-group local-tools` passes (`check-yaml` parses the
  file).
- Not verifiable before merge: whether GitHub accepts `pre-commit` without
  `enable-beta-ecosystems`. The changelog and the supported-ecosystems reference
  both list it as generally available, and the flag is documented as beta-only,
  so it should not be needed — but the authoritative signal is the repo's
  Dependabot tab after this lands. If it is rejected there, the fix is a
  one-line follow-up.

- [x] Not a bug fix; no `tests/e2e-cucumber/expectations.toml` xfail rows to narrow.