### PR TITLE
ci: regenerate the generated manifests in git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,3 +134,40 @@ repos:
         language: system
         files: \.ps1$
         groups: [local-tools] # runs in the dedicated `powershell-lint` CI job
+
+  # Generated manifests: MANIFEST.md's dependency table and THIRD_PARTY_NOTICES.txt
+  # are derived from the dependency graph and gated byte-for-byte in CI (`cargo
+  # xtask manifest --check` inside the `clippy` job; the `third-party-notices`
+  # job). Nothing regenerated them locally, so a dependency bump could only be
+  # discovered stale a full CI cycle later — between them these two files caused
+  # the large majority of red CI runs. Dependabot already gets this regeneration
+  # via dependabot-manifests.yml; these hooks give contributors the same.
+  #
+  # Both run the WRITE form, not `--check`: prek fails the commit when a hook
+  # modifies a file, so the refreshed file only needs re-staging. They only fire
+  # when the dependency graph (or the generator) actually changes, so ordinary
+  # source edits are unaffected. pre-commit, not pre-push, so the regenerated
+  # file lands in the same commit as the change that invalidated it.
+  - repo: local
+    hooks:
+      - id: cargo-manifest
+        name: MANIFEST.md dependency table is current
+        entry: cargo xtask manifest
+        language: system
+        files: '^((.*/)?Cargo\.(toml|lock)|xtask/.*|MANIFEST\.md)$'
+        pass_filenames: false
+        stages: [pre-commit]
+        groups: [local-tools] # compiles xtask; CI covers it in the `clippy` job
+      - id: cargo-tpn
+        name: THIRD_PARTY_NOTICES.txt is current
+        # `--if-available` skips cleanly when cargo-about is absent or not the
+        # pinned version, so contributors are never blocked from committing by a
+        # missing optional tool — and a mismatched version cannot rewrite the
+        # notices into a format that fails CI. The `third-party-notices` job
+        # remains the hard gate; clap forbids `--if-available` with `--check`.
+        entry: cargo xtask tpn --if-available
+        language: system
+        files: '^((.*/)?Cargo\.(toml|lock)|xtask/.*|about\.(toml|hbs)|THIRD_PARTY_NOTICES\.txt)$'
+        pass_filenames: false
+        stages: [pre-commit]
+        groups: [local-tools] # CI covers it in the `third-party-notices` job

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,13 @@ prek install                # fast checks on every commit
 prek install -t pre-push    # heavier checks on push (clippy + tests)
 ```
 
-`prek` runs the same checks locally that CI enforces: `cargo fmt`, `clippy`, `cargo test`, `ruff` (Python), `shellcheck` (shell), and PowerShell syntax.
+`prek` runs the same checks locally that CI enforces: `cargo fmt`, `clippy`, `cargo test`, `ruff` (Python), `shellcheck` (shell), PowerShell syntax, and the generated manifests (`MANIFEST.md`, `THIRD_PARTY_NOTICES.txt`).
+
+The manifest hooks only run when you change the dependency graph, and they *rewrite* the generated file rather than just reporting it stale — when that happens the commit stops so you can re-stage the refreshed file. `THIRD_PARTY_NOTICES.txt` additionally needs the pinned generator; without it that hook skips and CI remains the gate:
+
+```bash
+cargo install cargo-about@0.9.1 --locked --features cli   # optional, for THIRD_PARTY_NOTICES.txt
+```
 
 ### Workspace layout
 

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -741,6 +741,10 @@ cargo install cargo-about@0.9.1 --locked --features cli   # one-time
 cargo xtask tpn
 ```
 
