### PR TITLE
ci(e2e): refresh the shared pre-warmed runtime when a newer one exists (EAI-8057)

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -263,8 +263,8 @@ jobs:
           # unpacks an ~8.8 GiB devel tarball — is what blew the time cap). The
           # "a managed runtime is active" precondition symlinks each scenario's
           # data/runtimes here (see use_shared_runtimes); clean-slate scenarios
-          # stay isolated. Persisted across runs on RUNNER_WORKSPACE, so after the
-          # first run ever the pre-warm below is a no-op.
+          # stay isolated. Persisted across runs on RUNNER_WORKSPACE and refreshed
+          # by `xtask e2e-prewarm` when the channel index publishes a newer version.
           #
           # CRITICAL: the shared dir IS the pre-warm's own `data/runtimes`, and we
           # NEVER move it. `install sdk` bakes ABSOLUTE paths (install_root,
@@ -285,27 +285,20 @@ jobs:
 
           # Pre-warm the shared runtime ONCE, SERIALLY, before the suite — never
           # lazily inside a concurrent scenario (two multi-GiB installs racing the
-          # same dir). Skipped once the tree is populated (it persists across runs).
-          # Uses the prebuilt binary (no cargo run --release) and the shared uv + HF
-          # caches. Installs directly into the persistent pre-warm data dir (no mv),
-          # so the manifest's absolute install_root stays valid for every scenario.
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # same dir). Installs directly into the persistent pre-warm data dir (no
+          # mv), so the manifest's absolute install_root stays valid for every
+          # scenario. Uses the prebuilt binary (no cargo run --release) and the
+          # shared uv + HF caches.
+          #
+          # This is a CACHE, not a one-shot: `xtask e2e-prewarm` installs when the
+          # tree is empty, installs the newer runtime side-by-side and activates it
+          # when the channel index has moved on, and otherwise reuses what is there.
+          # The old guard here tested directory existence only, so it never
+          # reinstalled and every lane froze on the first runtime it ever saw
+          # (16 days stale on both MI300X runners when measured — EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+          UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           # Optional scenario-name filter for a scoped dispatch — lets a manual
           # run select only the large-model scenario instead of the whole suite.
@@ -455,24 +448,12 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          # Pre-warm once, serially, in place (no mv/symlink). Skipped once the tree
-          # is populated (persists across runs on RUNNER_WORKSPACE).
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
+          # the channel index has moved on — the tree is a cache, not a one-shot.
+          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
+          # existence-only guard froze this lane on its first runtime (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           # Optional scenario-name filter for a scoped manual dispatch.
           NAME_FILTER="${{ github.event.inputs.name_filter }}"
@@ -616,24 +597,13 @@ jobs:
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
           $env:ROCM_CLI_ROCMD_BINARY = "$targetDir\release\rocmd.exe"
 
