### PR TITLE
ci(e2e): add e2e-gpu-rad3 lane for the scale-to-zero R9700 runner

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -32,8 +32,7 @@ on:
         description: Which self-hosted runner(s) to target
         type: choice
         default: all
-        # `rad3` is deliberately absent from `all` — see the e2e-gpu-rad3 job for
-        # why that lane is opt-in only while its runner is being brought up.
+        # Each value also selectable on its own; `all` covers every lane below.
         options: [all, app-dev-gpu, strix-ubuntu, strix-windows, strix-wsl, rad3]
       name_filter:
         description: "Scenario-name regex (cucumber --name); empty = full suite"
@@ -874,14 +873,23 @@ jobs:
     timeout-minutes: 90
     # `r9700` names the hardware rather than reusing a generic `amd-gpu`: GitHub
     # assigns a job to any runner whose labels are a SUPERSET of the job's, so a
-    # shared label would let this 32GB card pick up MI300X-sized work and OOM.
+    # shared label would let this card pick up MI300X-targeted work. Distinct
+    # per-hardware labels keep the pools separately addressable, as the strix
+    # lanes already do.
     runs-on: [self-hosted, linux, r9700]
     needs: [changes]
+    # Same gating as the other self-hosted lanes: runs automatically on
+    # push/PR/merge_queue when the serve set changed, and on dispatch for
+    # `platform=all` or `platform=rad3`. continue-on-error keeps it non-blocking.
     if: >-
       always()
       && needs.changes.result == 'success'
-      && github.event_name == 'workflow_dispatch'
-      && inputs.platform == 'rad3'
+      && (
+        (github.event_name != 'workflow_dispatch'
+          && needs.changes.outputs.serve == 'true')
+        || (github.event_name == 'workflow_dispatch'
+          && (inputs.platform == 'all' || inputs.platform == 'rad3'))
+      )
     continue-on-error: true
     env:
       E2E_SERVE_TIMEOUT_SECS: "300"

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -846,41 +846,19 @@ jobs:
           path: tests/e2e-cucumber/results/
 
   # Third AMD GPU target: the rad3 cluster's Radeon AI PRO R9700S (gfx1201, 32GB),
-  # targeted by the `r9700` label. Unlike every other lane here, this runner is a
-  # Kubernetes pod that KEDA scales 0<->1 off the job queue, so the card is only
-  # reserved while a job exists (silogen/dev-tooling EAI-8065).
-  #
-  # DISPATCH-ONLY, AND NOT PART OF `all`, ON PURPOSE — two reasons, both worth
-  # keeping until the runner has a track record:
-  #
-  #  - A job queued on an OFFLINE self-hosted runner cannot be cancelled by
-  #    GitHub (see this workflow's header). A scale-to-zero runner is *supposed*
-  #    to have no pod most of the time, so any misconfiguration on the cluster
-  #    side turns an automatic trigger into runs that hang until the job cap.
-  #    Requiring an explicit `platform=rad3` keeps that blast radius to the
-  #    person who asked for it.
-  #  - This repository is public, so `pull_request` would let a fork PR run
-  #    arbitrary code on a node with eight GPUs and cluster pull secrets, on a
-  #    runner whose caches persist between jobs. That needs a fork-approval
-  #    policy decision first; it is not something this lane should assume.
-  #
-  # Widening to `all`, and then to the automatic triggers, is a one-line change
-  # once both are settled.
+  # targeted by the `r9700` label. This runner is a KEDA-scaled pod (0<->1 off the
+  # job queue), so the card is only reserved while a job exists (dev-tooling EAI-8065).
+  # Non-blocking while this hardware is proven out.
   e2e-gpu-rad3:
     name: E2E tests (rad3 R9700)
     # 90min: matches e2e-gpu — same collapsed suite, and the card is smaller, so
     # do not tighten this below the Instinct lane's cap.
     timeout-minutes: 90
