### PR TITLE
fix(lemonade): give the server a runtime dir when XDG_RUNTIME_DIR is unset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,6 +3735,7 @@ dependencies = [
  "anyhow",
  "clap",
  "flate2",
+ "libc",
  "rocm-core",
  "rocm-deps",
  "rocm-engine-protocol",

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use runtime::{
     runtime_path_text_is_absolute_for_platform, runtime_paths_equivalent,
     runtime_python_activation_hint, runtime_python_activation_script, runtime_python_bin_dir_name,
     runtime_python_env_bin_dir, runtime_python_executable_in_env, runtime_python_executable_name,
-    runtime_rocm_library_filename, shell_command_for_host,
+    runtime_rocm_library_filename, shell_command_for_host, user_runtime_dir,
 };
 pub use uv::{
     DEFAULT_UV_TIMEOUT_SECS, UV_CACHE_DIR_ENV, UV_CACHE_DIR_OVERRIDE_ENV, UvCacheSource,
@@ -5241,8 +5241,8 @@ pub struct RocmCliConfig {
 fn default_dashboard_socket() -> String {
     // Choose a socket location whose *parent* directory is always user-owned so
     // that run_unix can tighten it to 0o700 without EPERM. See
-    // `dashboard_socket_path` for the precedence. This resolver is mirrored in
-    // `rocm-dash-core` so the canonical `rocm` config and a standalone
+    // `runtime::user_runtime_dir` for the precedence. This resolver is mirrored
+    // in `rocm-dash-core` so the canonical `rocm` config and a standalone
     // `rocm-dash` config resolve to the same place; keep the two in sync.
     let path = dashboard_socket_path(
         std::env::var_os("XDG_RUNTIME_DIR"),
@@ -5266,48 +5266,18 @@ fn default_dashboard_socket() -> String {
 /// 2. `$HOME/.rocm/data/telemetry` — standard per-user data dir.
 /// 3. `temp_dir()/rocm-<user>` — user-named subdir so the parent is something we
 ///    create and own, not `/tmp` itself.
+///
+/// The tier chain itself lives in [`user_runtime_dir`], which the Lemonade
+/// engine also uses to synthesize a runtime directory for its child process.
+/// Only tier 2 needs the `telemetry` leaf: tiers 1 and 3 are already per-user
+/// runtime directories, so the socket sits directly in them.
 fn dashboard_socket_path(
     xdg_runtime_dir: Option<std::ffi::OsString>,
     home: Option<std::ffi::OsString>,
     user: Option<String>,
     temp_dir: std::path::PathBuf,
 ) -> std::path::PathBuf {
-    use std::path::PathBuf;
-    xdg_runtime_dir
-        .filter(|v| !v.is_empty())
-        .map(|d| PathBuf::from(d).join("rocmdashd.sock"))
-        .or_else(|| {
-            home.filter(|v| !v.is_empty()).map(|h| {
-                PathBuf::from(h)
-                    .join(".rocm")
-                    .join("data")
-                    .join("telemetry")
-                    .join("rocmdashd.sock")
-            })
-        })
-        .unwrap_or_else(|| {
-            let raw = user.unwrap_or_else(|| "user".to_owned());
-            // Sanitize: keep only alphanumeric, hyphen, and underscore so a path
-            // separator or `..` in the env var cannot escape the subdirectory.
-            let sanitized: String = raw
-                .chars()
-                .map(|c| {
-                    if c.is_alphanumeric() || c == '-' || c == '_' {
-                        c
-                    } else {
-                        '_'
-                    }
-                })
-                .collect();
-            let sanitized = if sanitized.is_empty() {
-                "user".to_owned()
-            } else {
-                sanitized
-            };
-            temp_dir
-                .join(format!("rocm-{sanitized}"))
-                .join("rocmdashd.sock")
-        })
+    user_runtime_dir(xdg_runtime_dir, home, user, temp_dir, "telemetry", "").join("rocmdashd.sock")
 }
 
 fn default_dashboard_listen() -> String {

--- a/crates/rocm-core/src/runtime.rs
+++ b/crates/rocm-core/src/runtime.rs
@@ -218,6 +218,80 @@ pub fn default_cache_dir() -> Option<PathBuf> {
         .or_else(|| project_dirs().map(|dirs| dirs.cache_dir().to_path_buf()))
 }
 
+/// Resolve a writable, user-owned directory for per-user runtime state from
+/// explicit environment inputs.
+///
+/// Runtime state (sockets, lock files, an engine's scratch area) needs a
+/// directory whose *parent* is user-owned, so it can be tightened to mode
+/// `0o700` without the `EPERM` that results from trying to `chmod` a shared,
+/// root-owned `/tmp` (mode `1777`). Precedence:
+///
+/// 1. `$XDG_RUNTIME_DIR` — already mode `0700` on systemd systems, ideal.
+/// 2. `$HOME/.rocm/data/<home_subdir>` — standard per-user data dir.
+/// 3. `temp_dir()/rocm-<user>/<temp_subdir>` — user-named subdir so the parent
+///    is something we create and own, not `/tmp` itself.
+///
+/// Tiers 2 and 3 are not exotic: `$XDG_RUNTIME_DIR` is populated by
+/// `pam_systemd` at login, so it is absent for every non-login process (cron
+/// jobs, CI runners, `systemd-run`, a bare container exec).
+///
+/// The environment is taken as arguments rather than read here so the
+/// precedence is testable without mutating process-global env vars, which is
+/// `unsafe` and racy under parallel tests in edition 2024.
+///
+/// `home_subdir` and `temp_subdir` name the caller's own leaf directory in
+/// tiers 2 and 3; either may be empty when the caller owns that whole tier.
+/// They are separate parameters because tier 2 lands inside the shared
+/// `.rocm/data` tree, where every component needs its own leaf, whereas tier 3
+/// is already under a rocm-private `rocm-<user>` directory.
+pub fn user_runtime_dir(
+    xdg_runtime_dir: Option<OsString>,
+    home: Option<OsString>,
+    user: Option<String>,
+    temp_dir: PathBuf,
+    home_subdir: &str,
+    temp_subdir: &str,
+) -> PathBuf {
+    if let Some(runtime_dir) = xdg_runtime_dir.filter(|value| !value.is_empty()) {
+        return PathBuf::from(runtime_dir);
+    }
+    if let Some(home) = home.filter(|value| !value.is_empty()) {
+        return join_subdir(PathBuf::from(home).join(".rocm").join("data"), home_subdir);
+    }
+    let user_dir = format!("rocm-{}", sanitized_user_path_component(user));
+    join_subdir(temp_dir.join(user_dir), temp_subdir)
+}
+
+fn join_subdir(mut base: PathBuf, subdir: &str) -> PathBuf {
+    if !subdir.is_empty() {
+        base.push(subdir);
+    }
+    base
+}
+
+/// Reduce a user name to a single safe path component: keep only alphanumeric,
+/// hyphen, and underscore so a path separator or `..` in the env var cannot
+/// escape the intended subdirectory. An absent or fully-stripped name yields
+/// `user`.
+fn sanitized_user_path_component(user: Option<String>) -> String {
+    let sanitized: String = user
+        .unwrap_or_default()
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "user".to_owned()
+    } else {
+        sanitized
+    }
+}
+
 pub fn managed_runtime_cache_dir(root: &Path) -> PathBuf {
     normalize_runtime_path_for_host(root).join("cache")
 }

--- a/crates/rocm-dash-core/src/config.rs
+++ b/crates/rocm-dash-core/src/config.rs
@@ -115,6 +115,12 @@ pub struct DaemonConfig {
 /// 2. `$HOME/.rocm/data/telemetry` — standard per-user data dir.
 /// 3. `temp_dir()/rocm-<user>` — user-named subdir so the parent is something
 ///    the daemon creates and owns, not `/tmp` itself.
+///
+/// In `rocm-core` the tier chain is shared as `runtime::user_runtime_dir`. This
+/// crate keeps its own copy on purpose: it is a standalone library with a
+/// deliberately lean dependency set, and depending on `rocm-core` to share ~30
+/// lines would pull in that crate's whole graph. Keep the two in sync — the
+/// tests below mirror `rocm-core`'s so a divergence is caught.
 fn default_socket() -> String {
     let path = socket_path(
         std::env::var_os("XDG_RUNTIME_DIR"),

--- a/engines/lemonade/Cargo.toml
+++ b/engines/lemonade/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 flate2 = "1"
+libc.workspace = true
 rocm-core = { path = "../../crates/rocm-core" }
 rocm-deps = { path = "../../crates/rocm-deps" }
 rocm-engine-protocol = { path = "../../crates/rocm-engine-protocol" }

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -22,6 +22,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{VecDeque, hash_map::DefaultHasher};
+#[cfg(unix)]
+use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
 use std::hash::{Hash, Hasher};
@@ -2236,6 +2238,7 @@ fn child_runtime_dir_var(
     {
         return Ok(Some(("XDG_RUNTIME_DIR", existing.clone())));
     }
+    let has_home = parent.home.as_ref().is_some_and(|value| !value.is_empty());
     let dir = rocm_core::user_runtime_dir(
         None,
         parent.home.clone(),
@@ -2244,7 +2247,12 @@ fn child_runtime_dir_var(
         RUNTIME_DIR_LEAF,
         RUNTIME_DIR_LEAF,
     );
-    create_private_runtime_dir(&dir).with_context(|| {
+    let prepare = if has_home {
+        create_private_runtime_dir(&dir)
+    } else {
+        create_private_tier3_runtime_dir(&dir)
+    };
+    prepare.with_context(|| {
         format!(
             "preparing a runtime directory for the Lemonade server at {} \
              (XDG_RUNTIME_DIR is unset in this environment)",
@@ -2254,17 +2262,357 @@ fn child_runtime_dir_var(
     Ok(Some(("XDG_RUNTIME_DIR", dir.into_os_string())))
 }
 
+#[cfg(unix)]
+fn create_private_tier3_runtime_dir(dir: &Path) -> Result<()> {
+    let user_parent = dir
+        .parent()
+        .ok_or_else(|| anyhow!("{} has no tier-3 user parent", dir.display()))?;
+    let temp_root = user_parent.parent().ok_or_else(|| {
+        anyhow!(
+            "{} has no temporary-directory parent",
+            user_parent.display()
+        )
+    })?;
+    let temp_root = open_safe_tier3_root(temp_root)?;
+    let user_component = single_directory_component(user_parent)?;
+    let user_parent = create_private_owned_directory_at(&temp_root, user_component, user_parent)?;
+    let leaf_component = single_directory_component(dir)?;
+    create_private_owned_directory_at(&user_parent, leaf_component, dir)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn single_directory_component(path: &Path) -> Result<&OsStr> {
+    path.file_name()
+        .filter(|component| Path::new(component).components().count() == 1)
+        .ok_or_else(|| anyhow!("{} has no safe final directory component", path.display()))
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn open_safe_tier3_root(temp_root: &Path) -> Result<fs::File> {
+    use std::ffi::CString;
+    use std::io::ErrorKind;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::path::Component;
+
+    if !temp_root.is_absolute() {
+        bail!(
+            "tier-3 temporary root {} is relative or otherwise unstable",
+            temp_root.display()
+        );
+    }
+    let mut components = temp_root.components();
+    if components.next() != Some(Component::RootDir) {
+        bail!(
+            "tier-3 temporary root {} has no filesystem-root anchor",
+            temp_root.display()
+        );
+    }
+
+    let mut directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(Path::new("/"))
+        .context("opening filesystem root without following symlinks")?;
+    let current_euid = effective_user_id();
+    let mut traversed = PathBuf::from("/");
+    let mut components = components.peekable();
+    while let Some(component) = components.next() {
+        let Component::Normal(component) = component else {
+            bail!(
+                "tier-3 temporary root {} contains a relative or unstable component",
+                temp_root.display()
+            );
+        };
+        validate_runtime_ancestry_container(&traversed, &directory, current_euid)?;
+        let child_path = traversed.join(component);
+        let component = CString::new(component.as_bytes()).with_context(|| {
+            format!(
+                "tier-3 temporary root {} contains a NUL byte",
+                temp_root.display()
+            )
+        })?;
+        let is_final = components.peek().is_none();
+        let raw_fd = match unsafe_openat_directory(directory.as_raw_fd(), &component) {
+            Ok(fd) => fd,
+            Err(error) if is_final && error.kind() == ErrorKind::NotFound => {
+                match unsafe_mkdirat(directory.as_raw_fd(), &component, 0o700) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                    Err(error) => {
+                        return Err(error).with_context(|| {
+                            format!("creating tier-3 temporary root {}", temp_root.display())
+                        });
+                    }
+                }
+                unsafe_openat_directory(directory.as_raw_fd(), &component).with_context(|| {
+                    format!(
+                        "opening newly created tier-3 temporary root {}",
+                        temp_root.display()
+                    )
+                })?
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "opening {} while securely traversing tier-3 temporary-root ancestry",
+                        child_path.display()
+                    )
+                });
+            }
+        };
+        // SAFETY: `unsafe_openat_directory` returned a new owned descriptor,
+        // transferred exactly once into a `File` that closes it on drop.
+        directory = unsafe { fs::File::from_raw_fd(raw_fd) };
+        validate_runtime_directory_type(&child_path, &unsafe_fstat(directory.as_raw_fd())?)?;
+        traversed = child_path;
+    }
+
+    let metadata = unsafe_fstat(directory.as_raw_fd())?;
+    if !directory_prevents_cross_uid_entry_replacement(
+        metadata.st_uid,
+        metadata.st_mode,
+        current_euid,
+        filesystem_is_read_only(directory.as_raw_fd())?,
+    ) {
+        bail!(
+            "tier-3 temporary root {} is unsafe: trusted owners require no group/other write or sticky protection; foreign owners require a read-only filesystem",
+            temp_root.display()
+        );
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+const fn directory_prevents_cross_uid_entry_replacement(
+    uid: u32,
+    mode: u32,
+    current_euid: u32,
+    filesystem_read_only: bool,
+) -> bool {
+    if uid == 0 || uid == current_euid {
+        return mode & 0o022 == 0 || mode & libc::S_ISVTX != 0;
+    }
+    filesystem_read_only
+}
+
+#[cfg(unix)]
+fn validate_runtime_ancestry_container(
+    path: &Path,
+    directory: &fs::File,
+    current_euid: u32,
+) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let metadata = unsafe_fstat(directory.as_raw_fd())?;
+    validate_runtime_directory_type(path, &metadata)?;
+    if !directory_prevents_cross_uid_entry_replacement(
+        metadata.st_uid,
+        metadata.st_mode,
+        current_euid,
+        filesystem_is_read_only(directory.as_raw_fd())?,
+    ) {
+        bail!(
+            "tier-3 temporary-root ancestor {} permits cross-UID rename or replacement",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn filesystem_is_read_only(fd: std::os::fd::RawFd) -> Result<bool> {
+    Ok(unsafe_fstatvfs(fd)?.f_flag & libc::ST_RDONLY != 0)
+}
+
+#[cfg(unix)]
+fn validate_runtime_directory_type(path: &Path, metadata: &libc::stat) -> Result<()> {
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        bail!("{} is not a directory", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_private_tier3_runtime_dir(dir: &Path) -> Result<()> {
+    create_private_runtime_dir(dir)
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn create_private_owned_directory_at(
+    parent: &fs::File,
+    component: &OsStr,
+    display_path: &Path,
+) -> Result<fs::File> {
+    use std::ffi::CString;
+    use std::io::ErrorKind;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let component = CString::new(component.as_bytes()).with_context(|| {
+        format!(
+            "{} contains a NUL byte in its final component",
+            display_path.display()
+        )
+    })?;
+    let mkdir_result = unsafe_mkdirat(parent.as_raw_fd(), &component, 0o700);
+    if let Err(error) = mkdir_result
+        && error.kind() != ErrorKind::AlreadyExists
+    {
+        return Err(error).with_context(|| format!("creating {}", display_path.display()));
+    }
+
+    let raw_fd = unsafe_openat_directory(parent.as_raw_fd(), &component).with_context(|| {
+        format!(
+            "opening {} relative to its validated parent without following symlinks",
+            display_path.display()
+        )
+    })?;
+    // SAFETY: `unsafe_openat_directory` returned a new owned descriptor, and
+    // this is its single transfer into a type that closes it on drop.
+    let directory = unsafe { fs::File::from_raw_fd(raw_fd) };
+    let current_euid = effective_user_id();
+    validate_runtime_directory_owner(
+        display_path,
+        &unsafe_fstat(directory.as_raw_fd())?,
+        current_euid,
+    )?;
+    unsafe_fchmod(directory.as_raw_fd(), 0o700)
+        .with_context(|| format!("restricting {} to mode 0700", display_path.display()))?;
+
+    let secured = unsafe_fstat(directory.as_raw_fd())?;
+    validate_runtime_directory_owner(display_path, &secured, current_euid)?;
+    if secured.st_mode & 0o777 != 0o700 {
+        bail!(
+            "{} is not private after chmod; expected mode 0700",
+            display_path.display()
+        );
+    }
+    Ok(directory)
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn unsafe_fstat(fd: std::os::fd::RawFd) -> std::io::Result<libc::stat> {
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `metadata` points to writable storage for one `libc::stat`, and
+    // `fd` is borrowed from a live `File`. On success fstat initializes it.
+    if unsafe { libc::fstat(fd, metadata.as_mut_ptr()) } == 0 {
+        // SAFETY: successful fstat initialized the full `libc::stat` value.
+        Ok(unsafe { metadata.assume_init() })
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn unsafe_fstatvfs(fd: std::os::fd::RawFd) -> std::io::Result<libc::statvfs> {
+    let mut metadata = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `metadata` points to writable storage for one `libc::statvfs`,
+    // and `fd` is borrowed from a live directory `File`. On success fstatvfs
+    // initializes it.
+    if unsafe { libc::fstatvfs(fd, metadata.as_mut_ptr()) } == 0 {
+        // SAFETY: successful fstatvfs initialized the full value.
+        Ok(unsafe { metadata.assume_init() })
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn unsafe_fchmod(fd: std::os::fd::RawFd, mode: libc::mode_t) -> std::io::Result<()> {
+    // SAFETY: `fd` is borrowed from a live directory `File`; fchmod does not
+    // retain it, and the supplied mode is a valid permission bitmask.
+    if unsafe { libc::fchmod(fd, mode) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn unsafe_mkdirat(
+    parent_fd: std::os::fd::RawFd,
+    component: &std::ffi::CStr,
+    mode: libc::mode_t,
+) -> std::io::Result<()> {
+    // SAFETY: `component` is NUL-terminated and lives for the call; `parent_fd`
+    // is borrowed from an open directory descriptor; mkdirat does not retain
+    // either argument.
+    if unsafe { libc::mkdirat(parent_fd, component.as_ptr(), mode) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn unsafe_openat_directory(
+    parent_fd: std::os::fd::RawFd,
+    component: &std::ffi::CStr,
+) -> std::io::Result<std::os::fd::RawFd> {
+    // SAFETY: `component` is NUL-terminated and lives for the call; `parent_fd`
+    // is an open directory descriptor. On success openat returns a new owned fd.
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            component.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd >= 0 {
+        Ok(fd)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn validate_runtime_directory_owner(
+    dir: &Path,
+    metadata: &libc::stat,
+    current_euid: u32,
+) -> Result<()> {
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        bail!("{} is not a directory", dir.display());
+    }
+    if metadata.st_uid != current_euid {
+        bail!(
+            "{} is owned by uid {}, not current euid {}",
+            dir.display(),
+            metadata.st_uid,
+            current_euid
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn effective_user_id() -> u32 {
+    // SAFETY: `geteuid` takes no arguments, has no caller-side preconditions,
+    // and only returns process identity state.
+    unsafe { libc::geteuid() }
+}
+
 /// Create `dir` (and its parents) restricted to the current user.
 ///
-/// The tier-3 fallback lands under a shared temp dir, so a pre-existing path
-/// there may not be ours. Both guards below only matter in that case:
+/// This is the existing recursive behavior used for the HOME-based fallback,
+/// where legitimate symlinked HOME or `.rocm` paths retain normal filesystem
+/// semantics. Tier 3 uses [`create_private_tier3_runtime_dir`] instead so its
+/// predictable parent is validated separately without following symlinks.
 ///
-/// * a symlink is refused outright — `chmod` follows it and would loosen an
-///   unrelated directory;
-/// * `DirBuilder::mode` applies only to directories it creates, so an existing
-///   directory is tightened explicitly. `chmod` needs ownership, so a failure
-///   here is a hard error rather than a warning: the server keeps its sockets
-///   and state in this directory.
+/// The leaf itself is still refused when it is a symlink, and an existing leaf
+/// is tightened explicitly because `DirBuilder::mode` only affects directories
+/// it creates.
 fn create_private_runtime_dir(dir: &Path) -> Result<()> {
     #[cfg(unix)]
     {
@@ -5096,6 +5444,13 @@ vllm                rocm        unsupported     Requires Linux                  
                 .map(|(_, value)| value.clone())
         }
 
+        fn runtime_scratch() -> tempfile::TempDir {
+            tempfile::Builder::new()
+                .prefix(".lemonade-runtime-test-")
+                .tempdir_in(std::env::current_dir().expect("current directory"))
+                .expect("private-ancestry scratch")
+        }
+
         fn vars_for(parent: &ParentRuntimeEnvironment) -> Vec<(&'static str, OsString)> {
             lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), parent)
                 .expect("building the child environment must succeed")
@@ -5123,7 +5478,7 @@ vllm                rocm        unsupported     Requires Linux                  
         /// child must be handed a directory that already exists.
         #[test]
         fn is_synthesized_when_the_parent_has_none() {
-            let scratch = tempfile::tempdir().expect("scratch");
+            let scratch = runtime_scratch();
             let home = scratch.path().join("home");
             let parent = ParentRuntimeEnvironment {
                 xdg_runtime_dir: None,
@@ -5146,7 +5501,7 @@ vllm                rocm        unsupported     Requires Linux                  
         /// mistaken for an operator's choice.
         #[test]
         fn is_synthesized_when_the_parent_value_is_empty() {
-            let scratch = tempfile::tempdir().expect("scratch");
+            let scratch = runtime_scratch();
             let parent = ParentRuntimeEnvironment {
                 xdg_runtime_dir: Some(OsString::new()),
                 home: Some(scratch.path().join("home").into_os_string()),
@@ -5167,11 +5522,37 @@ vllm                rocm        unsupported     Requires Linux                  
             );
         }
 
+        /// Tier 2 lives under the operator's HOME and must retain normal path
+        /// semantics; homes (or `.rocm`) are legitimately symlinked on some
+        /// systems. The no-follow hardening is intentionally tier-3-only.
+        #[test]
+        fn permits_a_symlinked_home_path_for_tier2() {
+            let scratch = runtime_scratch();
+            let real_home = scratch.path().join("real-home");
+            let linked_home = scratch.path().join("linked-home");
+            fs::create_dir_all(&real_home).expect("real home");
+            std::os::unix::fs::symlink(&real_home, &linked_home).expect("linked home");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: Some(linked_home.clone().into_os_string()),
+                user: Some("alice".to_owned()),
+                temp_dir: scratch.path().join("tmp"),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("the child must be given a runtime directory");
+
+            let dir = PathBuf::from(value);
+            assert_eq!(dir, linked_home.join(".rocm").join("data").join("lemonade"));
+            assert_private_dir(&dir);
+            assert!(real_home.join(".rocm/data/lemonade").is_dir());
+        }
+
         /// Tier 3: neither `XDG_RUNTIME_DIR` nor `HOME` — a user-named subdir of
         /// the temp dir, so the parent is one we create and own, not `/tmp`.
         #[test]
         fn falls_back_to_a_user_owned_temp_subdir_without_home() {
-            let scratch = tempfile::tempdir().expect("scratch");
+            let scratch = runtime_scratch();
             let temp_dir = scratch.path().join("tmp");
             let parent = ParentRuntimeEnvironment {
                 xdg_runtime_dir: None,
@@ -5193,7 +5574,7 @@ vllm                rocm        unsupported     Requires Linux                  
         /// it, so the resolver refuses rather than loosening another directory.
         #[test]
         fn refuses_a_symlinked_runtime_dir() {
-            let scratch = tempfile::tempdir().expect("scratch");
+            let scratch = runtime_scratch();
             let temp_dir = scratch.path().join("tmp");
             let elsewhere = scratch.path().join("elsewhere");
             fs::create_dir_all(temp_dir.join("rocm-alice")).expect("runtime root");
@@ -5213,6 +5594,417 @@ vllm                rocm        unsupported     Requires Linux                  
                     .expect_err("a symlinked runtime dir must be refused")
             );
             assert!(error.contains("symlink"), "{error}");
+        }
+
+        /// Tier 3 uses a predictable user parent under a shared temp directory.
+        /// Refuse that parent when it is a symlink: recursively creating the
+        /// leaf would otherwise follow it into an attacker-controlled tree.
+        #[test]
+        fn refuses_a_symlinked_tier3_user_parent() {
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("tmp");
+            let elsewhere = scratch.path().join("elsewhere");
+            fs::create_dir_all(&temp_dir).expect("temp root");
+            fs::create_dir_all(&elsewhere).expect("elsewhere");
+            std::os::unix::fs::symlink(&elsewhere, temp_dir.join("rocm-alice")).expect("symlink");
+
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir,
+            };
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("a symlinked tier-3 user parent must be refused")
+            );
+
+            assert!(error.contains("symlink"), "{error}");
+            assert!(
+                !elsewhere.join("lemonade").exists(),
+                "the resolver followed the tier-3 user-parent symlink"
+            );
+        }
+
+        /// A pre-existing tier-3 user parent may have been created with a
+        /// permissive umask. The resolver must secure that predictable parent,
+        /// not merely the Lemonade leaf beneath it.
+        #[test]
+        fn tightens_a_preexisting_non_private_tier3_user_parent() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("tmp");
+            let user_parent = temp_dir.join("rocm-alice");
+            fs::create_dir_all(&user_parent).expect("user parent");
+            fs::set_permissions(&user_parent, fs::Permissions::from_mode(0o755))
+                .expect("make parent non-private");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir,
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("the child must be given a runtime directory");
+
+            assert_eq!(PathBuf::from(value), user_parent.join("lemonade"));
+            assert_private_dir(&user_parent);
+            assert_private_dir(&user_parent.join("lemonade"));
+        }
+
+        /// A tier-3 root without sticky-directory protection lets another UID
+        /// rename or replace our predictable user component after validation.
+        #[test]
+        fn refuses_a_group_or_other_writable_non_sticky_temp_root() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("unsafe-tmp");
+            fs::create_dir(&temp_dir).expect("temp root");
+            fs::set_permissions(&temp_dir, fs::Permissions::from_mode(0o777))
+                .expect("make root unsafe");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: temp_dir.clone(),
+            };
+
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("a non-sticky writable temp root must be refused")
+            );
+
+            assert!(error.contains("sticky"), "{error}");
+            assert!(!temp_dir.join("rocm-alice").exists());
+        }
+
+        /// A private final temp root is still unstable when an ancestor lets
+        /// another UID replace the path entry that names it.
+        #[test]
+        fn refuses_a_private_temp_root_beneath_a_non_sticky_writable_parent() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let scratch = runtime_scratch();
+            let unsafe_parent = scratch.path().join("unsafe-parent");
+            let temp_dir = unsafe_parent.join("private-tmp");
+            fs::create_dir(&unsafe_parent).expect("unsafe parent");
+            fs::set_permissions(&unsafe_parent, fs::Permissions::from_mode(0o777))
+                .expect("make ancestor unsafe");
+            fs::create_dir(&temp_dir).expect("private temp root");
+            fs::set_permissions(&temp_dir, fs::Permissions::from_mode(0o700))
+                .expect("make final root private");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: temp_dir.clone(),
+            };
+
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("unsafe temp-root ancestry must be refused")
+            );
+
+            assert!(error.contains("ancestor"), "{error}");
+            assert!(!temp_dir.join("rocm-alice").exists());
+        }
+
+        #[test]
+        fn accepts_a_private_temp_root_with_private_ancestry() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let scratch = runtime_scratch();
+            let private_parent = scratch.path().join("private-parent");
+            let temp_dir = private_parent.join("private-tmp");
+            fs::create_dir(&private_parent).expect("private parent");
+            fs::set_permissions(&private_parent, fs::Permissions::from_mode(0o700))
+                .expect("private ancestor mode");
+            fs::create_dir(&temp_dir).expect("private temp root");
+            fs::set_permissions(&temp_dir, fs::Permissions::from_mode(0o700))
+                .expect("private root mode");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: temp_dir.clone(),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("private ancestry must be accepted");
+
+            assert_eq!(PathBuf::from(value), temp_dir.join("rocm-alice/lemonade"));
+        }
+
+        #[test]
+        fn accepts_standard_sticky_temp_root_semantics() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("sticky-tmp");
+            fs::create_dir(&temp_dir).expect("sticky temp root");
+            fs::set_permissions(&temp_dir, fs::Permissions::from_mode(0o1777))
+                .expect("standard sticky temp mode");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: temp_dir.clone(),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("trusted sticky temp semantics must be accepted");
+
+            assert_eq!(PathBuf::from(value), temp_dir.join("rocm-alice/lemonade"));
+            assert_private_dir(&temp_dir.join("rocm-alice"));
+        }
+
+        #[test]
+        fn accepts_the_host_standard_tmp_when_its_invariants_are_safe() {
+            use std::os::fd::AsRawFd;
+            use std::os::unix::fs::MetadataExt;
+
+            let path = Path::new("/tmp");
+            let metadata = fs::metadata(path).expect("/tmp metadata");
+            let directory = fs::File::open(path).expect("open /tmp");
+            if !directory_prevents_cross_uid_entry_replacement(
+                metadata.uid(),
+                metadata.mode(),
+                effective_user_id(),
+                filesystem_is_read_only(directory.as_raw_fd()).expect("/tmp filesystem flags"),
+            ) {
+                return;
+            }
+
+            open_safe_tier3_root(path).expect("safe host /tmp must be accepted");
+        }
+
+        #[test]
+        fn refuses_a_relative_tier3_temp_root() {
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: PathBuf::from("relative-tmp"),
+            };
+
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("relative tier-3 roots must be refused")
+            );
+
+            assert!(error.contains("relative"), "{error}");
+        }
+
+        #[test]
+        fn refuses_symlinked_temp_root_ancestry() {
+            let scratch = runtime_scratch();
+            let real_parent = scratch.path().join("real-parent");
+            let linked_parent = scratch.path().join("linked-parent");
+            fs::create_dir(&real_parent).expect("real parent");
+            std::os::unix::fs::symlink(&real_parent, &linked_parent).expect("linked ancestry");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: linked_parent.join("private-tmp"),
+            };
+
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("symlinked tier-3 ancestry must be refused")
+            );
+
+            assert!(error.contains("ancestry"), "{error}");
+            assert!(!real_parent.join("private-tmp").exists());
+        }
+
+        /// Sticky mode does not constrain the directory owner. A sticky root
+        /// owned by an unrelated non-root UID therefore cannot protect our
+        /// component from that UID replacing it.
+        #[test]
+        fn refuses_an_untrusted_foreign_owned_sticky_temp_root_when_available() {
+            use std::os::unix::fs::MetadataExt;
+
+            let current_euid = effective_user_id();
+            let candidate = [Path::new("/tmp"), Path::new("/var/tmp")]
+                .into_iter()
+                .filter_map(|path| fs::metadata(path).ok().map(|metadata| (path, metadata)))
+                .find(|(_, metadata)| {
+                    metadata.uid() != 0
+                        && metadata.uid() != current_euid
+                        && metadata.mode() & libc::S_ISVTX != 0
+                });
+            let Some((path, _)) = candidate else {
+                return;
+            };
+
+            let error = format!(
+                "{:#}",
+                open_safe_tier3_root(path)
+                    .expect_err("an untrusted sticky-root owner must be refused")
+            );
+            assert!(error.contains("sticky"), "{error}");
+            assert!(error.contains("owner"), "{error}");
+        }
+
+        #[test]
+        fn ancestry_safety_rejects_foreign_owned_mode_0555_on_writable_filesystem() {
+            assert!(!directory_prevents_cross_uid_entry_replacement(
+                1234, 0o555, 1000, false
+            ));
+        }
+
+        #[test]
+        fn ancestry_safety_rejects_foreign_owned_mode_0755() {
+            assert!(!directory_prevents_cross_uid_entry_replacement(
+                1234, 0o755, 1000, false
+            ));
+        }
+
+        #[test]
+        fn ancestry_safety_accepts_foreign_owned_writable_on_read_only_filesystem() {
+            assert!(directory_prevents_cross_uid_entry_replacement(
+                1234, 0o777, 1000, true
+            ));
+        }
+
+        #[test]
+        fn ancestry_safety_accepts_trusted_owned_mode_0755() {
+            assert!(directory_prevents_cross_uid_entry_replacement(
+                0, 0o755, 1000, false
+            ));
+        }
+
+        #[test]
+        fn ancestry_safety_rejects_trusted_owned_mode_0777_without_sticky() {
+            assert!(!directory_prevents_cross_uid_entry_replacement(
+                1000, 0o777, 1000, false
+            ));
+        }
+
+        #[test]
+        fn ancestry_safety_accepts_trusted_owned_mode_1777() {
+            assert!(directory_prevents_cross_uid_entry_replacement(
+                1000, 0o1777, 1000, false
+            ));
+        }
+
+        /// Once the temp root is open, replacing its pathname must not redirect
+        /// creation into the replacement tree. This deterministically models
+        /// the rename-and-replace window from the original implementation.
+        #[test]
+        fn descriptor_relative_creation_resists_temp_root_replacement() {
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("tmp");
+            fs::create_dir(&temp_dir).expect("temp root");
+            let root = open_safe_tier3_root(&temp_dir).expect("open root");
+
+            let original_root = scratch.path().join("original-tmp");
+            fs::rename(&temp_dir, &original_root).expect("rename open root");
+            fs::create_dir(&temp_dir).expect("replacement root");
+            let elsewhere = scratch.path().join("elsewhere");
+            fs::create_dir(&elsewhere).expect("elsewhere");
+            std::os::unix::fs::symlink(&elsewhere, temp_dir.join("rocm-alice"))
+                .expect("attacker replacement");
+
+            create_private_owned_directory_at(
+                &root,
+                OsStr::new("rocm-alice"),
+                &temp_dir.join("rocm-alice"),
+            )
+            .expect("descriptor-relative creation");
+
+            assert_private_dir(&original_root.join("rocm-alice"));
+            assert!(
+                fs::symlink_metadata(temp_dir.join("rocm-alice"))
+                    .expect("replacement symlink")
+                    .file_type()
+                    .is_symlink()
+            );
+            assert!(!elsewhere.join("rocm-alice").exists());
+        }
+
+        /// Leaf creation stays anchored to the validated user-parent object even
+        /// if its pathname is replaced with a symlink after it was opened.
+        #[test]
+        fn descriptor_relative_leaf_creation_resists_user_parent_replacement() {
+            let scratch = runtime_scratch();
+            let temp_dir = scratch.path().join("tmp");
+            fs::create_dir(&temp_dir).expect("temp root");
+            let root = open_safe_tier3_root(&temp_dir).expect("open root");
+            let user_path = temp_dir.join("rocm-alice");
+            let user_parent =
+                create_private_owned_directory_at(&root, OsStr::new("rocm-alice"), &user_path)
+                    .expect("create user parent");
+
+            let original_user_parent = temp_dir.join("original-rocm-alice");
+            fs::rename(&user_path, &original_user_parent).expect("rename user parent");
+            let elsewhere = scratch.path().join("elsewhere");
+            fs::create_dir(&elsewhere).expect("elsewhere");
+            std::os::unix::fs::symlink(&elsewhere, &user_path).expect("replacement symlink");
+
+            create_private_owned_directory_at(
+                &user_parent,
+                OsStr::new("lemonade"),
+                &user_path.join("lemonade"),
+            )
+            .expect("descriptor-relative leaf creation");
+
+            assert_private_dir(&original_user_parent.join("lemonade"));
+            assert!(!elsewhere.join("lemonade").exists());
+        }
+
+        /// Ownership can be exercised without root when the host exposes a
+        /// system-owned temp/root directory. The preparation routine must
+        /// reject it before changing its permissions.
+        #[test]
+        fn rejects_a_foreign_owned_tier3_user_parent_when_available() {
+            use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+            let current_euid = effective_user_id();
+            let foreign = [
+                (Path::new("/"), OsStr::new("tmp")),
+                (Path::new("/"), OsStr::new("var")),
+                (Path::new("/"), OsStr::new("run")),
+            ]
+            .into_iter()
+            .filter_map(|(parent, component)| {
+                let path = parent.join(component);
+                fs::metadata(&path)
+                    .ok()
+                    .map(|metadata| (parent, component, path, metadata))
+            })
+            .find(|(_, _, _, metadata)| metadata.is_dir() && metadata.uid() != current_euid);
+            let Some((parent_path, component, path, metadata)) = foreign else {
+                return;
+            };
+            let original_mode = metadata.mode();
+            let parent = fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+                .open(parent_path)
+                .expect("open foreign parent");
+
+            let error = format!(
+                "{:#}",
+                create_private_owned_directory_at(&parent, component, &path)
+                    .expect_err("foreign ownership must be refused")
+            );
+            assert!(error.contains("owned by uid"), "{error}");
+            assert!(error.contains(&current_euid.to_string()), "{error}");
+            assert_eq!(
+                fs::metadata(&path).expect("metadata after refusal").mode(),
+                original_mode,
+                "foreign directory permissions changed before ownership was validated"
+            );
         }
 
         /// A value the operator (or systemd) already set is handed to the child

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -2161,18 +2161,147 @@ fn apply_lemonade_process_environment(
     command: &mut ProcessCommand,
     env: &LemonadeProcessEnvironment,
 ) -> Result<()> {
-    for (key, value) in lemonade_process_environment_vars(env)? {
+    let vars = lemonade_process_environment_vars(env, &ParentRuntimeEnvironment::current())?;
+    apply_environment_vars(command, &vars);
+    Ok(())
+}
+
+/// Apply an already-resolved variable set. Callers that spawn repeatedly (the
+/// readiness poll) resolve once and reuse, so preparing the runtime directory
+/// does not repeat its syscalls on every attempt.
+fn apply_environment_vars(command: &mut ProcessCommand, vars: &[(&'static str, OsString)]) {
+    for (key, value) in vars {
         command.env(key, value);
     }
+}
+
+/// The parts of *this* process's environment that decide where the child's
+/// runtime directory goes.
+///
+/// Captured into a value instead of being read inside
+/// [`lemonade_process_environment_vars`] so the precedence is testable without
+/// mutating process-global env vars, which is `unsafe` and racy under parallel
+/// tests in edition 2024.
+#[derive(Debug, Clone, Default)]
+struct ParentRuntimeEnvironment {
+    xdg_runtime_dir: Option<OsString>,
+    home: Option<OsString>,
+    user: Option<String>,
+    temp_dir: PathBuf,
+}
+
+impl ParentRuntimeEnvironment {
+    fn current() -> Self {
+        Self {
+            xdg_runtime_dir: std::env::var_os("XDG_RUNTIME_DIR"),
+            home: std::env::var_os("HOME"),
+            // An empty `USER` must fall through to `LOGNAME`, not short-circuit it.
+            user: std::env::var("USER")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .or_else(|| std::env::var("LOGNAME").ok().filter(|v| !v.is_empty())),
+            temp_dir: std::env::temp_dir(),
+        }
+    }
+}
+
+/// Leaf directory the engine gets inside a fallback runtime root, so a crashing
+/// or misbehaving server cannot disturb the telemetry socket that shares the
+/// same root.
+const RUNTIME_DIR_LEAF: &str = "lemonade";
+
+/// Guarantee the child a usable `XDG_RUNTIME_DIR`.
+///
+/// `lemond` refuses to start unless it can resolve a writable runtime directory
+/// from `XDG_RUNTIME_DIR` or `RUNTIME_DIRECTORY`. Neither exists on a headless
+/// host: `XDG_RUNTIME_DIR` is populated by `pam_systemd` at login, so it is
+/// absent for every non-login process (cron jobs, CI runners, `systemd-run`, a
+/// bare container exec), and `RUNTIME_DIRECTORY` only exists for a systemd unit
+/// that declares `RuntimeDirectory=`. There, a managed serve failed
+/// deterministically before the server ever came up.
+///
+/// A value already present in the parent environment is passed through
+/// unchanged — an operator's choice always wins, and it is the tier the rest of
+/// this precedence exists to fall back from.
+fn child_runtime_dir_var(
+    parent: &ParentRuntimeEnvironment,
+) -> Result<Option<(&'static str, OsString)>> {
+    if !runtime_is_linux() {
+        return Ok(None);
+    }
+    if let Some(existing) = parent
+        .xdg_runtime_dir
+        .as_ref()
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(Some(("XDG_RUNTIME_DIR", existing.clone())));
+    }
+    let dir = rocm_core::user_runtime_dir(
+        None,
+        parent.home.clone(),
+        parent.user.clone(),
+        parent.temp_dir.clone(),
+        RUNTIME_DIR_LEAF,
+        RUNTIME_DIR_LEAF,
+    );
+    create_private_runtime_dir(&dir).with_context(|| {
+        format!(
+            "preparing a runtime directory for the Lemonade server at {} \
+             (XDG_RUNTIME_DIR is unset in this environment)",
+            dir.display()
+        )
+    })?;
+    Ok(Some(("XDG_RUNTIME_DIR", dir.into_os_string())))
+}
+
+/// Create `dir` (and its parents) restricted to the current user.
+///
+/// The tier-3 fallback lands under a shared temp dir, so a pre-existing path
+/// there may not be ours. Both guards below only matter in that case:
+///
+/// * a symlink is refused outright — `chmod` follows it and would loosen an
+///   unrelated directory;
+/// * `DirBuilder::mode` applies only to directories it creates, so an existing
+///   directory is tightened explicitly. `chmod` needs ownership, so a failure
+///   here is a hard error rather than a warning: the server keeps its sockets
+///   and state in this directory.
+fn create_private_runtime_dir(dir: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)
+            .with_context(|| format!("creating {}", dir.display()))?;
+        if fs::symlink_metadata(dir)?.file_type().is_symlink() {
+            bail!(
+                "{} is a symlink, so it may point somewhere another user controls",
+                dir.display()
+            );
+        }
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o700)).with_context(|| {
+            format!(
+                "restricting {} to mode 0700 — it is most likely owned by another user",
+                dir.display()
+            )
+        })?;
+    }
+    #[cfg(not(unix))]
+    fs::create_dir_all(dir)?;
     Ok(())
 }
 
 fn lemonade_process_environment_vars(
     env: &LemonadeProcessEnvironment,
+    parent: &ParentRuntimeEnvironment,
 ) -> Result<Vec<(&'static str, OsString)>> {
     let mut vars = Vec::new();
     if let Some(rocm_root) = env.rocm_root.as_ref() {
         vars.push(("ROCM_PATH", rocm_root.as_os_str().to_owned()));
+    }
+    if let Some(runtime_dir) = child_runtime_dir_var(parent)? {
+        vars.push(runtime_dir);
     }
     let mut path_entries = env.path_entries.clone();
     if runtime_is_windows() {
@@ -2218,6 +2347,10 @@ fn wait_for_lemonade_cli_status(
 ) -> Result<()> {
     let start = std::time::Instant::now();
     let mut last_status = None;
+    // Resolved once: the poll runs twice a second, and resolving also prepares
+    // the child's runtime directory on disk.
+    let env_vars =
+        lemonade_process_environment_vars(process_env, &ParentRuntimeEnvironment::current())?;
     while start.elapsed() < timeout {
         let mut command = ProcessCommand::new(&manifest.lemonade);
         command
@@ -2229,7 +2362,7 @@ fn wait_for_lemonade_cli_status(
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
-        apply_lemonade_process_environment(&mut command, process_env)?;
+        apply_environment_vars(&mut command, &env_vars);
         hide_child_console_window(&mut command);
         match command.status() {
             Ok(status) if status.success() => return Ok(()),
@@ -4949,5 +5082,162 @@ vllm                rocm        unsupported     Requires Linux                  
         assert!(error.contains("symlink"), "{error}");
         assert!(!destination.join("escape-link").exists());
         fs::remove_dir_all(&dir).ok();
+    }
+
+    // `XDG_RUNTIME_DIR` is a Linux/freedesktop concept and the Lemonade server
+    // only consults it there, so these are Linux-only by construction.
+    #[cfg(target_os = "linux")]
+    mod child_runtime_dir {
+        use super::*;
+
+        fn value_of(vars: &[(&'static str, OsString)], key: &str) -> Option<OsString> {
+            vars.iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| value.clone())
+        }
+
+        fn vars_for(parent: &ParentRuntimeEnvironment) -> Vec<(&'static str, OsString)> {
+            lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), parent)
+                .expect("building the child environment must succeed")
+        }
+
+        fn assert_private_dir(dir: &Path) {
+            use std::os::unix::fs::PermissionsExt;
+            assert!(
+                dir.is_dir(),
+                "{} must exist before the server is spawned",
+                dir.display()
+            );
+            let mode = fs::metadata(dir).expect("metadata").permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o700,
+                "{} must be private to this user",
+                dir.display()
+            );
+        }
+
+        /// Regression: on a headless host `pam_systemd` never runs, so
+        /// `XDG_RUNTIME_DIR` is unset and the Lemonade server exits during
+        /// startup with "Unable to resolve writable runtime directory". The
+        /// child must be handed a directory that already exists.
+        #[test]
+        fn is_synthesized_when_the_parent_has_none() {
+            let scratch = tempfile::tempdir().expect("scratch");
+            let home = scratch.path().join("home");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: Some(home.clone().into_os_string()),
+                user: Some("alice".to_owned()),
+                temp_dir: scratch.path().join("tmp"),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("the child must be given a runtime directory");
+
+            // Tier 2 of the shared precedence, with a `lemonade` leaf so the
+            // engine never shares a directory with the telemetry socket.
+            let dir = PathBuf::from(value);
+            assert_eq!(dir, home.join(".rocm").join("data").join("lemonade"));
+            assert_private_dir(&dir);
+        }
+
+        /// An exported-but-empty variable is as good as unset, and must not be
+        /// mistaken for an operator's choice.
+        #[test]
+        fn is_synthesized_when_the_parent_value_is_empty() {
+            let scratch = tempfile::tempdir().expect("scratch");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: Some(OsString::new()),
+                home: Some(scratch.path().join("home").into_os_string()),
+                user: Some("alice".to_owned()),
+                temp_dir: scratch.path().join("tmp"),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("an empty value must fall through, not be passed on");
+            assert_eq!(
+                PathBuf::from(value),
+                scratch
+                    .path()
+                    .join("home")
+                    .join(".rocm")
+                    .join("data")
+                    .join("lemonade")
+            );
+        }
+
+        /// Tier 3: neither `XDG_RUNTIME_DIR` nor `HOME` — a user-named subdir of
+        /// the temp dir, so the parent is one we create and own, not `/tmp`.
+        #[test]
+        fn falls_back_to_a_user_owned_temp_subdir_without_home() {
+            let scratch = tempfile::tempdir().expect("scratch");
+            let temp_dir = scratch.path().join("tmp");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir: temp_dir.clone(),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("the child must be given a runtime directory");
+
+            let dir = PathBuf::from(value);
+            assert_eq!(dir, temp_dir.join("rocm-alice").join("lemonade"));
+            assert_private_dir(&dir);
+        }
+
+        /// The tier-3 fallback lands under a shared temp dir, so the target may
+        /// already exist as a symlink someone else planted. Chmod would follow
+        /// it, so the resolver refuses rather than loosening another directory.
+        #[test]
+        fn refuses_a_symlinked_runtime_dir() {
+            let scratch = tempfile::tempdir().expect("scratch");
+            let temp_dir = scratch.path().join("tmp");
+            let elsewhere = scratch.path().join("elsewhere");
+            fs::create_dir_all(temp_dir.join("rocm-alice")).expect("runtime root");
+            fs::create_dir_all(&elsewhere).expect("elsewhere");
+            std::os::unix::fs::symlink(&elsewhere, temp_dir.join("rocm-alice").join("lemonade"))
+                .expect("symlink");
+
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: None,
+                home: None,
+                user: Some("alice".to_owned()),
+                temp_dir,
+            };
+            let error = format!(
+                "{:#}",
+                lemonade_process_environment_vars(&LemonadeProcessEnvironment::default(), &parent)
+                    .expect_err("a symlinked runtime dir must be refused")
+            );
+            assert!(error.contains("symlink"), "{error}");
+        }
+
+        /// A value the operator (or systemd) already set is handed to the child
+        /// unchanged: we never relocate a working runtime directory, and never
+        /// create anything of our own beside it.
+        #[test]
+        fn passes_an_existing_parent_value_through_unchanged() {
+            let scratch = tempfile::tempdir().expect("scratch");
+            let existing = scratch.path().join("run").join("user").join("1000");
+            let home = scratch.path().join("home");
+            let parent = ParentRuntimeEnvironment {
+                xdg_runtime_dir: Some(existing.clone().into_os_string()),
+                home: Some(home.clone().into_os_string()),
+                user: Some("alice".to_owned()),
+                temp_dir: scratch.path().join("tmp"),
+            };
+
+            let value = value_of(&vars_for(&parent), "XDG_RUNTIME_DIR")
+                .expect("the child must be given a runtime directory");
+
+            assert_eq!(PathBuf::from(value), existing);
+            assert!(
+                !home.exists(),
+                "no fallback directory may be created when the parent already has one"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #259.

## Symptom

`rocm serve --engine lemonade --managed` fails on any Linux host with no
`XDG_RUNTIME_DIR`. It is fully deterministic and independent of the model or the serve
path:

```
Error: request_failed: Lemonade server did not become ready: exit status: 1;
Lemonade startup log tail (.../engines/lemonade/runtime/install-lemond.log):
[Error] (main) Error: Unable to resolve writable runtime directory from
XDG_RUNTIME_DIR or RUNTIME_DIRECTORY
```

The same command works from an interactive desktop or SSH login on the same machine, so
it reads as a machine quirk when it is really a property of how the process was started:
a systemd unit, a cron job, a container, `ssh host 'rocm serve ...'` without lingering,
or any CI runner.

## Root cause

The message comes from the spawned server, not from rocm-cli — the string appears nowhere
in this tree and `RUNTIME_DIRECTORY` is never referenced here. The server needs a writable
runtime directory and consults exactly two sources, neither of which exists in a headless
context:

- `XDG_RUNTIME_DIR`, populated by `pam_systemd` at login and therefore absent for every
  non-login process;
- `RUNTIME_DIRECTORY`, which only exists for a systemd unit declaring `RuntimeDirectory=`.

`lemonade_process_environment_vars` is the single place the child environment is
assembled. It translated `ROCM_PATH`, `PATH`, `LD_LIBRARY_PATH`, `HIP_VISIBLE_DEVICES` and
`LEMONADE_API_KEY`, but nothing about the runtime directory. rocm-cli cannot change what
the server requires, but it owns the environment it hands over, so this is the layer that
can satisfy it.

## Fix

Reuse the precedence this repo already has rather than inventing a second one.
`dashboard_socket_path` already solves "pick a writable, user-owned runtime directory with
a fallback chain", as a pure function taking its env inputs as arguments:

1. `$XDG_RUNTIME_DIR`
2. `$HOME/.rocm/data/…`
3. `temp_dir()/rocm-<user>`, with the user name sanitized so a separator or `..` cannot
   escape the subdirectory

That tier chain moves into `rocm_core::user_runtime_dir`; `dashboard_socket_path` becomes
a thin caller over it and resolves to byte-identical paths in all three tiers (its three
existing tests are unchanged and still pass). The engine calls the same helper when the
parent environment has no usable value, creates the directory mode `0700` before spawning,
and passes it down.

## Why not fix this in CI

A workflow-level fix was considered and rejected. Exporting `XDG_RUNTIME_DIR` in
`.github/workflows/e2e-selfhosted.yml`, or setting it for piped scenarios in the E2E
harness, would turn the GPU lane green and leave every headless user exactly as broken.

`pty_env` (`tests/e2e-cucumber/tests/e2e.rs`) does set `HOME` and `XDG_RUNTIME_DIR`, but
only for PTY scenarios — its comment records that piped scenarios keep their historical
HOME/XDG environment, and the serve scenarios are piped. That is correct and stays: it is
precisely why the suite reproduces the real headless case instead of hiding it.

## Decisions worth reviewing

**A distinct directory for the engine, not the dashboard's.** In the fallback tiers the
engine gets a `lemonade` leaf (`$HOME/.rocm/data/lemonade`,
`temp_dir()/rocm-<user>/lemonade`). Sharing one directory would put engine scratch state
next to the telemetry socket, so a crashing or misbehaving server could disturb the
dashboard. The isolation costs one path component.

**A shared helper, but only for the two callers that can share one.** The tier chain is
extracted into `rocm-core`, used by `dashboard_socket_path` and by the engine, so there
are still two copies of this logic rather than three. `rocm-dash-core` keeps its own
mirror deliberately: it is a standalone library with a lean dependency set, and depending
on `rocm-core` to share ~30 lines would pull in that crate's whole graph. Its "keep the
two in sync" comment now names the shared helper so the sync target is unambiguous, and
the mirrored tests on both sides still catch divergence.

**`XDG_RUNTIME_DIR` rather than `RUNTIME_DIRECTORY`.** The server reads either.
`RUNTIME_DIRECTORY` is narrower, but it is a systemd-unit contract implying systemd
created the directory and will clean it up — untrue here, and misleading to anyone
debugging. `XDG_RUNTIME_DIR` is the freedesktop-standard variable whose absence is the bug;
supplying a valid one is strictly better for any descendant process than leaving it unset.
It is never overridden: a value already in the parent environment is passed through
unchanged.

**Hardening.** The tier-3 fallback lands under a shared temp dir, so a pre-existing path
there may not be ours. A symlink is refused rather than `chmod`-ed through, and a chmod
failure is a hard error naming the path.

## Verification

Ran locally on a headless Linux host (no `XDG_RUNTIME_DIR`, no `RUNTIME_DIRECTORY`):

- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings`
- `cargo test --workspace --all-targets`, plus the existing `dashboard_socket_path` and
  `rocm-dash-core` mirror tests
- driving the real resolver against this host's actual environment: it produced
  `$HOME/.rocm/data/lemonade`, created `drwx------`

Five new unit tests on `lemonade_process_environment_vars` cover synthesis when the parent
has no value, an exported-but-empty value, the no-`HOME` tier, pass-through of an existing
value, and refusal of a symlinked directory. All five fail before this change and pass
after. They take the environment as arguments rather than mutating process-global env, so
they behave identically under `cargo test` and nextest.

Re-verified after rebasing onto current `main`: all five gates above pass, and
`cargo test --workspace --all-targets` is now fully green. Two shared-process `cargo test`
failures noted here earlier
(`therock::tests::extracting_the_sdk_archive_removes_it`,
`providers::tests::local_provider_default_chat_requires_builtin_qwen_assistant`) were
pre-existing on `main` and are gone since #253 landed; nothing about them was ever related
to this change.

**The real verification is the GPU lane, and it is now green.** No GPU here, so a full
managed serve could not be run locally; `@id:serve-lemonade-inference` and
`@id:serve-hf-checkpoint-inference` (`@requires-gpu @requires-engine:lemonade`) exercise
this on `E2E tests (GPU)`, the MI300X lane where the failure reproduces.

| | before ([job](https://github.com/ROCm/rocm-cli/actions/runs/31679587566/job/94711980880), the run in #259) | after ([job](https://github.com/ROCm/rocm-cli/actions/runs/31800860515/job/94768346825)) |
|---|---|---|
| "Unable to resolve writable runtime directory" in the log | 2 occurrences | none |
| `serve-hf-checkpoint-inference` | failed | **passes** |
| reconciliation | 1 unexpected failure — lane red | 0 unexpected failures — lane green |

`serve-lemonade-inference` still xfails, but on the unrelated EAI-7423 symptom it is
already registered for ("did not serve model within 90s"), and it now gets past server
startup instead of exiting immediately.

Worth being explicit about the shape of that coverage: the scenarios are piped, so they
inherit the runner's environment rather than asserting on it — they regress this bug
because that runner is headless, not because the harness forces it. Making it explicit
would mean touching the piped scenarios' environment, which is the thing this fix
deliberately avoids.

`tests/e2e-cucumber/expectations.toml` was searched: no row describes this failure mode.
The lemonade Linux rows there are EAI-7423 ("reaches ready then shuts down immediately") on
the Strix Halo Ubuntu lane, a different symptom on a different host, and are left alone.