-          # Pre-warm once, in place (no move/symlink). Skipped once the tree is
-          # populated (persists across runs on RUNNER_WORKSPACE).
-          if (-not (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry")) {
-            Write-Host "pre-warming shared runtime (first run on this runner)..."
-            New-Item -ItemType Directory -Force -Path "$prewarm\data","$prewarm\config","$prewarm\cache" | Out-Null
-            $env:ROCM_CLI_CONFIG_DIR = "$prewarm\config"
-            $env:ROCM_CLI_DATA_DIR   = "$prewarm\data"
-            $env:ROCM_CLI_CACHE_DIR  = "$prewarm\cache"
-            & $env:ROCM_CLI_BINARY install sdk
-            Remove-Item Env:\ROCM_CLI_CONFIG_DIR,Env:\ROCM_CLI_DATA_DIR,Env:\ROCM_CLI_CACHE_DIR -ErrorAction SilentlyContinue
-            if (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry") {
-              Write-Host "shared runtime pre-warmed at $env:E2E_SHARED_RUNTIMES_DIR"
-            } else {
-              Write-Host "pre-warm did not produce a runtimes registry; scenarios will install their own"
-            }
-          } else {
-            Write-Host "shared runtime already present at $env:E2E_SHARED_RUNTIMES_DIR - skipping pre-warm"
-          }
+          # Pre-warm once, in place (no move/symlink), and refresh it when the
+          # channel index has moved on — the tree is a cache, not a one-shot. The
+          # decision lives in `xtask e2e-prewarm` rather than being reimplemented
+          # here in PowerShell, so this lane and the Linux lanes cannot drift
+          # (EAI-8057; the old existence-only guard never reinstalled).
+          cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Optional scenario-name filter for a scoped manual dispatch.
           $nameFilter = "${{ github.event.inputs.name_filter }}"
@@ -810,24 +780,12 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          # Pre-warm once, serially, in place (no mv/symlink). Skipped once the
-          # tree is populated (persists across runs on RUNNER_WORKSPACE).
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
+          # the channel index has moved on — the tree is a cache, not a one-shot.
+          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
+          # existence-only guard froze this lane on its first runtime (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           # Optional scenario-name filter for a scoped manual dispatch.
           NAME_FILTER="${{ github.event.inputs.name_filter }}"
@@ -949,23 +907,13 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
+          # the channel index has moved on — the tree is a cache, not a one-shot.
+          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
+          # existence-only guard froze this lane on its first runtime (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+          UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           # Optional scenario-name filter for a scoped manual dispatch — a cheap
           # way to exercise this lane against a single scenario without the full suite.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -389,19 +389,13 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          # Pre-warm the shared runtime once/serially before the suite; skipped
-          # once populated (persists across runs). Install in place (no mv) so the
-          # manifest's absolute paths stay valid. See ci.yml e2e-gpu for rationale.
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
-              "$ROCM_CLI_BINARY" install sdk
-          fi
+          # Pre-warm the shared runtime once/serially before the suite, refreshing
+          # it when the channel index has a newer version. Install in place (no mv)
+          # so the manifest's absolute paths stay valid. See the e2e-selfhosted.yml
+          # e2e-gpu lane and `xtask e2e-prewarm` for the full rationale (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+          UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           cargo xtask e2e
 
@@ -494,23 +488,12 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
+          # the channel index has published a newer runtime — the tree is a cache,
+          # not a one-shot. See `xtask e2e-prewarm` (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+          UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           cargo xtask e2e
 
@@ -599,22 +582,10 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Cache, not a one-shot: refreshed when the channel index has a newer
+          # version. See `xtask e2e-prewarm` (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           cargo xtask e2e
 
@@ -707,22 +678,11 @@ jobs:
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
           $env:ROCM_CLI_ROCMD_BINARY = "$targetDir\release\rocmd.exe"
 
-          if (-not (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry")) {
-            Write-Host "pre-warming shared runtime (first run on this runner)..."
-            New-Item -ItemType Directory -Force -Path "$prewarm\data","$prewarm\config","$prewarm\cache" | Out-Null
-            $env:ROCM_CLI_CONFIG_DIR = "$prewarm\config"
-            $env:ROCM_CLI_DATA_DIR   = "$prewarm\data"
-            $env:ROCM_CLI_CACHE_DIR  = "$prewarm\cache"
-            & $env:ROCM_CLI_BINARY install sdk
-            Remove-Item Env:\ROCM_CLI_CONFIG_DIR,Env:\ROCM_CLI_DATA_DIR,Env:\ROCM_CLI_CACHE_DIR -ErrorAction SilentlyContinue
-            if (Test-Path "$env:E2E_SHARED_RUNTIMES_DIR\registry") {
-              Write-Host "shared runtime pre-warmed at $env:E2E_SHARED_RUNTIMES_DIR"
-            } else {
-              Write-Host "pre-warm did not produce a runtimes registry; scenarios will install their own"
-            }
-          } else {
-            Write-Host "shared runtime already present at $env:E2E_SHARED_RUNTIMES_DIR - skipping pre-warm"
-          }
+          # Cache, not a one-shot: refreshed when the channel index has a newer
+          # version. The decision lives in `xtask e2e-prewarm` so this lane cannot
+          # drift from the Linux ones (EAI-8057).
+          cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           cargo xtask e2e
 
@@ -868,22 +828,10 @@ jobs:
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
-          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-            echo "pre-warming shared runtime (first run on this runner)…"
-            mkdir -p "$prewarm"/{data,config,cache}
-            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
-            ROCM_CLI_DATA_DIR="$prewarm/data" \
-            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
-            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-              "$ROCM_CLI_BINARY" install sdk
-            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
-              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
-            else
-              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
-            fi
-          else
-            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
-          fi
+          # Cache, not a one-shot: refreshed when the channel index has a newer
+          # version. See `xtask e2e-prewarm` (EAI-8057).
+          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
 
           cargo xtask e2e
 

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -139,6 +139,43 @@ Dispatch the GPU lanes with, e.g.:
 gh workflow run e2e-selfhosted.yml --ref <ref> -f platform=app-dev-gpu
 ```
 
+## The shared pre-warmed runtime
+
+Nearly every GPU serve scenario points its `data/runtimes` at one shared,
+pre-warmed managed runtime (`E2E_SHARED_RUNTIMES_DIR`), so a multi-GiB
+`rocm install sdk` happens once per runner instead of once per scenario. The tree
+lives on the runner's persistent workspace and survives `git clean`.
+
+It is a **cache with invalidation**, not a one-shot install. Each self-hosted lane calls
+
+```bash
+cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
+```
+
+before the suite, which asks `rocm update` whether the channel index has published
+a newer version and then:
+
+- installs the SDK when nothing is present for that channel;
+- installs the newer runtime **side-by-side** and activates it
+  (`rocm update --apply --runtime <key> --activate`) when the index is ahead;
+- reuses the existing tree when it is `up_to_date`, when it is `ahead_of_index`
+  (a pinned build newer than the index must not be rolled back), or when freshness
+  cannot be established at all — an unreachable index reuses and warns rather than
+  re-downloading gigabytes or failing the lane;
+- prunes with `rocm storage remove-old-installs` after any install or update, so
+  the multi-version cache stays bounded.
+
+The runtime is always installed **in place**: `install sdk` bakes absolute paths
+into the runtime manifest, so a tree that is moved after installation leaves every
+serve pointing at a path that no longer exists.
+
+This replaced an existence-only guard that never reinstalled, which had frozen both
+MI300X runners on a 16-day-old runtime and left drift from a fresh install untested
+(`EAI-8057`). The decision logic lives in `xtask` rather than the workflows because
+the pre-warm block is duplicated across eight jobs in two shells; `xtask/src/e2e_prewarm.rs`
+carries unit tests for each freshness verdict, and the `runtime-update-reports-freshness`
+scenario pins the `rocm update` output shape those tests assume.
+
 ## Blocking vs. non-blocking
 
 The self-hosted jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`,

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -172,9 +172,9 @@ serve pointing at a path that no longer exists.
 This replaced an existence-only guard that never reinstalled, which had frozen both
 MI300X runners on a 16-day-old runtime and left drift from a fresh install untested
 (`EAI-8057`). The decision logic lives in `xtask` rather than the workflows because
-the pre-warm block is duplicated across eight jobs in two shells; `xtask/src/e2e_prewarm.rs`
-carries unit tests for each freshness verdict, and the `runtime-update-reports-freshness`
-scenario pins the `rocm update` output shape those tests assume.
+the pre-warm block is duplicated across multiple jobs in two shells;
+`xtask/src/e2e_prewarm.rs` carries unit tests for each freshness verdict, and the
+`runtime-update-reports-freshness` scenario pins the `rocm update` output shape those tests assume.
 
 ## Blocking vs. non-blocking
 

--- a/tests/e2e-cucumber/features/runtime_setup.feature
+++ b/tests/e2e-cucumber/features/runtime_setup.feature
@@ -32,6 +32,21 @@ Feature: Runtime configuration
     When the user installs the SDK again
     Then the install reports the engine's requirements as satisfied
 
+  # The GPU E2E lanes no longer install the shared runtime once and keep it
+  # forever: `xtask e2e-prewarm` asks `rocm update` whether the channel index has
+  # published a newer version, and installs it side-by-side when it has (EAI-8057).
+  # That makes CI depend on the freshness line this scenario pins. A unit test on a
+  # hand-written fixture cannot catch the renderer drifting away from the parser —
+  # only running the real command can, which is why this is a scenario and not just
+  # an xtask test. Cheap enough for the per-PR lanes: one CLI call against the
+  # already-installed shared runtime. `status=error` is an ACCEPTED outcome, so an
+  # offline runner reports honestly instead of flaking.
+  @id:runtime-update-reports-freshness @requires-gpu
+  Scenario: 5 - The update check reports the active runtime's freshness
+    Given a managed runtime is active
+    When the user checks for runtime updates
+    Then the report states the runtime's freshness against the channel index
+
   # Linux-only: the step adopts a standard `/opt/rocm` install with a Unix python
   # path. On Windows those paths don't exist (the CLI resolves `/usr/bin/python3`
   # to a bogus `C:/usr/bin/python3` and errors on the missing path before it can

--- a/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/runtime_steps.rs
@@ -174,6 +174,62 @@ async fn assert_runtime_path_not_nested(world: &mut E2eWorld) {
     );
 }
 
+#[when("the user checks for runtime updates")]
+async fn user_checks_for_updates(world: &mut E2eWorld) {
+    // Plain `rocm update` — the check-only form. Without `--apply` it never
+    // mutates the runtime tree, so this is safe to run against the shared runtime
+    // the other scenarios serve from.
+    world.use_shared_runtimes();
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["update"]);
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+/// Freshness verdicts `runtime_update_plan` can emit, plus the degraded `error`
+/// form used when the index cannot be reached. `xtask e2e-prewarm` routes on
+/// exactly these, so a rename here must break this scenario rather than silently
+/// turn every pre-warm into a no-op reuse.
+const UPDATE_STATUSES: [&str; 4] = ["up_to_date", "update_available", "ahead_of_index", "error"];
+
+#[then("the report states the runtime's freshness against the channel index")]
+async fn assert_update_reports_freshness(world: &mut E2eWorld) {
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    let rc = world.cli_rc.expect("no command was run");
+    assert_eq!(rc, 0, "`rocm update` failed:\n{stdout}");
+
+    // The line `xtask e2e-prewarm` parses: `runtime <key> ... status=<verdict>`.
+    let Some(line) = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("runtime "))
+    else {
+        panic!("no `runtime <key> …` line in the update report:\n{stdout}");
+    };
+    let status = line
+        .split_whitespace()
+        .find_map(|field| field.strip_prefix("status="));
+    let Some(status) = status else {
+        panic!("update report line carries no `status=` field:\n{line}");
+    };
+    assert!(
+        UPDATE_STATUSES.contains(&status),
+        "unrecognised freshness status `{status}`; `xtask e2e-prewarm` routes on \
+         {UPDATE_STATUSES:?} and would silently reuse a stale runtime:\n{line}"
+    );
+    // The pre-warm selects the line for its own channel, so the field it filters
+    // on must be present too — except on the degraded error line, which the
+    // renderer emits without one.
+    if status != "error" {
+        assert!(
+            line.split_whitespace()
+                .any(|field| field.starts_with("channel=")),
+            "update report line carries no `channel=` field, so a per-channel \
+             pre-warm cannot attribute it:\n{line}"
+        );
+    }
+}
+
 #[then("the adoption is refused")]
 async fn assert_adoption_refused(world: &mut E2eWorld) {
     let rc = world.cli_rc.expect("no command was run");

--- a/xtask/src/e2e_prewarm.rs
+++ b/xtask/src/e2e_prewarm.rs
@@ -35,9 +35,9 @@
 //!   cache with a per-channel/format/family retention policy.
 //!
 //! Living in xtask rather than the workflows is deliberate: the pre-warm block is
-//! duplicated across eight jobs in two shells (bash on the Linux lanes, PowerShell
-//! on Strix Windows), so the decision logic would otherwise exist eight times in two
-//! languages and be untestable. Same reasoning as `e2e.rs` — the recipe belongs in
+//! duplicated across multiple jobs in two shells (bash on the Linux lanes,
+//! PowerShell on Strix Windows), so the decision logic would otherwise drift across
+//! copies and be untestable. Same reasoning as `e2e.rs` — the recipe belongs in
 //! one cross-platform place instead of a shell wrapper.
 
 use std::path::{Path, PathBuf};
@@ -81,18 +81,37 @@ pub fn decide(update_report: &str, channel: &str) -> Decision {
     let runtimes: Vec<RuntimeLine> = update_report
         .lines()
         .filter_map(RuntimeLine::parse)
-        .filter(|line| line.channel.as_deref() == Some(channel))
         .collect();
 
-    // Nothing installed for THIS channel. The tree may still hold another
-    // channel's runtime — that is the normal state once a per-channel pre-warm
-    // directory is shared, and the right response is still a cold install here.
-    if runtimes.is_empty() {
+    // A degraded `status=error` line omits `channel=` because resolution failed
+    // before the renderer had a plan. It proves a runtime exists but cannot be
+    // attributed safely, so the conservative choice is reuse, not a fresh
+    // multi-GiB install. A later healthy probe will identify the channel.
+    // In a mixed-channel tree the error may belong to another channel, but the
+    // report has discarded that identity. Reuse remains the safe floor until a
+    // healthy probe can distinguish "missing channel" from "unknown freshness".
+    if !runtimes
+        .iter()
+        .any(|line| line.channel.as_deref() == Some(channel))
+    {
+        if runtimes
+            .iter()
+            .any(|line| line.channel.is_none() && line.status.as_deref() == Some("error"))
+        {
+            return Decision::Reuse {
+                reason: "could not establish runtime freshness; leaving the shared tree untouched"
+                    .to_owned(),
+            };
+        }
+
+        // Nothing installed for THIS channel. The tree may still hold another
+        // channel's runtime, so install this one.
         return Decision::Install;
     }
 
     if let Some(stale) = runtimes
         .iter()
+        .filter(|line| line.channel.as_deref() == Some(channel))
         .find(|line| line.status.as_deref() == Some("update_available"))
     {
         return Decision::Update {
@@ -105,11 +124,13 @@ pub fn decide(update_report: &str, channel: &str) -> Decision {
     // "updating" backwards.
     let reason = if runtimes
         .iter()
+        .filter(|line| line.channel.as_deref() == Some(channel))
         .any(|line| line.status.as_deref() == Some("up_to_date"))
     {
         "runtime is up to date with the channel index"
     } else if runtimes
         .iter()
+        .filter(|line| line.channel.as_deref() == Some(channel))
         .any(|line| line.status.as_deref() == Some("ahead_of_index"))
     {
         "installed runtime is ahead of the channel index"
@@ -387,16 +408,25 @@ source: index\n"
 
     #[test]
     fn index_error_reuses_rather_than_reinstalling() {
-        // The offline/unreachable-index case. Reinstalling here would download
-        // multiple GiB on every run of an isolated runner, and failing would turn
-        // the lane red for a network blip.
+        // The renderer omits `channel=` when resolving the index fails. That is
+        // unknown freshness, not proof that this channel has no runtime, so the
+        // conservative pre-warm decision must reuse rather than download again.
         let text = "update\n  runtime release-wheel-gfx94x-dcgpu-7-13-0 format=wheel \
 status=error message=failed to reach https://repo.amd.com/rocm/whl after 3 tries\n";
-        // The degraded line carries no `channel=`, so it is not attributable to
-        // this channel and the report reads as "nothing installed for release".
-        // That is the one case where the fallback in `run` (registry on disk?)
-        // decides, not this function.
-        assert_eq!(decide(text, "release"), Decision::Install);
+        let Decision::Reuse { reason } = decide(text, "release") else {
+            panic!("an unattributable index error must reuse the existing tree");
+        };
+        assert!(reason.contains("could not establish"), "{reason}");
+    }
+
+    #[test]
+    fn unattributed_error_wins_over_a_known_other_channel() {
+        let text = format!(
+            "{}  runtime release-wheel-gfx94x-dcgpu-7-13-0 format=wheel \
+status=error message=failed to reach the index\n",
+            report("up_to_date", "nightly")
+        );
+        assert!(matches!(decide(&text, "release"), Decision::Reuse { .. }));
     }
 
     #[test]

--- a/xtask/src/e2e_prewarm.rs
+++ b/xtask/src/e2e_prewarm.rs
@@ -1,0 +1,486 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Prepare the shared managed runtime the GPU E2E lanes serve against.
+//!
+//! Nearly every GPU serve scenario points its `data/runtimes` at ONE shared,
+//! pre-warmed runtime tree (see `E2E_SHARED_RUNTIMES_DIR` and
+//! `E2eWorld::use_shared_runtimes`) so a multi-GiB `install sdk` happens once per
+//! runner instead of once per scenario. The lanes used to guard that install on
+//! directory existence alone:
+//!
+//! ```text
+//! if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then ... rocm install sdk ...; fi
+//! ```
+//!
+//! which never reinstalls. The tree persists on the runner's PVC, so after the
+//! first run ever the pre-warm was a permanent no-op and every lane kept serving
+//! against whatever runtime happened to be installed that day — 16 days stale on
+//! both MI300X runners when this was measured (EAI-8057). Drift between the
+//! shared tree and what a fresh install produces was therefore untested, and
+//! widened silently.
+//!
+//! This keeps the cache and invalidates it only when the channel index actually
+//! publishes something newer, reusing the primitives the CLI already ships
+//! rather than reimplementing version resolution in workflow shell:
+//!
+//! * `rocm update` reports, per installed runtime, `status=up_to_date |
+//!   update_available | ahead_of_index` by comparing against the channel index.
+//! * `rocm update --apply --runtime <key> --activate` installs the newer runtime
+//!   SIDE BY SIDE and makes it the default. Side-by-side matters: `install sdk`
+//!   bakes ABSOLUTE paths into the runtime manifest, so a runtime must be created
+//!   in its final location and never moved afterwards.
+//! * `rocm storage remove-old-installs --keep N` bounds the resulting multi-version
+//!   cache with a per-channel/format/family retention policy.
+//!
+//! Living in xtask rather than the workflows is deliberate: the pre-warm block is
+//! duplicated across eight jobs in two shells (bash on the Linux lanes, PowerShell
+//! on Strix Windows), so the decision logic would otherwise exist eight times in two
+//! languages and be untestable. Same reasoning as `e2e.rs` — the recipe belongs in
+//! one cross-platform place instead of a shell wrapper.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::paths::{binary_name, release_binary_dir, workspace_root};
+
+/// What the pre-warm should do with the shared tree, given the current
+/// `rocm update` report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// No managed runtime for this channel yet — do the cold `install sdk`.
+    Install,
+    /// The channel index has a newer version than the installed one; install it
+    /// alongside and activate it.
+    Update { runtime_key: String },
+    /// The tree is current, or its freshness could not be established. Serve
+    /// against what is already there.
+    Reuse { reason: String },
+}
+
+/// Decide from a `rocm update` report what the pre-warm should do for `channel`.
+///
+/// Pure so every branch is unit-testable without a GPU, a network, or an install.
+///
+/// The bias is deliberately conservative: anything this cannot read as "a newer
+/// version exists for our channel" resolves to [`Decision::Reuse`]. A GPU lane
+/// must not be turned red, nor a multi-GiB download triggered, because the
+/// package index was briefly unreachable — `rocm update` reports that per runtime
+/// as `status=error`, and an offline runner would otherwise reinstall on every run.
+#[must_use]
+pub fn decide(update_report: &str, channel: &str) -> Decision {
+    // The empty-registry wording from `render_update_report`. Checked before the
+    // per-runtime scan because there are no `runtime` lines at all in that case.
+    if update_report.contains("managed runtimes: none") {
+        return Decision::Install;
+    }
+
+    let runtimes: Vec<RuntimeLine> = update_report
+        .lines()
+        .filter_map(RuntimeLine::parse)
+        .filter(|line| line.channel.as_deref() == Some(channel))
+        .collect();
+
+    // Nothing installed for THIS channel. The tree may still hold another
+    // channel's runtime — that is the normal state once a per-channel pre-warm
+    // directory is shared, and the right response is still a cold install here.
+    if runtimes.is_empty() {
+        return Decision::Install;
+    }
+
+    if let Some(stale) = runtimes
+        .iter()
+        .find(|line| line.status.as_deref() == Some("update_available"))
+    {
+        return Decision::Update {
+            runtime_key: stale.runtime_key.clone(),
+        };
+    }
+
+    // `ahead_of_index` means the installed runtime is NEWER than anything the
+    // index offers (a hand-placed or pinned build). Reuse it rather than
+    // "updating" backwards.
+    let reason = if runtimes
+        .iter()
+        .any(|line| line.status.as_deref() == Some("up_to_date"))
+    {
+        "runtime is up to date with the channel index"
+    } else if runtimes
+        .iter()
+        .any(|line| line.status.as_deref() == Some("ahead_of_index"))
+    {
+        "installed runtime is ahead of the channel index"
+    } else {
+        // Only `status=error` (or a shape this does not recognise) remains.
+        "could not establish runtime freshness; leaving the shared tree untouched"
+    };
+    Decision::Reuse {
+        reason: reason.to_owned(),
+    }
+}
+
+/// One `  runtime <key> format=… channel=… … status=…` line from `rocm update`.
+///
+/// Both shapes that renderer emits are handled: the full report line, and the
+/// degraded `runtime <key> format=… status=error message=…` line. `message=` is
+/// free text that may contain spaces, but it is last and only `channel`/`status`
+/// are read, so a whitespace split is sufficient — trailing words of the message
+/// simply carry no `=` and are ignored.
+struct RuntimeLine {
+    runtime_key: String,
+    channel: Option<String>,
+    status: Option<String>,
+}
+
+impl RuntimeLine {
+    fn parse(line: &str) -> Option<Self> {
+        let rest = line.trim().strip_prefix("runtime ")?;
+        let mut fields = rest.split_whitespace();
+        let runtime_key = fields.next()?.to_owned();
+        let mut channel = None;
+        let mut status = None;
+        for field in fields {
+            match field.split_once('=') {
+                Some(("channel", value)) => channel = Some(value.to_owned()),
+                Some(("status", value)) => status = Some(value.to_owned()),
+                _ => {}
+            }
+        }
+        Some(Self {
+            runtime_key,
+            channel,
+            status,
+        })
+    }
+}
+
+/// Bring the shared pre-warm tree at `prewarm_dir` to the newest runtime the
+/// `channel` index offers, keeping `keep` recent installs per channel/format/family.
+pub fn run(channel: &str, keep: usize, prewarm_dir: &Path) -> Result<()> {
+    let rocm = resolve_rocm_binary()?;
+    for sub in ["config", "data", "cache"] {
+        let dir = prewarm_dir.join(sub);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("failed to create pre-warm directory {}", dir.display()))?;
+    }
+
+    let decision = match probe(&rocm, prewarm_dir) {
+        Ok(report) => decide(&report, channel),
+        Err(error) => {
+            // `rocm update` itself failed (not a per-runtime index error). Fall
+            // back to the guard the lanes used before this existed: install only
+            // when the registry is genuinely absent, otherwise serve against what
+            // is there. Preserves the old floor rather than failing the lane.
+            let registry = prewarm_dir.join("data").join("runtimes").join("registry");
+            if registry.is_dir() {
+                println!("pre-warm: `rocm update` failed ({error:#}); reusing the existing tree");
+                Decision::Reuse {
+                    reason: "update probe failed".to_owned(),
+                }
+            } else {
+                println!("pre-warm: `rocm update` failed ({error:#}); no registry yet, installing");
+                Decision::Install
+            }
+        }
+    };
+
+    match &decision {
+        Decision::Install => {
+            println!(
+                "pre-warm: installing the {channel} SDK into {}",
+                prewarm_dir.display()
+            );
+            rocm_command(&rocm, prewarm_dir)
+                .args(["install", "sdk", "--channel", channel])
+                .status_ok("rocm install sdk")?;
+        }
+        Decision::Update { runtime_key } => {
+            println!(
+                "pre-warm: {runtime_key} is behind the {channel} index; installing the newer runtime alongside it"
+            );
+            rocm_command(&rocm, prewarm_dir)
+                .args(["update", "--apply", "--runtime", runtime_key, "--activate"])
+                .status_ok("rocm update --apply")?;
+        }
+        Decision::Reuse { reason } => {
+            println!("pre-warm: reusing the shared {channel} runtime ({reason})");
+            return Ok(());
+        }
+    }
+
+    // An install/update that exits 0 without leaving a registry behind is the
+    // confusing case the lanes used to call out by hand: every scenario then falls
+    // back to installing its own runtime and the job quietly blows its time cap.
+    // Say so loudly, but do not fail — the suite can still run.
+    let registry = prewarm_dir.join("data").join("runtimes").join("registry");
+    if !registry.is_dir() {
+        println!(
+            "::warning::pre-warm produced no runtimes registry at {}; scenarios will install their own",
+            registry.display()
+        );
+    }
+
+    // Only reached after an install or update actually added a tree. Housekeeping:
+    // a failure here wastes disk but leaves a correct runtime in place, so it must
+    // not fail the lane.
+    let pruned = rocm_command(&rocm, prewarm_dir)
+        .args([
+            "storage",
+            "remove-old-installs",
+            "--keep",
+            &keep.to_string(),
+            "--yes",
+        ])
+        .status_ok("rocm storage remove-old-installs");
+    if let Err(error) = pruned {
+        println!("pre-warm: pruning old installs failed ({error:#}); continuing");
+    }
+    Ok(())
+}
+
+/// Ask the CLI whether the installed runtimes are current. Check-only: plain
+/// `rocm update` without `--apply` never mutates state.
+fn probe(rocm: &Path, prewarm_dir: &Path) -> Result<String> {
+    let output = rocm_command(rocm, prewarm_dir)
+        .arg("update")
+        .output()
+        .context("failed to run `rocm update`")?;
+    if !output.status.success() {
+        bail!(
+            "`rocm update` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// A `rocm` invocation scoped to the pre-warm tree.
+///
+/// The three `ROCM_CLI_*` directories are what make this a SHARED tree rather
+/// than the caller's own; `HF_HOME` / `UV_CACHE_DIR` are inherited from the job
+/// environment, which the lanes already export.
+fn rocm_command(rocm: &Path, prewarm_dir: &Path) -> Command {
+    let mut cmd = Command::new(rocm);
+    cmd.env("ROCM_CLI_CONFIG_DIR", prewarm_dir.join("config"))
+        .env("ROCM_CLI_DATA_DIR", prewarm_dir.join("data"))
+        .env("ROCM_CLI_CACHE_DIR", prewarm_dir.join("cache"));
+    cmd
+}
+
+/// Run a command for its exit status, turning a non-zero exit into an error that
+/// names the command.
+trait StatusOk {
+    fn status_ok(&mut self, what: &str) -> Result<()>;
+}
+
+impl StatusOk for Command {
+    fn status_ok(&mut self, what: &str) -> Result<()> {
+        let status = self
+            .status()
+            .with_context(|| format!("failed to run `{what}`"))?;
+        if !status.success() {
+            bail!("`{what}` exited with {status}");
+        }
+        Ok(())
+    }
+}
+
+/// The `rocm` binary to drive: `ROCM_CLI_BINARY` when the caller already built
+/// one (as every CI lane does, so the pre-warm and the suite share a build),
+/// otherwise the release binary in the active target directory.
+fn resolve_rocm_binary() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("ROCM_CLI_BINARY") {
+        // Absolutize as `e2e.rs` does: the Strix Windows lane sets a RELATIVE
+        // `target\release\rocm.exe` when `CARGO_TARGET_DIR` is unset, which would
+        // only resolve while the cwd happens to be the workspace root.
+        let path = PathBuf::from(path);
+        return if path.is_absolute() {
+            Ok(path)
+        } else {
+            Ok(std::env::current_dir()
+                .context("failed to read the current directory")?
+                .join(path))
+        };
+    }
+    let root = workspace_root()?;
+    let candidate = release_binary_dir(&root, None).join(binary_name("rocm"));
+    if !candidate.is_file() {
+        bail!(
+            "no rocm binary at {}; run `cargo build --release -p rocm` or set ROCM_CLI_BINARY",
+            candidate.display()
+        );
+    }
+    Ok(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real `rocm update` report on a machine with no managed runtime, captured
+    /// verbatim from the built binary rather than written by hand — the parser has
+    /// to survive the whole document, not an idealized excerpt of it.
+    ///
+    /// Note the `update_surfaces` block: `runtimes: status=none_configured` is one
+    /// character away from a real `runtime <key> … status=…` entry, and carries a
+    /// `status=` field of its own. See `update_surfaces_block_is_not_a_runtime_entry`.
+    const EMPTY: &str = "\
+update
+  policy: bounded startup check, cached metadata, prompt before mutating state.
+  managed runtimes: none
+  next step: run `rocm install sdk --channel release --dry-run` to resolve a TheRock runtime
+  update_surfaces:
+    cli: installed=0.1.0 status=not_configured reason=repository-owned CLI update feed is not published yet
+    engines: status=package_managed packaged=[lemonade,vllm] reason=first-party engine binaries update with the rocm-cli package; data-dir plugins are user-managed
+    model_recipes: status=built_in count=13 reason=external signed recipe index is not configured
+    runtimes: status=none_configured reason=TheRock runtime update checks above are the only live update checks in this build
+  note: `rocm update --apply` applies runtime updates only; CLI, engine, and recipe update feeds require published metadata before they can mutate state
+";
+
+    fn report(status: &str, channel: &str) -> String {
+        format!(
+            "update\n  policy: bounded startup check, cached metadata, prompt before mutating state.\n  \
+runtime {channel}-wheel-gfx94x-dcgpu-7-13-0 format=wheel channel={channel} \
+family=gfx94X-dcgpu installed=7.13.0 latest=7.15.0 status={status}\n    \
+install_root: /w/e2e-prewarm/data/runtimes/wheel/{channel}-wheel-gfx94x-dcgpu-7-13-0\n    \
+source: index\n"
+        )
+    }
+
+    #[test]
+    fn no_managed_runtime_installs() {
+        assert_eq!(decide(EMPTY, "release"), Decision::Install);
+    }
+
+    #[test]
+    fn newer_version_in_the_index_updates_that_runtime() {
+        assert_eq!(
+            decide(&report("update_available", "release"), "release"),
+            Decision::Update {
+                runtime_key: "release-wheel-gfx94x-dcgpu-7-13-0".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn current_runtime_is_reused() {
+        let Decision::Reuse { reason } = decide(&report("up_to_date", "release"), "release") else {
+            panic!("an up-to-date runtime must be reused, not reinstalled");
+        };
+        assert!(reason.contains("up to date"), "{reason}");
+    }
+
+    #[test]
+    fn runtime_ahead_of_the_index_is_not_downgraded() {
+        // A pinned or hand-placed build newer than the index must be left alone —
+        // "updating" it would move the lane backwards.
+        let Decision::Reuse { reason } = decide(&report("ahead_of_index", "release"), "release")
+        else {
+            panic!("a runtime ahead of the index must be reused");
+        };
+        assert!(reason.contains("ahead of"), "{reason}");
+    }
+
+    #[test]
+    fn index_error_reuses_rather_than_reinstalling() {
+        // The offline/unreachable-index case. Reinstalling here would download
+        // multiple GiB on every run of an isolated runner, and failing would turn
+        // the lane red for a network blip.
+        let text = "update\n  runtime release-wheel-gfx94x-dcgpu-7-13-0 format=wheel \
+status=error message=failed to reach https://repo.amd.com/rocm/whl after 3 tries\n";
+        // The degraded line carries no `channel=`, so it is not attributable to
+        // this channel and the report reads as "nothing installed for release".
+        // That is the one case where the fallback in `run` (registry on disk?)
+        // decides, not this function.
+        assert_eq!(decide(text, "release"), Decision::Install);
+    }
+
+    #[test]
+    fn index_error_on_an_attributable_line_is_reused() {
+        let text = "update\n  runtime release-wheel-gfx94x-dcgpu-7-13-0 format=wheel \
+channel=release status=error message=failed to reach the index\n";
+        let Decision::Reuse { reason } = decide(text, "release") else {
+            panic!("an unreadable freshness status must reuse the existing tree");
+        };
+        assert!(reason.contains("could not establish"), "{reason}");
+    }
+
+    #[test]
+    fn another_channels_runtime_does_not_satisfy_this_channel() {
+        // A per-channel pre-warm still shares one tree layout, and EAI-8056 adds a
+        // nightly lane: a release runtime must never be mistaken for a nightly one.
+        assert_eq!(
+            decide(&report("up_to_date", "release"), "nightly"),
+            Decision::Install
+        );
+    }
+
+    #[test]
+    fn the_stale_runtime_for_this_channel_is_the_one_updated() {
+        // Mixed tree: only the line matching our channel may be selected.
+        let text = format!(
+            "{}{}",
+            report("up_to_date", "release"),
+            report("update_available", "nightly")
+        );
+        assert_eq!(
+            decide(&text, "nightly"),
+            Decision::Update {
+                runtime_key: "nightly-wheel-gfx94x-dcgpu-7-13-0".to_owned()
+            }
+        );
+        // …and the release lane reading the same tree still sees a cache hit.
+        assert!(matches!(decide(&text, "release"), Decision::Reuse { .. }));
+    }
+
+    #[test]
+    fn unparseable_report_reuses() {
+        let Decision::Reuse { reason } = decide(
+            "update\n  runtime weird-key format=wheel channel=release\n",
+            "release",
+        ) else {
+            panic!("a report with no status must reuse");
+        };
+        assert!(reason.contains("could not establish"), "{reason}");
+    }
+
+    #[test]
+    fn message_text_containing_spaces_does_not_break_field_parsing() {
+        let line = "  runtime k format=wheel channel=release status=error \
+message=connect timed out after 30 s";
+        let parsed = RuntimeLine::parse(line).expect("line parses");
+        assert_eq!(parsed.runtime_key, "k");
+        assert_eq!(parsed.channel.as_deref(), Some("release"));
+        assert_eq!(parsed.status.as_deref(), Some("error"));
+    }
+
+    #[test]
+    fn non_runtime_lines_are_ignored() {
+        assert!(RuntimeLine::parse("  policy: bounded startup check").is_none());
+        assert!(RuntimeLine::parse("    install_root: /tmp/x").is_none());
+    }
+
+    #[test]
+    fn update_surfaces_block_is_not_a_runtime_entry() {
+        // `runtimes: status=none_configured` differs from a real entry only by the
+        // `s` where the prefix expects a space, and it does carry a `status=`
+        // field. Reading it as a runtime would make an empty tree look like an
+        // unrecognised-status one and resolve to Reuse — the pre-warm would then
+        // never do the very first install.
+        assert!(
+            RuntimeLine::parse(
+                "    runtimes: status=none_configured reason=TheRock runtime update checks \
+                 above are the only live update checks in this build"
+            )
+            .is_none(),
+            "the update_surfaces summary must not parse as an installed runtime"
+        );
+        assert!(RuntimeLine::parse("    cli: installed=0.1.0 status=not_configured").is_none());
+        // …and end to end, the real empty report still resolves to a cold install.
+        assert_eq!(decide(EMPTY, "release"), Decision::Install);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@
 mod affected;
 mod demos;
 mod e2e;
+mod e2e_prewarm;
 mod e2e_report;
 mod manifest;
 mod package;
@@ -171,6 +172,27 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Prepare the shared managed runtime the GPU E2E lanes serve against,
+    /// refreshing it when the channel index has published a newer version.
+    ///
+    /// Replaces the lanes' existence-only pre-warm guard, which never reinstalled
+    /// and so froze every GPU lane on whatever runtime was installed first. The
+    /// tree stays a cache: an install happens only when nothing is present for the
+    /// channel, an in-place side-by-side update only when the index is genuinely
+    /// ahead, and anything unclear (an unreachable index) reuses what is there.
+    E2ePrewarm {
+        /// TheRock package channel the shared runtime should track.
+        #[arg(long, default_value = "release")]
+        channel: String,
+        /// Recent installs to keep per channel, format, and GPU family when
+        /// pruning after an install or update.
+        #[arg(long, default_value_t = 2)]
+        keep: usize,
+        /// Pre-warm root holding `config/`, `data/`, and `cache/`. Its
+        /// `data/runtimes` is what the lanes export as `E2E_SHARED_RUNTIMES_DIR`.
+        #[arg(long)]
+        prewarm_dir: PathBuf,
+    },
     /// Consolidate per-platform E2E `report.json` files (one per CI job/runner)
     /// into a single cross-platform HTML report, and print a summary matrix to
     /// stdout for `$GITHUB_STEP_SUMMARY`.
@@ -245,6 +267,11 @@ fn run() -> Result<()> {
             target,
         } => package::run(&dist_name, &output_dir, target.as_deref())?,
         Command::E2e { args } => e2e::run(&args)?,
+        Command::E2ePrewarm {
+            channel,
+            keep,
+            prewarm_dir,
+        } => e2e_prewarm::run(&channel, keep, &prewarm_dir)?,
         Command::E2eReport {
             artifacts_dir,
             html_out,


### PR DESCRIPTION
## Summary

Nearly every GPU E2E scenario serves against one shared, pre-warmed managed
runtime, so a multi-GiB `rocm install sdk` happens once per runner instead of
once per scenario. That tree lives on the runner's persistent workspace and
survives `git clean`.

**Cause.** Every self-hosted lane guarded the install on directory existence
alone:

```bash
if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then … fi
```

A persistent directory plus an existence-only guard means that branch runs
exactly once in the lifetime of a runner. After the first run ever, every
subsequent run served against whatever runtime happened to be installed that
day — 16 days old on both MI300X runners when measured. Two consequences: the
lanes validate an increasingly historical SDK, and drift between the shared tree
and what a fresh `install sdk` produces is never exercised at all, so a break in
the install path can only be discovered by a new runner.

**Fix.** Keep the cache, but invalidate it when the channel index has actually
published something newer. `cargo xtask e2e-prewarm` replaces the guard in all
eight self-hosted lanes and resolves to one of four outcomes:

| Index vs. installed | Action |
|---|---|
| nothing installed for the channel | cold `install sdk` |
| index is ahead | install side-by-side, activate, prune |
| `up_to_date` / `ahead_of_index` | reuse |
| freshness unknown (index unreachable) | reuse, warn |

## Why it is shaped this way

**Reuse the CLI's primitives instead of reimplementing version resolution.**
`rocm update` already reports per-runtime freshness against the channel index,
`rocm update --apply --runtime <key> --activate` already installs a newer runtime
side-by-side, and `rocm storage remove-old-installs --keep N` already bounds the
resulting multi-version cache. Comparing versions in workflow shell would have
duplicated logic that exists — and is tested — in the product. It also means the
GPU lanes now exercise `update` and `storage` on real hardware, which nothing
did before.

**Side-by-side, never move the tree.** `install sdk` bakes absolute paths into
the runtime manifest, so a runtime has to be created in its final location. This
is why the update path uses `--apply --activate` rather than installing
elsewhere and swapping.

**In `xtask`, not in the workflows.** The pre-warm block is duplicated across
eight jobs in two shells (bash on the Linux lanes, PowerShell on Strix Windows).
Inline logic would exist eight times in two languages and be untestable; the
Strix Windows lanes lose their PowerShell copy rather than gaining a second
implementation to keep in sync. Same reasoning as the existing `xtask e2e`.

**Anything unclear reuses.** Only a report that positively reads as "a newer
version exists for our channel" triggers work. An unreachable package index
surfaces per-runtime as `status=error`, which reuses and warns — a briefly
offline index must not turn a GPU lane red, nor start a multi-GiB download on
every run. Install and update failures do propagate; a failed prune only warns.

**A scenario pins the output shape — partially, and the gap is worth naming.**
The decision is parsed out of `rocm update` text, so a fixture can drift from the
renderer it imitates. The new `runtime-update-reports-freshness` scenario runs the
real command on hardware and asserts the shape the parser depends on: a
`runtime <key> …` line carrying `channel=` and a recognised `status=`. That covers
structural drift — a renamed prefix or a dropped `channel=` filters every line out
and makes the lane reinstall on every run, which is loud; a renamed `status=`
field fails the scenario outright.

What it does not cover is a rename of the *value* `update_available`. A runner
that is currently up to date reports `up_to_date`, the assertion still passes, and
the decision quietly falls through to "reuse" — the exact defect this PR fixes.
Catching that reliably would need a runner that happens to be stale. The real
cause is that this is an unversioned text contract with more than one parser:
`rocmd` reads the same field by hand in
`update_output_reports_update_available`, also against hand-written fixtures, so
it carries the same exposure today. A machine-readable form of `update`, or a
shared constant for the status values, would close both. That is product-code
work and deliberately out of scope here.

## Test plan

Verified locally:

- `cargo test --workspace --all-targets` — 2215 passed, 0 failed. Includes 12 new
  unit tests covering every freshness verdict and the degraded paths.
- `cargo clippy --workspace --all-targets -- -D warnings` and
  `cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings` clean;
  `cargo fmt --all --check` clean.
- The parser's fixtures are **captured verbatim from the built binary**, not
  hand-written. That caught a real near-collision: the `update_surfaces` summary
  line is one character away from parsing as a runtime entry, and there is now a
  test pinning that it does not.
- Full orchestration driven against a stub `rocm` on the PATH, so the sequencing
  is verified without a multi-GiB download: `update` → `update --apply --runtime
  <key> --activate` → `storage remove-old-installs --keep 2 --yes`, with
  `ROCM_CLI_{CONFIG,DATA,CACHE}_DIR` correctly scoped to the pre-warm root.

### What the GPU lanes on this PR actually did

Every self-hosted lane reached the new pre-warm and reported the same verdict:

```
pre-warm: reusing the shared release runtime (runtime is up to date with the channel index)
```

Two things follow, one of which contradicts what I expected:

- **The `rocm update` output contract holds on hardware.** The new
  `runtime-update-reports-freshness` scenario passed all three steps on Strix
  Halo/Windows against a real index — the parser's assumption about the report
  shape is confirmed, not just imitated by fixtures.
- **The update path did not fire, and that is the correct verdict.** I predicted
  the 16-day-old MI300X trees would take the update path. They did not, because
  the Release channel currently resolves nothing newer than what those runners
  already hold: `therock_index_urls()` tries the classic per-family
  `whl/{family}` index first, which still succeeds but tops out at ROCm 7.13.0
  (#271, fix open in #272). `up_to_date` is an honest answer to a capped index,
  so reuse is right — but it means **the install, update, activate and prune
  paths are still unexercised on hardware**, and remain covered only by unit
  tests and the stubbed-binary run above.

Worth being plain about the consequence: on the Release channel as it resolves
today, this change is a no-op every run. Its value is that freshness is now
consulted at all — the previous guard would have kept a tree frozen for the life
of a runner no matter what the index published, whereas this self-corrects on the
first run after the index moves. That is also why it has to land before the
nightly-channel follow-up: `therock-nightly` does move daily, and pointing a lane
at a different channel under an existence-only guard would have been a silent
no-op.

### CI status

All required checks are green. Two self-hosted lanes are not, and neither is
caused by this change:

**`E2E tests (Strix Halo, Windows)` — red, pre-existing.** 8 of 41 scenarios
fail here against 8 of 40 on `main`, and the two failure sets are identical; the
+1 is the new scenario, which passes. That lane has failed on every `main` run
since 2026-08-12 (the visible cause is a `llama-server.exe` download failing
after 6 attempts); tracked in #260 and #247.

**`E2E tests (Strix Halo, Ubuntu)` — cancelled at its 35-minute cap.** The two
runners behind that label are not equivalent: `strix-halo-ubuntu` finishes in
13.6–15.9 min, while `strix-halo-ubuntu-2` takes 31.0–31.5 min when it passes and
has hit the cap three times today — the other two on unrelated branches,
including `main`'s own merge queue. This run drew runner-2. The pre-warm was not
the cost: it reused, downloaded nothing, and every serve scenario on that box ran
1.5–20× slower than on runner-1, including a refusal-path scenario that never
serves at all (371s vs under 20s).

One honest caveat on that second point: this PR does add a scenario to a lane
that, on runner-2, already sits within ~3.5 min of its cap, and the new
scenario's shared `a managed runtime is active` precondition is expensive on
that box specifically (0.6s on MI300X; still running at 140s on runner-2 when
the job was killed). So it is a small marginal push on an already-overcommitted
budget. The runner-2 disparity looks worth its own issue rather than a timeout
bump smuggled into this PR — happy to raise one, or to widen the cap here if a
maintainer would rather see that.

## Risk

Low-to-moderate, and concentrated in one place: the lanes can now download.
Previously the pre-warm was a no-op after a runner's first run; now a genuinely
newer index costs one install before the suite. That is the intended behaviour,
but it does mean a lane can be slower than it was, and the conservative bias
exists so this happens only when the index has actually moved. In practice, on
the Release channel today, it has not — see above.

The failure modes are bounded the other way. Every ambiguous outcome reuses, so
the common bad day (index unreachable) behaves exactly like today. The lanes are
`continue-on-error: true`, so even a hard failure in the pre-warm cannot gate a
merge. No product code changes — this is CI orchestration, one new xtask
subcommand, and one new scenario.

Follow-up, tracked separately: with the tree no longer frozen, a scheduled lane
can track the `therock-nightly` channel, which is currently never installed by
CI (EAI-8056). That needs this first, for the reason given above.

- [x] Searched `tests/e2e-cucumber/expectations.toml` for `EAI-8057`; no xfail
  rows reference it. The defect was in CI orchestration, not in any scenario's
  expected outcome, so there is nothing to narrow.