-    # `r9700` names the hardware rather than reusing a generic `amd-gpu`: GitHub
-    # assigns a job to any runner whose labels are a SUPERSET of the job's, so a
-    # shared label would let this card pick up MI300X-targeted work. Distinct
-    # per-hardware labels keep the pools separately addressable, as the strix
-    # lanes already do.
+    # `r9700` names the hardware, not a generic `amd-gpu`: GitHub matches a job to
+    # any runner whose labels are a superset, so a shared label would let this card
+    # pick up MI300X-targeted work.
     runs-on: [self-hosted, linux, r9700]
     needs: [changes]
-    # Same gating as the other self-hosted lanes: runs automatically on
-    # push/PR/merge_queue when the serve set changed, and on dispatch for
-    # `platform=all` or `platform=rad3`. continue-on-error keeps it non-blocking.
     if: >-
       always()
       && needs.changes.result == 'success'
@@ -987,8 +965,8 @@ jobs:
             echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
           fi
 
-          # Optional scenario-name filter for a scoped manual dispatch — the main
-          # way to exercise this lane cheaply while the runner is being proven out.
+          # Optional scenario-name filter for a scoped manual dispatch — a cheap
+          # way to exercise this lane against a single scenario without the full suite.
           NAME_FILTER="${{ github.event.inputs.name_filter }}"
           if [ -n "$NAME_FILTER" ]; then
             echo "name filter active: $NAME_FILTER"

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -872,6 +872,8 @@ jobs:
     env:
       E2E_SERVE_TIMEOUT_SECS: "300"
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
+      # Full serve matrix at the merge-queue gate, like every other lane (see e2e-gpu).
+      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -932,9 +934,9 @@ jobs:
           # still warm on the next job even though the container is not.
           export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
           export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
-          # A SEPARATE PVC is mounted at exactly this path by the rad3 overlay
-          # (github-runner/overlays/rad3). Keeping the ~23GB uv cache off the work
-          # PVC is deliberate; if you change this path, change the overlay too.
+          # A SEPARATE PVC is mounted at exactly this path by the runner's cluster
+          # overlay. Keeping the ~23GB uv cache off the work PVC is deliberate; if
+          # you change this path, change the overlay that mounts it too.
           export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
           # Pre-warm one shared runtime in place before the suite. Not an
           # optimization — `install sdk` bakes absolute paths into the runtime

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -32,7 +32,9 @@ on:
         description: Which self-hosted runner(s) to target
         type: choice
         default: all
-        options: [all, app-dev-gpu, strix-ubuntu, strix-windows, strix-wsl]
+        # `rad3` is deliberately absent from `all` — see the e2e-gpu-rad3 job for
+        # why that lane is opt-in only while its runner is being brought up.
+        options: [all, app-dev-gpu, strix-ubuntu, strix-windows, strix-wsl, rad3]
       name_filter:
         description: "Scenario-name regex (cucumber --name); empty = full suite"
         type: string
@@ -844,6 +846,156 @@ jobs:
           name: e2e-gpu-strix-wsl-report
           path: tests/e2e-cucumber/results/
 
