### PR TITLE
fix(uv): colocate the uv Python install dir with the ROCm CLI data dir

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -677,6 +677,13 @@ manages, on the order of several GB per SDK version installed. It is removed by
 `rocm uninstall` unless `--keep-data` is passed, and its location can be
 overridden with `ROCM_CLI_UV_CACHE_DIR`.
 
+When a managed Python interpreter is needed, `uv python install` downloads a
+standalone CPython build. That download is also kept in the managed data
+directory (at `<data-dir>/uv-python`) rather than `uv`'s own default of
+`$HOME/.local/share/uv/python/`. It is removed by `rocm uninstall` unless
+`--keep-data` is passed, and its location can be overridden with
+`ROCM_CLI_UV_PYTHON_INSTALL_DIR`.
+
 ### Lemonade Embeddable Runtime
 
 When `rocm engines install lemonade` is run, the CLI downloads a prebuilt

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -44,7 +44,7 @@ use rocm_core::{
     read_http_response_bounded, resolve_builtin_model_recipe, resolve_model_recipe,
     runtime_install_root_is_protected, runtime_path_is_same_or_inside,
     runtime_python_activation_hint, runtime_python_env_bin_dir, runtime_python_executable_in_env,
-    shell_command_for_host, uv_cache_source, write_all_tcp_stream,
+    shell_command_for_host, uv_cache_source, uv_python_install_dir_source, write_all_tcp_stream,
 };
 use rocm_engine_protocol::{
     DEFAULT_LOG_TAIL_LINES, DetectRequest, DetectResponse, DevicePolicy,
@@ -518,12 +518,13 @@ rocm logs --search error timeout")]
         /// Keep saved settings.
         #[arg(long)]
         keep_config: bool,
-        /// Keep app data such as logs, services, engines, and the uv package cache
-        /// (often the largest directory rocm-cli manages).
+        /// Keep app data such as logs, services, engines, the uv package cache, and the
+        /// uv-managed Python interpreter (often the largest directories rocm-cli manages).
         #[arg(long)]
         keep_data: bool,
-        /// Keep caches under the cache directory. Does not cover the uv package cache,
-        /// which lives under the data directory; use --keep-data for that.
+        /// Keep caches under the cache directory. Does not cover the uv package cache or
+        /// the uv-managed Python interpreter, which live under the data directory; use
+        /// --keep-data for those.
         #[arg(long)]
         keep_cache: bool,
         /// Allow removing development binaries inside the current build tree.
@@ -1133,6 +1134,7 @@ fn main() -> Result<()> {
 
     maybe_migrate_legacy_dashboard_config();
     maybe_notice_legacy_uv_cache();
+    maybe_notice_legacy_uv_python_install_dir();
 
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
     if raw_args.is_empty() {
@@ -1232,6 +1234,53 @@ fn maybe_notice_legacy_uv_cache() {
     eprintln!(
         "rocm: the uv cache now lives at {}; the previous cache at {} is no longer used by rocm-cli and can be removed if no other uv project needs it",
         cache.path().display(),
+        legacy.display()
+    );
+    let _ = fs::write(&marker, b"");
+}
+
+/// Legacy `uv`-managed Python install location, used before it was colocated with the
+/// managed data directory. Kept relative so the check works on every platform's home dir.
+const LEGACY_UV_PYTHON_INSTALL_DIR_RELATIVE: [&str; 4] = [".local", "share", "uv", "python"];
+
+/// One-shot notice that pre-colocation `uv`-managed Python interpreters are still
+/// occupying space at the default `uv` location. Nothing is migrated or deleted: removing
+/// it is the user's call. Silent when the managed dir does not exist yet (nothing has
+/// moved) or when an override is in effect.
+fn maybe_notice_legacy_uv_python_install_dir() {
+    let Ok(paths) = AppPaths::discover() else {
+        return;
+    };
+    let install_dir = uv_python_install_dir_source(&paths);
+    if install_dir.is_override() {
+        return;
+    }
+    // Only worth mentioning once the managed dir is actually in use; otherwise the legacy
+    // directory is simply still being used by other tools.
+    if !install_dir.path().is_dir() {
+        return;
+    }
+    let Some(home) = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+    else {
+        return;
+    };
+    let legacy = LEGACY_UV_PYTHON_INSTALL_DIR_RELATIVE
+        .iter()
+        .fold(home, |dir, part| dir.join(part));
+    if !legacy.is_dir() {
+        return;
+    }
+    // One-shot: a standing reminder on every invocation would be noise, and the user may
+    // reasonably decide to keep the legacy interpreters for other uv projects.
+    let marker = paths.data_dir.join(".legacy-uv-python-install-dir-notice");
+    if marker.exists() {
+        return;
+    }
+    eprintln!(
+        "rocm: the uv-managed Python interpreter now lives at {}; the previous location at {} is no longer used by rocm-cli and can be removed if no other uv project needs it",
+        install_dir.path().display(),
         legacy.display()
     );
     let _ = fs::write(&marker, b"");
@@ -17836,6 +17885,20 @@ fn shared_cache_candidates() -> Vec<(PathBuf, &'static str)> {
         ));
     }
 
+    // Same reasoning for the standalone interpreters `uv python install` downloads. The
+    // managed location sits under the data directory and is filtered out by
+    // `shared_cache_notes_for`; this only surfaces when it has been pointed elsewhere.
+    let uv_python = env_path("UV_PYTHON_INSTALL_DIR").or_else(|| {
+        rocm_core::runtime_home_dir()
+            .map(|home| home.join(".local").join("share").join("uv").join("python"))
+    });
+    if let Some(path) = uv_python {
+        candidates.push((
+            path,
+            "uv-managed Python interpreters are shared with other uv projects on this computer and are",
+        ));
+    }
+
     let hf_cache = env_path("HF_HOME")
         .map(|home| home.join("hub"))
         .or_else(|| env_path("HUGGINGFACE_HUB_CACHE"))
@@ -19285,6 +19348,31 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The uv-managed Python interpreters are now the other large thing rocm-cli causes
+    /// to be downloaded, so uninstall must account for them the same way it does the uv
+    /// cache. Drives the real candidate list rather than a hand-made one, so deleting the
+    /// production code fails this test.
+    #[test]
+    fn shared_cache_candidates_include_the_uv_python_install_dir() {
+        let lock = super::BUILTIN_ENGINE_ENV_LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("env lock poisoned");
+        let overridden = std::env::temp_dir().join(format!("rocm-uv-py-{}", std::process::id()));
+        let _scoped = super::ScopedEnvVar::set_path("UV_PYTHON_INSTALL_DIR", &overridden);
+
+        let candidates = super::shared_cache_candidates();
+        let entry = candidates
+            .iter()
+            .find(|(path, _)| path == &overridden)
+            .unwrap_or_else(|| {
+                panic!("UV_PYTHON_INSTALL_DIR missing from uninstall candidates: {candidates:?}")
+            });
+        assert!(
+            entry.1.contains("uv-managed Python"),
+            "unexpected description: {}",
+            entry.1
+        );
     }
 
     /// A cache that does not exist is not worth mentioning.

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1213,10 +1213,7 @@ fn maybe_notice_legacy_uv_cache() {
     if !cache.path().is_dir() {
         return;
     }
-    let Some(home) = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)
-    else {
+    let Some(home) = rocm_core::runtime_home_dir() else {
         return;
     };
     let legacy = LEGACY_UV_CACHE_RELATIVE
@@ -1260,10 +1257,7 @@ fn maybe_notice_legacy_uv_python_install_dir() {
     if !install_dir.path().is_dir() {
         return;
     }
-    let Some(home) = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)
-    else {
+    let Some(home) = rocm_core::runtime_home_dir() else {
         return;
     };
     let legacy = LEGACY_UV_PYTHON_INSTALL_DIR_RELATIVE
@@ -17852,7 +17846,7 @@ fn shared_cache_notes(paths: &AppPaths) -> Vec<String> {
         paths.data_dir.clone(),
         paths.cache_dir.clone(),
     ];
-    shared_cache_notes_for(&removed_roots, &shared_cache_candidates())
+    shared_cache_notes_for(&removed_roots, &shared_cache_candidates(paths))
 }
 
 /// The pure part of [`shared_cache_notes`], so the filtering is testable without
@@ -17870,34 +17864,23 @@ fn shared_cache_notes_for(
 }
 
 /// The shared caches worth reporting, with why each is left alone.
-fn shared_cache_candidates() -> Vec<(PathBuf, &'static str)> {
+fn shared_cache_candidates(paths: &AppPaths) -> Vec<(PathBuf, &'static str)> {
     let mut candidates = Vec::new();
 
-    // `uv` writes to `UV_CACHE_DIR` when set, otherwise its own default. Read it
-    // rather than assuming a location, so this stays correct wherever the cache
-    // has been pointed.
-    let uv_cache = env_path("UV_CACHE_DIR")
-        .or_else(|| rocm_core::runtime_home_dir().map(|home| home.join(".cache").join("uv")));
-    if let Some(path) = uv_cache {
-        candidates.push((
-            path,
-            "the uv package cache is shared with other uv projects on this computer and is",
-        ));
-    }
+    // Resolved through the same precedence `uv` is invoked with, so an override is
+    // reported at the location `uv` actually writes to. The managed location sits
+    // under the data directory and is filtered out by `shared_cache_notes_for`; this
+    // only surfaces when it has been pointed elsewhere.
+    candidates.push((
+        uv_cache_source(paths).path().to_path_buf(),
+        "the uv package cache is shared with other uv projects on this computer and is",
+    ));
 
-    // Same reasoning for the standalone interpreters `uv python install` downloads. The
-    // managed location sits under the data directory and is filtered out by
-    // `shared_cache_notes_for`; this only surfaces when it has been pointed elsewhere.
-    let uv_python = env_path("UV_PYTHON_INSTALL_DIR").or_else(|| {
-        rocm_core::runtime_home_dir()
-            .map(|home| home.join(".local").join("share").join("uv").join("python"))
-    });
-    if let Some(path) = uv_python {
-        candidates.push((
-            path,
-            "uv-managed Python interpreters are shared with other uv projects on this computer and are",
-        ));
-    }
+    // Same reasoning for the standalone interpreters `uv python install` downloads.
+    candidates.push((
+        uv_python_install_dir_source(paths).path().to_path_buf(),
+        "uv-managed Python interpreters are shared with other uv projects on this computer and are",
+    ));
 
     let hf_cache = env_path("HF_HOME")
         .map(|home| home.join("hub"))
@@ -19358,10 +19341,12 @@ mod tests {
     fn shared_cache_candidates_include_the_uv_python_install_dir() {
         let lock = super::BUILTIN_ENGINE_ENV_LOCK.get_or_init(|| Mutex::new(()));
         let _guard = lock.lock().expect("env lock poisoned");
+        let (root, paths) = test_paths("shared-cache-python-ambient");
         let overridden = std::env::temp_dir().join(format!("rocm-uv-py-{}", std::process::id()));
-        let _scoped = super::ScopedEnvVar::set_path("UV_PYTHON_INSTALL_DIR", &overridden);
+        let _scoped =
+            super::ScopedEnvVar::set_path(rocm_core::UV_PYTHON_INSTALL_DIR_ENV, &overridden);
 
-        let candidates = super::shared_cache_candidates();
+        let candidates = super::shared_cache_candidates(&paths);
         let entry = candidates
             .iter()
             .find(|(path, _)| path == &overridden)
@@ -19373,6 +19358,41 @@ mod tests {
             "unexpected description: {}",
             entry.1
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// The namespaced override takes precedence over the ambient variable when `uv` is
+    /// actually invoked, so uninstall reporting must resolve through the same
+    /// precedence for both the cache dir and the python install dir, or it reports a
+    /// path `uv` never wrote to.
+    #[test]
+    fn shared_cache_candidates_respect_the_namespaced_override() {
+        let lock = super::BUILTIN_ENGINE_ENV_LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("env lock poisoned");
+        let (root, paths) = test_paths("shared-cache-namespaced-override");
+        let overridden_cache =
+            std::env::temp_dir().join(format!("rocm-uv-cache-override-{}", std::process::id()));
+        let overridden_python =
+            std::env::temp_dir().join(format!("rocm-uv-python-override-{}", std::process::id()));
+        let _cache_scoped =
+            super::ScopedEnvVar::set_path(rocm_core::UV_CACHE_DIR_OVERRIDE_ENV, &overridden_cache);
+        let _python_scoped = super::ScopedEnvVar::set_path(
+            rocm_core::UV_PYTHON_INSTALL_DIR_OVERRIDE_ENV,
+            &overridden_python,
+        );
+
+        let candidates = super::shared_cache_candidates(&paths);
+        assert!(
+            candidates.iter().any(|(path, _)| path == &overridden_cache),
+            "ROCM_CLI_UV_CACHE_DIR override missing from uninstall candidates: {candidates:?}"
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|(path, _)| path == &overridden_python),
+            "ROCM_CLI_UV_PYTHON_INSTALL_DIR override missing from uninstall candidates: {candidates:?}"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     /// A cache that does not exist is not worth mentioning.

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1241,20 +1241,36 @@ fn maybe_notice_legacy_uv_cache() {
 /// `$HOME/.local/share/uv` on Unix; `%APPDATA%\uv\data` on Windows — uv does not use
 /// `%USERPROFILE%\.local\share`).
 fn legacy_uv_python_install_dir() -> Option<PathBuf> {
-    if rocm_core::runtime_is_windows() {
-        let appdata = std::env::var_os("APPDATA")
+    resolve_legacy_uv_python_install_dir(
+        rocm_core::runtime_is_windows(),
+        std::env::var_os("APPDATA"),
+        std::env::var_os("XDG_DATA_HOME"),
+        rocm_core::runtime_home_dir(),
+    )
+}
+
+/// Pure resolution logic for [`legacy_uv_python_install_dir`]. Split out so the Windows
+/// branch is table-testable: `runtime_is_windows()` is `cfg!(windows)`, so it can never
+/// be exercised by a test running on Linux CI otherwise.
+fn resolve_legacy_uv_python_install_dir(
+    is_windows: bool,
+    appdata: Option<OsString>,
+    xdg_data_home: Option<OsString>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if is_windows {
+        let appdata = appdata
             .map(PathBuf::from)
             .filter(|value| !value.as_os_str().is_empty())?;
         return Some(appdata.join("uv").join("data").join("python"));
     }
-    if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME")
+    if let Some(xdg_data_home) = xdg_data_home
         .map(PathBuf::from)
         .filter(|value| !value.as_os_str().is_empty())
     {
         return Some(xdg_data_home.join("uv").join("python"));
     }
-    let home = rocm_core::runtime_home_dir()?;
-    Some(home.join(".local").join("share").join("uv").join("python"))
+    Some(home?.join(".local").join("share").join("uv").join("python"))
 }
 
 /// One-shot notice that pre-colocation `uv`-managed Python interpreters are still
@@ -1269,14 +1285,14 @@ fn maybe_notice_legacy_uv_python_install_dir() {
     if install_dir.is_override() {
         return;
     }
-    // Only worth mentioning once the managed dir is actually in use; otherwise the legacy
-    // directory is simply still being used by other tools.
-    if !install_dir.path().is_dir() {
-        return;
-    }
     let Some(legacy) = legacy_uv_python_install_dir() else {
         return;
     };
+    // Gated on the legacy directory existing, not the managed one: relocation only
+    // happens when `uv python install` actually runs again (e.g. a manifest pointing
+    // outside the managed dir gets invalidated), which may never occur for a user
+    // whose PATH Python already satisfies every check. Waiting on the managed dir
+    // would leave such users with an un-reclaimed legacy install and no notice.
     if !legacy.is_dir() {
         return;
     }
@@ -17890,9 +17906,20 @@ fn shared_cache_candidates(paths: &AppPaths) -> Vec<(PathBuf, &'static str)> {
         "the uv package cache is shared with other uv projects on this computer and is",
     ));
 
-    // Same reasoning for the standalone interpreters `uv python install` downloads.
+    // Same reasoning for the standalone interpreters `uv python install` downloads. Falls
+    // back to the legacy location when the managed one was never created, so uninstall
+    // still tells the truth about a still-existing legacy interpreter.
+    let python_install_dir = uv_python_install_dir_source(paths);
+    let python_install_path =
+        if !python_install_dir.is_override() && !python_install_dir.path().is_dir() {
+            legacy_uv_python_install_dir()
+                .filter(|legacy| legacy.is_dir())
+                .unwrap_or_else(|| python_install_dir.path().to_path_buf())
+        } else {
+            python_install_dir.path().to_path_buf()
+        };
     candidates.push((
-        uv_python_install_dir_source(paths).path().to_path_buf(),
+        python_install_path,
         "uv-managed Python interpreters are shared with other uv projects on this computer and are",
     ));
 
@@ -19418,6 +19445,63 @@ mod tests {
             &[(missing, "the uv package cache")],
         );
         assert!(notes.is_empty(), "{notes:?}");
+    }
+
+    // `resolve_legacy_uv_python_install_dir` is pure and table-tested directly so the
+    // Windows branch is covered even though `runtime_is_windows()` (`cfg!(windows)`)
+    // makes it unreachable through `legacy_uv_python_install_dir()` on Linux CI.
+    #[test]
+    fn legacy_uv_python_install_dir_windows_uses_appdata() {
+        let appdata = std::ffi::OsString::from("/fake/AppData/Roaming");
+        let expected = std::path::PathBuf::from(&appdata)
+            .join("uv")
+            .join("data")
+            .join("python");
+        assert_eq!(
+            super::resolve_legacy_uv_python_install_dir(true, Some(appdata), None, None),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn legacy_uv_python_install_dir_windows_without_appdata_is_none() {
+        assert_eq!(
+            super::resolve_legacy_uv_python_install_dir(
+                true,
+                None,
+                None,
+                Some(std::path::PathBuf::from("/home/jane"))
+            ),
+            None,
+            "a missing APPDATA must not fall back to the Unix layout"
+        );
+    }
+
+    #[test]
+    fn legacy_uv_python_install_dir_unix_prefers_xdg_data_home() {
+        let xdg_data_home = std::ffi::OsString::from("/fake/xdg-data");
+        let expected = std::path::PathBuf::from(&xdg_data_home)
+            .join("uv")
+            .join("python");
+        assert_eq!(
+            super::resolve_legacy_uv_python_install_dir(
+                false,
+                None,
+                Some(xdg_data_home),
+                Some(std::path::PathBuf::from("/home/jane"))
+            ),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn legacy_uv_python_install_dir_unix_falls_back_to_home() {
+        let home = std::path::PathBuf::from("/home/jane");
+        let expected = home.join(".local").join("share").join("uv").join("python");
+        assert_eq!(
+            super::resolve_legacy_uv_python_install_dir(false, None, None, Some(home)),
+            Some(expected)
+        );
     }
 
     use super::*;

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1236,9 +1236,26 @@ fn maybe_notice_legacy_uv_cache() {
     let _ = fs::write(&marker, b"");
 }
 
-/// Legacy `uv`-managed Python install location, used before it was colocated with the
-/// managed data directory. Kept relative so the check works on every platform's home dir.
-const LEGACY_UV_PYTHON_INSTALL_DIR_RELATIVE: [&str; 4] = [".local", "share", "uv", "python"];
+/// Where `uv` puts Python installs absent `UV_PYTHON_INSTALL_DIR`: a `python`
+/// subdirectory of its persistent data dir (`$XDG_DATA_HOME/uv`, else
+/// `$HOME/.local/share/uv` on Unix; `%APPDATA%\uv\data` on Windows — uv does not use
+/// `%USERPROFILE%\.local\share`).
+fn legacy_uv_python_install_dir() -> Option<PathBuf> {
+    if rocm_core::runtime_is_windows() {
+        let appdata = std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .filter(|value| !value.as_os_str().is_empty())?;
+        return Some(appdata.join("uv").join("data").join("python"));
+    }
+    if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|value| !value.as_os_str().is_empty())
+    {
+        return Some(xdg_data_home.join("uv").join("python"));
+    }
+    let home = rocm_core::runtime_home_dir()?;
+    Some(home.join(".local").join("share").join("uv").join("python"))
+}
 
 /// One-shot notice that pre-colocation `uv`-managed Python interpreters are still
 /// occupying space at the default `uv` location. Nothing is migrated or deleted: removing
@@ -1257,12 +1274,9 @@ fn maybe_notice_legacy_uv_python_install_dir() {
     if !install_dir.path().is_dir() {
         return;
     }
-    let Some(home) = rocm_core::runtime_home_dir() else {
+    let Some(legacy) = legacy_uv_python_install_dir() else {
         return;
     };
-    let legacy = LEGACY_UV_PYTHON_INSTALL_DIR_RELATIVE
-        .iter()
-        .fold(home, |dir, part| dir.join(part));
     if !legacy.is_dir() {
         return;
     }

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -11,12 +11,12 @@ use rocm_core::{
     normalize_runtime_path_text_for_host, normalize_runtime_path_text_for_storage,
     normalize_therock_family, runtime_is_windows, runtime_os_name, runtime_path_for_windows_child,
     runtime_path_list_split, runtime_python_executable_in_env, unix_time_millis, uv_command_env,
-    uv_pip_install_base, uv_venv_args, verify_rsa_pkcs1_sha256_signature,
+    uv_pip_install_base, uv_python_install_dir_source, uv_venv_args,
+    verify_rsa_pkcs1_sha256_signature,
 };
 #[cfg(test)]
 use rocm_core::{
-    generate_rsa_signing_keypair, managed_uv_cache_dir, managed_uv_python_install_dir,
-    sign_rsa_pkcs1_sha256_signature,
+    generate_rsa_signing_keypair, managed_uv_cache_dir, sign_rsa_pkcs1_sha256_signature,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -3926,6 +3926,17 @@ fn save_managed_python_manifest(paths: &AppPaths, manifest: &ManagedPythonManife
     .with_context(|| format!("failed to write {}", path.display()))
 }
 
+/// Whether a manifest's recorded executable is inside the currently resolved `uv`
+/// Python install dir. A manifest written before this dir moved (e.g. the legacy
+/// pre-colocation location) must not be trusted as-is, or the relocation this PR
+/// exists to establish never actually happens for anyone who already has Python
+/// installed.
+fn manifest_executable_is_current(paths: &AppPaths, manifest: &ManagedPythonManifest) -> bool {
+    manifest
+        .executable
+        .starts_with(uv_python_install_dir_source(paths).path())
+}
+
 fn record_managed_python_config(paths: &AppPaths, python: &Path) -> Result<()> {
     let mut config = RocmCliConfig::load(paths).unwrap_or_default();
     config.tools.insert(
@@ -3961,9 +3972,12 @@ fn ensure_managed_python(paths: &AppPaths) -> Result<PythonLauncher> {
     let uv = ensure_uv_binary(paths)?;
 
     // Check the manifest first — if the recorded executable is still usable, skip the install.
+    // A manifest pointing outside the current install dir (e.g. the legacy location) is
+    // treated as stale so upgrading users actually get relocated.
     if let Ok(Some(manifest)) = load_managed_python_manifest(paths)
         && manifest.version == version
         && manifest.executable.is_file()
+        && manifest_executable_is_current(paths, &manifest)
         && python_launcher_install_ready(&manifest.executable).is_ok()
     {
         progress_line(format!(
@@ -4100,15 +4114,20 @@ fn resolve_python_launcher_in(paths: &AppPaths, env: &PythonResolverEnv) -> Resu
     if let Some(manifest) = load_managed_python_manifest(paths)?
         && manifest.executable.is_file()
     {
-        if python_launcher_install_ready(&manifest.executable).is_ok() {
+        if !manifest_executable_is_current(paths, &manifest) {
+            progress_line(
+                "Saved managed Python predates the current install location; preparing Python again.",
+            );
+        } else if python_launcher_install_ready(&manifest.executable).is_ok() {
             return Ok(PythonLauncher {
                 executable: manifest.executable,
                 source: "managed",
             });
+        } else {
+            progress_line(
+                "Saved managed Python cannot create a virtual environment; preparing Python again.",
+            );
         }
-        progress_line(
-            "Saved managed Python cannot create a virtual environment; preparing Python again.",
-        );
     }
 
     if managed_python_bootstrap_disabled() {
@@ -5769,13 +5788,21 @@ mod tests {
 
     #[test]
     fn uv_python_install_dir_does_not_follow_a_prefix_install_root() {
-        // Same documented non-goal as `uv_cache_does_not_follow_a_prefix_install_root`:
-        // `--prefix` moves install_root only, while the interpreters stay keyed off the
-        // data dir. Pins the claim `docs/manual-testing.md` makes about `uv-python`.
+        // Same documented non-goal as `uv_cache_does_not_follow_a_prefix_install_root`,
+        // but driven through the real `--prefix` plumbing: `resolved_install_root` is what
+        // `--prefix` actually calls, and `uv_python_install_dir_source` is what `uv` is
+        // actually invoked with, so this fails if either one stops holding.
         let (_root, paths) = test_paths("prefix-uv-python");
         let prefix_root = PathBuf::from("/mnt/elsewhere/envs/my-env");
-        let install_dir = managed_uv_python_install_dir(&paths.data_dir);
 
+        let install_root =
+            resolved_install_root(&paths, "wheel", "unused-key", Some(prefix_root.clone()));
+        assert_eq!(
+            install_root, prefix_root,
+            "--prefix did not move the install root"
+        );
+
+        let install_dir = uv_python_install_dir_source(&paths).path().to_path_buf();
         assert!(
             !install_dir.starts_with(&prefix_root),
             "python install dir {} unexpectedly followed the --prefix root",

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -15,7 +15,8 @@ use rocm_core::{
 };
 #[cfg(test)]
 use rocm_core::{
-    generate_rsa_signing_keypair, managed_uv_cache_dir, sign_rsa_pkcs1_sha256_signature,
+    generate_rsa_signing_keypair, managed_uv_cache_dir, managed_uv_python_install_dir,
+    sign_rsa_pkcs1_sha256_signature,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -5764,6 +5765,23 @@ mod tests {
             cache.display()
         );
         assert!(cache.starts_with(&paths.data_dir));
+    }
+
+    #[test]
+    fn uv_python_install_dir_does_not_follow_a_prefix_install_root() {
+        // Same documented non-goal as `uv_cache_does_not_follow_a_prefix_install_root`:
+        // `--prefix` moves install_root only, while the interpreters stay keyed off the
+        // data dir. Pins the claim `docs/manual-testing.md` makes about `uv-python`.
+        let (_root, paths) = test_paths("prefix-uv-python");
+        let prefix_root = PathBuf::from("/mnt/elsewhere/envs/my-env");
+        let install_dir = managed_uv_python_install_dir(&paths.data_dir);
+
+        assert!(
+            !install_dir.starts_with(&prefix_root),
+            "python install dir {} unexpectedly followed the --prefix root",
+            install_dir.display()
+        );
+        assert!(install_dir.starts_with(&paths.data_dir));
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -56,14 +56,15 @@ pub use runtime::{
     RuntimeHost, RuntimePlatform, current_executable_path, default_cache_dir, default_config_dir,
     default_data_dir, default_interactive_shell_program, managed_logs_dir, managed_pip_cache_dir,
     managed_runtime_cache_dir, managed_runtime_data_root, managed_tools_dir, managed_uv_cache_dir,
-    normalize_runtime_path_for_host, normalize_runtime_path_for_storage,
-    normalize_runtime_path_text_for_host, normalize_runtime_path_text_for_platform,
-    normalize_runtime_path_text_for_storage, platform_binary_name, prepend_runtime_path,
-    resolve_path_through_symlinks, runtime_directory_label, runtime_drive_root_for_key,
-    runtime_drive_roots, runtime_exe_suffix, runtime_home_dir, runtime_install_root_is_protected,
-    runtime_is_linux, runtime_is_windows, runtime_os_name, runtime_path_for_child,
-    runtime_path_for_windows_child, runtime_path_is_same_or_inside, runtime_path_list_join,
-    runtime_path_list_split, runtime_path_sort_key, runtime_path_text_is_absolute_for_host,
+    managed_uv_python_install_dir, normalize_runtime_path_for_host,
+    normalize_runtime_path_for_storage, normalize_runtime_path_text_for_host,
+    normalize_runtime_path_text_for_platform, normalize_runtime_path_text_for_storage,
+    platform_binary_name, prepend_runtime_path, resolve_path_through_symlinks,
+    runtime_directory_label, runtime_drive_root_for_key, runtime_drive_roots, runtime_exe_suffix,
+    runtime_home_dir, runtime_install_root_is_protected, runtime_is_linux, runtime_is_windows,
+    runtime_os_name, runtime_path_for_child, runtime_path_for_windows_child,
+    runtime_path_is_same_or_inside, runtime_path_list_join, runtime_path_list_split,
+    runtime_path_sort_key, runtime_path_text_is_absolute_for_host,
     runtime_path_text_is_absolute_for_platform, runtime_paths_equivalent,
     runtime_python_activation_hint, runtime_python_activation_script, runtime_python_bin_dir_name,
     runtime_python_env_bin_dir, runtime_python_executable_in_env, runtime_python_executable_name,
@@ -71,9 +72,11 @@ pub use runtime::{
 };
 pub use uv::{
     DEFAULT_UV_TIMEOUT_SECS, DependencyViolation, UV_CACHE_DIR_ENV, UV_CACHE_DIR_OVERRIDE_ENV,
-    UvCacheSource, ViolationSubject, check_dependencies, ensure_uv_binary, split_local_version,
-    uv_binary_name, uv_cache_source, uv_command_env, uv_http_timeout_secs, uv_pip_check_args,
-    uv_pip_freeze_args, uv_pip_install_base, uv_venv_args, violation_subject, violations_requiring,
+    UV_PYTHON_INSTALL_DIR_ENV, UV_PYTHON_INSTALL_DIR_OVERRIDE_ENV, UvCacheSource,
+    UvPythonInstallDirSource, ViolationSubject, check_dependencies, ensure_uv_binary,
+    split_local_version, uv_binary_name, uv_cache_source, uv_command_env, uv_http_timeout_secs,
+    uv_pip_check_args, uv_pip_freeze_args, uv_pip_install_base, uv_python_install_dir_source,
+    uv_venv_args, violation_subject, violations_requiring,
 };
 
 pub const DEFAULT_LOCAL_PORT: u16 = 11_435;

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -306,6 +306,15 @@ pub fn managed_uv_cache_dir(root: &Path) -> PathBuf {
     normalize_runtime_path_for_host(root).join("uv-cache")
 }
 
+/// Standalone CPython interpreters downloaded by `uv python install`, kept under the managed
+/// root for the same reason as `managed_uv_cache_dir`.
+///
+/// Without this, `uv` falls back to `$HOME/.local/share/uv/python/`, leaking outside the
+/// managed root.
+pub fn managed_uv_python_install_dir(root: &Path) -> PathBuf {
+    normalize_runtime_path_for_host(root).join("uv-python")
+}
+
 pub fn managed_logs_dir(root: &Path) -> PathBuf {
     normalize_runtime_path_for_host(root).join("logs")
 }

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -1004,6 +1004,23 @@ All installed packages are compatible
         );
     }
 
+    /// `uv_command_env(paths)` is the entrypoint every real caller spawns `uv` with; every
+    /// other test here drives the private `uv_command_env_for` with hand-built sources, so
+    /// the one-line wiring from `paths` through to the actual env pair was unprotected.
+    #[test]
+    fn command_env_wires_paths_through_to_the_python_install_dir() {
+        let paths = test_paths("/managed/root");
+        let env = uv_command_env(&paths);
+        assert_eq!(
+            python_install_dir_in(&env),
+            Some(
+                managed_uv_python_install_dir(&paths.data_dir)
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
     #[test]
     fn command_env_keeps_an_inherited_python_install_dir() {
         let paths = test_paths("/managed/root");

--- a/crates/rocm-core/src/uv.rs
+++ b/crates/rocm-core/src/uv.rs
@@ -19,7 +19,8 @@ use std::process::Command;
 use std::time::Duration;
 
 use crate::runtime::{
-    managed_tools_dir, managed_uv_cache_dir, runtime_is_windows, runtime_os_name,
+    managed_tools_dir, managed_uv_cache_dir, managed_uv_python_install_dir, runtime_is_windows,
+    runtime_os_name,
 };
 use crate::{AppPaths, download_file_to_path, unix_time_millis};
 
@@ -140,24 +141,88 @@ fn meaningful_cache_dir(value: Option<&OsStr>) -> Option<PathBuf> {
     Some(PathBuf::from(trimmed))
 }
 
+/// Environment variable `uv` reads to locate where it installs standalone CPython
+/// interpreters (`uv python install`).
+pub const UV_PYTHON_INSTALL_DIR_ENV: &str = "UV_PYTHON_INSTALL_DIR";
+
+/// Environment variable used to place the `uv`-managed Python install dir explicitly.
+///
+/// Namespaced like [`UV_CACHE_DIR_OVERRIDE_ENV`] for the same reason: a bare
+/// `UV_PYTHON_INSTALL_DIR` a developer exported for unrelated Python work should not
+/// silently opt a user out of the managed colocation.
+pub const UV_PYTHON_INSTALL_DIR_OVERRIDE_ENV: &str = "ROCM_CLI_UV_PYTHON_INSTALL_DIR";
+
+/// Where the `uv`-managed Python install directory for a spawned command comes from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UvPythonInstallDirSource {
+    /// Derived from the managed data directory.
+    Managed(PathBuf),
+    /// Set explicitly via [`UV_PYTHON_INSTALL_DIR_OVERRIDE_ENV`].
+    Override(PathBuf),
+    /// Inherited from an ambient [`UV_PYTHON_INSTALL_DIR_ENV`] in the environment.
+    Inherited(PathBuf),
+}
+
+impl UvPythonInstallDirSource {
+    /// The directory this source resolves to.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Managed(path) | Self::Override(path) | Self::Inherited(path) => path,
+        }
+    }
+
+    /// Whether the managed colocation was bypassed, so callers can report it.
+    pub const fn is_override(&self) -> bool {
+        !matches!(self, Self::Managed(_))
+    }
+}
+
+/// Resolve the `uv` Python install directory from the managed paths and the two override
+/// variables. Same precedence and blank-handling as [`uv_cache_source`].
+pub fn uv_python_install_dir_source(paths: &AppPaths) -> UvPythonInstallDirSource {
+    resolve_uv_python_install_dir_source(
+        paths,
+        std::env::var_os(UV_PYTHON_INSTALL_DIR_OVERRIDE_ENV).as_deref(),
+        std::env::var_os(UV_PYTHON_INSTALL_DIR_ENV).as_deref(),
+    )
+}
+
+fn resolve_uv_python_install_dir_source(
+    paths: &AppPaths,
+    override_dir: Option<&OsStr>,
+    inherited_dir: Option<&OsStr>,
+) -> UvPythonInstallDirSource {
+    if let Some(value) = meaningful_cache_dir(override_dir) {
+        return UvPythonInstallDirSource::Override(value);
+    }
+    if let Some(value) = meaningful_cache_dir(inherited_dir) {
+        return UvPythonInstallDirSource::Inherited(value);
+    }
+    UvPythonInstallDirSource::Managed(managed_uv_python_install_dir(&paths.data_dir))
+}
+
 /// Environment pairs to apply when spawning `uv`.
 ///
 /// Network behavior is configured consistently (uv reads `UV_HTTP_TIMEOUT` rather than
-/// accepting a `--timeout` flag) and the cache lives beside the managed environments it
-/// populates.
+/// accepting a `--timeout` flag), the package cache and the standalone-Python install
+/// directory both live beside the managed environments they populate.
 ///
 /// Without a cache inside the managed root, `uv` caches under `$HOME/.cache/uv`; when
 /// that is on a different filesystem from the data directory, `uv` cannot hardlink and
 /// silently copies every file, so each environment carries a full duplicate of the SDK
-/// and torch stack.
+/// and torch stack. Likewise, without `UV_PYTHON_INSTALL_DIR` pinned, `uv python install`
+/// downloads standalone CPython interpreters to `$HOME/.local/share/uv/python/`.
 ///
 /// Note this colocates with the *data directory*, not with a `--prefix` install root; see
 /// the `--prefix` caveat in `docs/manual-testing.md`.
 pub fn uv_command_env(paths: &AppPaths) -> Vec<(String, String)> {
-    uv_command_env_for_cache(uv_cache_source(paths))
+    uv_command_env_for(uv_cache_source(paths), uv_python_install_dir_source(paths))
 }
 
-fn uv_command_env_for_cache(cache: UvCacheSource) -> Vec<(String, String)> {
+fn uv_command_env_for(
+    cache: UvCacheSource,
+    python_install_dir: UvPythonInstallDirSource,
+) -> Vec<(String, String)> {
     vec![
         (
             "UV_HTTP_TIMEOUT".to_owned(),
@@ -166,6 +231,10 @@ fn uv_command_env_for_cache(cache: UvCacheSource) -> Vec<(String, String)> {
         (
             UV_CACHE_DIR_ENV.to_owned(),
             cache.path().to_string_lossy().into_owned(),
+        ),
+        (
+            UV_PYTHON_INSTALL_DIR_ENV.to_owned(),
+            python_install_dir.path().to_string_lossy().into_owned(),
         ),
     ]
 }
@@ -807,10 +876,23 @@ All installed packages are compatible
             .map(|(_, value)| value.clone())
     }
 
+    fn python_install_dir_in(env: &[(String, String)]) -> Option<String> {
+        env.iter()
+            .find(|(key, _)| key == UV_PYTHON_INSTALL_DIR_ENV)
+            .map(|(_, value)| value.clone())
+    }
+
+    fn managed_python_install_dir_source(paths: &AppPaths) -> UvPythonInstallDirSource {
+        resolve_uv_python_install_dir_source(paths, None, None)
+    }
+
     #[test]
     fn command_env_cache_dir_is_derived_from_data_dir() {
         let paths = test_paths("/managed/root");
-        let env = uv_command_env_for_cache(resolve_uv_cache_source(&paths, None, None));
+        let env = uv_command_env_for(
+            resolve_uv_cache_source(&paths, None, None),
+            managed_python_install_dir_source(&paths),
+        );
         assert_eq!(
             cache_dir_in(&env),
             Some(
@@ -833,7 +915,10 @@ All installed packages are compatible
             UvCacheSource::Inherited(PathBuf::from("/shared/uv-cache"))
         );
         assert_eq!(
-            cache_dir_in(&uv_command_env_for_cache(source)),
+            cache_dir_in(&uv_command_env_for(
+                source,
+                managed_python_install_dir_source(&paths)
+            )),
             Some("/shared/uv-cache".to_owned())
         );
     }
@@ -898,6 +983,107 @@ All installed packages are compatible
         assert!(
             source.path().starts_with("/mnt/big/rocm"),
             "cache {} should sit under the relocated data dir",
+            source.path().display()
+        );
+    }
+
+    #[test]
+    fn command_env_python_install_dir_is_derived_from_data_dir() {
+        let paths = test_paths("/managed/root");
+        let env = uv_command_env_for(
+            resolve_uv_cache_source(&paths, None, None),
+            resolve_uv_python_install_dir_source(&paths, None, None),
+        );
+        assert_eq!(
+            python_install_dir_in(&env),
+            Some(
+                managed_uv_python_install_dir(&paths.data_dir)
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn command_env_keeps_an_inherited_python_install_dir() {
+        let paths = test_paths("/managed/root");
+        let source = resolve_uv_python_install_dir_source(
+            &paths,
+            None,
+            Some(OsStr::new("/shared/uv-python")),
+        );
+        assert_eq!(
+            source,
+            UvPythonInstallDirSource::Inherited(PathBuf::from("/shared/uv-python"))
+        );
+        assert_eq!(
+            python_install_dir_in(&uv_command_env_for(
+                resolve_uv_cache_source(&paths, None, None),
+                source
+            )),
+            Some("/shared/uv-python".to_owned())
+        );
+    }
+
+    #[test]
+    fn namespaced_override_wins_over_an_ambient_uv_python_install_dir() {
+        let paths = test_paths("/managed/root");
+        let source = resolve_uv_python_install_dir_source(
+            &paths,
+            Some(OsStr::new("/chosen/uv-python")),
+            Some(OsStr::new("/ambient/uv-python")),
+        );
+        assert_eq!(
+            source,
+            UvPythonInstallDirSource::Override(PathBuf::from("/chosen/uv-python"))
+        );
+        assert!(source.is_override());
+    }
+
+    #[test]
+    fn blank_python_install_dir_overrides_fall_back_to_the_managed_location() {
+        let paths = test_paths("/managed/root");
+        let managed =
+            UvPythonInstallDirSource::Managed(managed_uv_python_install_dir(&paths.data_dir));
+        for blank in ["", "   ", "\t\n"] {
+            assert_eq!(
+                resolve_uv_python_install_dir_source(&paths, Some(OsStr::new(blank)), None),
+                managed,
+                "blank ROCM_CLI_UV_PYTHON_INSTALL_DIR {blank:?} should not count as an override"
+            );
+            assert_eq!(
+                resolve_uv_python_install_dir_source(&paths, None, Some(OsStr::new(blank))),
+                managed,
+                "blank UV_PYTHON_INSTALL_DIR {blank:?} should not count as an override"
+            );
+        }
+        assert!(!managed.is_override());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed_from_a_python_install_dir_override() {
+        let paths = test_paths("/managed/root");
+        assert_eq!(
+            resolve_uv_python_install_dir_source(
+                &paths,
+                Some(OsStr::new("  /chosen/uv-python \n")),
+                None
+            ),
+            UvPythonInstallDirSource::Override(PathBuf::from("/chosen/uv-python"))
+        );
+    }
+
+    #[test]
+    fn managed_python_install_dir_tracks_rocm_cli_data_dir() {
+        let moved = test_paths("/home/user/.rocm").with_managed_root("/mnt/big/rocm", false);
+        let source = resolve_uv_python_install_dir_source(&moved, None, None);
+        assert_eq!(
+            source,
+            UvPythonInstallDirSource::Managed(managed_uv_python_install_dir(&moved.data_dir))
+        );
+        assert!(
+            source.path().starts_with("/mnt/big/rocm"),
+            "python install dir {} should sit under the relocated data dir",
             source.path().display()
         );
     }

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -53,6 +53,13 @@ packages; set `ROCM_CLI_UV_CACHE_DIR` to a folder on the prefix filesystem to
 restore hardlinking. Making `--prefix` do this automatically is tracked
 separately.
 
+Likewise, the standalone Python interpreters that `uv python install`
+downloads do **not** follow `--prefix` either. They live at
+`<data-dir>\uv-python` rather than `uv`'s own default of
+`%USERPROFILE%\.local\share\uv\python\` (or `$HOME/.local/share/uv/python/` on
+Linux/macOS); override with `ROCM_CLI_UV_PYTHON_INSTALL_DIR` if you need it on
+the prefix filesystem instead.
+
 ## 1. First-Time Setup
 
 Start rocm-cli:

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -56,7 +56,7 @@ separately.
 Likewise, the standalone Python interpreters that `uv python install`
 downloads do **not** follow `--prefix` either. They live at
 `<data-dir>\uv-python` rather than `uv`'s own default of
-`%USERPROFILE%\.local\share\uv\python\` (or `$HOME/.local/share/uv/python/` on
+`%APPDATA%\uv\data\python\` on Windows (or `$HOME/.local/share/uv/python/` on
 Linux/macOS); override with `ROCM_CLI_UV_PYTHON_INSTALL_DIR` if you need it on
 the prefix filesystem instead.
 


### PR DESCRIPTION
## Summary

Follow-on to #170. That PR pointed `uv` at a cache inside the ROCm CLI data directory; this one does the same for the standalone CPython interpreters `uv python install` downloads, which still land in `$HOME`.

## Root cause

`uv_command_env()` now sets `UV_CACHE_DIR`, but never set `UV_PYTHON_INSTALL_DIR`. `ensure_managed_python` shells out to `uv python install`, so the interpreter falls back to `uv`'s own default — `$HOME/.local/share/uv/python/` on Linux/macOS, `%USERPROFILE%\.local\share\uv\python\` on Windows — regardless of where `ROCM_CLI_DATA_DIR` points.

That is ~100MB of standalone CPython per interpreter version, outside the managed root. Measured with uv 0.12.3 against a throwaway `HOME`:

```
$ uv python install 3.12          # UV_PYTHON_INSTALL_DIR unset
$ du -sh $HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu
104M
```

With the variable set to a managed location, the same 104M lands under the data dir and `$HOME` keeps only uv's 12KB `bin/python3.12` shim — a symlink into the managed interpreter, not a copy.

This is the same class of bug as #160 and it bites the same users: a split `/home`, a container overlay, or anyone who set `ROCM_CLI_DATA_DIR` to a larger disk and expects the CLI to stay there. `rocm uninstall` also could not reclaim it, since it only removes directories it knows about.

## Technical decisions

**Keyed off `data_dir`**, for the same reason as the cache: `uv` hardlinks interpreters into the environments it creates, and `ROCM_CLI_CACHE_DIR` can point at a different filesystem from those environments.

**Mirrors `UvCacheSource` exactly.** `UvPythonInstallDirSource` has the same `Managed` / `Override` / `Inherited` variants, the same `path()` / `is_override()` surface, and the same precedence: namespaced `ROCM_CLI_UV_PYTHON_INSTALL_DIR` > ambient `UV_PYTHON_INSTALL_DIR` > managed default. It reuses `meaningful_cache_dir` for trimming rather than duplicating it. The two variables should read as one design applied twice, not two designs.

**`uv_command_env(&AppPaths)` keeps its signature.** Both env vars are composed inside it, so `therock.rs`, `comfyui.rs`, and the vLLM engine pick up the fix with no call-site edits. This matters for correctness beyond tidiness: `ensure_managed_python` calls `uv python install` and `uv python find` through the same helper, so `find` cannot disagree with where `install` put the interpreter.

**A one-shot notice, not a migration**, following `maybe_notice_legacy_uv_cache` with its own marker file. Nothing is moved or deleted — the legacy directory may hold interpreters other `uv` projects depend on.

## Non-goal: `--prefix` installs — #187

Same gap as the cache, same reason. `--prefix` relocates `install_root` only; the interpreters stay keyed off `data_dir`. Documented in `docs/manual-testing.md` and pinned by `uv_python_install_dir_does_not_follow_a_prefix_install_root`, mirroring the existing cache test.

## Consequences worth noting

- `rocm uninstall` now reclaims the interpreters too, since they sit under the data directory. `--keep-data` / `--keep-cache` help text updated to say so; `--keep-cache` does *not* cover them.
- Where the install dir has been pointed *outside* the data directory, uninstall now reports it as a shared cache it is not removing, extending #175's reporting rather than silently leaving ~100MB behind.
- The interpreters are no longer shared with other `uv` projects. `ROCM_CLI_UV_PYTHON_INSTALL_DIR` restores that.
- Existing installs re-download the interpreter once.

## Tests

Six new resolution tests mirroring the cache suite — unset, empty, whitespace-only, trimmed, inherited, namespaced-override, and precedence between the two — driving the pure resolver, so they need no `set_var` and stay parallel-safe. `managed_python_install_dir_tracks_rocm_cli_data_dir` goes through `AppPaths::with_managed_root`.

The uninstall-reporting test is the exception: it drives the real `shared_cache_candidates()` behind the existing env lock, because a version calling the pure helper with hand-built inputs still passed when the production block was deleted. Each new test was mutation-checked — production code removed, test confirmed failing, code restored.

`cargo fmt --all --check` and `cargo clippy --locked --workspace --all-targets -- -D warnings` are clean. Full workspace suite passes.

## Manual verification

`uv python install 3.12` under a throwaway `HOME` with both variables set: the 104M interpreter lands under the managed data dir, and `$HOME` receives only the 12KB shim symlink.
