### PR TITLE
fix(help): recommend a resolvable model and label bare rocm as the launcher (EAI-8011)

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -81,7 +81,7 @@ const SUPPORTED_ENGINES: [&str; 2] = ["lemonade", "vllm"];
     about = "ROCm AI Command Center CLI",
     long_about = "ROCm AI Command Center CLI: install ROCm, manage local inference engines, \
 and run OpenAI-compatible model servers on AMD GPUs.\n\n\
-Run `rocm` with no subcommand to open the interactive dashboard (TUI). Use `rocm examine` \
+Run `rocm` with no subcommand to open the interactive launcher (TUI). Use `rocm examine` \
 to check that your GPU and ROCm install are ready, then `rocm serve <model>` to start a server.",
     version,
     // The `chat` example was dropped from this list when `chat` became
@@ -93,7 +93,7 @@ rocm examine                      Check GPU, ROCm install, and engines\n  \
 rocm install sdk                  Install ROCm wheels into a managed environment\n  \
 rocm engines list                 Show the local inference engines available\n  \
 rocm model                        List models this machine can run\n  \
-rocm serve qwen2.5-7b-instruct    Start a local OpenAI-compatible server\n  \
+rocm serve qwen                   Start a local OpenAI-compatible server\n  \
 rocm services list                Show running model servers\n\n\
 Commands marked [preview] work but are outside the Tech Preview's supported\n\
 scope: treat them as unfinished and do not depend on their behaviour yet.\n\n\
@@ -244,13 +244,13 @@ enum Command {
     /// configure a remote provider; the `local` provider talks to a running server.
     #[command(after_help = "EXAMPLES:\n  \
 rocm chat --prompt \"Explain ROCm in one sentence\"\n  \
-rocm chat --provider local --model qwen2.5-7b-instruct --prompt \"Hello\"\n  \
+rocm chat --provider local --model qwen --prompt \"Hello\"\n  \
 echo \"Summarize this\" | rocm chat --provider anthropic")]
     Chat {
         /// Assistant provider to use.
         #[arg(long)]
         provider: Option<Provider>,
-        /// Model name to request from the provider, such as qwen2.5-7b-instruct.
+        /// Model name to request from the provider, such as qwen.
         #[arg(long)]
         model: Option<String>,
         /// Prompt to send. If omitted, rocm-cli reads from standard input when possible.
@@ -337,9 +337,9 @@ rocm model --verbose"
     /// server running, or Ctrl-C to stop it. Inspect or stop servers later with
     /// `rocm services`.
     #[command(after_help = "EXAMPLES:\n  \
-rocm serve qwen2.5-7b-instruct\n  \
-rocm serve qwen2.5-7b-instruct --engine vllm --port 8000\n  \
-rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
+rocm serve qwen\n  \
+rocm serve qwen --engine vllm --port 8000\n  \
+rocm serve qwen --verbose --device gpu_required")]
     Serve {
         /// Model name, alias, or local model file path.
         model: String,


### PR DESCRIPTION
## Summary

Two help-text defects surfaced by the README walkthrough (EAI-8011), fixed in `apps/rocm/src/main.rs`. Help/doc text only — no behaviour change.

- **The worked serve examples named a model the CLI cannot resolve.** `rocm serve qwen2.5-7b-instruct` is neither a catalog name nor an `owner/repo` reference, so copying an example verbatim fails. Replaced all six help/doc occurrences with `qwen`, a real catalog alias for the built-in assistant (`Qwen3-4B-Instruct-2507-GGUF`) that `rocm model` resolves. Realigned the top-level EXAMPLES column for the shorter name.
- **The help described bare `rocm` as opening the dashboard** — the same thing it says `rocm dash` does. Running `rocm` with no subcommand actually opens the launcher (`launch_default` → `run_launcher`), so the `long_about` now says "interactive launcher (TUI)". The `dash` command's own help row still describes the dashboard, so the two read distinctly.

These are the two EAI-8011 rows pinned as expected failures in #241; once both land those rows XPASS and retire themselves.

## Test plan

- [x] Built `rocm` on Linux (macOS can't build this repo — known platform-gated `st_mode` failure in `rocm-engine-lemonade`).
- [x] Ran `rocm help`, `rocm serve --help`, `rocm model --verbose` against the built binary at wide terminal width; confirmed every `rocm serve` example names `qwen` (listed in `model --verbose` as `aliases=[qwen, ...]`) and the no-subcommand sentence no longer says "dashboard" while the `dash` row still does.
- [x] Linux workspace gate (clippy + full test suite) green apart from an unrelated full-disk environment failure.