### PR TITLE
fix(core): retry an HTTP response read interrupted by a signal

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1049,6 +1049,14 @@ fn read_http_response_bounded(stream: &mut TcpStream, deadline: Instant) -> Resu
             {
                 bail!("timed out reading HTTP response");
             }
+            // A signal delivered to this thread aborts the read with `EINTR`.
+            // `SA_RESTART` does not save us: Linux never restarts a socket read
+            // that has a receive timeout set, and this loop sets one on every
+            // pass (see signal(7), "Interruption of system calls"). Any handler
+            // in the process is enough — `crossterm`'s `SIGWINCH` hook is linked
+            // into the CLI. Nothing is wrong with the connection, so read again;
+            // `deadline` still bounds the total wait.
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
             Err(error) => return Err(error).context("failed to read TCP stream"),
         }
     }
@@ -8443,6 +8451,104 @@ mod tests {
         );
 
         let _ = server.join();
+        Ok(())
+    }
+
+    /// A signal arriving mid-response must not fail the request.
+    ///
+    /// A signal delivered while the client is parked in `read` aborts it with
+    /// `EINTR`. `SA_RESTART` does not save us: Linux never restarts a socket read
+    /// that has a receive timeout set, and this client sets one on every pass.
+    /// Any handler in the process is enough to trigger it — `crossterm`'s
+    /// `SIGWINCH` hook is linked into the CLI — so treating `EINTR` as a
+    /// transport error turned an unrelated signal into a spurious "endpoint
+    /// unreachable".
+    ///
+    /// Linux-only on purpose. The guarantee being exercised — a receive timeout
+    /// defeats `SA_RESTART` — is documented for Linux; BSD-derived kernels may
+    /// restart the read instead, which would leave this passing without ever
+    /// reaching the retry. CI has no macOS runner to tell the difference.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn http_read_survives_a_signal_arriving_mid_response() -> Result<()> {
+        extern "C" fn noop_handler(_signal: libc::c_int) {}
+
+        let body = r#"{"data":[{"id":"qwen"}]}"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let server = std::thread::spawn(move || -> Result<()> {
+            let (mut stream, _) = listener.accept()?;
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            // Answer late, so the client is blocked in `read` while the signals
+            // land rather than racing them.
+            std::thread::sleep(Duration::from_millis(400));
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            )?;
+            stream.flush()?;
+            Ok(())
+        });
+
+        // Install the handler with SA_RESTART set, to show that the flag is not
+        // what protects this read.
+        //
+        // The handler is left installed rather than restored: the default
+        // disposition for SIGUSR1 is to kill the process, so putting it back
+        // would let a signal still in flight take the whole test binary down.
+        // Leaving a no-op handler is inert — nothing else here raises SIGUSR1,
+        // and the signals below are aimed at this thread alone, so no other
+        // test sharing this process can observe either one.
+        #[allow(unsafe_code)] // libc FFI
+        unsafe {
+            let mut action: libc::sigaction = std::mem::zeroed();
+            action.sa_sigaction = noop_handler as *const () as libc::sighandler_t;
+            action.sa_flags = libc::SA_RESTART;
+            libc::sigemptyset(&raw mut action.sa_mask);
+            assert_eq!(
+                libc::sigaction(libc::SIGUSR1, &raw const action, std::ptr::null_mut()),
+                0,
+                "failed to install the SIGUSR1 handler"
+            );
+        }
+
+        // Target this thread specifically: a process-directed signal could land
+        // on any thread and disturb an unrelated test sharing this process.
+        #[allow(unsafe_code)] // libc FFI
+        let reader = unsafe { libc::pthread_self() };
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let signaller = {
+            let stop = std::sync::Arc::clone(&stop);
+            std::thread::spawn(move || {
+                // Let the connect and the request write finish first; only the
+                // response read is under test.
+                std::thread::sleep(Duration::from_millis(50));
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    #[allow(unsafe_code)] // libc FFI
+                    unsafe {
+                        libc::pthread_kill(reader, libc::SIGUSR1);
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            })
+        };
+
+        let endpoint = format!("http://127.0.0.1:{port}/v1");
+        let response =
+            http_get_text_with_auth(&endpoint, "/v1/models", None, Duration::from_secs(5));
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        signaller.join().expect("signaller thread should not panic");
+        server.join().expect("server thread should not panic")?;
+
+        assert_eq!(
+            response?, body,
+            "an interrupted read is retryable, not a failed request"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No matching rows.)

## Summary

- Treat `EINTR` as retryable in the bounded HTTP response reader instead of failing the request.
- Why: a signal delivered to the reading thread makes an otherwise healthy endpoint report as unreachable. A managed service health probe can fail for no reason, and because a failed inference probe is latched onto the service record for the 15s retry interval, one interrupted read also makes every later readiness check in that window report the service as not ready.
- Risk: low. One added match arm on an error kind that previously aborted the read; the existing deadline still bounds the total wait, so a signal storm cannot spin forever.

## Root cause

`read_http_response_bounded` handled `WouldBlock` and `TimedOut` and treated every other `read` error as a transport failure. A signal delivered while the client is parked in `read` fails it with `EINTR`, which fell into that catch-all.

`SA_RESTART` does not prevent it. Linux never restarts a socket read that has a receive timeout set (`signal(7)`, "Interruption of system calls"), and this reader sets one on every pass so the total wait stays bounded. Any signal handler in the process is enough to trigger it, and `crossterm`'s `SIGWINCH` hook is linked into the CLI.

`EINTR` says nothing is wrong with the connection, so the read should simply be retried — which is what `std`'s own `read_to_end` does, and why the sibling `read_tcp_stream_to_string` helper was never affected.

## Verification

Found by instrumenting the client while reproducing a flaky test:

```
listing ERROR http://127.0.0.1:34091/v1 -> failed to read TCP stream
Caused by: Interrupted system call (os error 4)
```

Server-side timing showed 42ms from accept to read, ruling out a slow peer or a starved thread.

The regression test drives real signals at the reading thread with `pthread_kill` while it waits on a deliberately late response, with the handler installed using `SA_RESTART` to show the flag is not what protects the read. It fails without the fix, with the same "Broken pipe" symptom the original flake produced (the client aborts, so the server's write hits `EPIPE`).

In the test suite this surfaced as `providers::tests::local_provider_default_chat_requires_builtin_qwen_assistant` failing three different ways — `Broken pipe`, `no_ready_local_service`, and `no_ready_builtin_assistant_service`, all explained by that one aborted read. Over 20 consecutive `cargo test -p rocm --bin rocm` runs:

| | before | after |
| --- | --- | --- |
| failures | 3/20 | 0/20 |

Also run: `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings`, `cargo test --workspace --all-targets --exclude e2e-cucumber`, `prek run --all-files`.

## Scope and gaps

- **No Gherkin scenario.** The behaviour is user-observable in principle (a probe no longer fails at random), but it needs a signal to land inside a specific syscall window, which a scenario cannot trigger deterministically. Covered by the unit test instead; flagging the gap rather than leaving it implied.
- **The regression test is Linux-only.** The guarantee it exercises — a receive timeout defeating `SA_RESTART` — is documented for Linux; BSD-derived kernels may restart the read, which would leave the test passing without reaching the retry. CI has no macOS runner to tell the difference. The fix itself is unconditional.
- **Not fixed here:** `read_close_delimited_sse_body` in `apps/rocm/src/providers.rs` has the same gap on the chat-streaming path. Same class of bug, but I have no reproduction for it, so it is not folded into a fix whose repro I can demonstrate. Happy to follow up.