### PR TITLE
test(e2e): activate shared runtime precondition

### DIFF
--- a/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
@@ -45,6 +45,21 @@ async fn setup_active_runtime(world: &mut E2eWorld) {
         !stdout.contains("installed: none"),
         "no managed runtime is active:\n{stdout}"
     );
+    let active = stdout
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("active_runtime_key:"))
+        .map_or("", str::trim);
+    if active.is_empty() || active == "<unset>" {
+        let runtime_key = stdout
+            .lines()
+            .filter(|line| line.contains(" status=ready"))
+            .find_map(|line| {
+                line.split_whitespace()
+                    .find(|field| *field != "*" && *field != "-")
+            })
+            .unwrap_or_else(|| panic!("no ready managed runtime to activate:\n{stdout}"));
+        crate::run_rocm_ok(world, &["runtimes", "activate", runtime_key]);
+    }
 }
 
 #[when("the user installs the SDK")]


### PR DESCRIPTION
## Summary
- activate the ready shared runtime in each scenario’s isolated config
- make the `a managed runtime is active` precondition match its stated contract
- fix the Strix Halo Windows runtime-path scenario after PR #222

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p e2e-cucumber --lib`
- `cargo test --locked -p e2e-cucumber --test e2e --no-run`

Signed-off-by: Roman Sirokov <roman.sirokov@amd.com>