### PR TITLE
fix(lemonade): find llama-server under nested backend dirs (EAI-8026)

### DIFF
--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2619,7 +2619,7 @@ fn find_binary_in(dir: &Path, binary: &str) -> Option<PathBuf> {
     }
     fs::read_dir(dir)
         .ok()?
-        .filter_map(|entry| entry.ok())
+        .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_dir())
         .map(|subdir| subdir.join(binary))

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2599,22 +2599,43 @@ const DIRECT_LLAMA_SERVER_BACKENDS: [&str; 4] = ["rocm-stable", "rocm-nightly", 
 /// Find an installed Lemonade `llama-server` binary under `bin/llamacpp/<backend>/`,
 /// checking known backends in priority order. This lets direct serving work wherever
 /// Lemonade installed a backend (e.g. `vulkan` on WSL2), not just the ROCm build.
+///
+/// Lemonade's backend installer extracts some llama.cpp releases straight into
+/// `<backend>/`, but others land one level deeper under a build-numbered directory
+/// (e.g. `rocm-stable/llama-b9752/llama-server`), so both layouts are checked.
 fn find_llama_server_binary(manifest: &LemonadeInstallManifest) -> Option<PathBuf> {
     let llamacpp_dir = manifest.runtime_dir.join("bin").join("llamacpp");
     let binary = platform_binary_name("llama-server");
     DIRECT_LLAMA_SERVER_BACKENDS
         .into_iter()
-        .map(|backend| llamacpp_dir.join(backend).join(&binary))
+        .find_map(|backend| find_binary_in(&llamacpp_dir.join(backend), &binary))
+}
+
+/// Look for `binary` directly in `dir`, then one level down in each subdirectory.
+fn find_binary_in(dir: &Path, binary: &str) -> Option<PathBuf> {
+    let direct = dir.join(binary);
+    if direct.is_file() {
+        return Some(direct);
+    }
+    fs::read_dir(dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .map(|subdir| subdir.join(binary))
         .find(|candidate| candidate.is_file())
 }
 
-/// The backend label for a packaged llama-server, taken from its parent directory name
-/// (e.g. `vulkan`, `rocm-stable`); falls back to the ROCm backend name.
+/// The backend label for a packaged llama-server, taken from the nearest ancestor
+/// directory matching a known backend name (e.g. `vulkan`, `rocm-stable`) so it still
+/// resolves correctly when Lemonade nests the binary under a build-numbered
+/// subdirectory; falls back to the ROCm backend name.
 fn llama_server_backend_label(server: &Path) -> String {
     server
-        .parent()
-        .and_then(|dir| dir.file_name())
-        .and_then(|name| name.to_str())
+        .ancestors()
+        .filter_map(|dir| dir.file_name())
+        .filter_map(|name| name.to_str())
+        .find(|name| DIRECT_LLAMA_SERVER_BACKENDS.contains(name))
         .unwrap_or(ROCM_BACKEND_NAME)
         .to_owned()
 }
@@ -3655,6 +3676,23 @@ mod tests {
         // With only cpu present, nothing is returned (no silent CPU fallback).
         fs::remove_dir_all(llamacpp.join("vulkan")).unwrap();
         assert_eq!(find_llama_server_binary(&manifest), None);
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn find_llama_server_binary_finds_build_numbered_nesting() {
+        // Some Lemonade llama.cpp releases extract one level deeper than
+        // `<backend>/llama-server`, e.g. `rocm-stable/llama-b9752/llama-server`.
+        let dir = scratch_dir("find-server-nested");
+        let runtime_dir = dir.join("runtime");
+        let llamacpp = runtime_dir.join("bin").join("llamacpp");
+        let nested = llamacpp.join("rocm-stable").join("llama-b9752");
+        fs::create_dir_all(&nested).unwrap();
+        let server = nested.join(platform_binary_name("llama-server"));
+        fs::write(&server, b"x").unwrap();
+        let manifest = test_manifest(runtime_dir);
+        assert_eq!(find_llama_server_binary(&manifest), Some(server.clone()));
+        assert_eq!(llama_server_backend_label(&server), "rocm-stable");
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -68,6 +68,22 @@ Feature: Model serving
     Then the response contains a model reply
     And the response identifies the correct model
 
+  # HF-checkpoint direct-serve canary (EAI-8026). An `owner/repo:variant` ref
+  # bypasses Lemonade's model router and runs a packaged llama-server directly
+  # (`serve_hf_checkpoint`), which bails explicitly if no backend binary is found
+  # under bin/llamacpp/<backend>/ — unlike the short-recipe-name path above, whose
+  # managed-lemonade fallback would mask the identical failure behind the
+  # unrelated EAI-7423 xfail. Reuses the same small Qwen3-0.6B-GGUF checkpoint as
+  # `serve-lemonade-inference` (cache-shared, no extra download) so this stays a
+  # fast per-PR canary rather than needing the @nightly large-checkpoint path.
+  @id:serve-hf-checkpoint-inference @requires-gpu @requires-engine:lemonade
+  Scenario: 14 - A canonical Hugging Face checkpoint serves and responds to inference
+    Given a managed runtime is active
+    And a canonical Hugging Face GGUF checkpoint is being served on lemonade
+    When the user sends a chat completion request
+    Then the response contains a model reply
+    And the response identifies the correct model
+
   # Default-engine serve (no --engine): the effective engine is the platform
   # default from the capability probe, so this covers whichever engine the host
   # would actually pick.

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -520,6 +520,29 @@ async fn setup_lemonade_model(world: &mut E2eWorld) {
     .await;
 }
 
+#[given("a canonical Hugging Face GGUF checkpoint is being served on lemonade")]
+async fn setup_lemonade_hf_checkpoint_model(world: &mut E2eWorld) {
+    // Forces the `owner/repo:variant` direct-serve path (`serve_hf_checkpoint`,
+    // EAI-8026) instead of the short-recipe-name router that `setup_lemonade_model`
+    // exercises. Same underlying checkpoint (unsloth/Qwen3-0.6B-GGUF, Q4_0), so the
+    // GGUF is already warm in the HF cache when both scenarios run in one job.
+    let model = "unsloth/Qwen3-0.6B-GGUF:Q4_0";
+    ensure_serve_port_free().await;
+    let (stdout, _, rc) = crate::run_rocm(
+        world,
+        &["serve", model, "--engine", "lemonade", "--managed"],
+    );
+    assert!(rc == 0, "rocm serve failed:\n{stdout}");
+    world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
+    world.model_name = Some(model.to_string());
+    wait_for_model(
+        "http://127.0.0.1:11435/v1/models",
+        Some("Qwen3-0.6B"),
+        serve_timeout_for(world),
+    )
+    .await;
+}
+
 #[given("a large model is being served on GPU")]
 async fn setup_large_gpu_model(world: &mut E2eWorld) {
     // Large-model nightly coverage follows the host's serving path. MI300X uses


### PR DESCRIPTION
## Summary
- `rocm serve` failed with "no GPU llama-server backend is installed" on Strix Halo (gfx1151) even right after a successful `rocm engines install lemonade`, because Lemonade's installer sometimes extracts llama.cpp one directory deeper than expected (`rocm-stable/llama-b9752/llama-server` instead of `rocm-stable/llama-server`).
- `find_llama_server_binary` now also checks one level of subdirectories under each backend directory.
- `llama_server_backend_label` now walks ancestor directories to recover the correct backend name (`rocm-stable`, `vulkan`, etc.) even when nested.
- Added an E2E canary (`serve-hf-checkpoint-inference`) that serves an `owner/repo:variant` HF checkpoint on lemonade, exercising the `serve_hf_checkpoint` bail path directly instead of through the short-recipe-name router, whose managed-serve fallback is masked by the unrelated EAI-7423 xfail on Linux.

## Test plan
- [x] `cargo test -p rocm-engine-lemonade find_llama_server_binary` (includes new regression test reproducing the exact nested layout observed on Strix Halo)
- [x] Full `rocm-engine-lemonade` test suite passes (65/65)
- [x] `cargo clippy --locked --workspace --all-targets -- -D warnings` passes
- [x] `cargo check -p e2e-cucumber --tests` passes with the new scenario
- [x] Validate new build on Strix Halo (gfx1151) machine using `rocm serve`
