### PR TITLE
fix(install): stop relying on RuntimeInformation.OSArchitecture

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -575,9 +575,12 @@ if ([string]::IsNullOrWhiteSpace($InstallDir)) {
 }
 $InstallDir = Resolve-InstallerPath $InstallDir
 
-$architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+$architecture = $env:PROCESSOR_ARCHITEW6432
+if ([string]::IsNullOrWhiteSpace($architecture)) {
+    $architecture = $env:PROCESSOR_ARCHITECTURE
+}
 switch ($architecture) {
-    "X64" { $platformArch = "amd64" }
+    "AMD64" { $platformArch = "amd64" }
     default { Fail "unsupported architecture: $architecture (installer currently supports Windows x86_64 only)" }
 }
 


### PR DESCRIPTION
## Summary
- `RuntimeInformation.OSArchitecture` can return `$null` on some Windows PowerShell 5.1 / .NET Framework setups (e.g. a locked-down corporate image missing a facade assembly), which made `install.ps1` throw `You cannot call a method on a null-valued expression` before printing anything useful.
- Switch to `PROCESSOR_ARCHITEW6432` (falling back to `PROCESSOR_ARCHITECTURE`) — plain env vars Windows always sets, no .NET type resolution involved. This also preserves the original intent of detecting the true OS architecture rather than the running process's bitness (the WOW64 case).
- Root-caused from a real user's `ScriptStackTrace` pointing at the failing line; confirmed unrelated to their corporate proxy or PowerShell language mode, both of which were ruled out first.

## Test plan
- [x] Verify `install.ps1` completes past architecture detection on a real x86_64 Windows machine (originally reported failing on a tester's personal machine) -> Verified to be working
- [x] Confirm `$env:PROCESSOR_ARCHITEW6432` / `$env:PROCESSOR_ARCHITECTURE` resolve to `AMD64` on standard x86_64 Windows and installer proceeds normally