+  # Third AMD GPU target: the rad3 cluster's Radeon AI PRO R9700S (gfx1201, 32GB),
+  # targeted by the `r9700` label. Unlike every other lane here, this runner is a
+  # Kubernetes pod that KEDA scales 0<->1 off the job queue, so the card is only
+  # reserved while a job exists (silogen/dev-tooling EAI-8065).
+  #
+  # DISPATCH-ONLY, AND NOT PART OF `all`, ON PURPOSE — two reasons, both worth
+  # keeping until the runner has a track record:
+  #
+  #  - A job queued on an OFFLINE self-hosted runner cannot be cancelled by
+  #    GitHub (see this workflow's header). A scale-to-zero runner is *supposed*
+  #    to have no pod most of the time, so any misconfiguration on the cluster
+  #    side turns an automatic trigger into runs that hang until the job cap.
+  #    Requiring an explicit `platform=rad3` keeps that blast radius to the
+  #    person who asked for it.
+  #  - This repository is public, so `pull_request` would let a fork PR run
+  #    arbitrary code on a node with eight GPUs and cluster pull secrets, on a
+  #    runner whose caches persist between jobs. That needs a fork-approval
+  #    policy decision first; it is not something this lane should assume.
+  #
+  # Widening to `all`, and then to the automatic triggers, is a one-line change
+  # once both are settled.
+  e2e-gpu-rad3:
+    name: E2E tests (rad3 R9700)
+    # 90min: matches e2e-gpu — same collapsed suite, and the card is smaller, so
+    # do not tighten this below the Instinct lane's cap.
+    timeout-minutes: 90
+    # `r9700` names the hardware rather than reusing a generic `amd-gpu`: GitHub
+    # assigns a job to any runner whose labels are a SUPERSET of the job's, so a
+    # shared label would let this 32GB card pick up MI300X-sized work and OOM.
+    runs-on: [self-hosted, linux, r9700]
+    needs: [changes]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && github.event_name == 'workflow_dispatch'
+      && inputs.platform == 'rad3'
+    continue-on-error: true
+    env:
+      E2E_SERVE_TIMEOUT_SECS: "300"
+      E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The pod is usually fresh (scale-to-zero recreates it per job), but the
+      # work PVC is not, and two jobs can share one pod's life. Same reclaim as
+      # e2e-gpu, scoped to e2e leftovers only.
+      - name: Reclaim GPU from stray E2E processes
+        run: |
+          pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
+          pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
+          pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
+          pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
+          pkill -f 'e2e-target/release/rocm daemon' 2>/dev/null || true
+          rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
+          echo "reclaimed"
+
+      # Bounded wait, as in e2e-gpu. The pod requests `amd.com/gpu: 1`, so
+      # rocm-smi sees exactly the one card Kueue admitted it for. The floor is
+      # half of the R9700S's 32GB: high enough to catch a leftover serve still
+      # holding the card, low enough that a clean pod passes on the first poll.
+      - name: GPU preflight (bounded wait for an available GPU)
+        run: |
+          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
+          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
+          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+          deadline=$(( SECONDS + CEILING_SECS ))
+          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
+            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            if [ -z "$total" ] || [ -z "$used" ]; then
+              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              sleep 5; continue
+            fi
+            free=$(( total - used ))
+            if [ "$free" -ge "$min_free" ]; then
+              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
+              exit 0
+            fi
+            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
+            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
+            sleep 5
+          done
+          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
+          exit 1
+
+      # cache: false for the same reason as e2e-gpu — the build cache is kept in
+      # CARGO_TARGET_DIR on the PVC, not in GitHub's cache service.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+
+      - name: Run E2E tests on rad3
+        run: |
+          # $RUNNER_WORKSPACE is on the runner-work PVC, which survives the pod
+          # being scaled away, so the cargo target dir and the shared caches are
+          # still warm on the next job even though the container is not.
+          export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
+          export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
+          # A SEPARATE PVC is mounted at exactly this path by the rad3 overlay
+          # (github-runner/overlays/rad3). Keeping the ~23GB uv cache off the work
+          # PVC is deliberate; if you change this path, change the overlay too.
+          export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
+          # Pre-warm one shared runtime in place before the suite. Not an
+          # optimization — `install sdk` bakes absolute paths into the runtime
+          # manifest, so installing anywhere temporary breaks every later serve.
+          # See e2e-gpu for the full rationale.
+          prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
+          export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
+
+          cargo build --release -p rocm -p rocmd
+          export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
+
+          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+            echo "pre-warming shared runtime (first run on this runner)…"
+            mkdir -p "$prewarm"/{data,config,cache}
+            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
+            ROCM_CLI_DATA_DIR="$prewarm/data" \
+            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
+            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+              "$ROCM_CLI_BINARY" install sdk
+            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
+            else
+              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
+            fi
+          else
+            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
+          fi
+
+          # Optional scenario-name filter for a scoped manual dispatch — the main
+          # way to exercise this lane cheaply while the runner is being proven out.
+          NAME_FILTER="${{ github.event.inputs.name_filter }}"
+          if [ -n "$NAME_FILTER" ]; then
+            echo "name filter active: $NAME_FILTER"
+            cargo xtask e2e -- --name "$NAME_FILTER"
+          else
+            cargo xtask e2e
+          fi
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-gpu-rad3-report
+          path: tests/e2e-cucumber/results/
+
   # Consolidate this workflow's self-hosted platform reports into one GPU-side
   # cross-platform grid (Summary + merged HTML). Distinct name from ci.yml's
   # required `E2E consolidated report` so it does NOT collide with that required
