### PR TITLE
test(e2e): xfail the Windows HF-checkpoint serve (EAI-8031)

### DIFF
--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -178,3 +178,33 @@ flaky = true
 when = { is_wsl = true, therock_family = "gfx*" }
 bug = "EAI-7998"
 reason = "`examine --json` reports has_amd_gpu:false on a WSL2 host whose own summary names a gfx target."
+
+# --- EAI-8031 (public mirror: ROCm/rocm-cli#260): on a Strix Halo WINDOWS host,
+# serving a canonical Hugging Face checkpoint through the `owner/repo:variant`
+# direct-serve path (`unsloth/Qwen3-0.6B-GGUF:Q4_0`) exits 0 but `/v1/models`
+# never lists the model, so the endpoint never becomes ready. Fails on every run
+# since the scenario was introduced by 37a3b63c (#242, 2026-08-12); it is the
+# lane's only host-independent unexpected failure.
+#
+# os=windows: this is specific to Windows AND to this serve path — the Strix Halo
+# Ubuntu lane passes the scenario, and on Windows the short-recipe-name path
+# (`serve-lemonade-inference`, same checkpoint) passes too. So it is not lemonade
+# managed serve at large, and must not widen to a bare `when = {}`.
+# therock_family/has_amd_gpu mirror the sibling rows and document intent: the
+# scenario is @requires-gpu, so on a no-GPU Windows lane it is SKIPPED, never
+# xfail'd.
+#
+# serve_timeout_secs: the lane leaves `E2E_SERVE_TIMEOUT_SECS` unset, so this
+# waits out the full 600s default on a serve that never arrives — ~10 minutes of
+# every run spent on a known bug. A HEALTHY lemonade serve of this same
+# (cache-warm) checkpoint on this host reaches ready in ~120s: measured on run
+# 32185662513, where the three passing GPU-serve scenarios took 117s, 117s and
+# 120s. 240s therefore keeps ~2x headroom — deliberately NOT the 90s used by the
+# EAI-7423 rows above, which is below a healthy serve here and would mask the
+# fix by keeping the scenario red once the bug is closed. Remove this row when
+# EAI-8031 lands; the resulting XPASS is the signal that it did. ---
+[["serve-hf-checkpoint-inference"]]
+when = { os = "windows", therock_family = "gfx*", has_amd_gpu = true }
+bug = "EAI-8031"
+reason = "Managed lemonade serve of a Hugging Face `owner/repo:variant` checkpoint exits 0 but the endpoint never becomes ready on Windows."
+serve_timeout_secs = 240

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -1050,6 +1050,48 @@ flaky = true
         assert!(!m.is_xfail("examine-both-forms-agree-on-gpu", &cap("wsl"), "lemonade"));
     }
 
