### PR TITLE
fix(install): never let apt remove ROCm packages during dependency setup (EAI-7957)

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -6869,6 +6869,70 @@ fn ensure_torch_runtime_dep(approved: bool, dep: &TorchRuntimeDep) {
     }
 }
 
+/// Refuse an `apt-get install` step that would remove ROCm/AMDGPU packages.
+///
+/// `apt-get install -y` assumes yes for *removals* as well as installs, so a
+/// dependency solution that evicts the ROCm stack would otherwise be applied
+/// unattended (this runs automatically under `rocm install sdk` whenever root or
+/// passwordless sudo is available). Simulating first turns that silent breakage
+/// into an actionable error naming every package at risk.
+///
+/// Only apt is gated: the dnf/zypper/pacman plans install additive runtime
+/// packages and have no equivalent assume-yes removal path. A simulation that
+/// cannot be run (apt missing, transient failure) is not treated as a refusal —
+/// the real command reports the failure with better context.
+fn ensure_apt_install_preserves_rocm(argv: &[String]) -> Result<()> {
+    let Some(simulate_argv) = rocm_core::openmpi::apt_simulate_argv(argv) else {
+        return Ok(());
+    };
+    let (program, args) = simulate_argv
+        .split_first()
+        .context("apt simulation has no program to run")?;
+    let Ok(output) = ProcessCommand::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+    else {
+        return Ok(());
+    };
+    if !output.status.success() {
+        return Ok(());
+    }
+
+    let removals =
+        rocm_core::openmpi::parse_apt_simulate_removals(&String::from_utf8_lossy(&output.stdout));
+    let protected: Vec<&String> = removals
+        .iter()
+        .filter(|package| rocm_core::openmpi::is_protected_rocm_package(package))
+        .collect();
+    if protected.is_empty() {
+        return Ok(());
+    }
+
+    let rendered = |packages: &[&String]| {
+        packages
+            .iter()
+            .map(|package| package.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let others: Vec<&String> = removals
+        .iter()
+        .filter(|package| !rocm_core::openmpi::is_protected_rocm_package(package))
+        .collect();
+    let other_detail = if others.is_empty() {
+        String::new()
+    } else {
+        format!("\n  other packages it would remove: {}", rendered(&others))
+    };
+    bail!(
+        "refusing to run `{}`: it would remove ROCm packages and break this installation\n  ROCm packages it would remove: {}{}\n  action: install the dependency manually after resolving the conflict (for example with a package version that does not evict ROCm), then rerun",
+        argv.join(" "),
+        rendered(&protected),
+        other_detail
+    );
+}
+
 fn run_system_package_install_plan(
     plan: &rocm_core::openmpi::SystemPackageInstallPlan,
 ) -> Result<()> {
@@ -6878,6 +6942,8 @@ fn run_system_package_install_plan(
         // are not already root (where `sudo` may be absent); the argv runs
         // directly without a shell.
         let argv = command.resolved_argv(root);
+        // Never let an automatic dependency install evict the ROCm stack.
+        ensure_apt_install_preserves_rocm(&argv)?;
         // Inherit stdin so an interactive `sudo` password prompt (the case the
         // `--yes` approval exists for) can be answered. When already root or
         // passwordless sudo is configured, sudo does not prompt and the inherited

--- a/crates/rocm-core/src/openmpi.rs
+++ b/crates/rocm-core/src/openmpi.rs
@@ -914,6 +914,86 @@ pub(crate) fn parse_os_release_field(text: &str, key: &str) -> Option<String> {
     None
 }
 
+/// Build a non-mutating apt invocation for a planned `apt-get install` command.
+///
+/// Returns `None` for other commands. Any `sudo` prefix is dropped along with
+/// assume-yes flags: `apt-get -s` changes nothing, so it needs neither root nor
+/// approval, and keeping the resulting argv visibly non-destructive makes it
+/// safe to log and test.
+pub fn apt_simulate_argv(argv: &[String]) -> Option<Vec<String>> {
+    let argv = match argv.split_first() {
+        Some((program, rest)) if program == "sudo" => rest,
+        _ => argv,
+    };
+    if argv.first().map(String::as_str) != Some("apt-get")
+        || !argv.iter().any(|arg| arg == "install")
+    {
+        return None;
+    }
+
+    let mut simulated = Vec::with_capacity(argv.len() + 1);
+    simulated.push("apt-get".to_owned());
+    simulated.push("-s".to_owned());
+    simulated.extend(
+        argv.iter()
+            .skip(1)
+            .filter(|arg| !matches!(arg.as_str(), "-y" | "--yes" | "--assume-yes"))
+            .cloned(),
+    );
+    Some(simulated)
+}
+
+/// Parse package removals from `apt-get -s` output.
+///
+/// Apt emits one `Remv <package> ...` operation per package after its readable
+/// summary. Parsing those operation records avoids depending on summary wrapping
+/// and strips apt's optional trailing `*` marker.
+pub fn parse_apt_simulate_removals(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let package = line
+                .trim_start()
+                .strip_prefix("Remv ")?
+                .split_whitespace()
+                .next()?;
+            Some(package.trim_end_matches('*').to_owned())
+        })
+        .collect()
+}
+
+/// Whether an apt package belongs to the ROCm/AMDGPU system stack and must not
+/// be removed as a side effect of automatic dependency setup.
+pub fn is_protected_rocm_package(package: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        "amd-smi",
+        "amdgpu",
+        "comgr",
+        "hip",
+        "hsa",
+        "migraphx",
+        "miopen",
+        "mivisionx",
+        "rccl",
+        "rocblas",
+        "rocfft",
+        "rocprofiler",
+        "rocm",
+        "rocprim",
+        "rocrand",
+        "rocsolver",
+        "rocsparse",
+        "rocthrust",
+        "roctracer",
+        "rpp",
+    ];
+    // Strip any architecture qualifier (`amdgpu-core:amd64`) before matching.
+    let package = package.split(':').next().unwrap_or(package);
+    PREFIXES
+        .iter()
+        .any(|prefix| package == *prefix || package.starts_with(&format!("{prefix}-")))
+}
+
 fn resolve_package_manager(os_id: &str, id_like: &str) -> Option<PackageManager> {
     const APT: &[&str] = &[
         "ubuntu",
@@ -1297,6 +1377,91 @@ mod tests {
         assert!(plan.package_manager.is_none());
         assert!(plan.commands.is_empty());
         assert!(plan.reason.contains("manually"));
+    }
+
+    #[test]
+    fn apt_simulate_argv_drops_assume_yes_and_simulates() {
+        let install = InstallCommand::sudo(&["apt-get", "install", "-y", "openmpi-bin"]);
+        assert_eq!(
+            apt_simulate_argv(&install.argv).unwrap(),
+            vec!["apt-get", "-s", "install", "openmpi-bin"]
+        );
+        // The executor passes the resolved argv, which carries a `sudo` prefix
+        // when not already root; the simulation must still be recognized.
+        assert_eq!(
+            apt_simulate_argv(&install.resolved_argv(false)).unwrap(),
+            vec!["apt-get", "-s", "install", "openmpi-bin"]
+        );
+        // Non-install apt commands and other package managers are not simulated.
+        assert!(apt_simulate_argv(&InstallCommand::sudo(&["apt-get", "update"]).argv).is_none());
+        assert!(
+            apt_simulate_argv(&InstallCommand::sudo(&["dnf", "install", "-y", "openmpi"]).argv)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parses_removals_from_apt_simulation() {
+        // Mirrors the EAI-7957 report: OpenMPI setup pulling older distro
+        // toolchain packages while marking the ROCm stack for removal.
+        let output = "\
+Reading package lists...
+The following packages will be REMOVED:
+  rocm rocm-hip rocm-hip-runtime-dev mivisionx-dev rpp-dev
+The following NEW packages will be installed:
+  openmpi-bin libopenmpi-dev
+Remv rocm [7.14.0]
+Remv rocm-hip [7.14.0]
+Remv rocm-hip-runtime-dev* [7.14.0]
+Remv mivisionx-dev [7.14.0]
+Remv rpp-dev [7.14.0]
+Inst openmpi-bin (4.1.6 Ubuntu:24.04 [amd64])
+";
+        assert_eq!(
+            parse_apt_simulate_removals(output),
+            vec![
+                "rocm",
+                "rocm-hip",
+                "rocm-hip-runtime-dev",
+                "mivisionx-dev",
+                "rpp-dev"
+            ]
+        );
+        // A purely additive transaction removes nothing.
+        assert!(parse_apt_simulate_removals("Inst libnuma1 (2.0.18 [amd64])\n").is_empty());
+    }
+
+    #[test]
+    fn protects_rocm_stack_packages_only() {
+        for package in [
+            "rocm",
+            "rocm-hip-runtime-dev",
+            "mivisionx-dev",
+            "rpp-dev",
+            "amdgpu-dkms",
+            "hip-runtime-amd",
+            "amdgpu-core:amd64",
+        ] {
+            assert!(
+                is_protected_rocm_package(package),
+                "{package} must be protected"
+            );
+        }
+        // Packages the plans legitimately install/replace must stay removable,
+        // including names that merely start with a protected prefix's letters.
+        for package in [
+            "openmpi-bin",
+            "libopenmpi-dev",
+            "libnuma1",
+            "libatomic1",
+            "hipster",
+            "rocmap",
+        ] {
+            assert!(
+                !is_protected_rocm_package(package),
+                "{package} must not be protected"
+            );
+        }
     }
 
     #[test]

--- a/crates/rocm-core/src/openmpi.rs
+++ b/crates/rocm-core/src/openmpi.rs
@@ -964,34 +964,43 @@ pub fn parse_apt_simulate_removals(output: &str) -> Vec<String> {
 
 /// Whether an apt package belongs to the ROCm/AMDGPU system stack and must not
 /// be removed as a side effect of automatic dependency setup.
+///
+/// Matching is by *family prefix* rather than an exhaustive package list: ROCm
+/// ships hundreds of packages and adds more every release, so enumerating exact
+/// names would silently stop protecting whatever was added last. The prefixes
+/// below cover the component families ROCm publishes — note that many are
+/// dashless (`hipblas`, `rocminfo`, `hsakmt-roct`, `llvm-amdgpu`), so a
+/// dash-separated match would miss them.
+///
+/// This deliberately favors recall over precision. A false positive only makes
+/// the CLI refuse an automatic install and ask the user to resolve it by hand,
+/// whereas a false negative silently breaks their ROCm installation. The
+/// prefixes are still specific enough not to match the packages these plans
+/// legitimately install or replace (`openmpi-bin`, `libnuma1`, `mpich`, ...).
 pub fn is_protected_rocm_package(package: &str) -> bool {
     const PREFIXES: &[&str] = &[
         "amd-smi",
         "amdgpu",
         "comgr",
+        // hip, hipcc, hipblas, hipfft, hipsolver, hip-runtime-amd, hipify-clang
         "hip",
+        // hsa-rocr, hsakmt-roct, hsa-amd-aqlprofile
         "hsa",
+        "llvm-amdgpu",
         "migraphx",
         "miopen",
         "mivisionx",
+        "openmp-extras",
         "rccl",
-        "rocblas",
-        "rocfft",
-        "rocprofiler",
-        "rocm",
-        "rocprim",
-        "rocrand",
-        "rocsolver",
-        "rocsparse",
-        "rocthrust",
-        "roctracer",
+        // rocm*, plus the dashless libraries: rocblas, rocfft, rocrand,
+        // rocsolver, rocsparse, rocthrust, rocprim, rocprofiler, roctracer,
+        // rocalution, rocwmma, rocdecode, rocjpeg, rocdbgapi, rocminfo, rocr-runtime
+        "roc",
         "rpp",
     ];
     // Strip any architecture qualifier (`amdgpu-core:amd64`) before matching.
     let package = package.split(':').next().unwrap_or(package);
-    PREFIXES
-        .iter()
-        .any(|prefix| package == *prefix || package.starts_with(&format!("{prefix}-")))
+    PREFIXES.iter().any(|prefix| package.starts_with(prefix))
 }
 
 fn resolve_package_manager(os_id: &str, id_like: &str) -> Option<PackageManager> {
@@ -1434,10 +1443,25 @@ Inst openmpi-bin (4.1.6 Ubuntu:24.04 [amd64])
     #[test]
     fn protects_rocm_stack_packages_only() {
         for package in [
+            // The packages the EAI-7957 report saw apt mark for removal.
             "rocm",
+            "rocm-hip",
             "rocm-hip-runtime-dev",
             "mivisionx-dev",
             "rpp-dev",
+            // Core packages whose names do not follow a `<family>-` shape, so a
+            // dash-separated match would miss them and let apt remove the ROCm
+            // stack anyway.
+            "hsakmt-roct",
+            "llvm-amdgpu",
+            "rocminfo",
+            "hipblas",
+            "rocblas",
+            "hipcc",
+            "comgr",
+            "hsa-rocr",
+            "openmp-extras-runtime",
+            // Driver packages and architecture-qualified names.
             "amdgpu-dkms",
             "hip-runtime-amd",
             "amdgpu-core:amd64",
@@ -1447,15 +1471,18 @@ Inst openmpi-bin (4.1.6 Ubuntu:24.04 [amd64])
                 "{package} must be protected"
             );
         }
-        // Packages the plans legitimately install/replace must stay removable,
-        // including names that merely start with a protected prefix's letters.
+        // The packages these plans legitimately install, and the MPI
+        // implementation apt may swap out to satisfy them, must stay removable
+        // or the guard would block its own install.
         for package in [
             "openmpi-bin",
             "libopenmpi-dev",
+            "openmpi4",
+            "mpich",
+            "libmpich-dev",
             "libnuma1",
+            "numactl",
             "libatomic1",
-            "hipster",
-            "rocmap",
         ] {
             assert!(
                 !is_protected_rocm_package(package),

--- a/tests/e2e-cucumber/features/dependency_guard.feature
+++ b/tests/e2e-cucumber/features/dependency_guard.feature
@@ -1,0 +1,20 @@
+Feature: System dependency installs preserve ROCm
+
+  # vLLM needs the OpenMPI runtime, which the CLI installs through the host
+  # package manager. `apt-get install -y` assumes yes for *removals* as well as
+  # installs, so when apt chose to satisfy OpenMPI by evicting the ROCm stack it
+  # did so unattended — reported in the field as `rocm install sdk` removing
+  # rocm, rocm-hip, rocm-hip-runtime-dev, mivisionx-dev and rpp-dev while pulling
+  # an older toolchain, breaking a working ROCm install.
+  #
+  # The package manager is planted rather than real, so the scenario owns the
+  # dependency solution apt reports and needs no GPU, no engine install and no
+  # network. Linux-only: the dependency-setup path does not run on Windows.
+  @id:deps-guard-refuses-rocm-removal @requires-os:linux
+  Scenario: 1 - Installing a dependency never silently removes ROCm
+    Given a machine with a registered ROCm runtime
+    And installing OpenMPI would remove the ROCm packages
+    When the user installs the vLLM engine and approves system changes
+    Then the CLI refuses instead of removing them
+    And it does so before changing anything on the system
+    And it lists every ROCm package that would have been removed

--- a/tests/e2e-cucumber/features/dependency_guard.feature
+++ b/tests/e2e-cucumber/features/dependency_guard.feature
@@ -10,6 +10,13 @@ Feature: System dependency installs preserve ROCm
   # The package manager is planted rather than real, so the scenario owns the
   # dependency solution apt reports and needs no GPU, no engine install and no
   # network. Linux-only: the dependency-setup path does not run on Windows.
+  #
+  # It also assumes an apt host, which every Linux lane is — the guard is
+  # apt-specific by design, because only `apt-get install -y` assumes yes for
+  # removals. On a Linux host whose /etc/os-release selects dnf/zypper/pacman
+  # the CLI plans a different, additive command and there is no refusal to
+  # assert; move this behind a package-manager capability gate if such a lane
+  # is ever added.
   @id:deps-guard-refuses-rocm-removal @requires-os:linux
   Scenario: 1 - Installing a dependency never silently removes ROCm
     Given a machine with a registered ROCm runtime

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -18,6 +18,7 @@ mod e2e {
     pub mod bench_steps;
     pub mod chat_steps;
     pub mod dash_steps;
+    pub mod dependency_guard_steps;
     pub mod diagnose_steps;
     pub mod engines_steps;
     pub mod examine_steps;

--- a/tests/e2e-cucumber/tests/e2e/dependency_guard_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dependency_guard_steps.rs
@@ -99,6 +99,11 @@ async fn plant_destructive_apt(world: &mut E2eWorld) {
     );
     write_shim(&shim.join("apt-get"), &apt_body);
     write_shim(&shim.join("ldconfig"), "#!/bin/sh\nexit 0\n");
+    // The CLI prepends `sudo` whenever it is not already root, so whether the
+    // real `sudo` exists would otherwise decide if this scenario reaches the
+    // guard at all (it runs as root in a container, as a normal user in CI).
+    // Standing in for it too makes the run identical either way.
+    write_shim(&shim.join("sudo"), "#!/bin/sh\nexec \"$@\"\n");
 }
 
 #[when("the user installs the vLLM engine and approves system changes")]

--- a/tests/e2e-cucumber/tests/e2e/dependency_guard_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dependency_guard_steps.rs
@@ -1,0 +1,176 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Steps for the ROCm-preserving guard on automatic system-package installs.
+//!
+//! `rocm engines install vllm` installs the OpenMPI runtime vLLM needs through
+//! the host package manager. `apt-get install -y` assumes yes for *removals* as
+//! well as installs, so a dependency solution that evicts the ROCm stack used to
+//! be applied without asking. These steps stand in for the package manager so a
+//! scenario can present that exact solution and assert the CLI refuses it.
+
+use std::path::PathBuf;
+
+use cucumber::{given, then, when};
+
+use crate::E2eWorld;
+
+/// Runtime key for the planted managed runtime. Any key works; the CLI matches
+/// the registry entry by name.
+const RUNTIME_KEY: &str = "therock-release-gfx94X-dcgpu-e2e-guard";
+
+/// The ROCm packages the planted `apt-get` simulation reports as removals,
+/// mirroring the set seen in the field report.
+const REMOVED_ROCM: &[&str] = &[
+    "rocm",
+    "rocm-hip",
+    "rocm-hip-runtime-dev",
+    "mivisionx-dev",
+    "rpp-dev",
+];
+
+fn shim_dir(world: &E2eWorld) -> PathBuf {
+    let root = world.isolated_root.as_ref().expect("no isolated root");
+    root.path().join("guard-bin")
+}
+
+/// Write `body` to `path` and mark it executable.
+fn write_shim(path: &PathBuf, body: &str) {
+    std::fs::write(path, body)
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|e| panic!("failed to mark {} executable: {e}", path.display()));
+    }
+}
+
+#[given("a machine with a registered ROCm runtime")]
+async fn plant_runtime(world: &mut E2eWorld) {
+    // Plant the registry entry `rocm install sdk` would have written, so the
+    // engine install reaches the dependency-setup step without a GPU or a
+    // multi-GiB SDK pull. Black-box: plain JSON matching the CLI's on-disk
+    // schema, not a typed import from the product crates.
+    let root = world.isolated_root.as_ref().expect("no isolated root");
+    let install_root = root.path().join("guard-runtime");
+    std::fs::create_dir_all(&install_root).expect("failed to create the planted install root");
+
+    let registry = root.path().join("data").join("runtimes").join("registry");
+    std::fs::create_dir_all(&registry).expect("failed to create the runtime registry dir");
+
+    let manifest = serde_json::json!({
+        "runtime_key": RUNTIME_KEY,
+        "runtime_id": RUNTIME_KEY,
+        "channel": "release",
+        "format": "wheel",
+        "family": "gfx94X-dcgpu",
+        "family_source": "e2e",
+        "version": "7.14.0",
+        "install_root": install_root.display().to_string(),
+        "selected_artifact_url": "https://example.invalid/e2e.whl",
+        "installed_at_unix_ms": 1,
+    });
+    std::fs::write(
+        registry.join(format!("{RUNTIME_KEY}.json")),
+        serde_json::to_vec_pretty(&manifest).expect("manifest serialises"),
+    )
+    .expect("failed to write the planted runtime manifest");
+}
+
+#[given("installing OpenMPI would remove the ROCm packages")]
+async fn plant_destructive_apt(world: &mut E2eWorld) {
+    // Stand in for the host package manager so the scenario owns the dependency
+    // solution apt reports. `apt-get -s` (the simulation the CLI runs before
+    // installing) prints the operation records apt itself would print; any other
+    // apt invocation succeeds silently. A companion `ldconfig` shim reports no
+    // libmpi, so OpenMPI reads as missing whatever the host has installed.
+    let shim = shim_dir(world);
+    std::fs::create_dir_all(&shim).expect("failed to create the package-manager shim dir");
+
+    let removals = REMOVED_ROCM
+        .iter()
+        .map(|package| format!("echo 'Remv {package} [7.14.0]'"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let apt_body = format!(
+        "#!/bin/sh\nfor arg in \"$@\"; do\n  if [ \"$arg\" = -s ]; then\n{removals}\n    echo 'Inst openmpi-bin (4.1.6 [amd64])'\n    exit 0\n  fi\ndone\nexit 0\n"
+    );
+    write_shim(&shim.join("apt-get"), &apt_body);
+    write_shim(&shim.join("ldconfig"), "#!/bin/sh\nexit 0\n");
+}
+
+#[when("the user installs the vLLM engine and approves system changes")]
+async fn install_vllm_approving_changes(world: &mut E2eWorld) {
+    // A PATH of only the shim dir keeps the run hermetic: the CLI finds the
+    // planted `apt-get` / `ldconfig`, and finds no `mpirun`, so OpenMPI reads as
+    // missing on any host. `--yes` is the approval the guard has to override —
+    // that is the whole point, since the reported break happened unattended.
+    let shim = shim_dir(world);
+    let (stdout, stderr, rc) = crate::run_rocm_with_env(
+        world,
+        &[
+            "engines",
+            "install",
+            "vllm",
+            "--runtime-id",
+            RUNTIME_KEY,
+            "--yes",
+        ],
+        &[("PATH", shim.display().to_string().as_str())],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+/// Everything the CLI wrote to either stream, which is what a user sees.
+fn combined_output(world: &E2eWorld) -> String {
+    format!(
+        "{}{}",
+        world.cli_output.as_deref().unwrap_or_default(),
+        world.cli_stderr.as_deref().unwrap_or_default()
+    )
+}
+
+#[then("the CLI refuses instead of removing them")]
+async fn assert_refused(world: &mut E2eWorld) {
+    let rc = world.cli_rc.expect("no exit code recorded");
+    let output = combined_output(world);
+    assert!(
+        rc != 0,
+        "expected a non-zero exit for the refusal, got {rc}:\n{output}"
+    );
+    assert!(
+        output.contains("would remove ROCm packages"),
+        "expected the CLI to say it refused because ROCm would be removed:\n{output}"
+    );
+}
+
+#[then("it does so before changing anything on the system")]
+async fn assert_refused_before_install(world: &mut E2eWorld) {
+    let output = combined_output(world);
+    // The apt shim records nothing, so assert on the CLI's own account of what
+    // it did: the refusal must precede the engine install it was guarding, or
+    // the damage is already done by the time the user reads it.
+    assert!(
+        !output.contains("engine install"),
+        "the engine install proceeded despite the refusal:\n{output}"
+    );
+    assert!(
+        !output.contains("status: installed"),
+        "a system package install was reported despite the refusal:\n{output}"
+    );
+}
+
+#[then("it lists every ROCm package that would have been removed")]
+async fn assert_lists_removals(world: &mut E2eWorld) {
+    let output = combined_output(world);
+    for package in REMOVED_ROCM {
+        assert!(
+            output.contains(package),
+            "the refusal did not name `{package}`:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`rocm install sdk` could remove a working ROCm installation without asking.

Installing vLLM needs the OpenMPI runtime, which the CLI installs through the host package manager with `apt-get install -y`. That `-y` assumes yes for package **removals** as well as installs, so when apt decided to satisfy OpenMPI by evicting the ROCm stack, it went ahead unattended — the SDK install runs this path automatically whenever it has root or passwordless sudo. The field report saw `rocm`, `rocm-hip`, `rocm-hip-runtime-dev`, `mivisionx-dev` and `rpp-dev` removed while an older toolchain was pulled in, breaking a working ROCm 7.14 install.

This makes that transaction fail loudly instead of silently destroying the installation.

## Changes

- Before running an `apt-get install` step, simulate it first with `apt-get -s` and parse the removals apt reports.
- If the transaction would remove any ROCm/AMDGPU package, refuse: print every affected package and tell the user to resolve the conflict manually. This applies on the `--yes` path and the unattended path alike, since the reported breakage happened unattended.
- Packages are matched by component family rather than an exhaustive list, because ROCm ships hundreds of packages and adds more each release. Many core names are dashless (`hsakmt-roct`, `llvm-amdgpu`, `rocminfo`, `hipblas`), so matching only on a `<family>-` shape would miss them.
- The matcher deliberately favours recall: a false positive only asks the user to install by hand, while a false negative breaks their ROCm install. It still leaves the packages these plans legitimately install or swap (`openmpi-bin`, `mpich`, `libnuma1`, `libatomic1`) removable, so the guard cannot block the very install it protects.
- Other package managers are untouched — dnf/zypper/pacman plans are additive and have no assume-yes removal path.
- The guard fails open if the simulation itself cannot run, so it never blocks an otherwise healthy install.

## Test plan

- Unit tests in `crates/rocm-core/src/openmpi.rs` cover removal parsing (including apt's trailing `*`), the simulate argv (adds `-s`, drops `-y`, tolerates a `sudo` prefix, ignores non-apt commands), and the package classifier — with the dashless core package names as explicit regression cases.
- New scenario `@id:deps-guard-refuses-rocm-removal` (`tests/e2e-cucumber/features/dependency_guard.feature`) covers the user-visible behaviour: it asserts the CLI refuses, refuses *before* installing anything, and names every ROCm package at risk. It plants a runtime registry entry and stands in for the package manager, so it needs no GPU, no engine install and no network, and runs on the default mock lane.
- Verified as a real regression test: with the guard removed the scenario fails, and passes with it restored.
- Linux container run: clippy clean, 434 unit tests pass, and the e2e suite runs the new scenario green.

The scenario is Linux-only (`@requires-os:linux`) and assumes an apt host, which every Linux CI lane is; the guard is apt-specific by design. That precondition is recorded in the feature file.

Fixes EAI-7957.
