### PR TITLE
ci(dependabot): hold sha2 at 0.10 until rsa 0.10 ships

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,24 @@ updates:
     # cargo bump touches `Cargo.lock`, which the `heavy` and `tpn` filters both
     # match, so every rebase of every open cargo PR re-runs the heavy lanes.
     rebase-strategy: disabled
+    ignore:
+      # sha2 0.11 is built on `digest` 0.11, and `rsa` 0.9 -- the newest stable
+      # release; 0.10 is still a release candidate -- is built on `digest` 0.10.
+      # The two generic trait sets are not interchangeable, so under sha2 0.11
+      # `SigningKey::<Sha256>` and `VerifyingKey::<Sha256>` in rocm-core stop
+      # satisfying rsa's bounds and the release-signing path fails to compile.
+      # Nothing on our side fixes that, and putting signing on a release
+      # candidate is not a trade worth making, so the major is held rather than
+      # reopened every week. Revisit when rsa 0.10 ships stable: bump both
+      # together and drop this entry.
+      #
+      # Scoped to the major on purpose. An unscoped `ignore` would also suppress
+      # security updates for the dependency; restricting it to a
+      # `version-update:` type does not, because those types never match a
+      # security-driven update. Minor and patch bumps keep flowing too.
+      - dependency-name: sha2
+        update-types:
+          - version-update:semver-major
     groups:
       cargo-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

Holds `sha2` at 0.10 for major bumps, so Dependabot stops reopening a PR that
cannot be merged.

**Root cause.** sha2 0.11 is built on `digest` 0.11. `rsa` 0.9.10 — the newest
*stable* release, 0.10 still being at `0.10.0-rc.18` — is built on `digest`
0.10. The two generic trait sets are not interchangeable, so under sha2 0.11
the `SigningKey::<Sha256>` and `VerifyingKey::<Sha256>` uses in
`crates/rocm-core/src/lib.rs` stop satisfying `HashMarker` / `FixedOutput` and
the release-signing path fails to compile. That is #226 in full: six trait
errors, none of them fixable on our side.

The alternative is moving the signing path onto an rsa release candidate, which
isn't a trade worth making for a routine bump. So the major is held and #226
gets closed, with the revisit condition written into the config: when rsa 0.10
ships stable, bump both together and delete the entry.

**Scoped to the major deliberately.** An unscoped `ignore` would also suppress
*security* updates for the dependency. Restricting it to a `version-update:`
type does not, because those types never match a security-driven update — so
advisories and minor/patch bumps keep flowing.

Risk: low, and it is the reversible kind — deleting three lines restores the
bumps.

## Test plan

- `prek run --all-files --no-group local-tools` passes (`check-yaml` parses the
  file).
- The incompatibility is not inferred from the version numbers: it is the actual
  compiler output on #226, reproduced against `rsa` 0.9.10 in `Cargo.lock`, and
  `cargo search rsa` confirms 0.10 has no stable release.
- Whether Dependabot honors the entry is only observable after merge; if #226
  reappears, that is the signal it did not take.

- [x] Not a bug fix; no `tests/e2e-cucumber/expectations.toml` xfail rows to narrow.