+With the prek hooks installed this runs automatically whenever you commit a
+dependency-graph change, so the notices rarely go stale by hand; the hook skips
+if cargo-about is absent or not the pinned version.
+
 CI verifies the committed file is current with `cargo xtask tpn --check`; a new
 dependency under a license not listed in `about.toml` fails the check until the
 license is reviewed and added (or the dependency dropped). CI pins the

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,6 +106,10 @@ enum Command {
         /// Verify the notices file is up to date without writing; exit non-zero if it would change.
         #[arg(long)]
         check: bool,
+        /// Skip silently when cargo-about is missing or not the pinned version, instead of
+        /// failing. For the local git hook; conflicts with --check so CI's gate always runs.
+        #[arg(long, conflicts_with = "check")]
+        if_available: bool,
     },
     /// Verify that commits in a range are cryptographically signed and carry a
     /// DCO `Signed-off-by` trailer.
@@ -216,7 +220,10 @@ fn run() -> Result<()> {
         Command::VerifyPinnedKeys => verify_pinned_keys::run()?,
         Command::Affected { base } => affected::run(base)?,
         Command::Manifest { check } => manifest::run(check)?,
-        Command::Tpn { check } => tpn::run(check)?,
+        Command::Tpn {
+            check,
+            if_available,
+        } => tpn::run(check, if_available)?,
         Command::VerifyCommits {
             base,
             require_verified,

--- a/xtask/src/tpn.rs
+++ b/xtask/src/tpn.rs
@@ -26,6 +26,11 @@ const TPN_FILE: &str = "THIRD_PARTY_NOTICES.txt";
 const ABOUT_TEMPLATE: &str = "about.hbs";
 /// cargo-about config, committed at the workspace root.
 const ABOUT_CONFIG: &str = "about.toml";
+/// cargo-about version the committed notices are reproducible with. Different
+/// versions format the output differently, so regenerating with anything else
+/// produces a file that fails the byte-for-byte `--check` gate in CI. Kept in
+/// sync with the workflows by `pinned_version_matches_workflows` below.
+const ABOUT_VERSION: &str = "0.9.1";
 
 /// What to do with freshly generated notices relative to what is on disk.
 #[derive(Debug, PartialEq, Eq)]
@@ -49,6 +54,38 @@ fn decide(check: bool, current: Option<&str>, generated: &str) -> Decision {
         Decision::Stale
     } else {
         Decision::Write
+    }
+}
+
+/// Usability of the local cargo-about install.
+#[derive(Debug, PartialEq, Eq)]
+enum Generator {
+    /// Installed at [`ABOUT_VERSION`]; its output will match CI byte-for-byte.
+    Ready,
+    /// Not installed at all.
+    Absent,
+    /// Installed, but at a version whose output would not match CI.
+    WrongVersion,
+}
+
+/// Pure policy: classify the generator from the detected version (`None` when
+/// the subcommand is absent or unrecognisable).
+fn classify_generator(detected: Option<&str>) -> Generator {
+    match detected {
+        Some(ABOUT_VERSION) => Generator::Ready,
+        Some(_) => Generator::WrongVersion,
+        None => Generator::Absent,
+    }
+}
+
+/// Pure parser for `cargo about --version` output, which prints
+/// `cargo-about <semver>`. `None` if the output is not in that form, so an
+/// unexpected format is treated as "unusable" rather than silently accepted.
+fn parse_about_version(stdout: &str) -> Option<&str> {
+    let mut parts = stdout.split_whitespace();
+    match (parts.next(), parts.next()) {
+        (Some("cargo-about"), Some(version)) => Some(version),
+        _ => None,
     }
 }
 
@@ -77,27 +114,30 @@ fn workspace_root() -> Result<PathBuf> {
     })
 }
 