+    /// EAI-8031 is the Windows `owner/repo:variant` direct-serve path only. The
+    /// row must not widen: the Strix Halo Ubuntu lane serves the same checkpoint
+    /// correctly, and on Windows the short-recipe-name path still passes, so
+    /// letting either inherit the xfail would turn a real regression into a
+    /// silently expected failure.
+    #[test]
+    fn hf_checkpoint_serve_xfail_is_scoped_to_windows_gpu_hosts() {
+        let m = Expectations::parse(include_str!("../expectations.toml")).unwrap();
+        assert!(m.is_xfail(
+            "serve-hf-checkpoint-inference",
+            &cap("strix-windows"),
+            "lemonade"
+        ));
+        assert!(!m.is_xfail(
+            "serve-hf-checkpoint-inference",
+            &cap("strix-ubuntu"),
+            "lemonade"
+        ));
+        assert!(!m.is_xfail(
+            "serve-lemonade-inference",
+            &cap("strix-windows"),
+            "lemonade"
+        ));
+    }
+
+    /// The shortened wait must stay clear of a HEALTHY serve on this host (~120s
+    /// measured), or a fixed EAI-8031 would keep failing and never surface as the
+    /// XPASS that tells us to delete the row.
+    #[test]
+    fn hf_checkpoint_serve_xfail_shortens_the_wait_with_headroom() {
+        let m = Expectations::parse(include_str!("../expectations.toml")).unwrap();
+        let secs = m
+            .serve_timeout_for(
+                "serve-hf-checkpoint-inference",
+                &cap("strix-windows"),
+                "lemonade",
+            )
+            .expect("the EAI-8031 row shortens the serve wait");
+        assert!(secs < 600, "must be shorter than the global default");
+        assert!(secs >= 240, "must stay well above a ~120s healthy serve");
+    }
+
     #[test]
     fn glob_matches_family() {
         assert!(glob_match("gfx94*", "gfx942"));


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — n/a, this PR *adds* a row for an open bug.

## Summary

The `E2E tests (Strix Halo, Windows)` lane has been red on every run for as long
as the check history goes back, so it is red on every open PR — which is exactly
the state in which a genuine new Windows regression goes unnoticed.

Across the last 17 runs of that lane there is exactly one *host-independent*
unexpected failure: `serve-hf-checkpoint-inference`. It fails on both Windows
runners, every time, and has since the scenario was introduced in #242. Root
cause is tracked in #260: serving `unsloth/Qwen3-0.6B-GGUF:Q4_0` through the
`owner/repo:variant` direct path exits 0, but `/v1/models` never lists the
model, so the endpoint never becomes ready.

This declares that scenario as the known bug it is, and shortens its wait.

**Why scoped to Windows GPU hosts and not wider:** the Strix Halo Ubuntu lane
serves the same checkpoint correctly, and on Windows the short-recipe-name path
(`serve-lemonade-inference`, same checkpoint) still passes. A broader row would
turn a real regression on either into a silently expected failure. Two unit
tests pin that scoping so it cannot drift.

**Why 240s and not the 90s the neighbouring rows use:** the lane leaves
`E2E_SERVE_TIMEOUT_SECS` unset, so today it spends the full 600s default waiting
for a serve that never arrives — about 10 minutes of every run. A *healthy*
lemonade serve of this cache-warm checkpoint takes ~120s on this host (measured
on run 32185662513: the three passing GPU-serve scenarios took 117s, 117s and
120s). 90s would sit below that, which would keep the scenario red even after
#260 is fixed and hide the XPASS that tells us to delete the row. 240s cuts six
minutes off the lane while keeping ~2x headroom.

Risk: low. Test-expectation data plus unit tests; no product code changes.

## Scope boundary — this does not make the lane green on its own

The remaining Windows failures are **not** product bugs and are deliberately not
xfail'd here. One of the two Windows runners cannot complete a TLS connection to
`github.com`:

```
Failed to download llama-server.exe from: .../llama-b9752-bin-win-rocm-7.13-x64.zip
  - Download failed after 6 attempts.
Last error: Download failed: SSL connect error (CURL code: 35)
```

so the lemonade llama.cpp backend install always fails there, taking out
`bench-load-real-serve`, `chat-tool-definitions-accepted`,
`chat-end-to-end-local-model` and `serve-lemonade-inference`. The split is
clean: those four fail 10/10 runs on the affected machine and pass 7/7 on the
healthy one, over a ~23h window.

Those four therefore need a runner fix, not an expectations row. Marking them
xfail would either fail the lane as stale XPASSes whenever it lands on the
healthy runner, or — with `flaky = true` — permanently blind four real GPU
scenarios to regressions while recording an infrastructure fault as a product
bug.

## Test plan

- `cargo test -p e2e-cucumber --lib expectation` — 27 passed, including the two
  new tests. Both fail without the new row (verified by reverting it) and pass
  with it.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` and
  `cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- The lane itself is the real check: expect `serve-hf-checkpoint-inference` to
  reconcile as xfail rather than an unexpected failure, and the lane to pass
  outright when it lands on the healthy runner.