### PR TITLE
feat(cli): consolidate examine and diagnose into rocm doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This produces the two binaries under `target/release/`:
 Run without installing:
 
 ```bash
-cargo run --release --bin rocm -- examine
+cargo run --release --bin rocm -- doctor
 ```
 
 Or copy the release binaries onto your `PATH`:
@@ -184,7 +184,7 @@ rocm install sdk
 ```
 
 This downloads TheRock ROCm wheels and a matching PyTorch stack into a managed
-environment. On machines with an existing ROCm install, `rocm examine` will
+environment. On machines with an existing ROCm install, `rocm doctor` will
 show it as `legacy_rocm_status: detected_unmanaged` — running `rocm install sdk`
 creates a separate managed runtime alongside it.
 
@@ -207,7 +207,7 @@ requirements.
 | Command | Description |
 |---|---|
 | `rocm` | Open the launcher menu (setup, serve, diagnose, chat, dashboard) |
-| `rocm examine` | Check GPU, ROCm install, engines, and managed folders |
+| `rocm doctor` | Check GPU, ROCm install, engines, and managed folders, and what looks wrong |
 | `rocm install sdk` | Install TheRock ROCm wheels into a managed Python environment |
 | `rocm install driver` | Install the AMD kernel driver on Linux |
 | `rocm serve <model>` | Start a local OpenAI-compatible model server |

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -81,7 +81,7 @@ const SUPPORTED_ENGINES: [&str; 2] = ["lemonade", "vllm"];
     about = "ROCm AI Command Center CLI",
     long_about = "ROCm AI Command Center CLI: install ROCm, manage local inference engines, \
 and run OpenAI-compatible model servers on AMD GPUs.\n\n\
-Run `rocm` with no subcommand to open the interactive dashboard (TUI). Use `rocm examine` \
+Run `rocm` with no subcommand to open the interactive dashboard (TUI). Use `rocm doctor` \
 to check that your GPU and ROCm install are ready, then `rocm serve <model>` to start a server.",
     version,
     // The `chat` example was dropped from this list when `chat` became
@@ -89,7 +89,7 @@ to check that your GPU and ROCm install are ready, then `rocm serve <model>` to 
     // preview elsewhere contradicts itself. `engines list` keeps the six-step
     // narrative and is in scope.
     after_help = "EXAMPLES:\n  \
-rocm examine                      Check GPU, ROCm install, and engines\n  \
+rocm doctor                       Check GPU, ROCm install, and engines, and what looks wrong\n  \
 rocm install sdk                  Install ROCm wheels into a managed environment\n  \
 rocm engines list                 Show the local inference engines available\n  \
 rocm model                        List models this machine can run\n  \
@@ -106,7 +106,53 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Check this computer's health: what ROCm found, and what looks wrong.
+    ///
+    /// One read-only pass over the machine. It reports the GPU, ROCm install,
+    /// engines and setup folders, then matches what it found against a fixed
+    /// catalog of known misconfigurations and ranks them.
+    ///
+    /// This command never changes anything. Each recognised cause is printed
+    /// with an `id:` and an `apply with:` command; `rocm fix` is what carries
+    /// the change out.
+    ///
+    /// The catalog is closed, so no match means "not recognised", not "nothing
+    /// is wrong" -- in that case it points you at where to report the symptom.
+    ///
+    /// Supersedes `rocm examine` and `rocm diagnose`, which still work but are
+    /// no longer advertised.
+    #[command(after_help = "EXAMPLES:\n  \
+rocm doctor\n  \
+rocm doctor --symptom \"hipErrorNoBinaryForGpu\"\n  \
+rocm doctor --json")]
+    Doctor {
+        /// Raw error text from the user; sharpens keyword scoring.
+        #[arg(long)]
+        symptom: Option<String>,
+        /// Show at most this many matches (default 5).
+        #[arg(long, default_value_t = 5)]
+        top: usize,
+        /// Emit the machine-readable report (host state plus findings).
+        #[arg(long)]
+        json: bool,
+        /// Which machine-learning framework to inspect (affects --json only).
+        #[arg(long, value_enum, default_value_t = FrameworkArg::Auto)]
+        framework: FrameworkArg,
+        /// Diagnose a previously captured report instead of inspecting this
+        /// machine. Takes a path, or `-` to read standard input.
+        ///
+        /// The saved report may describe a different machine, so only the
+        /// findings are printed -- this machine's own inventory is left out
+        /// rather than mixed in with someone else's host state.
+        #[arg(long = "from-examination", value_name = "PATH")]
+        from_examination: Option<String>,
+    },
     /// Check this computer's GPU, ROCm install, engines, and setup folders.
+    ///
+    /// Superseded by `rocm doctor`, which reports the same thing and also says
+    /// what looks wrong. Kept working, and kept out of the advertised surface,
+    /// so existing scripts and tooling kept calling it do not break.
+    #[command(hide = true)]
     Examine {
         /// Emit the machine-readable Examination JSON (for diagnosis tooling).
         #[arg(long)]
@@ -133,6 +179,11 @@ enum Command {
     /// Each cause is printed with an `id:` and an `apply with:` command. The
     /// leading `#1`, `#2` are ranking positions for reading order only; `rocm fix`
     /// takes the id, not the position.
+    ///
+    /// Superseded by `rocm doctor`, which runs the same catalog against the same
+    /// probe and reports the host state alongside it. Kept working, and kept out
+    /// of the advertised surface, so existing callers do not break.
+    #[command(hide = true)]
     Diagnose {
         /// Raw error text from the user; sharpens keyword scoring.
         #[arg(long)]
@@ -144,9 +195,9 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Apply a known fix by id (see `rocm diagnose`); run with no id to list fixes.
+    /// Apply a known fix by id (see `rocm doctor`); run with no id to list fixes.
     ///
-    /// Takes the `id:` that `rocm diagnose` reports against a cause — not the
+    /// Takes the `id:` that `rocm doctor` reports against a cause — not the
     /// `#1`/`#2` ranking position, which belongs to one report and is not a name.
     /// With no id it lists the whole catalog.
     ///
@@ -1398,7 +1449,7 @@ fn render_freeform_read_only_answer(
         return Ok(None);
     }
     match plan.actions[0].args.as_slice() {
-        [command] if command == "examine" => {
+        [command] if command == "examine" || command == "doctor" => {
             render_freeform_examine_answer(request, paths, config).map(Some)
         }
         [command, subcommand] if command == "comfyui" && subcommand == "status" => {
@@ -1565,6 +1616,19 @@ fn dispatch(cli: Cli) -> Result<()> {
     }
 
     match cli.command {
+        Some(Command::Doctor {
+            symptom,
+            top,
+            json,
+            framework,
+            from_examination,
+        }) => doctor(
+            symptom,
+            top,
+            json,
+            framework.into(),
+            from_examination.as_deref(),
+        ),
         Some(Command::Examine { json, framework }) => examine(json, framework.into()),
         Some(Command::Diagnose { symptom, top, json }) => diagnose(symptom, top, json),
         Some(Command::Fix {
@@ -2022,7 +2086,7 @@ fn build_codex_bridge_gpu_snapshot(config: &RocmCliConfig) -> CodexBridgeGpuSnap
         amd_smi_available: false,
         static_snapshot: None,
         monitor_snapshot: None,
-        note: Some("Use `rocm examine` for the current local AMD GPU summary.".to_owned()),
+        note: Some("Use `rocm doctor` for the current local AMD GPU summary.".to_owned()),
     }
 }
 
@@ -2091,6 +2155,123 @@ struct ExamineJsonSummary<'a> {
     previous_runtime_key: Option<&'a str>,
 }
 
+/// `doctor --json`: everything `examine --json` reports, plus the findings.
+///
+/// Deliberately a superset. Tooling written against the examine document keeps
+/// reading the same keys at the same places and simply gains `findings`.
+#[derive(serde::Serialize)]
+struct DoctorJson<'a> {
+    #[serde(flatten)]
+    examine: ExamineJson<'a>,
+    findings: &'a rocm_core::DiagnoseReport,
+}
+
+/// Read a previously captured report, or probe this machine.
+///
+/// `from` is a path, or `-` for standard input. Both the bare `Examination`
+/// document and the fuller `doctor --json` document deserialize here — the
+/// latter carries the examination's fields at the top level and the extra keys
+/// are ignored — so a report captured from either form round-trips.
+fn collect_examination(
+    from: Option<&str>,
+    framework: rocm_core::FrameworkProbe,
+) -> Result<rocm_core::Examination> {
+    let Some(source) = from else {
+        return Ok(rocm_core::Examination::probe(framework));
+    };
+    let raw = if source == "-" {
+        let mut buffer = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buffer)
+            .context("failed to read the saved report from standard input")?;
+        buffer
+    } else {
+        std::fs::read_to_string(source)
+            .with_context(|| format!("failed to read the saved report from {source}"))?
+    };
+    serde_json::from_str::<rocm_core::Examination>(&raw)
+        .context("the saved report is not a valid examination document")
+}
+
+fn doctor(
+    symptom: Option<String>,
+    top: usize,
+    json: bool,
+    framework: rocm_core::FrameworkProbe,
+    from_examination: Option<&str>,
+) -> Result<()> {
+    // Read-only, and exits 0 whether or not it found anything: the exit code
+    // reports whether the check RAN. Callers branch on `status`, `has_match` and
+    // `out_of_scope` in `--json`, never on the exit code. A genuine inability to
+    // run propagates as an error via `?`.
+    //
+    // The host probe runs once here and feeds the findings; the inventory half
+    // comes from `ExamineSummary`, which is a different collection. What this
+    // removes is the duplicate `Examination::probe` that `examine` followed by
+    // `diagnose` used to pay for twice, framework interpreter start included.
+    let examination = collect_examination(from_examination, framework)?;
+    let report = rocm_core::run_diagnose(&examination, &symptom.unwrap_or_default());
+
+    // A saved report may describe a different machine, so pairing it with this
+    // machine's inventory would be actively misleading. Findings only.
+    if from_examination.is_some() {
+        if json {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        } else {
+            print!(
+                "{}",
+                rocm_core::render_diagnose_text(&report, top, "rocm doctor")
+            );
+        }
+        return Ok(());
+    }
+
+    let paths = AppPaths::discover()?;
+    let config = RocmCliConfig::load(&paths).unwrap_or_default();
+    if json {
+        // `gather` rather than `examine_human_report`, for the reason given in
+        // `examine`: the latter writes, and `--json` is the form tooling calls
+        // in a loop.
+        let host = ExamineSummary::gather()?;
+        let configured_default_engine = config.default_engine.as_deref();
+        let document = DoctorJson {
+            examine: ExamineJson {
+                examination: &examination,
+                summary: ExamineJsonSummary {
+                    configured_default_engine,
+                    effective_default_engine: configured_default_engine
+                        .unwrap_or(&host.default_engine),
+                    active_runtime_id: config.default_runtime_id.as_deref(),
+                    active_runtime_key: config.active_runtime_key.as_deref(),
+                    previous_runtime_key: config.previous_runtime_key.as_deref(),
+                    host: &host,
+                },
+            },
+            findings: &report,
+        };
+        println!("{}", serde_json::to_string_pretty(&document)?);
+        return Ok(());
+    }
+
+    // `recover: false` is what makes the "never changes anything" claim in this
+    // command's help true. The cost is that a setup runtime present on disk but
+    // missing from the registry is reported as missing rather than silently
+    // re-registered; `rocm examine` still repairs it.
+    let (text, summary) = examine_human_report(&paths, &config, "rocm doctor", false)?;
+    print!("{text}");
+    // When the catalog routes the host out, the findings section below already
+    // explains why. Printing the examine-side note as well would say the same
+    // thing twice, in two different wordings.
+    if report.out_of_scope.is_none() && summary.wsl.as_ref().is_some_and(|w| w.is_wsl) {
+        println!("\n{}", rocm_core::WSL_ROUTE_OUT_NOTE);
+    }
+    println!();
+    print!(
+        "{}",
+        rocm_core::render_diagnose_text(&report, top, "rocm doctor")
+    );
+    Ok(())
+}
+
 fn examine(json: bool, framework: rocm_core::FrameworkProbe) -> Result<()> {
     // `rocm examine` is the general system inspector: the exit code reports
     // whether it RAN, not what it found. Any finding (no GPU, WSL, degraded) is
@@ -2120,7 +2301,7 @@ fn examine(json: bool, framework: rocm_core::FrameworkProbe) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&document)?);
         return Ok(());
     }
