### PR TITLE
fix: raise the supported Linux minimum to Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,21 @@ Lemonade and vLLM.
 
 | Platform | Prebuilt binary | Notes |
 |---|---|---|
-| Linux (x86_64) | Yes | Full support, including the live dashboard and both inference engines |
+| Linux (x86_64) | Yes | Ubuntu 24.04 or newer; full support, including the live dashboard and both inference engines |
 | Windows (x86_64) | Yes | CLI and Lemonade serving; no live dashboard or vLLM |
-| WSL2 (x86_64) | Yes (Linux binary) | Full support, including the live dashboard; see [docs/wsl.md](docs/wsl.md) for setup |
+| WSL2 (x86_64) | Yes (Linux binary) | Ubuntu 24.04 or newer; full support, including the live dashboard; see [docs/wsl.md](docs/wsl.md) for setup |
 | macOS | No | No official installer, release, CI, or QA coverage |
 
 Live dashboard telemetry requires Linux or WSL2 (see
 [Interactive interfaces](#interactive-interfaces)). vLLM serving is Linux/WSL2
 only (see [docs/vllm.md](docs/vllm.md)).
+
+The minimum supported Linux release, native or under WSL2, is Ubuntu 24.04. On
+other distributions the equivalent requirement is glibc 2.38 with
+`GLIBCXX_3.4.32`: that is what the Lemonade engine is linked against, and every
+published build of it needs those versions, so there is no older release to fall
+back to. Ubuntu 22.04 ships glibc 2.35 and cannot run it; Ubuntu 24.04 provides
+glibc 2.39 and `GLIBCXX_3.4.33`.
 
 > [!IMPORTANT]
 > **Tech Preview** -- This software is provided as-is, without warranty or

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -14,7 +14,10 @@ virtual environments and ROCDXG (`librocdxg`).
 The AMD WSL path is:
 
 1. Windows 11 with the AMD Adrenalin WSL-capable driver.
-2. WSL2 with Ubuntu 24.04 or Ubuntu 22.04.
+2. WSL2 with Ubuntu 24.04 or newer. Ubuntu 22.04 is not supported: it ships
+   glibc 2.35, below the glibc 2.38 / `GLIBCXX_3.4.32` floor that every
+   published Lemonade embeddable requires, so the Lemonade engine cannot start
+   there. Ubuntu 24.04 provides glibc 2.39 and `GLIBCXX_3.4.33`.
 3. ROCDXG (`librocdxg`) installed inside WSL.
 4. A TheRock runtime installed by `rocm-cli` into a managed Python venv.
 

--- a/scripts/wsl_preflight.py
+++ b/scripts/wsl_preflight.py
@@ -258,8 +258,10 @@ def evaluate(
     sdk_headers = state.get("windows_sdk_headers") or []
 
     version_id = str(os_release.get("VERSION_ID") or "")
+    # 22.04 is deliberately absent: its glibc 2.35 is below the glibc 2.38 /
+    # GLIBCXX_3.4.32 floor every published Lemonade embeddable is linked
+    # against, so the Lemonade engine cannot start on it. See docs/wsl.md.
     supported_ubuntu = os_release.get("ID") == "ubuntu" and version_id in {
-        "22.04",
         "24.04",
         "26.04",
     }
@@ -270,7 +272,9 @@ def evaluate(
     checks = [
         Check("wsl", bool(state.get("is_wsl")), "WSL marker or /dev/dxg detected"),
         Check(
-            "ubuntu", supported_ubuntu, f"Ubuntu VERSION_ID={version_id or '<unknown>'}"
+            "ubuntu",
+            supported_ubuntu,
+            f"Ubuntu 24.04 or newer (VERSION_ID={version_id or '<unknown>'})",
         ),
         Check("dxg_device", bool(paths.get("/dev/dxg")), "/dev/dxg"),
         Check(
@@ -390,6 +394,14 @@ def self_test() -> None:
     ready_state["ldconfig"]["librocdxg"] = True
     checks = evaluate(ready_state, require_rocm_tools=False)
     assert all(check.ok for check in checks if check.required), checks
+
+    # 22.04 is below the Lemonade glibc floor, so an otherwise perfect host
+    # must still fail the ubuntu check rather than report itself ready.
+    jammy_state = json.loads(json.dumps(ready_state))
+    jammy_state["os_release"]["VERSION_ID"] = "22.04"
+    checks = evaluate(jammy_state, require_rocm_tools=False)
+    assert any(check.name == "ubuntu" and not check.ok for check in checks), checks
+    assert not all(check.ok for check in checks if check.required), checks
 
 
 def main() -> int:

--- a/scripts/wsl_preflight.py
+++ b/scripts/wsl_preflight.py
@@ -258,13 +258,20 @@ def evaluate(
     sdk_headers = state.get("windows_sdk_headers") or []
 
     version_id = str(os_release.get("VERSION_ID") or "")
-    # 22.04 is deliberately absent: its glibc 2.35 is below the glibc 2.38 /
+    # 22.04 is deliberately unsupported: its glibc 2.35 is below the glibc 2.38 /
     # GLIBCXX_3.4.32 floor every published Lemonade embeddable is linked
     # against, so the Lemonade engine cannot start on it. See docs/wsl.md.
-    supported_ubuntu = os_release.get("ID") == "ubuntu" and version_id in {
-        "24.04",
-        "26.04",
-    }
+    version_parts = version_id.split(".")
+    ubuntu_version = None
+    if len(version_parts) == 2 and all(
+        part.isascii() and part.isdecimal() for part in version_parts
+    ):
+        ubuntu_version = (int(version_parts[0]), int(version_parts[1]))
+    supported_ubuntu = (
+        os_release.get("ID") == "ubuntu"
+        and ubuntu_version is not None
+        and ubuntu_version >= (24, 4)
+    )
     build_tools = all(
         tools.get(name) for name in ["git", "cmake", "gcc", "g++", "make"]
     )
@@ -395,11 +402,25 @@ def self_test() -> None:
     checks = evaluate(ready_state, require_rocm_tools=False)
     assert all(check.ok for check in checks if check.required), checks
 
-    # 22.04 is below the Lemonade glibc floor, so an otherwise perfect host
-    # must still fail the ubuntu check rather than report itself ready.
-    jammy_state = json.loads(json.dumps(ready_state))
-    jammy_state["os_release"]["VERSION_ID"] = "22.04"
-    checks = evaluate(jammy_state, require_rocm_tools=False)
+    for version_id in ["24.04", "24.10", "25.04", "26.04", "28.04"]:
+        supported_state = json.loads(json.dumps(ready_state))
+        supported_state["os_release"]["VERSION_ID"] = version_id
+        checks = evaluate(supported_state, require_rocm_tools=False)
+        assert any(check.name == "ubuntu" and check.ok for check in checks), checks
+        assert all(check.ok for check in checks if check.required), checks
+
+    # 22.04 is below the Lemonade glibc floor, and malformed or unknown
+    # versions must fail closed rather than report an otherwise perfect host ready.
+    for version_id in ["22.04", "24.04.1", "unknown", ""]:
+        unsupported_state = json.loads(json.dumps(ready_state))
+        unsupported_state["os_release"]["VERSION_ID"] = version_id
+        checks = evaluate(unsupported_state, require_rocm_tools=False)
+        assert any(check.name == "ubuntu" and not check.ok for check in checks), checks
+        assert not all(check.ok for check in checks if check.required), checks
+
+    missing_version_state = json.loads(json.dumps(ready_state))
+    del missing_version_state["os_release"]["VERSION_ID"]
+    checks = evaluate(missing_version_state, require_rocm_tools=False)
     assert any(check.name == "ubuntu" and not check.ok for check in checks), checks
     assert not all(check.ok for check in checks if check.required), checks
 


### PR DESCRIPTION
## The problem

The docs promise a platform one of the two shipped engines cannot run on.

`README.md` advertised Linux (x86_64) as *"Full support, including the live
dashboard and both inference engines"*, and `docs/wsl.md` listed
*"WSL2 with Ubuntu 24.04 or Ubuntu 22.04"* as a prerequisite. Together those tell a
22.04 user — native or WSL2 — that both engines work.

They do not. Every published Lemonade embeddable, v10.2.0 through v11.5.2 (all 15
`ubuntu-x64` releases), is linked against `GLIBC_2.38` and `GLIBCXX_3.4.32`. Ubuntu
22.04 ships glibc 2.35 and `GLIBCXX_3.4.30`, so `lemond` is refused by the dynamic
loader before it starts. There is no older release to pin back to and no supported
way to put glibc 2.38 on jammy. Full analysis in #258.

This is option 1 from that issue — narrow the documented matrix to match reality.

## What changed

One flat minimum: **Ubuntu 24.04 or newer**, for Linux and WSL2 alike.

- `README.md`: both the Linux and WSL2 rows now say "Ubuntu 24.04 or newer", and a
  short paragraph below gives the glibc number behind that line — glibc 2.38 with
  `GLIBCXX_3.4.32` — so the requirement still means something to a reader on RHEL,
  SLES, or Fedora who cannot map an Ubuntu version onto their own distribution.
- `docs/wsl.md`: prerequisite 2 is now "Ubuntu 24.04 or newer", with the same reason
  stated inline.
- `scripts/wsl_preflight.py`: `22.04` dropped from the supported set, and the
  `ubuntu` check detail now names the minimum. Covered by a new `--self-test` case
  (an otherwise-ready 22.04 host must fail the check), which fails against the old
  set and passes against the new one, and runs in CI on both the Linux and Windows
  lanes.

The minimum is deliberately stated as a single number rather than split per engine.
The Lemonade floor is the binding one; a per-engine matrix would be more precise but
harder to state and harder to test, and the simpler line is the one being supported.

## The one edit a maintainer might want reverted

`scripts/wsl_preflight.py` is a behaviour change, not documentation — hence the `fix:`
title rather than `docs:`. It is included because that script is the automated form of
the `docs/wsl.md` prerequisite list and is invoked directly from it; leaving it
reporting `ubuntu: ok` on a host Lemonade cannot run on would relocate the
inconsistency rather than fix it. If you would rather keep this PR strictly to prose,
it is a self-contained three-line revert.

## Also found, deliberately not changed

- `apps/rocm/src/main.rs` driver-install matrix (`("ubuntu", "22.04" | "24.04")`,
  `codename_for_version`). That mirrors AMD's own documented amdgpu-dkms install
  matrix, which is a separate upstream support matrix; `rocm install driver` still
  produces a correct plan on 22.04 and narrowing it would be a behaviour change beyond
  this issue.
- `crates/rocm-core/src/diagnose.rs` suggesting `rocm/dev-ubuntu-22.04` as a
  known-good container image. A container brings its own userland, so the host glibc
  claim does not apply; it is not a host-OS support statement.

## This does not fix the user experience, only the promise

#258 also asks for a preflight error — *"the lemonade engine requires glibc 2.38 or
newer; this host has 2.35"* — instead of a raw loader message. That is deliberately
out of scope here, but worth stating plainly: **no such preflight exists today.** The
only glibc-aware code in the tree is a low-weight ``"version `?glibc"`` keyword in the
`rocm diagnose` classifier, explicitly annotated "tangential"; there is no glibc check
anywhere in the Lemonade download or launch path. A 22.04 user who has not read these
docs still gets an opaque ``version `GLIBC_2.38' not found`` out of a subprocess. The
preflight remains worth doing on its own, and it would be worth tracking separately
rather than letting it lapse when this merges.

## Related

- #237 — the same class of problem for vLLM: an unsupported interpreter/glibc produces
  misleading uv advice rather than the real cause. Worth noting that vLLM's floor is a
  different and lower one (glibc 2.34, plus CPython 3.12 that `rocm` provisions
  itself), so the flat 24.04 minimum here is set by Lemonade and is marginally
  stricter than vLLM alone would require. That tradeoff was taken deliberately in
  favour of a support matrix that is simple to state and simple to test.
- #259 — also a Lemonade start failure the docs do not warn about (`XDG_RUNTIME_DIR`
  unset on headless hosts). It was masked by the glibc floor tracked here.
- #247 — where the glibc floor was first hit, in CI.

## Verification

`prek run --all-files --no-group local-tools` (all passed: whitespace, EOF, yaml,
merge-conflict, line endings, ruff check, ruff format, shellcheck, cargo fmt),
`hawkeye check --config licenserc.toml` (no missing headers), `cargo fmt --all
--check` (clean), `python3 scripts/wsl_preflight.py --self-test` (ok; and confirmed
the new assertion still fails against the pre-change supported set).

No Gherkin scenario accompanies this: the `rocm`/`rocmd` binaries have no observable
behaviour change. The one behavioural edit is to a standalone helper script, whose
contract is covered by its own `--self-test`, already run by CI.

Searched `tests/e2e-cucumber/expectations.toml` for stale xfails tied to this issue —
the Lemonade rows there are all EAI-7423 (managed serve shutting down after ready),
unrelated to the glibc floor, so nothing to remove or narrow.

Fixes #258
