### PR TITLE
ci: stop Dependabot rebasing PRs that do not need it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,17 @@ updates:
     # widen it. Cooldown delays only version updates, never security updates.
     cooldown:
       default-days: 7
+    # `main` no longer requires a branch to be up to date before merging: the
+    # merge queue already builds `main` + PR and runs the full required set
+    # against that merged tree, so an out-of-date branch is not a merge blocker.
+    # Left on `auto`, Dependabot re-pushes every open PR each time `main` moves,
+    # and because every path filter in ci.yml folds in `.github/workflows/**`,
+    # each of those re-pushes drags the whole suite — self-hosted GPU lanes
+    # included — through a full rerun that changes no outcome. Disable it and let
+    # the queue be the thing that reconciles with `main`. Cost: Dependabot also
+    # stops auto-resolving genuine conflicts, so a PR that truly conflicts (most
+    # often on `Cargo.lock`) needs `@dependabot recreate` by hand.
+    rebase-strategy: disabled
     groups:
       github-actions:
         patterns:
@@ -48,6 +59,11 @@ updates:
     # Above the default of 5 so a backlog of separate major bumps cannot starve
     # the grouped minor/patch PR, but still bounded so the queue stays readable.
     open-pull-requests-limit: 10
+    # Same reasoning as the github-actions entry above: the merge queue, not a
+    # rebase, is what reconciles a PR with `main`. This matters more here — a
+    # cargo bump touches `Cargo.lock`, which the `heavy` and `tpn` filters both
+    # match, so every rebase of every open cargo PR re-runs the heavy lanes.
+    rebase-strategy: disabled
     groups:
       cargo-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

`main` no longer requires a branch to be up to date before merging (`strict` is off). The merge queue already builds `main` + PR and runs the full required check set against that merged tree, so an out-of-date branch was never what kept a bad merge out — it only forced churn.

Left on the default `auto` strategy, Dependabot re-pushes **every** open PR each time `main` lands a commit. That is expensive here specifically:

- every path filter in `ci.yml` folds in `.github/workflows/**`, and
- a cargo bump touches `Cargo.lock`, which both the `heavy` and `tpn` filters match,

so each re-push drags the whole suite — self-hosted GPU lanes included — through a rerun that changes no outcome. With 10 open dependency PRs and roughly 2–3 merges a day, that is a large share of what those scarce runners are doing.

Set `rebase-strategy: disabled` on both ecosystems and let the merge queue be the thing that reconciles a PR with `main`.

**Trade-off, stated plainly:** Dependabot also stops auto-resolving *genuine* conflicts. A PR that really does conflict — most often on `Cargo.lock` when two dependency PRs land close together — will now sit in a conflicting state until someone runs `@dependabot recreate`. There is no "rebase only on conflict" setting, so this is the cost of removing the churn. It is rare and visible, unlike what it replaces.

Risk: low and fully reversible — deleting the two lines restores current behaviour.

## Test plan

Configuration-only; there is no local harness for Dependabot behaviour, so this is verified by inspection and observation rather than a test:

- `prek run check-yaml` passes.
- Placement verified against the [`rebase-strategy` schema](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#rebase-strategy) — a top-level key on each `updates` entry, alongside `cooldown` / `groups`.
- The observable effect is negative (absence of re-pushes), so confirmation is that open Dependabot PRs stop being force-pushed when `main` moves. Worth a look a few days after merge.