-    let (text, summary) = examine_human_report(&paths, &config)?;
+    let (text, summary) = examine_human_report(&paths, &config, "rocm examine", true)?;
     print!("{text}");
     if summary.wsl.as_ref().is_some_and(|w| w.is_wsl) {
         // Informational route-out guidance for humans (the verdict is also in
@@ -2139,7 +2320,10 @@ fn diagnose(symptom: Option<String>, top: usize, json: bool) -> Result<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
-        print!("{}", rocm_core::render_diagnose_text(&report, top));
+        print!(
+            "{}",
+            rocm_core::render_diagnose_text(&report, top, "rocm diagnose")
+        );
     }
     Ok(())
 }
@@ -2664,12 +2848,12 @@ fn render_driver_reconciliation(paths: &AppPaths, state: &DriverInstallState) ->
         {
             let _ = writeln!(
                 output,
-                "  action: reconciliation recorded missing passive checks; run `rocm examine` and inspect driver logs"
+                "  action: reconciliation recorded missing passive checks; run `rocm doctor` and inspect driver logs"
             );
         } else {
             let _ = writeln!(
                 output,
-                "  action: reconciliation complete; run `rocm examine` for the full host summary"
+                "  action: reconciliation complete; run `rocm doctor` for the full host summary"
             );
         }
     }
@@ -2845,10 +3029,10 @@ fn build_driver_install_plan(
             version_id: String::new(),
             codename: String::new(),
             repo_version_expr,
-            reason: "Windows driver install is validate-only in rocm-cli; use `rocm examine` to inspect the AMD display driver.".to_owned(),
+            reason: "Windows driver install is validate-only in rocm-cli; use `rocm doctor` to inspect the AMD display driver.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
-            checks: vec!["rocm examine".to_owned()],
+            checks: vec!["rocm doctor".to_owned()],
         };
     }
     if examine.wsl.as_ref().is_some_and(|wsl| wsl.is_wsl) {
@@ -2863,7 +3047,7 @@ fn build_driver_install_plan(
             reason: "WSL uses the Windows host driver plus ROCDXG; run `scripts/wsl_setup_rocdxg.sh` inside WSL instead of installing Linux DKMS.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
-            checks: vec!["rocm examine".to_owned(), "scripts/wsl_preflight.py".to_owned()],
+            checks: vec!["rocm doctor".to_owned(), "scripts/wsl_preflight.py".to_owned()],
         };
     }
 
@@ -2951,7 +3135,7 @@ fn build_driver_install_plan(
             reason: "Linux DKMS driver install is currently planned only for AMD-documented Ubuntu, Debian, RHEL, Oracle Linux, SLES, and Rocky versions; no commands were guessed for this distro.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
-            checks: vec!["rocm examine".to_owned()],
+            checks: vec!["rocm doctor".to_owned()],
         }),
     }
 }
@@ -4637,7 +4821,7 @@ fn serve(args: ServeArgs) -> Result<()> {
     {
         bail!(
             "no usable AMD GPU detected; `rocm serve` requires a GPU under the {policy} \
-             policy and does not fall back to CPU. Check the driver with `rocm examine`, \
+             policy and does not fall back to CPU. Check the driver with `rocm doctor`, \
              confirm /dev/kfd is present, and ensure HIP_VISIBLE_DEVICES / \
              ROCR_VISIBLE_DEVICES are not masking every device.",
             policy = device_policy_name(&device_policy)
@@ -8594,8 +8778,8 @@ fn fallback_rocm_tool_call_for_prompt(prompt: &str) -> Option<providers::ChatToo
     }
     if asks_how && mentions_setup && any_substring(&normalized, &["therock", "rocm"]) {
         return Some(providers::ChatToolCall {
-            id: Some("fallback-therock-examine".to_owned()),
-            name: "examine".to_owned(),
+            id: Some("fallback-therock-doctor".to_owned()),
+            name: "doctor".to_owned(),
             arguments: serde_json::json!({}),
         });
     }
@@ -8637,8 +8821,8 @@ fn fallback_rocm_tool_call_for_prompt(prompt: &str) -> Option<providers::ChatToo
         );
     if asks_status && any_substring(&normalized, &["gpu", "rocm", "therock", "setup"]) {
         return Some(providers::ChatToolCall {
-            id: Some("fallback-examine".to_owned()),
-            name: "examine".to_owned(),
+            id: Some("fallback-doctor".to_owned()),
+            name: "doctor".to_owned(),
             arguments: serde_json::json!({}),
         });
     }
@@ -9067,7 +9251,7 @@ fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
         .position(|window| window.eq_ignore_ascii_case(needle))
 }
 