-/// Fail early with an actionable message if cargo-about is not installed, rather
-/// than surfacing cargo's opaque "no such subcommand" error.
-fn ensure_cargo_about(cargo: &std::ffi::OsStr) -> Result<()> {
-    let probe = Command::new(cargo).args(["about", "--version"]).output();
-    let ok = matches!(probe, Ok(output) if output.status.success());
-    if !ok {
-        bail!(
-            "cargo-about is required to generate {TPN_FILE}.\n\
-             Install it with: cargo install cargo-about --locked --features cli"
-        );
+/// Probe the installed cargo-about version, so a missing or mismatched
+/// generator produces an actionable message rather than cargo's opaque "no such
+/// subcommand" error or notices that silently fail CI.
+fn detect_about_version(cargo: &std::ffi::OsStr) -> Option<String> {
+    let output = Command::new(cargo)
+        .args(["about", "--version"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
     }
-    Ok(())
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    parse_about_version(&stdout).map(str::to_owned)
+}
+
+/// The `cargo install` line that produces the exact generator CI uses.
+fn install_hint() -> String {
+    format!("cargo install cargo-about@{ABOUT_VERSION} --locked --features cli")
 }
 
 /// Run `cargo about generate` against the committed template/config and return
 /// the rendered notices.
-fn generate(root: &Path) -> Result<String> {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    ensure_cargo_about(&cargo)?;
-
-    let output = Command::new(&cargo)
+fn generate(root: &Path, cargo: &std::ffi::OsStr) -> Result<String> {
+    let output = Command::new(cargo)
         .current_dir(root)
         .args([
             "about",
@@ -119,9 +159,50 @@ fn generate(root: &Path) -> Result<String> {
 }
 
 /// Entry point for the `tpn` subcommand.
-pub fn run(check: bool) -> Result<()> {
+///
+/// With `if_available`, an unusable generator is a clean no-op instead of an
+/// error, so the local git hook does not block commits for contributors who
+/// have not installed cargo-about (or have a different version). CI never
+/// passes it, and clap forbids combining it with `--check`, so the staleness
+/// gate can never be silently skipped.
+pub fn run(check: bool, if_available: bool) -> Result<()> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let generator = classify_generator(detect_about_version(&cargo).as_deref());
+
+    match (&generator, if_available) {
+        (Generator::Ready, _) => {}
+        (Generator::Absent, true) => {
+            eprintln!(
+                "tpn: cargo-about not installed; skipping {TPN_FILE} regeneration. \
+                 Install it with: {}",
+                install_hint()
+            );
+            return Ok(());
+        }
+        (Generator::WrongVersion, true) => {
+            eprintln!(
+                "tpn: cargo-about is not version {ABOUT_VERSION}; skipping {TPN_FILE} \
+                 regeneration, because other versions format the notices differently and \
+                 would fail CI. Pin it with: {}",
+                install_hint()
+            );
+            return Ok(());
+        }
+        (Generator::Absent, false) => bail!(
+            "cargo-about is required to generate {TPN_FILE}.\n\
+             Install it with: {}",
+            install_hint()
+        ),
+        (Generator::WrongVersion, false) => bail!(
+            "cargo-about must be version {ABOUT_VERSION} to generate {TPN_FILE} \
+             reproducibly; other versions format the notices differently.\n\
+             Pin it with: {}",
+            install_hint()
+        ),
+    }
+
     let root = workspace_root()?;
-    let generated = generate(&root)?;
+    let generated = generate(&root, &cargo)?;
     let path = root.join(TPN_FILE);
     let current = fs::read_to_string(&path).ok();
 
@@ -158,5 +239,42 @@ mod tests {
     fn write_mode_writes_on_diff_or_missing() {
         assert_eq!(decide(false, Some("old"), "new"), Decision::Write);
         assert_eq!(decide(false, None, "new"), Decision::Write);
+    }
+
+    #[test]
+    fn generator_is_ready_only_at_the_pinned_version() {
+        assert_eq!(classify_generator(Some(ABOUT_VERSION)), Generator::Ready);
+        assert_eq!(classify_generator(Some("0.9.0")), Generator::WrongVersion);
+        assert_eq!(classify_generator(Some("0.10.0")), Generator::WrongVersion);
+        assert_eq!(classify_generator(None), Generator::Absent);
+    }
+
+    #[test]
+    fn version_parser_accepts_cargo_about_output_only() {
+        assert_eq!(parse_about_version("cargo-about 0.9.1\n"), Some("0.9.1"));
+        // Unexpected shapes must read as unusable, never as a usable version.
+        assert_eq!(parse_about_version("cargo-about"), None);
+        assert_eq!(parse_about_version("cargo-deny 0.9.1"), None);
+        assert_eq!(parse_about_version(""), None);
+    }
+
+    /// The pinned constant and the version CI installs must never drift: if they
+    /// do, the hook regenerates notices that fail the byte-for-byte gate.
+    #[test]
+    fn pinned_version_matches_workflows() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask crate has a parent directory")
+            .to_path_buf();
+        let expected = format!("cargo-about@{ABOUT_VERSION}");
+        for workflow in ["ci.yml", "dependabot-manifests.yml"] {
+            let path = root.join(".github/workflows").join(workflow);
+            let yaml = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+            assert!(
+                yaml.contains(&expected),
+                "{workflow} must install {expected} to match ABOUT_VERSION in tpn.rs"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`MANIFEST.md`'s dependency table and `THIRD_PARTY_NOTICES.txt` are generated from the dependency graph and gated byte-for-byte in CI, but nothing regenerated them locally. A dependency bump could only be discovered stale a full CI cycle later.

That gap is the single largest source of red CI right now. Across the last 15 failed `ci.yml` runs, the failing steps in the two most-failing jobs were:

| Failing step | Count |
| --- | --- |
| `THIRD_PARTY_NOTICES.txt is current` | 10 |
| `MANIFEST.md dependency table is current` | 9 |
| real `clippy` failures | 2 |

Dependabot already gets this regeneration automatically via `dependabot-manifests.yml`; contributors did not.

- Add two prek hooks running the **write** form of each generator, so a stale file is refreshed and re-staged at commit time instead of failing CI a cycle later.
- They fire only when the dependency graph or a generator changes, so ordinary source edits are unaffected.
- Pin the cargo-about version in one place, and treat a missing **or mismatched** generator as unusable.
- Add `cargo xtask tpn --if-available`, which skips cleanly instead of failing, for use by the hook.

Why the version pinning is part of this change rather than a follow-up: CI's check is byte-for-byte, and other cargo-about versions format the notices differently. A hook that regenerated with whatever version happened to be installed would rewrite the file into a form that fails the very check it exists to prevent — strictly worse than the status quo. `--if-available` therefore treats a wrong version exactly like a missing one.

`--if-available` conflicts with `--check` at the clap level, so CI's staleness gate cannot be silently disabled, and a contract test asserts the pinned constant matches what `ci.yml` and `dependabot-manifests.yml` install, so the three cannot drift.

Risk: low. No product code changes; the only behaviour change outside the hooks is that `cargo xtask tpn` now rejects a non-pinned cargo-about instead of silently generating notices that fail CI.

Non-goals: the local clippy hook still diverges from CI (`--exclude e2e-cucumber`, no `--locked`), which accounts for the 2 real lint failures above. Closing that gap makes pre-push materially slower, so it is worth deciding separately rather than bundling here.

## Test plan

Both failures were reproduced and confirmed fixed, not assumed:

- Removed a generated dependency row from `MANIFEST.md` → `cargo xtask manifest --check` fails (reproducing the CI step) → hook regenerates → check passes → file byte-identical to the committed original.
- Appended a stray line to `THIRD_PARTY_NOTICES.txt` → `cargo xtask tpn --check` fails → hook regenerates → check passes → byte-identical.
- Generator-absent and wrong-version paths exercised with cargo shims: both skip cleanly under `--if-available` and leave the file untouched; both still hard-fail without it.
- `--check --if-available` is rejected by clap.
- Filters: editing a `.rs` file reports `Skipped` for both hooks; editing `Cargo.toml` / `Cargo.lock` fires them.
- `cargo test -p xtask` (94 pass, 3 new), `cargo fmt --all --check`, `cargo clippy --locked -p xtask --all-targets -- -D warnings`, and `prek run --all-files --no-group local-tools` all clean.
- Both hooks ran during this PR's own commit.

Clippy was scoped to `xtask` locally since the Rust changes are confined to that crate; CI runs the full workspace. Not exercised on Windows.

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — n/a, no product bug fixed