### PR TITLE
test(e2e): show stderr when a step fails on a CLI exit code

### DIFF
--- a/tests/e2e-cucumber/src/lib.rs
+++ b/tests/e2e-cucumber/src/lib.rs
@@ -12,6 +12,34 @@ pub mod model_id;
 pub mod panic_capture;
 pub mod serve_log;
 
+/// Render everything known about a failed `rocm` invocation.
+///
+/// Both streams are always shown, each labelled and each with an explicit
+/// `(empty)` marker. A bare `(empty)` is a finding in itself — it says the CLI
+/// died without explaining itself — whereas an omitted section just looks like
+/// the harness lost the output.
+///
+/// Exists because a step that asserts on the exit code while printing only
+/// stdout leaves a failed step undiagnosable: the panic reads `rocm serve
+/// failed:` followed by nothing at all, which is what EAI-8031 hit on the
+/// MI300X lane. The CLI reports its errors on stderr.
+pub fn cli_failure_report(args: &[&str], rc: i32, stdout: &str, stderr: &str) -> String {
+    fn section(label: &str, body: &str) -> String {
+        let body = body.trim_end();
+        if body.is_empty() {
+            format!("--- {label}: (empty) ---")
+        } else {
+            format!("--- {label} ---\n{body}")
+        }
+    }
+    format!(
+        "`rocm {}` failed (rc={rc})\n{}\n{}",
+        args.join(" "),
+        section("stdout", stdout),
+        section("stderr", stderr),
+    )
+}
+
 pub fn chat_response_is_successful(response: &serde_json::Value) -> bool {
     response
         .get("choices")
@@ -27,7 +55,47 @@ pub use e2e_report as report;
 
 #[cfg(test)]
 mod tests {
-    use super::chat_response_is_successful;
+    use super::{chat_response_is_successful, cli_failure_report};
+
+    /// The regression this whole helper exists for: a serve that dies with
+    /// nothing on stdout must still show the reason, which is on stderr.
+    #[test]
+    fn failure_report_shows_stderr_when_stdout_is_empty() {
+        let report = cli_failure_report(
+            &["serve", "unsloth/Qwen3-0.6B-GGUF:Q4_0", "--managed"],
+            1,
+            "",
+            "error: no llama-server backend found",
+        );
+        assert!(
+            report.contains("no llama-server backend found"),
+            "the reason must survive into the panic message:\n{report}"
+        );
+        assert!(
+            report.contains("rc=1"),
+            "exit code must be shown:\n{report}"
+        );
+        assert!(
+            report.contains("serve unsloth/Qwen3-0.6B-GGUF:Q4_0 --managed"),
+            "the failing invocation must be identifiable:\n{report}"
+        );
+    }
+
+    /// An empty stream is labelled rather than omitted: "the CLI said nothing"
+    /// and "the harness dropped the output" are different diagnoses.
+    #[test]
+    fn failure_report_marks_empty_streams_explicitly() {
+        let report = cli_failure_report(&["examine"], 2, "", "");
+        assert!(report.contains("stdout: (empty)"), "{report}");
+        assert!(report.contains("stderr: (empty)"), "{report}");
+    }
+
+    #[test]
+    fn failure_report_keeps_both_streams_when_both_are_present() {
+        let report = cli_failure_report(&["install", "sdk"], 3, "plan line", "boom");
+        assert!(report.contains("plan line"), "{report}");
+        assert!(report.contains("boom"), "{report}");
+    }
 
     #[test]
     fn chat_success_requires_non_empty_choices_array() {

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -11,6 +11,7 @@
 use std::path::PathBuf;
 
 use cucumber::{World as _, WriterExt as _};
+use e2e_cucumber::cli_failure_report;
 use e2e_cucumber::mock_server::{MockServer, ServiceRecordOptions, write_service_record_with};
 use tempfile::TempDir;
 
@@ -489,6 +490,21 @@ pub fn run_rocm(world: &E2eWorld, args: &[&str]) -> (String, String, i32) {
         String::from_utf8_lossy(&output.stderr).to_string(),
         rc,
     )
+}
+
+/// Run `rocm`, returning stdout, and panic with the full diagnostic bundle
+/// ([`cli_failure_report`]) if it exits non-zero.
+///
+/// Use this instead of asserting on [`run_rocm`]'s `rc` by hand — that idiom is
+/// what left a failed step undiagnosable in EAI-8031.
+pub fn run_rocm_ok(world: &E2eWorld, args: &[&str]) -> String {
+    let (stdout, stderr, rc) = run_rocm(world, args);
+    assert!(
+        rc == 0,
+        "{}",
+        cli_failure_report(args, rc, &stdout, &stderr)
+    );
+    stdout
 }
 
 /// Like [`run_rocm`], but with extra environment variables set on the child.

--- a/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
@@ -38,8 +38,7 @@ async fn setup_active_runtime(world: &mut E2eWorld) {
     world.use_shared_runtimes();
     let (stdout, _, _) = crate::run_rocm(world, &["runtimes", "list"]);
     if stdout.contains("installed: none") {
-        let (install_out, _, rc) = crate::run_rocm(world, &["install", "sdk"]);
-        assert!(rc == 0, "rocm install sdk failed (rc={rc}):\n{install_out}");
+        crate::run_rocm_ok(world, &["install", "sdk"]);
     }
     let (stdout, _, _) = crate::run_rocm(world, &["runtimes", "list"]);
     assert!(
@@ -50,8 +49,7 @@ async fn setup_active_runtime(world: &mut E2eWorld) {
 
 #[when("the user installs the SDK")]
 async fn user_installs_sdk(world: &mut E2eWorld) {
-    let (stdout, _, rc) = crate::run_rocm(world, &["install", "sdk"]);
-    assert!(rc == 0, "rocm install sdk failed (rc={rc}):\n{stdout}");
+    let stdout = crate::run_rocm_ok(world, &["install", "sdk"]);
     world.cli_output = Some(stdout);
 }
 

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -502,11 +502,10 @@ async fn setup_lemonade_model(world: &mut E2eWorld) {
     // serve+inference coverage. Qwen3-0.6B-GGUF is the smallest lemonade recipe.
     let model = "Qwen3-0.6B-GGUF";
     ensure_serve_port_free().await;
-    let (stdout, _, rc) = crate::run_rocm(
+    crate::run_rocm_ok(
         world,
         &["serve", model, "--engine", "lemonade", "--managed"],
     );
-    assert!(rc == 0, "rocm serve failed:\n{stdout}");
     world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
     world.model_name = Some(model.to_string());
     // Wait for this lemonade model specifically (see setup_gpu_model): guards
@@ -528,11 +527,10 @@ async fn setup_lemonade_hf_checkpoint_model(world: &mut E2eWorld) {
     // GGUF is already warm in the HF cache when both scenarios run in one job.
     let model = "unsloth/Qwen3-0.6B-GGUF:Q4_0";
     ensure_serve_port_free().await;
-    let (stdout, _, rc) = crate::run_rocm(
+    crate::run_rocm_ok(
         world,
         &["serve", model, "--engine", "lemonade", "--managed"],
     );
-    assert!(rc == 0, "rocm serve failed:\n{stdout}");
     world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
     world.model_name = Some(model.to_string());
     wait_for_model(
@@ -569,9 +567,7 @@ async fn setup_large_gpu_model(world: &mut E2eWorld) {
             ("Qwen/Qwen3.6-27B", "vllm", "Qwen3.6-27B")
         };
     ensure_serve_port_free().await;
-    let (stdout, _, rc) =
-        crate::run_rocm(world, &["serve", model, "--engine", engine, "--managed"]);
-    assert!(rc == 0, "rocm serve failed:\n{stdout}");
+    crate::run_rocm_ok(world, &["serve", model, "--engine", engine, "--managed"]);
     world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
     world.model_name = Some(model.to_string());
     wait_for_model(
@@ -660,13 +656,16 @@ async fn user_serves_default_engine(world: &mut E2eWorld) {
     // fn's doc comment.
     let model = default_engine_serve_target();
     ensure_serve_port_free().await;
-    let (stdout, _, rc) = crate::run_rocm(world, &["serve", model, "--managed"]);
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["serve", model, "--managed"]);
     // The model the CLI resolved (what actually gets served) can differ from the
     // requested id, so downstream reachability/readiness checks must look for the
     // resolved model on the shared port; fall back to the requested id.
     let served = resolved_model(&stdout).unwrap_or(model).to_string();
     let ready_substr = ready_substr_for(&served).to_string();
     world.cli_output = Some(stdout);
+    // rc is asserted by a later Then step, so stderr has to survive with it —
+    // otherwise that deferred assertion reports a failure it cannot explain.
+    world.cli_stderr = Some(stderr);
     world.cli_rc = Some(rc);
     world.endpoint = Some("http://127.0.0.1:11435/v1".to_string());
     world.model_name = Some(served);
@@ -690,9 +689,12 @@ async fn user_serves_vllm_capable_default(world: &mut E2eWorld) {
     // platform. Qwen2.5-0.5B is the smallest vLLM-preferred catalog entry. Omit
     // `--engine` so the CLI's own default selection is what's exercised.
     ensure_serve_port_free().await;
-    let (stdout, _, rc) =
+    let (stdout, stderr, rc) =
         crate::run_rocm(world, &["serve", "Qwen/Qwen2.5-0.5B-Instruct", "--managed"]);
     world.cli_output = Some(stdout);
+    // See the note in user_serves_default_engine: the rc is asserted later, so
+    // stderr must be carried along to explain a non-zero one.
+    world.cli_stderr = Some(stderr);
     world.cli_rc = Some(rc);
 }
 
@@ -936,7 +938,16 @@ async fn assert_vllm_default(world: &mut E2eWorld) {
     // non-zero rc after a good plan-print (e.g. the engine fails to start) would
     // otherwise go undetected since this scenario only inspected the plan line.
     let rc = world.cli_rc.expect("no serve rc recorded");
-    assert!(rc == 0, "rocm serve failed (rc={rc}):\n{output}");
+    assert!(
+        rc == 0,
+        "{}",
+        e2e_cucumber::cli_failure_report(
+            &["serve", "<default engine>", "--managed"],
+            rc,
+            output,
+            world.cli_stderr.as_deref().unwrap_or(""),
+        )
+    );
     let engine = selected_engine(output);
     assert_eq!(
         engine, "vllm",


### PR DESCRIPTION
## Summary

E2E steps that assert on `rocm`'s exit code printed only stdout — and `rocm`
reports its failures on stderr. So a failed serve panicked with:

```
Step panicked. Captured output: rocm serve failed:
```

…and nothing after the colon. That is the real state of the MI300X lane today:
a red scenario that cannot be diagnosed from CI logs at all (#247).

`run_rocm` has returned `(stdout, stderr, rc)` all along — the five assertion
sites simply bound stderr to `_`:

```rust
let (stdout, _, rc) = crate::run_rocm(world, &[...]);
assert!(rc == 0, "rocm serve failed:\n{stdout}");
```

They now go through a `run_rocm_ok` helper that panics with a shared
`cli_failure_report`: the invocation, the exit code, and both streams, each
labelled and each marked `(empty)` rather than omitted. That last detail is the
point — "the CLI said nothing" and "the harness dropped the output" are
different diagnoses, and the current message can't tell them apart.

The same failure now reads:

```
`rocm serve unsloth/Qwen3-0.6B-GGUF:Q4_0 --engine lemonade --managed` failed (rc=1)
--- stdout: (empty) ---
--- stderr ---
<the reason>
```

Two serve steps defer their `rc` assertion to a later `Then` step
(`assert_vllm_default`), so they now carry stderr in the world next to the `rc`
they already store — `cli_stderr` is an existing `E2eWorld` field that several
other steps already populate, so this follows the established pattern rather
than inventing one.

## Why the formatter lives in the library

`tests/e2e-cucumber/src/lib.rs`, not the harness target. The `e2e` target sets
`test = false`, so unit tests written there would never run; the library is
covered by the existing `cargo test -p e2e-cucumber --lib` job. Putting the pure
formatting logic there is what makes it testable at all.

## Scope

Only the sites that **panic on a CLI failure**. Steps that deliberately record
`rc` for a later content assertion (`diagnose`, `examine`) are untouched — they
aren't failing on the exit code, and their `Then` steps have their own
stderr-capturing `When` counterparts.

This does not fix the MI300X or Strix Halo Windows failures in #247. It is the
prerequisite: right now there is no way to see why the MI300X serve exits
non-zero. I don't have the hardware to reproduce either failure, so this is
deliberately the part that can be done and verified without it.

Risk: low — test-harness only, no product code, no behavior change to any
passing scenario.

## Test plan

Three unit tests on `cli_failure_report`, the first pinning the exact regression
(empty stdout, populated stderr → the reason survives into the panic):

```
test tests::failure_report_shows_stderr_when_stdout_is_empty ... ok
test tests::failure_report_marks_empty_streams_explicitly ... ok
test tests::failure_report_keeps_both_streams_when_both_are_present ... ok
test result: ok. 73 passed; 0 failed
```

Also run locally: `cargo clippy --locked --workspace --all-targets -- -D warnings`,
`cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings` (the harness is
excluded from the first, so both are needed), and
`prek run --all-files --no-group local-tools`.

Being straight about one thing: these tests cover a new function, so there is no
"fails before, passes after" — the old code path had nothing to assert on. The
before/after evidence is the message shape shown above. The end-to-end proof is
the next MI300X failure actually printing a reason, which needs a self-hosted run.

Closes nothing on its own; unblocks #247.

- [x] Not a bug fix in product code; no `tests/e2e-cucumber/expectations.toml` xfail rows to narrow.