-const ROCM_CHAT_TOOL_SYSTEM_PROMPT: &str = "You are ROCm CLI's local assistant. Speak in simple English for non-technical Windows users. Use the provided ROCm tools when you need to inspect this machine, preview setup, read service logs, check updates, inspect automations, install or start ROCm-managed apps, or request ROCm/TheRock, config, engine, app, and local model server changes. For simple greetings or thanks like hello, hi, hey, ok, or thank you, reply normally; do not inspect ROCm, do not call tools, and do not launch or propose a model server. Tool-use rules: inspect first with read-only tools; call rocm_command only with argv-style args and no shell text; use natural_language_plan for ROCm requests that do not fit another read-only tool; ask for a mutating tool call only after explaining why it is needed; summarize tool results after they are returned. Read-only tools may run immediately. Tools that install, launch, stop, delete, or change state require user approval; request rocm_command and explain why. For 'is X running?', 'what is running?', status, or port questions, inspect before answering and do not start, stop, install, or serve anything. For ComfyUI or port 8188 use [\"comfyui\",\"status\"] or port_status. For vLLM, Lemonade, qwen, or local model servers use [\"services\",\"list\",\"--all\"] for running state and [\"engines\",\"list\"] for installed/available engine state. Treat ready/running as running, starting/recovering as starting, failed/stopped as not running, and no matching record as unknown or not managed by ROCm CLI. Interpret Examine carefully: active_runtime_status=ready means ROCm CLI has an active managed TheRock/ROCm runtime; legacy_rocm_status=not_detected only means no global system ROCm install was found. If active_runtime_status=ready, tell the user ROCm/TheRock is installed and active for ROCm CLI. For 'is TheRock installed', 'is ROCm installed', or 'which GPU is on this machine', use examine or gpu_snapshot before answering. For 'how do I setup TheRock' or install/setup requests, guide the user to choose an install folder first; do not answer with only a status check. For 'which LLMs can this machine support', use rocm_command args [\"model\"] or natural_language_plan before answering. For TheRock installs, always let the user choose the install folder. If the user names a folder or prefix, preserve that exact folder with [\"--prefix\",\"PATH\"]; you may call path_exists first to check whether that user-provided folder or its parent exists. If the user asks you to install TheRock/ROCm but has not named a folder, ask for the folder or let the guided setup folder picker collect it; do not invent a hidden default folder and do not request an install command without --prefix. Use rocm_command args [\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"wheel\",\"--prefix\",\"PATH\"] only when the user asks you to install it and a folder is known; for a requested build date add [\"--build-date\",\"YYYY-MM-DD\"] and for a requested exact version add [\"--version\",\"VERSION\"]. For config changes, inspect with [\"config\",\"show\"] first when useful, then request config subcommands such as [\"config\",\"set-default-engine\",\"lemonade\"], [\"config\",\"set-default-runtime\",\"RUNTIME_KEY\"], or [\"config\",\"set-telemetry\",\"local\"] only after explaining why. For ComfyUI, use rocm_command with args like [\"comfyui\",\"status\"], [\"comfyui\",\"logs\"], [\"comfyui\",\"install\"], [\"comfyui\",\"start\"], or [\"comfyui\",\"stop\"]. First-time setup is the same thing as bootstrap in ROCm CLI; it is a deterministic ROCm setup flow, not a separate model chat. The built-in local assistant is fixed to qwen, which maps to Qwen3-4B-Instruct-2507-GGUF served by Lemonade with gpu_required. vLLM and Lemonade are the general serving engines; inspect or manage them when the user asks about general model serving, but do not switch the built-in assistant away from Lemonade. Use qwen-smoke only for a quick server smoke test. On native Windows, vLLM is skipped; use WSL/Linux for that ROCm GPU engine. For vLLM management, inspect engines first and use [\"engines\",\"install\",\"vllm\"] or [\"serve\",\"MODEL\",\"--engine\",\"vllm\",\"--device\",\"gpu_required\",\"--managed\"] only where the host supports it. Do not invent shell commands and do not request CPU fallback.";
+const ROCM_CHAT_TOOL_SYSTEM_PROMPT: &str = "You are ROCm CLI's local assistant. Speak in simple English for non-technical Windows users. Use the provided ROCm tools when you need to inspect this machine, preview setup, read service logs, check updates, inspect automations, install or start ROCm-managed apps, or request ROCm/TheRock, config, engine, app, and local model server changes. For simple greetings or thanks like hello, hi, hey, ok, or thank you, reply normally; do not inspect ROCm, do not call tools, and do not launch or propose a model server. Tool-use rules: inspect first with read-only tools; call rocm_command only with argv-style args and no shell text; use natural_language_plan for ROCm requests that do not fit another read-only tool; ask for a mutating tool call only after explaining why it is needed; summarize tool results after they are returned. Read-only tools may run immediately. Tools that install, launch, stop, delete, or change state require user approval; request rocm_command and explain why. For 'is X running?', 'what is running?', status, or port questions, inspect before answering and do not start, stop, install, or serve anything. For ComfyUI or port 8188 use [\"comfyui\",\"status\"] or port_status. For vLLM, Lemonade, qwen, or local model servers use [\"services\",\"list\",\"--all\"] for running state and [\"engines\",\"list\"] for installed/available engine state. Treat ready/running as running, starting/recovering as starting, failed/stopped as not running, and no matching record as unknown or not managed by ROCm CLI. Interpret Doctor carefully: active_runtime_status=ready means ROCm CLI has an active managed TheRock/ROCm runtime; legacy_rocm_status=not_detected only means no global system ROCm install was found. If active_runtime_status=ready, tell the user ROCm/TheRock is installed and active for ROCm CLI. For 'is TheRock installed', 'is ROCm installed', or 'which GPU is on this machine', use doctor or gpu_snapshot before answering. For 'how do I setup TheRock' or install/setup requests, guide the user to choose an install folder first; do not answer with only a status check. For 'which LLMs can this machine support', use rocm_command args [\"model\"] or natural_language_plan before answering. For TheRock installs, always let the user choose the install folder. If the user names a folder or prefix, preserve that exact folder with [\"--prefix\",\"PATH\"]; you may call path_exists first to check whether that user-provided folder or its parent exists. If the user asks you to install TheRock/ROCm but has not named a folder, ask for the folder or let the guided setup folder picker collect it; do not invent a hidden default folder and do not request an install command without --prefix. Use rocm_command args [\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"wheel\",\"--prefix\",\"PATH\"] only when the user asks you to install it and a folder is known; for a requested build date add [\"--build-date\",\"YYYY-MM-DD\"] and for a requested exact version add [\"--version\",\"VERSION\"]. For config changes, inspect with [\"config\",\"show\"] first when useful, then request config subcommands such as [\"config\",\"set-default-engine\",\"lemonade\"], [\"config\",\"set-default-runtime\",\"RUNTIME_KEY\"], or [\"config\",\"set-telemetry\",\"local\"] only after explaining why. For ComfyUI, use rocm_command with args like [\"comfyui\",\"status\"], [\"comfyui\",\"logs\"], [\"comfyui\",\"install\"], [\"comfyui\",\"start\"], or [\"comfyui\",\"stop\"]. First-time setup is the same thing as bootstrap in ROCm CLI; it is a deterministic ROCm setup flow, not a separate model chat. The built-in local assistant is fixed to qwen, which maps to Qwen3-4B-Instruct-2507-GGUF served by Lemonade with gpu_required. vLLM and Lemonade are the general serving engines; inspect or manage them when the user asks about general model serving, but do not switch the built-in assistant away from Lemonade. Use qwen-smoke only for a quick server smoke test. On native Windows, vLLM is skipped; use WSL/Linux for that ROCm GPU engine. For vLLM management, inspect engines first and use [\"engines\",\"install\",\"vllm\"] or [\"serve\",\"MODEL\",\"--engine\",\"vllm\",\"--device\",\"gpu_required\",\"--managed\"] only where the host supports it. Do not invent shell commands and do not request CPU fallback.";
 const ROCM_CHAT_TOOL_SKILL: &str = include_str!("../../../skills/rocm-cli-assistant/SKILL.md");
 
 fn rocm_chat_tool_system_prompt() -> String {
@@ -9663,7 +9847,7 @@ fn chat_rocm_command_action_from_args(mut args: Vec<String>) -> Result<ChatRocmC
     let first = args.first().map(|value| value.to_ascii_lowercase());
     let second = args.get(1).map(|value| value.to_ascii_lowercase());
     match first.as_deref() {
-        Some("examine" | "version" | "model" | "models" | "daemon" | "logs") => {
+        Some("doctor" | "examine" | "version" | "model" | "models" | "daemon" | "logs") => {
             Ok(ChatRocmCommandAction::ReadOnly(args))
         }
         Some("update") if !args.iter().any(|arg| arg == "--apply") => {
@@ -10015,7 +10199,11 @@ pub(crate) fn chat_tool_call_is_read_only(call: &providers::ChatToolCall) -> boo
 }
 
 fn deterministic_rocm_tool_summary(tool_text: &str) -> Option<String> {
-    if !tool_text.contains("examine:") {
+    // The block is labelled with the tool's own name (see the `follow_up_text`
+    // writer). That name is now `doctor`; `examine:` stays accepted because a
+    // model may still issue the superseded name, and silently returning None
+    // would drop the summary rather than fail visibly.
+    if !tool_text.contains("doctor:") && !tool_text.contains("examine:") {
         return None;
     }
     let mut lines = Vec::new();
@@ -10227,7 +10415,7 @@ fn deterministic_model_tool_summary(tool_text: &str) -> Option<String> {
 
     if !lines.is_empty() {
         lines.push(
-            "  Run `rocm examine` to refresh GPU memory details before starting anything large."
+            "  Run `rocm doctor` to refresh GPU memory details before starting anything large."
                 .to_owned(),
         );
     }
@@ -10649,7 +10837,7 @@ pub(crate) fn run_internal_mcp_call(
             } else if gpu.amd_smi_available {
                 "Captured amd-smi GPU snapshot."
             } else {
-                "Use `rocm examine` for the current local AMD GPU summary."
+                "Use `rocm doctor` for the current local AMD GPU summary."
             };
             Ok(internal_mcp_tool_success(
                 status.to_owned(),
@@ -10975,7 +11163,10 @@ fn run_rocm_read_only_in_process(paths: &AppPaths, args: &[String]) -> Result<St
     let config = RocmCliConfig::load(paths).unwrap_or_default();
     match args {
         [] => bail!("rocm command requires at least one argument"),
-        [command] if command.eq_ignore_ascii_case("examine") => {
+        [command]
+            if command.eq_ignore_ascii_case("doctor")
+                || command.eq_ignore_ascii_case("examine") =>
+        {
             render_examine_text_with_paths(paths, &config)
         }
         [command]
@@ -11421,7 +11612,7 @@ const fn chat_read_only_tool_status_label(is_error: bool) -> &'static str {
 
 fn chat_tool_display_label(name: &str) -> String {
     match name {
-        "examine" => "Checked this computer".to_owned(),
+        "examine" | "doctor" => "Checked this computer".to_owned(),
         "gpu_snapshot" => "Checked GPU status".to_owned(),
         "engines" => "Checked local engines".to_owned(),
         "services" => "Checked model servers".to_owned(),
@@ -11451,7 +11642,12 @@ fn chat_tool_call_display_label(call: &providers::ChatToolCall) -> String {
         return "rocm command".to_owned();
     };
     match args.as_slice() {
-        [command] if command.eq_ignore_ascii_case("examine") => "Checked this computer".to_owned(),
+        [command]
+            if command.eq_ignore_ascii_case("examine")
+                || command.eq_ignore_ascii_case("doctor") =>
+        {
+            "Checked this computer".to_owned()
+        }
         [command]
             if command.eq_ignore_ascii_case("model") || command.eq_ignore_ascii_case("models") =>
         {
@@ -11619,19 +11815,30 @@ pub(crate) fn render_examine_text() -> Result<String> {
 }
 
 fn render_examine_text_with_paths(paths: &AppPaths, config: &RocmCliConfig) -> Result<String> {
-    Ok(examine_human_report(paths, config)?.0)
+    // Reached from the read-only tool surface, so no repair write here either.
+    Ok(examine_human_report(paths, config, "rocm doctor", false)?.0)
 }
 
-/// Build the human examine report and return it alongside the `ExamineSummary`
-/// it was built from, so callers can derive scope/exit-code without re-probing.
+/// Build the human host report and return it alongside the `ExamineSummary` it
+/// was built from, so callers can derive scope/exit-code without re-probing.
+///
+/// `command` labels the output with whichever command produced it. `recover`
+/// controls the one write on this path: re-registering a setup runtime that is
+/// present on disk but missing from the registry. That is a repair, not a
+/// reading, so a command that promises not to change anything must pass `false`
+/// — see the note in `doctor`.
 fn examine_human_report(
     paths: &AppPaths,
     config: &RocmCliConfig,
+    command: &str,
+    recover: bool,
 ) -> Result<(String, ExamineSummary)> {
-    recover_setup_runtime_registration(paths, config)?;
+    if recover {
+        recover_setup_runtime_registration(paths, config)?;
+    }
     let summary = ExamineSummary::gather()?;
     let mut output = render_examine_plain_header(&summary);
-    output.push_str(&summary.render_text());
+    output.push_str(&summary.render_text(command));
     append_examine_runtime_state(&mut output, paths, config)?;
     append_examine_engine_inventory(&mut output, paths, config, &summary.default_engine);
     Ok((output, summary))
@@ -12384,7 +12591,7 @@ fn append_model_host_ram_fit_lines(
             );
             let _ = writeln!(
                 output,
-                "      system_ram_action: run /examine to refresh host telemetry"
+                "      system_ram_action: run /doctor to refresh host telemetry"
             );
         }
     }
@@ -12451,7 +12658,7 @@ fn append_model_fit_lines(
                 );
                 let _ = writeln!(
                     output,
-                    "      action: run /examine or refresh GPU telemetry, then retry /model {}",
+                    "      action: run /doctor or refresh GPU telemetry, then retry /model {}",
                     recipe_display_ref(recipe)
                 );
             }
@@ -14846,7 +15053,7 @@ fn build_freeform_plan_with_recipes(
             actions: vec![
                 PlannedToolCall::read_only(
                     "Inspect host/runtime state",
-                    vec!["examine".to_owned()],
+                    vec!["doctor".to_owned()],
                     "read-only inspection",
                 ),
                 PlannedToolCall::read_only(
@@ -14889,7 +15096,7 @@ fn build_freeform_plan_with_recipes(
             actions: vec![
                 PlannedToolCall::read_only(
                     "Inspect host/driver state",
-                    vec!["examine".to_owned()],
+                    vec!["doctor".to_owned()],
                     "read-only inspection",
                 ),
                 PlannedToolCall::approval_required(
@@ -15034,7 +15241,7 @@ fn build_freeform_plan_with_recipes(
             actions: vec![
                 PlannedToolCall::read_only(
                     "Inspect current runtime",
-                    vec!["examine".to_owned()],
+                    vec!["doctor".to_owned()],
                     "read-only inspection",
                 ),
                 PlannedToolCall::approval_required(
@@ -15118,7 +15325,7 @@ fn build_freeform_plan_with_recipes(
             parsed: vec![("engine".to_owned(), default_engine.to_owned())],
             actions: vec![PlannedToolCall::read_only(
                 "Inspect local ROCm state",
-                vec!["examine".to_owned()],
+                vec!["doctor".to_owned()],
                 "read-only inspection",
             )],
             notes: vec![
@@ -15289,7 +15496,7 @@ fn resolve_freeform_plan_with_provider(
 
 fn build_provider_planner_prompt(request: &str, deterministic: &StructuredRequestPlan) -> String {
     let next_tool_call = deterministic.actions.last().map_or_else(
-        || "rocm examine".to_owned(),
+        || "rocm doctor".to_owned(),
         |action| format_structured_tool_call(action.tool, &action.args),
     );
     format!(
@@ -15298,7 +15505,7 @@ fn build_provider_planner_prompt(request: &str, deterministic: &StructuredReques
 \"confidence\":\"high|medium|low\",\
 \"tool_call\":{{\"tool\":\"rocm\",\"args\":[\"...\"]}},\
 \"notes\":[\"short note\"]}}.\n\
-Allowed rocm actions: examine; engines list; install sdk; install driver; update; serve; uninstall. Install sdk must include --prefix PATH chosen by the user, and may include --build-date YYYY-MM-DD or --version VERSION.\n\
+Allowed rocm actions: doctor; engines list; install sdk; install driver; update; serve; uninstall. Install sdk must include --prefix PATH chosen by the user, and may include --build-date YYYY-MM-DD or --version VERSION.\n\
 Do not invent CPU fallback. Do not include shell commands. Do not include markdown.\n\
 User request: {request}\n\
 Deterministic planner intent: {}\n\
@@ -15416,7 +15623,7 @@ fn validate_provider_planner_tool_call(call: &ProviderPlannerToolCall) -> Result
         .context("provider planner returned a rocm command that is not valid")?;
 
     match call.args.as_slice() {
-        [command] if command == "examine" => {}
+        [command] if command == "examine" || command == "doctor" => {}
         [command, subcommand] if command == "engines" && subcommand == "list" => {}
         [command, subcommand, ..] if command == "install" && subcommand == "sdk" => {
             validate_chat_rocm_command_safety(&call.args)?;
@@ -15460,7 +15667,7 @@ fn planner_intent_from_provider_response(intent: &str, args: &[String]) -> Resul
         "install_driver" | "install driver" => PlannerIntent::InstallDriver,
         "update" => PlannerIntent::Update,
         "uninstall" => PlannerIntent::Uninstall,
-        "inspect" | "examine" => PlannerIntent::Inspect,
+        "inspect" | "examine" | "doctor" => PlannerIntent::Inspect,
         _ => bail!("provider planner returned unsupported intent `{intent}`"),
     };
     if declared != args_intent {
@@ -15484,7 +15691,7 @@ fn planner_intent_from_args(args: &[String]) -> Result<PlannerIntent> {
         }
         Some("update") => Ok(PlannerIntent::Update),
         Some("uninstall") => Ok(PlannerIntent::Uninstall),
-        Some("examine" | "engines") => Ok(PlannerIntent::Inspect),
+        Some("examine" | "doctor" | "engines") => Ok(PlannerIntent::Inspect),
         _ => bail!("unsupported provider planner args"),
     }
 }
@@ -15576,6 +15783,7 @@ fn planner_is_inspect_request(lower: &str) -> bool {
         || contains_planner_word(lower, "check")
         || contains_planner_word(lower, "status")
         || contains_planner_word(lower, "examine")
+        || contains_planner_word(lower, "doctor")
         || contains_planner_word(lower, "which")
         || contains_planner_word(lower, "where")
         || lower.contains("what is installed")
@@ -17208,6 +17416,10 @@ fn service_model_names_match(left: &str, right: &str) -> bool {
 
 fn treat_as_natural_language(args: &[String]) -> bool {
     const STRUCTURED: &[&str] = &[
+        "doctor",
+        // Hidden but still dispatched, so they must stay structured: falling
+        // through to the natural-language planner would silently change what an
+        // existing caller gets back.
         "examine",
         "diagnose",
         "fix",
@@ -17357,16 +17569,21 @@ mod tests {
     fn the_framework_choice_is_offered_on_the_command_line() {
         // Guards the actual regression: the variants existed in the library and
         // were unreachable from here. A user must be able to see and pass them.
-        let help = Cli::command()
-            .find_subcommand_mut("examine")
-            .expect("examine subcommand")
-            .render_long_help()
-            .to_string();
-        for choice in ["auto", "pytorch", "llama-cpp", "skip"] {
-            assert!(
-                help.contains(choice),
-                "`{choice}` must be offered by `rocm examine --help`:\n{help}"
-            );
+        // Both the advertised command and the superseded one must offer the
+        // choices: `doctor` because that is what users are pointed at, `examine`
+        // because hiding it must not have quietly narrowed what it accepts.
+        for command in ["doctor", "examine"] {
+            let help = Cli::command()
+                .find_subcommand_mut(command)
+                .unwrap_or_else(|| panic!("{command} subcommand"))
+                .render_long_help()
+                .to_string();
+            for choice in ["auto", "pytorch", "llama-cpp", "skip"] {
+                assert!(
+                    help.contains(choice),
+                    "`{choice}` must be offered by `rocm {command} --help`:\n{help}"
+                );
+            }
         }
     }
 
@@ -17829,8 +18046,8 @@ mod tests {
             }
             // A known visible subcommand must still be present.
             assert!(
-                output.contains("examine"),
-                "visible subcommand `examine` missing from {shell:?} completions"
+                output.contains("doctor"),
+                "visible subcommand `doctor` missing from {shell:?} completions"
             );
         }
     }
@@ -17843,9 +18060,19 @@ mod tests {
             .collect();
         // Visible subcommands are preserved.
         assert!(
-            names.iter().any(|n| n == "examine"),
+            names.iter().any(|n| n == "doctor"),
             "filtered command tree dropped a visible subcommand; got {names:?}"
         );
+        // `examine` and `diagnose` still dispatch, but `doctor` supersedes them
+        // and they are no longer advertised. Asserting on the name list rather
+        // than a substring search keeps this from tripping over prose in help
+        // text that happens to mention the old names.
+        for superseded in ["examine", "diagnose"] {
+            assert!(
+                !names.iter().any(|n| n == superseded),
+                "superseded subcommand `{superseded}` is still advertised; got {names:?}"
+            );
+        }
         assert!(
             names.iter().any(|n| n == "completions"),
             "filtered command tree dropped `completions`; got {names:?}"
@@ -18956,7 +19183,7 @@ mod tests {
         assert!(
             plan.actions
                 .iter()
-                .all(|action| action.args == vec!["examine".to_owned()])
+                .all(|action| action.args == vec!["doctor".to_owned()])
         );
     }
 
@@ -18973,7 +19200,7 @@ mod tests {
             assert_eq!(plan.approval, "not required for inspection", "{prompt}");
             assert_eq!(plan.actions.len(), 1, "{prompt}");
             assert_eq!(plan.actions[0].approval, "not required", "{prompt}");
-            assert_eq!(plan.actions[0].args, vec!["examine".to_owned()], "{prompt}");
+            assert_eq!(plan.actions[0].args, vec!["doctor".to_owned()], "{prompt}");
         }
     }
 
@@ -19536,7 +19763,7 @@ runtime_state:
     }
 
     #[test]
-    fn fallback_tool_call_routes_where_installed_to_read_only_examine() {
+    fn fallback_tool_call_routes_where_installed_to_read_only_doctor() {
         for prompt in [
             "where is rocm installed?",
             "where is TheRock installed?",
@@ -19544,7 +19771,7 @@ runtime_state:
             "where did rocm install to?",
         ] {
             let call = fallback_rocm_tool_call_for_prompt(prompt).unwrap();
-            assert_eq!(call.name, "examine", "{prompt}");
+            assert_eq!(call.name, "doctor", "{prompt}");
             assert!(chat_tool_call_is_read_only(&call), "{prompt}");
         }
     }
@@ -19619,7 +19846,7 @@ model recipes
         assert!(summary.contains("lemonade, vllm"));
         assert!(summary.contains("Qwen/Qwen3.5-4B asks for 12 GiB"));
         assert!(summary.contains("Native Windows note"));
-        assert!(summary.contains("Run `rocm examine`"));
+        assert!(summary.contains("Run `rocm doctor`"));
     }
 
     #[test]
@@ -20780,7 +21007,7 @@ model recipes
             "Check this ROCm setup.",
         ] {
             let call = fallback_rocm_tool_call_for_prompt(prompt).unwrap();
-            assert_eq!(call.name, "examine");
+            assert_eq!(call.name, "doctor");
             assert_eq!(call.arguments, serde_json::json!({}));
         }
     }
@@ -20952,7 +21179,7 @@ model recipes
         let (_root, paths) = test_paths("chat-install-intent-latest-message");
         let prompt = "\
 Conversation so far:
-Assistant: Use /examine to refresh actual GPU memory fit before starting anything large.
+Assistant: Use /doctor to refresh actual GPU memory fit before starting anything large.
 Assistant: Native Windows note: models may use WSL/Linux through Windows.
 
 New message:
@@ -21273,6 +21500,7 @@ install therock";
         assert_eq!(chat_read_only_tool_status_label(false), "done");
         assert_eq!(chat_read_only_tool_status_label(true), "reported an error");
         assert_eq!(chat_tool_display_label("examine"), "Checked this computer");
+        assert_eq!(chat_tool_display_label("doctor"), "Checked this computer");
         assert_eq!(
             chat_tool_display_label("gpu_snapshot"),
             "Checked GPU status"
@@ -23453,8 +23681,8 @@ VERSION_ID="41"
         assert!(rendered.contains("approval: not required"));
         assert!(rendered.contains("execution_commands: <none>"));
         assert!(rendered.contains("post_reboot_checks:"));
-        assert!(rendered.contains("use `rocm examine`"));
-        assert!(rendered.contains("rocm examine"));
+        assert!(rendered.contains("use `rocm doctor`"));
+        assert!(rendered.contains("rocm doctor"));
         assert!(plan.commands.is_empty());
     }
 

--- a/apps/rocm/src/providers.rs
+++ b/apps/rocm/src/providers.rs
@@ -1015,7 +1015,7 @@ fn openai_chat_request_body_with_stream(
 fn rocm_openai_tool_definitions() -> Vec<serde_json::Value> {
     vec![
         rocm_openai_tool(
-            "examine",
+            "doctor",
             "Read the current ROCm host, GPU, runtime, driver, and engine status.",
             serde_json::json!({
                 "type": "object",
@@ -2354,7 +2354,7 @@ mod tests {
 
         assert!(request.contains("\"tools\""));
         assert!(request.contains("\"tool_choice\":\"auto\""));
-        assert!(request.contains("\"name\":\"examine\""));
+        assert!(request.contains("\"name\":\"doctor\""));
         assert_eq!(response.content, "I will check first.");
         assert_eq!(response.tool_calls.len(), 1);
         assert_eq!(response.tool_calls[0].name, "examine");

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -1457,6 +1457,9 @@ struct CommandKey {
 /// coverage % reflects the real surface (a deliberate, reviewable denominator
 /// beats silently drifting).
 const KNOWN_COMMAND_SURFACE: &[&str] = &[
+    "rocm doctor",
+    // Superseded by `rocm doctor` and hidden from the advertised surface, but
+    // still dispatched and still covered, so they stay in the denominator.
     "rocm examine",
     "rocm diagnose",
     "rocm fix",

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1299,9 +1299,9 @@ fn route_when_no_match(e: &Examination) -> Route {
 #[must_use]
 pub fn diagnose(e: &Examination, symptom: &str) -> DiagnoseReport {
     // WSL2 is a distinct platform (it uses /dev/dxg + the Windows host driver,
-    // not the in-tree amdgpu module or /dev/kfd), and `examine` already treats
-    // it as out of scope (exit_code() == 2). Mirror that here: skip the
-    // bare-metal Linux catalog entirely so we don't emit false positives like
+    // not the in-tree amdgpu module or /dev/kfd), and the host report already
+    // routes it out via the "wsl" status. Mirror that here: skip the bare-metal
+    // Linux catalog entirely so we don't emit false positives like
     // fix-4-render-group / fix-5-amdgpu-load on a healthy WSL2 box.
     let out_of_scope = wsl_out_of_scope_message(e);
     let matched = if out_of_scope.is_some() {
@@ -1318,38 +1318,34 @@ pub fn diagnose(e: &Examination, symptom: &str) -> DiagnoseReport {
     }
 }
 
-/// ROCm-on-WSL2 setup guidance (distinct from the bare-metal catalog).
-const WSL_DOCS_URL: &str = "https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/wsl/howto_wsl.html";
-
 fn wsl_out_of_scope_message(e: &Examination) -> Option<String> {
-    e.is_wsl.then(|| {
-        format!(
-            "ROCm on WSL2 is a distinct platform: it uses /dev/dxg and the Windows host \
-             driver (dxgkrnl), not the in-tree amdgpu kernel module or /dev/kfd. This catalog \
-             targets bare-metal Linux, so its checks (render group, /dev/kfd, modprobe amdgpu) \
-             do not apply here. For ROCm-on-WSL2 setup, see {WSL_DOCS_URL}"
-        )
-    })
+    // Shared with the host report rather than restated: this verdict was
+    // previously explained twice, in two wordings, and the two had drifted.
+    e.is_wsl
+        .then(|| crate::examine::WSL_ROUTE_OUT_NOTE.to_owned())
 }
 
 /// Render the human-facing diagnosis view (mirrors `diagnose.py`'s text output).
 #[must_use]
-pub fn render_report_text(report: &DiagnoseReport, top: usize) -> String {
+pub fn render_report_text(report: &DiagnoseReport, top: usize, command: &str) -> String {
     use std::fmt::Write as _;
     let mut out = String::new();
     if let Some(reason) = &report.out_of_scope {
-        out.push_str("rocm diagnose: out of scope for this platform.\n\n");
+        let _ = writeln!(out, "{command}: out of scope for this platform.\n");
         out.push_str(reason);
         out.push('\n');
         return out;
     }
     if report.matched.is_empty() {
         let route = &report.route_when_no_match;
-        out.push_str("rocm diagnose: no known misconfiguration matched.\n\n");
+        let _ = writeln!(out, "{command}: no known misconfiguration matched.\n");
         out.push_str("This is the explicit 'I don't recognise this failure mode' case. Do not speculate; file the symptom + this examination output upstream:\n");
         let _ = writeln!(out, "  {:>12}: {}", route.target, route.url);
         out.push('\n');
-        out.push_str("Include the JSON from `rocm examine --json` in your report.\n");
+        let _ = writeln!(
+            out,
+            "Include the JSON from `{command} --json` in your report."
+        );
         return out;
     }
     for (i, d) in report.matched.iter().take(top).enumerate() {
@@ -1482,7 +1478,7 @@ mod tests {
             "fixture must stay below the threshold for this test to mean anything"
         );
 
-        let out = render_report_text(&report, 5);
+        let out = render_report_text(&report, 5, "rocm doctor");
         assert!(
             out.contains("below the HIGH_CONFIDENCE threshold"),
             "the confidence caution must survive:\n{out}"
@@ -1499,7 +1495,7 @@ mod tests {
         e.in_render_group = Some(false);
         e.in_video_group = Some(false);
         let report = diagnose(&e, "");
-        let out = render_report_text(&report, 5);
+        let out = render_report_text(&report, 5, "rocm doctor");
 
         let applies = out.matches("apply with: rocm fix ").count();
         let shown = report.matched.len().min(5);
@@ -1523,7 +1519,7 @@ mod tests {
         let mut e = linux_base();
         e.in_render_group = Some(false);
         let report = diagnose(&e, "");
-        let out = render_report_text(&report, 5);
+        let out = render_report_text(&report, 5, "rocm doctor");
         let top = &report.matched[0];
         assert!(
             out.contains(&format!("#1 ({})", top.id)),
@@ -1540,7 +1536,7 @@ mod tests {
         if report.matched.len() < 2 {
             return; // nothing to truncate on this fixture
         }
-        let out = render_report_text(&report, 1);
+        let out = render_report_text(&report, 1, "rocm doctor");
         assert!(
             out.contains("Showing 1 of"),
             "a truncated list must not read as the complete set:\n{out}"

--- a/crates/rocm-core/src/examine.rs
+++ b/crates/rocm-core/src/examine.rs
@@ -232,7 +232,13 @@ impl Default for Examination {
 
 /// Route-out guidance shown when WSL2 is detected (out of scope for this
 /// catalog, which targets bare-metal Linux). Mirrors `examine.py`.
-pub const WSL_ROUTE_OUT_NOTE: &str = "Detected WSL2. rocm examine does not cover the ROCm-on-WSL flow (it requires Adrenalin Pro + the WSL kernel update on the Windows host). Either run `rocm examine` on the native Linux host, or follow AMD's WSL guide directly: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/wsl/howto_wsl.html";
+/// Why WSL2 is routed out, and where to go instead.
+///
+/// One text, shared by the host report and the diagnosis catalog. These used to
+/// be two independently-written explanations of the same verdict — one blamed
+/// the Adrenalin driver, the other explained `/dev/dxg` — with the same doc URL
+/// duplicated in both files. They had already drifted apart.
+pub const WSL_ROUTE_OUT_NOTE: &str = "ROCm on WSL2 is a distinct platform: it uses /dev/dxg and the Windows host driver (dxgkrnl), not the in-tree amdgpu kernel module or /dev/kfd. The bare-metal Linux checks (render group, /dev/kfd, modprobe amdgpu) cannot apply here, so they are not run. Either run `rocm doctor` on a native Linux host, or follow AMD's ROCm-on-WSL2 guide: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/wsl/howto_wsl.html";
 
 /// Which framework probe to run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -294,7 +300,7 @@ impl Examination {
             probe_framework(&mut e, framework);
         } else {
             e.notes.push(format!(
-                "rocm examine supports Linux and Windows; got {}. This skill cannot help on this platform.",
+                "rocm doctor supports Linux and Windows; got {}. This platform is not covered.",
                 e.os_family
             ));
         }

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -380,7 +380,7 @@ const fn current_os() -> &'static str {
     }
 }
 
-/// Whether `value` is a `rocm diagnose` ranking position (`#2`, or a bare `2`)
+/// Whether `value` is a `rocm doctor` ranking position (`#2`, or a bare `2`)
 /// rather than a fix-id.
 ///
 /// Used only to turn an unknown-id refusal into a corrective one; it never
@@ -457,18 +457,16 @@ pub fn apply(fix_id: &str, opts: &FixOptions) -> i32 {
     let Some(recipe) = find_recipe(fix_id) else {
         eprintln!("Unknown fix-id: {fix_id}");
         if looks_like_a_diagnosis_position(fix_id) {
-            // `rocm diagnose` ranks findings `#1`, `#2`, and users reach for that
+            // `rocm doctor` ranks findings `#1`, `#2`, and users reach for that
             // number here. It is a position in one report, not a name -- and it
             // does not line up with the catalog's `fix-1 … fix-15` either, so a
             // bare "unknown id" left them with nothing to correct.
+            eprintln!("`{fix_id}` looks like a position in a `rocm doctor` report, not a fix-id.");
             eprintln!(
-                "`{fix_id}` looks like a position in a `rocm diagnose` report, not a fix-id."
-            );
-            eprintln!(
-                "Use the `id:` shown against that cause — `rocm diagnose` prints an `apply with:` line you can copy."
+                "Use the `id:` shown against that cause — `rocm doctor` prints an `apply with:` line you can copy."
             );
         } else {
-            eprintln!("Run `rocm diagnose` to see which fix-id applies.");
+            eprintln!("Run `rocm doctor` to see which fix-id applies.");
         }
         return 2;
     };
@@ -781,11 +779,7 @@ fn run_path_export_linux(opts: &FixOptions) -> i32 {
     if !confirm(&format!("Append to {}?", rc_file.display()), opts.yes) {
         return 5;
     }
-    if let Err(exc) = append_line(
-        &rc_file,
-        "# Added by rocm examine (fix-6-path)",
-        &export_line,
-    ) {
+    if let Err(exc) = append_line(&rc_file, "# Added by rocm fix (fix-6-path)", &export_line) {
         println!("Failed to write {}: {exc}", rc_file.display());
         return 4;
     }
@@ -892,7 +886,7 @@ fn run_hip_visible_devices_linux(opts: &FixOptions) -> i32 {
     }
     if let Err(exc) = append_line(
         &rc_file,
-        "# Added by rocm examine (fix-9-igpu-dgpu)",
+        "# Added by rocm fix (fix-9-igpu-dgpu)",
         &export_line,
     ) {
         println!("Failed to write {}: {exc}", rc_file.display());
@@ -1165,7 +1159,7 @@ mod tests {
 
     #[test]
     fn diagnosis_positions_are_recognised_as_positions() {
-        // What `rocm diagnose` shows as `#1`/`#2`, plus the bare number a user
+        // What `rocm doctor` shows as `#1`/`#2`, plus the bare number a user
         // might type instead.
         for value in ["#1", "#2", "1", "12", " #3 "] {
             assert!(

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -2012,7 +2012,13 @@ impl ExamineSummary {
         })
     }
 
-    pub fn render_text(&self) -> String {
+    /// Render the host summary, labelled with the command that produced it.
+    ///
+    /// `examine` and `diagnose` are superseded but still dispatched, and their
+    /// stdout is a contract that shipped scripts assert on by exact substring.
+    /// So each command names itself rather than sharing one hardcoded label.
+    #[must_use]
+    pub fn render_text(&self, command: &str) -> String {
         let legacy_paths = if self.legacy_rocm.paths.is_empty() {
             "<none>".to_owned()
         } else {
@@ -2034,7 +2040,8 @@ impl ExamineSummary {
             "false (this run's output is captured, so the CLI will not prompt)"
         };
         format!(
-            "rocm examine\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_version: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
+            "{}\n  os: {}\n  arch: {}\n  kernel: {}\n  distro: {}\n  cpu: {}\n  system_ram: {}\n  interactive_terminal: {}\n  default_engine: {}\n  detected_gfx_target: {}\n  compatible_therock_family: {}\n  detected_therock_family: {}\n  driver_policy: {}\n  driver_status: {}\n  driver_detail: {}\n  legacy_rocm_status: {}\n  legacy_rocm_paths: {}\n  legacy_rocm_version: {}\n  legacy_rocm_detail: {}\n  legacy_rocm_guidance: {}\n  wsl: {}\n  wsl_dxg_device: {}\n  wsl_dxcore: {}\n  wsl_librocdxg: {}\n  wsl_rocdxg_dids: {}\n  wsl_ldconfig_librocdxg: {}\n  wsl_global_rocminfo: {}\n  wsl_cargo: {}\n  wsl_detail: {}\n  managed_runtimes: {}\n  managed_services: {}\n  model_cache_entries: {}\n  config_dir: {}\n  data_dir: {}\n  cache_dir: {}\n",
+            command,
             self.os,
             self.arch,
             self.kernel.as_deref().unwrap_or("<unknown>"),
@@ -9450,7 +9457,7 @@ Class Name:                Display
             cache_dir: PathBuf::from("cache"),
         };
 
-        let rendered = summary.render_text();
+        let rendered = summary.render_text("rocm examine");
         assert!(rendered.contains("distro: Windows"));
         assert!(rendered.contains("cpu: AMD Ryzen"));
         assert!(rendered.contains("system_ram: 64 GiB"));
@@ -9507,14 +9514,14 @@ Class Name:                Display
             cache_dir: PathBuf::from("cache"),
         };
 
-        let interactive = summary.render_text();
+        let interactive = summary.render_text("rocm examine");
         assert!(
             interactive.contains("interactive_terminal: true (this run has a terminal"),
             "the true case must say it is about this run:\n{interactive}"
         );
 
         summary.interactive_terminal = false;
-        let captured = summary.render_text();
+        let captured = summary.render_text("rocm examine");
         assert!(
             captured.contains("interactive_terminal: false (this run's output is captured"),
             "the false case must explain why, not just report it:\n{captured}"
@@ -9560,7 +9567,7 @@ Class Name:                Display
             cache_dir: PathBuf::from("cache"),
         };
 
-        let rendered = summary.render_text();
+        let rendered = summary.render_text("rocm examine");
 
         assert!(rendered.contains(
             "legacy_rocm_guidance: legacy ROCm detected; install a managed TheRock runtime"

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -57,7 +57,7 @@ pub enum Focus {
     Setup,
     /// The serve-a-model wizard — the launcher's `Serve a model` row.
     Serve,
-    /// Read-only `rocm examine` environment check — the launcher's
+    /// Read-only `rocm doctor` environment check — the launcher's
     /// `Diagnose & fix` row. Auto-runs on open.
     Examine,
 }
@@ -1561,7 +1561,7 @@ fn focused_close_key_blocked(state: &AppState, focus: Option<Focus>, code: KeyCo
 }
 
 /// Open the single overlay a focused host should host, returning any initial
-/// job-bridge side effects to pump (Examine auto-runs `rocm examine` on open;
+/// job-bridge side effects to pump (Doctor auto-runs `rocm doctor` on open;
 /// Setup/Serve open their form and wait for input). Clears any other overlay
 /// first (mutually-exclusive invariant). Pure w.r.t. process I/O — the caller
 /// runs the returned effects through [`crate::jobs::run_effects`].
@@ -1990,7 +1990,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                         crate::jobs::run_effects(fx, &job_tx);
                     }
                     // The examine overlay, when open, owns all keys (read-only
-                    // `rocm examine` job through the job-bridge).
+                    // `rocm doctor` job through the job-bridge).
                     Some(Ok(CtEvent::Key(k))) if state.examine_manager.is_some() => {
                         let fx = crate::ui::examine_manager::on_key(
                             &mut state.examine_manager,
@@ -5137,7 +5137,7 @@ mod tests {
             rocm_dash_core::state::SideEffect::SpawnJob { cmd, args, .. } => {
                 assert!(cmd.contains("rocm"), "cmd resolves to the rocm exe: {cmd}");
                 assert!(
-                    args.iter().any(|a| a == "examine"),
+                    args.iter().any(|a| a == "doctor"),
                     "examine in args: {args:?}"
                 );
             }
@@ -5145,7 +5145,7 @@ mod tests {
         }
         assert_eq!(
             s.examine_manager.as_ref().unwrap().active_job.as_deref(),
-            Some("examine"),
+            Some("doctor"),
             "the auto-run wires the active job"
         );
     }
@@ -5167,7 +5167,7 @@ mod tests {
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect();
-        assert!(out.contains("Examine"), "overlay content present: {out:?}");
+        assert!(out.contains("Doctor"), "overlay content present: {out:?}");
         assert!(
             !out.contains("1–5"),
             "no dash tab-shell hint in focused mode"
@@ -5192,7 +5192,7 @@ mod tests {
         // Job terminal → first Esc dismisses the console back to the intro card;
         // the overlay is still open, so the gate stays shut.
         s.jobs.apply(rocm_dash_core::state::StateEvent::JobDone {
-            id: "examine".into(),
+            id: "doctor".into(),
             code: 0,
         });
         let _ = crate::ui::examine_manager::on_key(
@@ -5257,7 +5257,7 @@ mod tests {
 
         // Once the job is terminal, close keys are allowed again → normal exit.
         s.jobs.apply(rocm_dash_core::state::StateEvent::JobDone {
-            id: "examine".into(),
+            id: "doctor".into(),
             code: 0,
         });
         assert!(

--- a/crates/rocm-dash-tui/src/ui/examine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/examine_manager.rs
@@ -4,7 +4,7 @@
 
 //! Examine overlay (Phase 3 Wave 2).
 //!
-//! Runs `rocm examine` — a read-only environment check — through the job-bridge
+//! Runs `rocm doctor` — a read-only environment check — through the job-bridge
 //! and shows its streamed output in the shared job console. Read-only, so it
 //! needs no approval gate (the gate is for mutating actions only). This is the
 //! read-only-report archetype every diagnostic screen reuses.
@@ -26,7 +26,7 @@ use crate::ui::theme::Theme;
 /// Overlay state. `None` on `AppState` means the overlay is closed.
 #[derive(Debug, Clone, Default)]
 pub struct ExamineManagerState {
-    /// In-flight (or just-finished) `rocm examine` job id.
+    /// In-flight (or just-finished) `rocm doctor` job id.
     pub active_job: Option<String>,
 }
 
@@ -81,14 +81,14 @@ pub fn open_running(jobs: &mut State) -> (ExamineManagerState, Vec<SideEffect>) 
     (d, fx)
 }
 
-/// Spawn `rocm examine` (read-only). A stable id replaces any prior console.
+/// Spawn `rocm doctor` (read-only). A stable id replaces any prior console.
 fn run_examine(d: &mut ExamineManagerState, jobs: &mut State) -> Vec<SideEffect> {
     let cmd = resolve_exe();
-    let id = "examine".to_string();
+    let id = "doctor".to_string();
     let fx = jobs.apply(StateEvent::StartJob {
         id: id.clone(),
         cmd,
-        args: vec!["examine".to_string()],
+        args: vec!["doctor".to_string()],
     });
     // Examine uses a single stable id, so a no-op (a prior run still going)
     // means re-attach to that same console — intentional, unlike the
@@ -110,7 +110,7 @@ pub fn draw_examine_manager(
     let inner = panel::bento(
         f,
         area,
-        Some("Examine — environment check"),
+        Some("Doctor — environment check"),
         BoxRole::Primary,
         false,
         theme,
@@ -127,7 +127,7 @@ pub fn draw_examine_manager(
     f.render_widget(
         Paragraph::new(vec![
             Line::from(Span::styled(
-                "Checks this machine's GPU, ROCm install, engines, and folders.",
+                "Checks this machine's GPU, ROCm install, engines, and folders, and what looks wrong.",
                 Style::default().fg(theme.fg),
             )),
             Line::from(""),
@@ -137,7 +137,7 @@ pub fn draw_examine_manager(
             )),
             Line::from(""),
             Line::from(Span::styled(
-                "  [ Enter: run `rocm examine` ]  ",
+                "  [ Enter: run `rocm doctor` ]  ",
                 Style::default()
                     .bg(theme.accent)
                     .fg(theme.bg)
@@ -172,7 +172,7 @@ mod tests {
         let fx = on_key(&mut d, &mut jobs, key(KeyCode::Enter));
         assert_eq!(fx.len(), 1, "spawns one job, no approval step");
         assert!(matches!(fx[0], SideEffect::SpawnJob { .. }));
-        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("examine"));
+        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("doctor"));
     }
 
     #[test]
@@ -198,14 +198,14 @@ mod tests {
         let mut jobs = State::default();
         on_key(&mut d, &mut jobs, key(KeyCode::Enter)); // first run
         jobs.apply(StateEvent::JobDone {
-            id: "examine".into(),
+            id: "doctor".into(),
             code: 0,
         });
         // `r` on a terminal job re-runs (spawns again).
         let fx = on_key(&mut d, &mut jobs, key(KeyCode::Char('r')));
         assert_eq!(fx.len(), 1, "r re-runs after a terminal result");
         assert!(matches!(fx[0], SideEffect::SpawnJob { .. }));
-        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("examine"));
+        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("doctor"));
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
         let mut jobs = State::default();
         let fx = on_key(&mut d, &mut jobs, key(KeyCode::Char('r')));
         assert_eq!(fx.len(), 1);
-        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("examine"));
+        assert_eq!(d.as_ref().unwrap().active_job.as_deref(), Some("doctor"));
     }
 
     #[test]
@@ -231,7 +231,7 @@ mod tests {
         let mut jobs = State::default();
         on_key(&mut d, &mut jobs, key(KeyCode::Enter));
         jobs.apply(StateEvent::JobDone {
-            id: "examine".into(),
+            id: "doctor".into(),
             code: 0,
         });
         on_key(&mut d, &mut jobs, key(KeyCode::Esc));
@@ -257,7 +257,7 @@ mod tests {
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect();
-        assert!(out.contains("Examine"));
-        assert!(out.contains("rocm examine"));
+        assert!(out.contains("Doctor"));
+        assert!(out.contains("rocm doctor"));
     }
 }

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -58,7 +58,7 @@ Neither demo downloads a model or calls a cloud provider.
 
 `cli.tape` demonstrates:
 
-1. `rocm examine`
+1. `rocm doctor`
 2. `rocm engines list`
 3. `rocm model`
 4. `rocm services list`

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -96,13 +96,13 @@ Quiet UI rule:
 After setup, check the machine state:
 
 ```powershell
-rocm examine
+rocm doctor
 rocm runtimes list
 ```
 
 Expected result:
 
-- `rocm examine` shows a managed runtime.
+- `rocm doctor` shows a managed runtime.
 - `rocm runtimes list` shows the runtime key for the installed TheRock venv.
 - The active runtime is ready, or the output gives one clear next command.
 
@@ -114,7 +114,7 @@ This tests the command-line install path without using the TUI:
 rocm install sdk --channel release --format wheel --prefix .\.rocm-work\data\envs\default
 rocm runtimes list
 rocm runtimes activate <runtime_key>
-rocm examine
+rocm doctor
 ```
 
 Replace `<runtime_key>` with the exact key printed by `rocm runtimes list`.
@@ -132,7 +132,7 @@ Expected result:
 - Runtime validation uses TheRock's runtime/devel package roots and
   `rocm_sdk.find_libraries`; `rocm-sdk path --root` is expected after the
   pinned `rocm[libraries,devel]` install succeeds.
-- `rocm examine` reports the active runtime as ready.
+- `rocm doctor` reports the active runtime as ready.
 
 Developer-only deterministic override:
 

--- a/docs/tapes/cli.tape
+++ b/docs/tapes/cli.tape
@@ -14,7 +14,7 @@ Set Padding 20
 Set Theme "Catppuccin Mocha"
 Set TypingSpeed 35ms
 
-Type "rocm examine"
+Type "rocm doctor"
 Sleep 500ms
 Enter
 Sleep 4s

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -103,7 +103,7 @@ cargo test -p rocm --bin rocm permissions_
 ```
 
 Self-hosted GPU CI smoke is intentionally non-mutating. The MI300X job builds
-the workspace, runs `rocm examine`, then runs `detect` and `capabilities` for
+the workspace, runs `rocm doctor`, then runs `detect` and `capabilities` for
 all first-party engine adapters: Lemonade and vLLM.
 Live serving acceptance remains separate because it needs engine-specific
 runtime installs, model artifacts, and supported upstream GPU targets.
@@ -113,7 +113,7 @@ WSL live examine sanity after building with a Linux target directory:
 ```bash
 export CARGO_TARGET_DIR=/home/user/.cache/rocm-cli-target
 cargo build --workspace
-rocm examine
+rocm doctor
 ```
 
 Expected WSL fields when a managed TheRock runtime is registered and ROCDXG is
@@ -800,7 +800,7 @@ generated public-key PEM installer verification; verify first-install PATH setup
 (Windows persists the install folder to the user PATH and restores it afterward;
 Linux writes the shell profile); reinstall stale-manifest purge and config
 preservation; a Windows loopback-HTTP install; isolated installed-binary
-directory smoke checks (`rocm examine` must read only the isolated
+directory smoke checks (`rocm doctor` must read only the isolated
 config/data/cache, never the real user `.rocm` state); and full-purge uninstall.
 Each scenario generates its own local keys, package, and install root under a
 per-scenario temp directory, so they are independent and use generated local

--- a/docs/ux-guidelines.md
+++ b/docs/ux-guidelines.md
@@ -143,7 +143,7 @@ not append raw command reports to the transcript as the primary experience.
 Hidden compatibility aliases should follow the same navigability rules when
 typed, even when they are intentionally left out of completions and help.
 
-Current navigable surfaces include `/home`, `/examine`, `/setup`, `/permissions`,
+Current navigable surfaces include `/home`, `/doctor`, `/setup`, `/permissions`,
 `/runtimes`, `/engine`, `/model`, `/plan`, `/config`, `/automations`,
 `/reviews`, `/approve`, `/reject`, `/edit`, `/install`, `/services`, `/logs`,
 `/gpu`, `/update`, `/daemon`, `/chat`, `/provider`, `/uninstall`, `/comfyui`,

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -126,7 +126,7 @@ and apply that environment before launching HIP apps such as Lemonade's bundled
 
 ## Examine And Install UX Recommendations
 
-`rocm examine` should detect WSL cheaply and report:
+`rocm doctor` should detect WSL cheaply and report:
 
 - `wsl: true`
 - WSL distro/version

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -1145,7 +1145,7 @@ fn ensure_best_llamacpp_backend(
             "Lemonade reports no supported GPU llama.cpp backend for this host (status: {}). \
              The GPU-required policy does not fall back to CPU; install a ROCm or Vulkan \
              backend (e.g. `rocm engines install lemonade`) or verify the GPU driver with \
-             `rocm examine`.",
+             `rocm doctor`.",
             describe_llamacpp_backends(&backends)
         );
     };
@@ -3289,7 +3289,7 @@ fn resolve_gpu_indices_against(requested: &[u32], usable: Option<Vec<u32>>) -> R
         bail!(
             "no usable AMD GPU detected; `rocm serve` requires a GPU under the default \
              GPU-required policy and does not fall back to CPU. Check the driver with \
-             `rocm examine`, confirm /dev/kfd is present, and ensure HIP_VISIBLE_DEVICES / \
+             `rocm doctor`, confirm /dev/kfd is present, and ensure HIP_VISIBLE_DEVICES / \
              ROCR_VISIBLE_DEVICES are not masking every device."
         );
     }

--- a/engines/vllm/src/lib.rs
+++ b/engines/vllm/src/lib.rs
@@ -1107,7 +1107,7 @@ fn resolve_gpu_indices_against(requested: &[u32], usable: Option<Vec<u32>>) -> R
     if usable.is_empty() {
         bail!(
             "no usable AMD GPU detected; vLLM requires ROCm GPU execution and does not fall back \
-             to CPU. Check the driver with `rocm examine` and ensure HIP_VISIBLE_DEVICES / \
+             to CPU. Check the driver with `rocm doctor` and ensure HIP_VISIBLE_DEVICES / \
              ROCR_VISIBLE_DEVICES are not masking every device."
         );
     }

--- a/install.ps1
+++ b/install.ps1
@@ -721,7 +721,7 @@ try {
 
     Write-Host "run:"
     if (Test-PathInList $env:Path $InstallDir) {
-        Write-Host "  rocm examine"
+        Write-Host "  rocm doctor"
     } else {
         $rocmExe = Join-Path $InstallDir "rocm.exe"
         Write-Host "  & `"$rocmExe`" examine"

--- a/install.sh
+++ b/install.sh
@@ -468,13 +468,13 @@ case ":${PATH}:" in
     ;;
   *)
     echo "note: rocm is installed but this shell could not update PATH"
-    echo "  run: ${INSTALL_DIR}/rocm examine"
+    echo "  run: ${INSTALL_DIR}/rocm doctor"
     ;;
 esac
 
 echo "next:"
 if [ "${UPDATE_SHELL_PATH}" = "1" ]; then
-  echo "  open a new terminal, then run: rocm examine"
+  echo "  open a new terminal, then run: rocm doctor"
 else
-  echo "  ${INSTALL_DIR}/rocm examine"
+  echo "  ${INSTALL_DIR}/rocm doctor"
 fi

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -31,6 +31,8 @@ tests/e2e-cucumber/
 │
 ├── features/                     # .feature files — one per feature area
 │   ├── chat.feature
+│   ├── diagnose.feature
+│   ├── doctor.feature
 │   ├── examine.feature
 │   ├── model_serving.feature
 │   └── runtime_setup.feature
@@ -39,6 +41,7 @@ tests/e2e-cucumber/
 │   ├── e2e.rs                    # World struct, runner, expectation reconciliation, Drop cleanup
 │   └── e2e/                      # step functions — one file per feature area
 │       ├── chat_steps.rs
+│       ├── doctor_steps.rs
 │       ├── examine_steps.rs
 │       ├── runtime_steps.rs
 │       └── serving_steps.rs

--- a/tests/e2e-cucumber/features/doctor.feature
+++ b/tests/e2e-cucumber/features/doctor.feature
@@ -1,0 +1,78 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+Feature: Checking whether this machine is healthy
+
+  # One read-only command reports what the machine has and what the CLI makes of
+  # it. It supersedes the two commands that used to split that job in half, and
+  # which asked the machine the same questions twice to do it.
+  #
+  # Every scenario here is black-box and GPU-independent (no serve, no download,
+  # no mutation), so they all run on the mock lane / per-PR tier. They assert the
+  # SHAPE of a report rather than any specific finding: what the catalog matches
+  # is environment-dependent, and is covered by diagnose.feature.
+
+  @id:doctor-reports-state-and-findings
+  Scenario: 1 - One command reports both what was found and what looks wrong
+    When the user asks the CLI to check this machine
+    Then the CLI reports what hardware and ROCm setup it found
+    And the CLI reports what it makes of them
+
+  @id:doctor-changes-nothing
+  Scenario: 2 - Checking the machine never changes it
+    When the user asks the CLI to check this machine
+    Then nothing on the machine is changed
+
+  # The sharp version of scenario 2. The host report has one write on it: an
+  # install that is present on disk but missing from the CLI's own records gets
+  # silently re-recorded. That is a repair, and a command that promises to change
+  # nothing must not do it. The second half is the control — it proves the setup
+  # really would have been repaired, so the first half cannot pass vacuously.
+  @id:doctor-does-not-repair-records
+  Scenario: 3 - Checking does not repair what the superseded inspection repairs
+    Given a machine with a ROCm install missing from the CLI's records
+    When the user asks the CLI to check this machine
+    Then the install is still missing from the records
+    When a script runs the superseded host inspection
+    Then the install has been added to the records
+
+  # The two superseded commands are hidden, not removed. Scripts, the packaged
+  # daemon, and the suite's own capability probe still call them, so "hidden"
+  # must not have quietly become "broken".
+  @id:doctor-supersedes-older-commands
+  Scenario: 4 - Scripts written against the older inspection commands keep working
+    Given a script written against an earlier release
+    When it runs the superseded inspection commands
+    Then each one still reports what it always did
+
+  @id:doctor-is-the-only-advertised-check
+  Scenario: 5 - Only one health check is advertised
+    When the user asks the CLI what it can do
+    Then a single health check is offered
+    And the superseded inspection commands are not advertised
+
+  # The whole point of being able to hand a captured report back in: a machine
+  # that cannot be reached interactively can still be reasoned about, and the
+  # expensive inspection is not repeated to do it.
+  @id:doctor-checks-a-saved-report
+  Scenario: 6 - A report captured earlier can be checked without inspecting the machine again
+    Given a report captured from an earlier check
+    When the user asks the CLI to check that saved report
+    Then the CLI reports what it makes of the saved report
+    And the CLI does not describe this machine
+
+  @id:doctor-checks-a-saved-report-from-stdin
+  Scenario: 7 - A saved report can be handed over on the standard input
+    Given a report captured from an earlier check
+    When the user pipes that saved report into the CLI
+    Then the CLI reports what it makes of the saved report
+
+  # The machine-readable report is a superset of the one the superseded command
+  # emitted, so tooling written against that document keeps reading every key it
+  # already relied on and simply gains the findings.
+  @id:doctor-json-is-a-superset
+  Scenario: 8 - The machine-readable report still carries everything it used to
+    When the user asks for both machine-readable reports
+    Then the newer report carries every fact the superseded one did
+    And the newer report also carries the findings

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -19,6 +19,7 @@ mod e2e {
     pub mod chat_steps;
     pub mod dash_steps;
     pub mod diagnose_steps;
+    pub mod doctor_steps;
     pub mod engines_steps;
     pub mod examine_steps;
     pub mod lifecycle_steps;

--- a/tests/e2e-cucumber/tests/e2e/doctor_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/doctor_steps.rs
@@ -1,0 +1,365 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+use cucumber::{given, then, when};
+
+use crate::E2eWorld;
+
+/// The first line of the host report. Present on every platform the CLI runs
+/// on, so it is a safe marker for "this output describes a machine" without
+/// pinning any hardware-dependent detail.
+const HOST_REPORT_MARKER: &str = "ROCm setup check";
+
+/// Where the captured report is written inside the scenario's isolated root.
+fn saved_report_path(world: &E2eWorld) -> std::path::PathBuf {
+    world
+        .isolated_root
+        .as_ref()
+        .expect("scenario has no isolated root")
+        .path()
+        .join("captured-report.json")
+}
+
+/// Root of the scenario's isolated tree.
+fn root(world: &E2eWorld) -> std::path::PathBuf {
+    world
+        .isolated_root
+        .as_ref()
+        .expect("scenario has no isolated root")
+        .path()
+        .to_path_buf()
+}
+
+/// The runtime key planted by the "missing from the records" fixture.
+const PLANTED_RUNTIME_KEY: &str = "e2e-doctor-readonly";
+
+/// Where the CLI records a runtime once it knows about it.
+fn registry_entry(world: &E2eWorld) -> std::path::PathBuf {
+    root(world)
+        .join("data")
+        .join("runtimes")
+        .join("registry")
+        .join(format!("{PLANTED_RUNTIME_KEY}.json"))
+}
+
+/// Whether the output carries a findings section.
+///
+/// The catalog renders one of three ways depending on the host: a scored match
+/// (`#1 [HIGH score=90/100] ...`), no known match, or out of scope for the
+/// platform. All three are a verdict; which one appears is environment-
+/// dependent, so the scenarios assert that a verdict was reached at all.
+///
+/// Matched without the command's own name, because each command labels the
+/// section with itself — `rocm doctor:` or `rocm diagnose:` — and this helper is
+/// used against both.
+fn has_findings(output: &str) -> bool {
+    output.contains("score=")
+        || output.contains(": out of scope for this platform.")
+        || output.contains(": no known misconfiguration matched.")
+}
+
+// ── Given ──────────────────────────────────────────────────────────
+
+#[given("a script written against an earlier release")]
+async fn script_against_earlier_release(_world: &mut E2eWorld) {
+    // Nothing to arrange: the point is that the old command names still work
+    // with no migration step on the caller's side.
+}
+
+#[given("a report captured from an earlier check")]
+async fn report_captured_earlier(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["doctor", "--json"]);
+    assert_eq!(rc, 0, "capturing a report should exit 0:\n{stderr}");
+    let path = saved_report_path(world);
+    std::fs::write(&path, &stdout).expect("failed to write the captured report");
+    world.model_name = Some(path.display().to_string());
+}
+
+#[given("a machine with a ROCm install missing from the CLI's records")]
+async fn install_missing_from_records(world: &mut E2eWorld) {
+    // An install that is real on disk (a payload file plus its own manifest) and
+    // configured as the setup runtime, but absent from the CLI's registry. That
+    // is exactly the state the host report used to silently repair.
+    let install_root = root(world).join("setup-install");
+    std::fs::create_dir_all(&install_root).expect("failed to create the install root");
+    std::fs::write(install_root.join("payload.txt"), "payload\n").expect("failed to write payload");
+    let manifest = serde_json::json!({
+        "runtime_key": PLANTED_RUNTIME_KEY,
+        "runtime_id": "e2e-doctor-readonly-id",
+        "channel": "release",
+        "format": "tarball",
+        "family": "gfx110X",
+        "family_source": "e2e",
+        "version": "0.0.0-e2e",
+        "install_root": install_root,
+        "selected_artifact_url": "https://example.invalid/e2e.tar.gz",
+        "installed_at_unix_ms": 0,
+    });
+    std::fs::write(
+        install_root.join(".rocm-cli-runtime.json"),
+        serde_json::to_vec_pretty(&manifest).expect("failed to encode the runtime manifest"),
+    )
+    .expect("failed to plant the runtime manifest");
+
+    let config_dir = root(world).join("config");
+    std::fs::create_dir_all(&config_dir).expect("failed to create the config dir");
+    let config = serde_json::json!({ "setup": { "therock_venv": install_root } });
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::to_vec_pretty(&config).expect("failed to encode the config"),
+    )
+    .expect("failed to plant the config");
+
+    assert!(
+        !registry_entry(world).exists(),
+        "the fixture must start with the install absent from the records"
+    );
+}
+
+// ── When ───────────────────────────────────────────────────────────
+
+#[when("the user asks the CLI to check this machine")]
+async fn user_checks_machine(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["doctor"]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[when("it runs the superseded inspection commands")]
+async fn run_superseded_commands(world: &mut E2eWorld) {
+    let (host, _, host_rc) = crate::run_rocm(world, &["examine"]);
+    let (findings, _, findings_rc) = crate::run_rocm(world, &["diagnose"]);
+    // Both halves are stashed together so the assertion can check each kept its
+    // own shape — the risk being that hiding a command silently reroutes it to
+    // the other one's output.
+    world.cli_output = Some(format!("--- host ---\n{host}--- findings ---\n{findings}"));
+    world.cli_rc = Some(host_rc.max(findings_rc));
+}
+
+#[when("the user asks the CLI what it can do")]
+async fn user_lists_commands(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["--help"]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[when("the user asks the CLI to check that saved report")]
+async fn user_checks_saved_report(world: &mut E2eWorld) {
+    let path = world.model_name.clone().expect("no saved report path");
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["doctor", "--from-examination", &path]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[when("a script runs the superseded host inspection")]
+async fn run_superseded_host_inspection(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["examine"]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[when("the user pipes that saved report into the CLI")]
+async fn user_pipes_saved_report(world: &mut E2eWorld) {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let path = world.model_name.clone().expect("no saved report path");
+    let report = std::fs::read(&path).expect("failed to read the captured report");
+    let mut cmd = std::process::Command::new(crate::rocm_binary());
+    cmd.args(["doctor", "--from-examination", "-"]);
+    world.isolate_cmd(&mut cmd);
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn the CLI");
+    child
+        .stdin
+        .take()
+        .expect("no stdin on the spawned CLI")
+        .write_all(&report)
+        .expect("failed to pipe the report in");
+    let out = child.wait_with_output().expect("the CLI did not finish");
+    world.cli_output = Some(String::from_utf8_lossy(&out.stdout).to_string());
+    world.cli_stderr = Some(String::from_utf8_lossy(&out.stderr).to_string());
+    world.cli_rc = Some(out.status.code().unwrap_or(-1));
+}
+
+#[when("the user asks for both machine-readable reports")]
+async fn user_asks_for_both_json_reports(world: &mut E2eWorld) {
+    let (newer, stderr, rc) = crate::run_rocm(world, &["doctor", "--json"]);
+    assert_eq!(rc, 0, "the newer report should exit 0:\n{stderr}");
+    let (superseded, stderr, rc) = crate::run_rocm(world, &["examine", "--json"]);
+    assert_eq!(rc, 0, "the superseded report should exit 0:\n{stderr}");
+    world.cli_output = Some(newer);
+    world.cli_stderr = Some(superseded);
+    world.cli_rc = Some(0);
+}
+
+// ── Then ───────────────────────────────────────────────────────────
+
+#[then("the CLI reports what hardware and ROCm setup it found")]
+async fn assert_reports_host_state(world: &mut E2eWorld) {
+    assert_eq!(
+        world.cli_rc,
+        Some(0),
+        "a health check should exit 0 (it reports whether it RAN, not what it found)"
+    );
+    let output = world.cli_output.as_ref().expect("no output");
+    assert!(
+        output.contains(HOST_REPORT_MARKER),
+        "expected the host report:\n{output}"
+    );
+}
+
+#[then("the CLI reports what it makes of them")]
+async fn assert_reports_findings(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no output");
+    // Reporting state without a verdict is what the two old commands did between
+    // them; the whole point of one command is that both arrive together.
+    assert!(
+        has_findings(output),
+        "expected a findings section alongside the host report:\n{output}"
+    );
+}
+
+#[then("each one still reports what it always did")]
+async fn assert_superseded_still_work(world: &mut E2eWorld) {
+    assert_eq!(world.cli_rc, Some(0), "both should still exit 0");
+    let output = world.cli_output.as_ref().expect("no output");
+    let (host, findings) = output
+        .split_once("--- findings ---")
+        .expect("both halves should have been captured");
+    assert!(
+        host.contains(HOST_REPORT_MARKER),
+        "the host inspection lost its report:\n{host}"
+    );
+    assert!(
+        has_findings(findings),
+        "the diagnosis lost its findings:\n{findings}"
+    );
+    // Each kept its own scope: the diagnosis must not have started printing the
+    // host report too, which is what a careless alias to the merged command
+    // would do.
+    assert!(
+        !findings.contains(HOST_REPORT_MARKER),
+        "the diagnosis should not have gained the host report:\n{findings}"
+    );
+}
+
+#[then("a single health check is offered")]
+async fn assert_one_health_check_offered(world: &mut E2eWorld) {
+    assert_eq!(world.cli_rc, Some(0), "--help should exit 0");
+    let output = world.cli_output.as_ref().expect("no help output");
+    assert!(
+        output.contains("doctor"),
+        "expected the health check to be listed:\n{output}"
+    );
+}
+
+#[then("the superseded inspection commands are not advertised")]
+async fn assert_superseded_not_advertised(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no help output");
+    for superseded in ["examine", "diagnose"] {
+        assert!(
+            !output.contains(superseded),
+            "`{superseded}` is still advertised in the command list:\n{output}"
+        );
+    }
+}
+
+#[then("the CLI reports what it makes of the saved report")]
+async fn assert_saved_report_findings(world: &mut E2eWorld) {
+    assert_eq!(
+        world.cli_rc,
+        Some(0),
+        "checking a saved report should exit 0:\n{:?}",
+        world.cli_stderr
+    );
+    let output = world.cli_output.as_ref().expect("no output");
+    assert!(
+        has_findings(output),
+        "expected findings for the saved report:\n{output}"
+    );
+}
+
+#[then("the CLI does not describe this machine")]
+async fn assert_saved_report_omits_local_host(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no output");
+    // A saved report may have come from another machine entirely. Printing this
+    // machine's inventory next to someone else's findings would read as one
+    // coherent picture of a single host, and it would not be one.
+    assert!(
+        !output.contains(HOST_REPORT_MARKER),
+        "a saved report must not be mixed with this machine's inventory:\n{output}"
+    );
+}
+
+#[then("the install is still missing from the records")]
+async fn assert_install_still_missing(world: &mut E2eWorld) {
+    assert_eq!(
+        world.cli_rc,
+        Some(0),
+        "the health check should still succeed:\n{:?}",
+        world.cli_stderr
+    );
+    assert!(
+        !registry_entry(world).exists(),
+        "the health check wrote {} — it promises to change nothing",
+        registry_entry(world).display()
+    );
+}
+
+#[then("the install has been added to the records")]
+async fn assert_install_now_recorded(world: &mut E2eWorld) {
+    // The control for the assertion above: if this fails, the fixture never put
+    // the machine in a repairable state and the read-only claim went unproven.
+    assert!(
+        registry_entry(world).exists(),
+        "the fixture is inert — the superseded inspection did not record {} either",
+        registry_entry(world).display()
+    );
+}
+
+#[then("the newer report carries every fact the superseded one did")]
+async fn assert_json_superset(world: &mut E2eWorld) {
+    let newer: serde_json::Value =
+        serde_json::from_str(world.cli_output.as_ref().expect("no newer report"))
+            .expect("the newer report is not valid JSON");
+    let superseded: serde_json::Value =
+        serde_json::from_str(world.cli_stderr.as_ref().expect("no superseded report"))
+            .expect("the superseded report is not valid JSON");
+    let newer = newer
+        .as_object()
+        .expect("the newer report is not an object");
+    let superseded = superseded
+        .as_object()
+        .expect("the superseded report is not an object");
+    // Keys only: the values describe a live machine and some of them (timings,
+    // probe ordering) legitimately differ between two consecutive runs.
+    let missing: Vec<&String> = superseded
+        .keys()
+        .filter(|key| !newer.contains_key(*key))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "the newer report dropped keys tooling already relies on: {missing:?}"
+    );
+}
+
+#[then("the newer report also carries the findings")]
+async fn assert_json_has_findings(world: &mut E2eWorld) {
+    let newer: serde_json::Value =
+        serde_json::from_str(world.cli_output.as_ref().expect("no newer report"))
+            .expect("the newer report is not valid JSON");
+    assert!(
+        newer.get("findings").is_some(),
+        "the newer report carries no findings section"
+    );
+}


### PR DESCRIPTION
## Summary

`rocm examine` and `rocm diagnose` both read as "check my machine", and split one job in half. The overlap was structural, not cosmetic:

- **The host probe ran twice.** `diagnose` re-ran the same probe `examine --json` had just run, framework interpreter start included, with no way to hand one command's output to the other.
- **The WSL2 route-out verdict was written twice**, in two independently-authored wordings that had already drifted, with the same doc URL duplicated in both files.
- A stale comment cited an `exit_code()` that no longer exists.

This adds **`rocm doctor`**: one read-only pass that reports what the machine has *and* what the catalog makes of it.

- `--from-examination <path|->` diagnoses a report captured earlier without inspecting the machine again. Since that report may describe a different host, it prints findings only rather than mixing in local inventory.
- `doctor --json` is a strict superset of `examine --json` — same keys in the same places, plus `findings`.
- `examine` and `diagnose` are hidden but still dispatch, output unchanged, so scripts, the packaged daemon, and the suite's own capability probe keep working.

The dash already advertised `rocm doctor`, routed `/doctor`, and registered a `doctor` LLM tool. The CLI was the only layer that did not — this closes that gap rather than opening a new name.

### Non-obvious decisions

**Read-only is enforced, not asserted.** The host report carried one write: re-registering a setup runtime that is present on disk but missing from the registry. That is a repair, and a command whose help says it changes nothing must not do it. The write is now opt-in — `examine` still repairs, `doctor` declines. The visible cost: for that user, `doctor` reports the install as unregistered instead of silently fixing it.

**Hidden, not deleted.** This decouples the user-facing consolidation from migrating ~30 internal call sites, and keeps existing scripts working. Migrating `rocmd` and the e2e capability probe is mechanical follow-up.

**`examine` and `diagnose` output is byte-identical to before, with exactly one deliberate exception**: the WSL2 note, which is the de-duplication this change exists to do. Verified by diffing both commands against a build of `main`. Nothing in the repo asserts on that text.

### Out of scope

WSL2 catalog dispatch, splitting the CLI's own inventory out as `rocm status`, and folding the coarse five-bucket status into the catalog. Each is a follow-up.

## Test plan

- `cargo test --workspace --all-targets` — green. Two tests flake on this host (`therock::extracting_the_sdk_archive_removes_it`, a pre-existing race where tests mutate the process-global `PATH` and a concurrent test spawning `tar` dies; and a provider test needing a live local service). Both confirmed flaking on unmodified `main`.
- `cargo clippy --workspace --all-targets` — 0 warnings.
- `python3 scripts/smoke_local.py` — passes.
- E2E: 50 scenarios, 0 unexpected failures, 3 pre-existing xfail. New `doctor.feature` covers 8 scenarios including a planted repairable install that asserts `doctor` leaves the registry untouched *and* that `examine` writes it — the second half is a control, so the read-only claim cannot pass vacuously.
- Manual on a WSL2 host without GPU paravirtualisation: `doctor`, `doctor --json`, both `--from-examination` forms, and byte-diffs of `examine`/`diagnose` against `main`.

Not verifiable here: `@requires-gpu` / `@requires-bare-metal` scenarios need the amd-gpu lane.

**Risk: low.** Additive command; superseded commands keep working with unchanged output; the one behaviour change (no repair write under `doctor`) is deliberate and covered.

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — Not a bug fix; no rows touched. The E2E reconciliation reports `0 stale`, confirming none became obsolete.