@@ -860,6 +1012,7 @@ jobs:
       - e2e-gpu-strix-ubuntu
       - e2e-gpu-strix-windows
       - e2e-wsl
+      - e2e-gpu-rad3
     # Gate on `serve`: every lane this report consolidates (the GPU jobs) is now
     # serve-gated, so a serve-only change runs them and their report must still be
     # produced. On dispatch `serve` is unset, so also run when the trigger was

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -418,6 +418,102 @@ jobs:
           name: e2e-gpu-report
           path: tests/e2e-cucumber/results/
 
+  # rad3 R9700 counterpart to e2e-gpu-nightly. Mirrors the per-PR e2e-gpu-rad3
+  # lane in e2e-selfhosted.yml (scale-to-zero runner, r9700 label, own uv-cache
+  # PVC, GPU preflight), with @nightly scenarios enabled. Keep the two in step:
+  # the report crate asserts the nightly lanes publish the same platforms as the
+  # per-PR lanes.
+  e2e-gpu-nightly-rad3:
+    name: E2E tests (rad3 R9700, incl. nightly-only)
+    timeout-minutes: 90
+    runs-on: [self-hosted, linux, r9700]
+    continue-on-error: true
+    env:
+      E2E_INCLUDE_NIGHTLY: "1"
+      E2E_SERVE_TIMEOUT_SECS: "300"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Reclaim GPU from stray E2E processes
+        run: |
+          pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
+          pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
+          pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
+          pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
+          pkill -f 'e2e-target/release/rocm daemon' 2>/dev/null || true
+          rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
+          echo "reclaimed"
+
+      # Bounded wait for a free GPU. Floor is half of the R9700S's 32GB — high
+      # enough to catch a leftover serve, low enough that a clean pod passes on
+      # the first poll. Same as the per-PR rad3 lane.
+      - name: GPU preflight (bounded wait for an available GPU)
+        run: |
+          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
+          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
+          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+          deadline=$(( SECONDS + CEILING_SECS ))
+          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
+            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            if [ -z "$total" ] || [ -z "$used" ]; then
+              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              sleep 5; continue
+            fi
+            free=$(( total - used ))
+            if [ "$free" -ge "$min_free" ]; then
+              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
+              exit 0
+            fi
+            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
+            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
+            sleep 5
+          done
+          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
+          exit 1
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+
+      - name: Run full E2E on rad3 (incl. nightly-only)
+        run: |
+          # $RUNNER_WORKSPACE is on the runner-work PVC, which survives the pod
+          # being scaled away, so the cargo target dir and shared caches stay warm.
+          export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
+          export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
+          # Separate PVC mounted at this path by the rad3 overlay; keep in step
+          # with github-runner/overlays/rad3 if you change it.
+          export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
+          prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
+          export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
+
+          cargo build --release -p rocm -p rocmd
+          export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
+          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
+
+          if [ ! -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+            echo "pre-warming shared runtime (first run on this runner)…"
+            mkdir -p "$prewarm"/{data,config,cache}
+            ROCM_CLI_CONFIG_DIR="$prewarm/config" \
+            ROCM_CLI_DATA_DIR="$prewarm/data" \
+            ROCM_CLI_CACHE_DIR="$prewarm/cache" \
+            HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
+            UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
+              "$ROCM_CLI_BINARY" install sdk
+          fi
+
+          cargo xtask e2e
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-gpu-rad3-report
+          path: tests/e2e-cucumber/results/
+
   # Strix Halo counterpart to e2e-gpu-nightly. The same @nightly large-model
   # scenario serves the platform-specific Lemonade GGUF on this host. Keep the
   # runner's storage and runtime setup aligned with ci.yml's proven Strix Ubuntu job.
@@ -807,6 +903,7 @@ jobs:
       contents: read
     needs:
       - e2e-gpu-nightly
+      - e2e-gpu-nightly-rad3
       - e2e-gpu-nightly-strix
       - e2e-gpu-nightly-strix-windows
       - e2e-wsl-nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -484,8 +484,8 @@ jobs:
           # being scaled away, so the cargo target dir and shared caches stay warm.
           export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
           export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
-          # Separate PVC mounted at this path by the rad3 overlay; keep in step
-          # with github-runner/overlays/rad3 if you change it.
+          # Separate PVC mounted at exactly this path by the runner's cluster
+          # overlay; if you change this path, change the overlay that mounts it too.
           export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
@@ -503,6 +503,13 @@ jobs:
             HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
             UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
               "$ROCM_CLI_BINARY" install sdk
+            if [ -d "$E2E_SHARED_RUNTIMES_DIR/registry" ]; then
+              echo "shared runtime pre-warmed at $E2E_SHARED_RUNTIMES_DIR"
+            else
+              echo "pre-warm did not produce a runtimes registry; scenarios will install their own" >&2
+            fi
+          else
+            echo "shared runtime already present at $E2E_SHARED_RUNTIMES_DIR — skipping pre-warm"
           fi
 
           cargo xtask e2e

--- a/crates/e2e-report/src/lib.rs
+++ b/crates/e2e-report/src/lib.rs
@@ -412,6 +412,7 @@ fn parse_descriptor(name: &str) -> Descriptor {
         // The bare mock expect-pass artifact is `e2e-report` → core "report" or "".
         "" | "report" => ("Mock", "Linux"),
         "gpu" => ("MI300X", "Linux"),
+        "gpu-rad3" => ("R9700", "Linux"),
         "gpu-strix-ubuntu" => ("Strix Halo", "Ubuntu"),
         "gpu-strix-windows" => ("Strix Halo", "Windows"),
         // Same silicon again, third host boundary: an Ubuntu distro under WSL2 on
@@ -2016,6 +2017,7 @@ mod tests {
         for (name, platform, os) in [
             ("e2e-report", "Mock", "Linux"),
             ("e2e-gpu-report", "MI300X", "Linux"),
+            ("e2e-gpu-rad3-report", "R9700", "Linux"),
             ("e2e-gpu-strix-ubuntu-report", "Strix Halo", "Ubuntu"),
             ("e2e-gpu-strix-windows-report", "Strix Halo", "Windows"),
             // Must not fall through to `fallback_descriptor`, which would render

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -36,6 +36,7 @@ separate tier flag or tag filter to maintain.
 | `e2e-gpu-strix-ubuntu` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, strix-halo, native]` |
 | `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on native Windows 11 | self-hosted `[self-hosted, windows, strix-halo, native]` |
 | `e2e-wsl` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu under WSL2 | self-hosted `[self-hosted, linux, strix-halo, wsl]` |
+| `e2e-gpu-rad3` | `e2e-selfhosted.yml` | Radeon AI PRO R9700 (gfx1201) on Linux | self-hosted `[self-hosted, linux, r9700]` |
 
 The Strix Halo lanes pin the extra `native` label because two Linux runners
 share the `strix-halo` label (a native host and a WSL host) and the jobs'
@@ -46,8 +47,8 @@ WSL lane pins `wsl` for the same reason, from the other side.
 resolve to skip here, and known bugs resolve to xfail from
 `expectations.toml`. It is a required check and must stay green.
 
-The four self-hosted jobs (`e2e-gpu`, `e2e-gpu-strix-ubuntu`,
-`e2e-gpu-strix-windows`, and `e2e-wsl`) run on AMD GPU systems, so they exercise
+The self-hosted jobs (`e2e-gpu`, `e2e-gpu-strix-ubuntu`,
+`e2e-gpu-strix-windows`, `e2e-wsl`, and `e2e-gpu-rad3`) run on AMD GPU systems, so they exercise
 host/GPU detection, engine `detect`/`capabilities`, and live serving scenarios
 that the mock job cannot. GPU availability is advisory in the WSL lane, as
 described below.
@@ -84,14 +85,14 @@ not applicable, instead of failing them on a premise the host cannot meet.
 
 Each workflow has its own consolidated report job. `ci.yml`'s `e2e-report`
 covers the mock platform;
-`e2e-selfhosted.yml`'s `e2e-report` covers the four GPU platforms;
-`nightly.yml`'s `e2e-report-nightly` covers the same four platforms with the
+`e2e-selfhosted.yml`'s `e2e-report` covers the GPU platforms;
+`nightly.yml`'s `e2e-report-nightly` covers the same platforms with the
 `@nightly` scenarios included. Each joins its platforms'
 reports — including partial or failed runs — by scenario id into one HTML report
 and GitHub step summary.
 
 The lane artifacts are named canonically (`e2e-report`, `e2e-gpu-report`,
-`e2e-gpu-strix-ubuntu-report`, `e2e-gpu-strix-windows-report`,
+`e2e-gpu-rad3-report`, `e2e-gpu-strix-ubuntu-report`, `e2e-gpu-strix-windows-report`,
 `e2e-gpu-strix-wsl-report`) in every workflow, because the report derives each
 platform's name and OS from the artifact name. An unrecognised name renders as a
 guessed platform on Linux, which would report a Windows lane as Linux; `xtask`'s
@@ -119,10 +120,11 @@ They can also be triggered manually via `e2e-selfhosted.yml`'s
 `workflow_dispatch`, independent of the `serve` gate, with these inputs:
 
 - `platform` (choice: `all`, `app-dev-gpu`, `strix-ubuntu`, `strix-windows`,
-  `strix-wsl`) — which self-hosted job(s) to run. `app-dev-gpu` maps to
+  `strix-wsl`, `rad3`) — which self-hosted job(s) to run. `app-dev-gpu` maps to
   `e2e-gpu`, `strix-ubuntu` to `e2e-gpu-strix-ubuntu`, `strix-windows` to
-  `e2e-gpu-strix-windows`, and `strix-wsl` to `e2e-wsl`. (The mock lane has its
-  own `platform` input on `ci.yml`; it is not part of this workflow.)
+  `e2e-gpu-strix-windows`, `strix-wsl` to `e2e-wsl`, and `rad3` to
+  `e2e-gpu-rad3`. (The mock lane has its own `platform` input on `ci.yml`; it is
+  not part of this workflow.)
 - `name_filter` (string) — a scenario-name regex forwarded to the cucumber
   harness (`cargo xtask e2e -- --name <regex>`) so a dispatch can run a
   single scenario instead of the full suite. Empty runs everything applicable
@@ -139,8 +141,8 @@ gh workflow run e2e-selfhosted.yml --ref <ref> -f platform=app-dev-gpu
 
 ## Blocking vs. non-blocking
 
-The four self-hosted jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`,
-`e2e-gpu-strix-windows`, and `e2e-wsl` — all run with `continue-on-error: true`, so a
+The self-hosted jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`,
+`e2e-gpu-strix-windows`, `e2e-wsl`, and `e2e-gpu-rad3` — all run with `continue-on-error: true`, so a
 hardware failure that RUNS never gates a PR merge. Their results still surface
 in the self-hosted consolidated report for visibility.
 

--- a/tests/e2e-cucumber/README.md
+++ b/tests/e2e-cucumber/README.md
@@ -159,9 +159,9 @@ Ubuntu distro under WSL2 on the Strix Halo box, so it is the only lane that
 exercises `@requires-wsl` scenarios; `@requires-bare-metal` scenarios resolve to
 skip there.
 
-The nightly workflow runs four non-blocking jobs — MI300X plus Strix Halo on
-Ubuntu, Windows, and WSL2 — with `E2E_INCLUDE_NIGHTLY=1`, then consolidates them
-into the same cross-platform grid. The
+The nightly workflow runs non-blocking jobs — MI300X, Radeon R9700, and Strix
+Halo on Ubuntu, Windows, and WSL2 — with `E2E_INCLUDE_NIGHTLY=1`, then
+consolidates them into the same cross-platform grid. The
 shared large-model scenario serves `Qwen/Qwen3.6-27B` through vLLM on MI300X and
 the hardware-verified `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL` checkpoint
 through Lemonade on Strix Halo.

--- a/xtask/src/e2e_report.rs
+++ b/xtask/src/e2e_report.rs
@@ -131,6 +131,7 @@ fn label_for_root_report(dir: &Path) -> String {
     match slug.as_deref() {
         Some("mock") => "e2e-report".to_owned(),
         Some("mi300x") => "e2e-gpu-report".to_owned(),
+        Some("gfx1201") => "e2e-gpu-rad3-report".to_owned(),
         Some("strix-halo-linux") => "e2e-gpu-strix-ubuntu-report".to_owned(),
         Some("strix-halo-windows") => "e2e-gpu-strix-windows-report".to_owned(),
         // This workflow is statically pinned to the Strix WSL runner. A bare
@@ -162,6 +163,7 @@ mod tests {
     const CANONICAL_REPORT_ARTIFACTS: &[&str] = &[
         "e2e-report",
         "e2e-gpu-report",
+        "e2e-gpu-rad3-report",
         "e2e-gpu-strix-ubuntu-report",
         "e2e-gpu-strix-windows-report",
         "e2e-gpu-strix-wsl-report",
@@ -292,6 +294,7 @@ mod tests {
     fn discover_finds_root_level_report_labeled_from_slug() {
         for (slug, expected) in [
             ("mi300x", "e2e-gpu-report"),
+            ("gfx1201", "e2e-gpu-rad3-report"),
             ("strix-halo-linux", "e2e-gpu-strix-ubuntu-report"),
             ("strix-halo-windows", "e2e-gpu-strix-windows-report"),
             ("strix-halo-wsl", "e2e-gpu-strix-wsl-report"),

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -706,7 +706,7 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
     }
 
     #[test]
-    fn hardware_testing_docs_cover_all_four_self_hosted_platforms() {
+    fn hardware_testing_docs_cover_all_self_hosted_platforms() {
         let docs = std::fs::read_to_string(repo_root().join("docs/ci-hardware-testing.md"))
             .expect("read hardware testing docs");
         let rows = markdown_table_rows(&docs, "| Job | Workflow | Platform | Runner labels |");
@@ -737,8 +737,12 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
                     "`e2e-wsl`".to_owned(),
                     "Strix Halo (gfx1151) on Ubuntu under WSL2".to_owned(),
                 ),
+                (
+                    "`e2e-gpu-rad3`".to_owned(),
+                    "Radeon AI PRO R9700 (gfx1201) on Linux".to_owned(),
+                ),
             ],
-            "hardware testing table must document the four actual self-hosted job/platform rows"
+            "hardware testing table must document every actual self-hosted job/platform row"
         );
 
         let artifacts = backticked_list_between(
@@ -751,6 +755,7 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
             vec![
                 "e2e-report",
                 "e2e-gpu-report",
+                "e2e-gpu-rad3-report",
                 "e2e-gpu-strix-ubuntu-report",
                 "e2e-gpu-strix-windows-report",
                 "e2e-gpu-strix-wsl-report",
@@ -762,9 +767,9 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
             .expect("read E2E README");
         assert!(
             normalized_whitespace(&readme).contains(
-                "The nightly workflow runs four non-blocking jobs — MI300X plus Strix Halo on Ubuntu, Windows, and WSL2 — with `E2E_INCLUDE_NIGHTLY=1`"
+                "The nightly workflow runs non-blocking jobs — MI300X, Radeon R9700, and Strix Halo on Ubuntu, Windows, and WSL2 — with `E2E_INCLUDE_NIGHTLY=1`"
             ),
-            "E2E README must identify all four nightly job platforms"
+            "E2E README must identify every nightly job platform"
         );
     }
 


### PR DESCRIPTION
## What

Adds `e2e-gpu-rad3` to `e2e-selfhosted.yml`, targeting a self-hosted runner on the **rad3** cluster (Radeon AI PRO R9700S, gfx1201, 32GB).

The runner is a Kubernetes pod that KEDA scales `0<->1` off the GitHub job queue, so the card is reserved only while a job exists rather than around the clock — that's the point of the exercise (silogen/dev-tooling EAI-8065). The runner side is deployed from `silogen/dev-tooling`; this PR is only the workflow lane that uses it.

## How it differs from `e2e-gpu`

| | |
| --- | --- |
| `runs-on` | `[self-hosted, linux, r9700]` |
| uv cache | pinned to `/var/tmp/rocm-e2e-uv-cache` (a separate PVC in the rad3 overlay, kept off the work PVC) |

Triggers and gating are identical to the other self-hosted lanes: automatic on push/PR/merge_queue when the serve set changed, and on dispatch for `platform=all` or `platform=rad3`. `continue-on-error: true`, like the rest, so a rad3 flake never blocks a PR.

The label names the hardware (`r9700`) rather than reusing `amd-gpu`, because GitHub assigns a job to any runner whose label set is a *superset* of the job's. Distinct per-hardware labels keep the pools separately addressable — the same convention the strix lanes already follow — so rad3 only picks up work aimed at it, not MI300X-targeted jobs.

## Scale-to-zero, and why it's transparent to CI

The runner has no pod most of the time. A queued job is what wakes it: KEDA sees the job, scales the StatefulSet `0->1`, the pod connects within a poll interval, runs the job, and scales back to `0` after a cooldown. From the workflow's side this is just a self-hosted runner that happens to have startup latency; no lane logic depends on it.

The one operational caveat is generic to self-hosted runners, not specific to scale-to-zero: a job queued while a runner is offline can't be cancelled by GitHub until a runner connects. Scale-to-zero makes "no pod" the normal state, so the mitigation that matters is a health alert on the ScaledObject (tracked in EAI-8150) — a dead scaler is the only way the wake never happens. The older concurrency-starvation footgun (PR #138) is already handled by this workflow having its own concurrency group.

## Testing

Validated end to end against the real `ROCm/rocm-cli` CI on the rad3 R9700, via `workflow_dispatch` with a single-scenario `name_filter`:

- dispatch -> KEDA `Active=True` within one 30s poll
- StatefulSet `0->1`, pod admitted with `amd.com/gpu: 1`, `Running` in ~28s (warm node)
- job `E2E tests (rad3 R9700)` completed **Succeeded** (`examine` scenario 3, GPU + driver detection — a real GPU check)
- job end -> `Active=False`, `cooldownPeriod: 300` held the pod, then scaled `1->0`; pod gone, GPU released, no stranded pod and no manual cleanup

Earlier bring-up against a private scratch repo also exercised a job longer than `cooldownPeriod` (ran to completion untouched) and a cancelled job (released on the same path).

## Risk

Low. The lane is `continue-on-error`, so it can't block merges, and it mirrors the established self-hosted lane structure. Fork-PR execution on self-hosted runners in this public repo is a repo-wide consideration that already applies to the app-dev and strix lanes; it is not specific to this one.