### PR TITLE
fix(comfyui): pin managed torch stack during install (EAI-8051)

### DIFF
--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -1438,6 +1438,16 @@ const TORCH_STACK_VERSION_PROBE: &str = "import json,sys\n\
 /// each package currently present, so the ComfyUI dependency resolution is pinned
 /// to them and cannot pull a CUDA build. An absent package yields no line — we
 /// only constrain what the runtime actually ships.
+///
+/// Constraining only the installed packages is safe here because the full
+/// torch/torchvision/torchaudio trio is an invariant of a managed runtime:
+/// `therock` installs all three atomically and refuses to install unless it finds
+/// a mutually-compatible set (see `select_compatible_stack` — it bails with "no
+/// mutually compatible ... torch, torchvision, and torchaudio versions"), and
+/// ComfyUI install only ever targets such a runtime (`select_runtime` requires a
+/// managed wheel install). So there is no "torch present, torchvision/torchaudio
+/// absent" runtime in which an unpinned CUDA `torchvision` could resolve against
+/// the release part of the pinned ROCm torch and install a mixed CUDA/ROCm stack.
 fn torch_stack_constraints(
     python: &Path,
     runtime_env: Option<&ComfyUiRuntimeEnvironment>,

--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -347,10 +347,18 @@ pub(crate) fn install(
         let _ = io::stdout().flush();
         let uv = ensure_uv_binary(paths)
             .context("failed to acquire uv binary for ComfyUI dependency install")?;
+        // Pin the managed runtime's ROCm torch stack to its exact installed
+        // versions so a transitive ComfyUI dependency cannot resolve `torch` (and
+        // its `nvidia-*` CUDA deps) from PyPI and clobber it (EAI-8051). Filtering
+        // torch out of the direct specs is not enough — the resolver reaches it
+        // transitively. A constraint fails loudly on a genuine version conflict,
+        // which leaves the runtime intact rather than silently corrupting it.
+        let constraints = torch_stack_constraints(&runtime.python, Some(&runtime_env), &mut log)?;
+        let constraints_path = write_torch_constraints(&app_root, &constraints, &mut log)?;
         run_uv_logged_command(
             paths,
             &uv,
-            uv_install_args(&runtime.python, &packages),
+            uv_install_args(&runtime.python, &packages, constraints_path.as_deref()),
             Some(&runtime_env),
             &mut log,
             "install ComfyUI dependencies",
@@ -1393,11 +1401,122 @@ fn requirement_package_name(spec: &str) -> Option<String> {
     (end > 0).then(|| trimmed[..end].replace('_', "-").to_ascii_lowercase())
 }
 
-fn uv_install_args(venv_python: &Path, packages: &[String]) -> Vec<String> {
+fn uv_install_args(
+    venv_python: &Path,
+    packages: &[String],
+    constraints_path: Option<&Path>,
+) -> Vec<String> {
     let mut args = uv_pip_install_base(venv_python);
     args.push("--upgrade".to_owned());
+    if let Some(path) = constraints_path {
+        args.push("--constraint".to_owned());
+        args.push(path.to_string_lossy().into_owned());
+    }
     args.extend(packages.iter().cloned());
     args
+}
+
+/// The torch-stack packages whose managed ROCm versions must be preserved across
+/// a ComfyUI dependency install.
+const TORCH_STACK_PACKAGES: [&str; 3] = ["torch", "torchvision", "torchaudio"];
+
+/// Probe of an installed distribution's version, read from metadata WITHOUT
+/// importing the package (importing torch needs the runtime's native env). Emits
+/// JSON: a map from package name to version string for the ones present.
+const TORCH_STACK_VERSION_PROBE: &str = "import json,sys\n\
+     from importlib import metadata\n\
+     out={}\n\
+     for name in ('torch','torchvision','torchaudio'):\n\
+     \x20 try:\n\
+     \x20   out[name]=metadata.version(name)\n\
+     \x20 except Exception:\n\
+     \x20   pass\n\
+     sys.stdout.write(json.dumps(out))\n";
+
+/// Read the exact installed versions of the managed runtime's torch stack via
+/// dist metadata (no native import). Returns constraint lines (`torch==X`) for
+/// each package currently present, so the ComfyUI dependency resolution is pinned
+/// to them and cannot pull a CUDA build. An absent package yields no line — we
+/// only constrain what the runtime actually ships.
+fn torch_stack_constraints(
+    python: &Path,
+    runtime_env: Option<&ComfyUiRuntimeEnvironment>,
+    log: &mut fs::File,
+) -> Result<Vec<String>> {
+    let versions = probe_torch_stack_versions(python, runtime_env)?;
+    let constraints = torch_constraint_lines(&versions);
+    writeln!(
+        log,
+        "Pinning managed torch stack: {}",
+        if constraints.is_empty() {
+            "none found".to_owned()
+        } else {
+            constraints.join(", ")
+        }
+    )?;
+    Ok(constraints)
+}
+
+fn probe_torch_stack_versions(
+    python: &Path,
+    runtime_env: Option<&ComfyUiRuntimeEnvironment>,
+) -> Result<Vec<(String, String)>> {
+    let mut command = Command::new(python);
+    command.arg("-c").arg(TORCH_STACK_VERSION_PROBE);
+    if let Some(runtime_env) = runtime_env {
+        apply_runtime_environment(&mut command, runtime_env)?;
+    }
+    let output = capture_configured_command(
+        command,
+        &format!("probe managed torch stack with {}", python.display()),
+    )?;
+    if !output.status.success() {
+        bail!(
+            "failed to read the managed runtime's torch versions (status {}).\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: std::collections::BTreeMap<String, String> = serde_json::from_str(stdout.trim())
+        .with_context(|| format!("failed to parse torch stack version probe output: {stdout}"))?;
+    Ok(parsed.into_iter().collect())
+}
+
+/// Build `name==version` constraint lines for the torch-stack packages that were
+/// found, in a stable order. Pure and side-effect free for unit testing.
+fn torch_constraint_lines(versions: &[(String, String)]) -> Vec<String> {
+    TORCH_STACK_PACKAGES
+        .iter()
+        .filter_map(|package| {
+            versions
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case(package))
+                .map(|(_, version)| format!("{package}=={version}"))
+        })
+        .collect()
+}
+
+/// Write the torch-stack constraints to a file uv can read via `--constraint`.
+/// Returns `None` when there is nothing to pin (no constraint file is needed).
+fn write_torch_constraints(
+    app_root: &Path,
+    constraints: &[String],
+    log: &mut fs::File,
+) -> Result<Option<PathBuf>> {
+    if constraints.is_empty() {
+        return Ok(None);
+    }
+    let path = app_root.join("torch-constraints.txt");
+    fs::create_dir_all(
+        path.parent()
+            .context("ComfyUI constraints path has no parent directory")?,
+    )?;
+    let mut contents = constraints.join("\n");
+    contents.push('\n');
+    fs::write(&path, contents).with_context(|| format!("failed to write {}", path.display()))?;
+    writeln!(log, "Wrote torch constraints to {}.", path.display())?;
+    Ok(Some(path))
 }
 
 fn run_uv_logged_command(
@@ -1707,6 +1826,50 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(kept, vec!["numpy>=1.25".to_owned(), "aiohttp".to_owned()]);
+    }
+
+    #[test]
+    fn torch_constraint_lines_pin_present_stack_in_stable_order() {
+        // Probe output arrives unordered and case-mixed; constraints come out in
+        // the canonical torch/torchvision/torchaudio order, one per present pkg.
+        let versions = vec![
+            ("torchvision".to_owned(), "0.22.0+gitabc".to_owned()),
+            ("Torch".to_owned(), "2.11.0+gitd0c8b1f".to_owned()),
+        ];
+        assert_eq!(
+            torch_constraint_lines(&versions),
+            vec![
+                "torch==2.11.0+gitd0c8b1f".to_owned(),
+                "torchvision==0.22.0+gitabc".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn torch_constraint_lines_empty_when_stack_absent() {
+        assert!(torch_constraint_lines(&[]).is_empty());
+        assert!(torch_constraint_lines(&[("numpy".to_owned(), "1.25.0".to_owned())]).is_empty());
+    }
+
+    #[test]
+    fn uv_install_args_include_constraint_flag_when_pinned() {
+        let python = Path::new("/runtime/bin/python");
+        let packages = vec!["numpy".to_owned()];
+        let constraints = PathBuf::from("/tmp/torch-constraints.txt");
+
+        let with_pin = uv_install_args(python, &packages, Some(&constraints));
+        assert!(
+            with_pin
+                .windows(2)
+                .any(|pair| pair == ["--constraint".to_owned(), constraints.display().to_string()]),
+            "expected --constraint <path> in {with_pin:?}"
+        );
+
+        let without_pin = uv_install_args(python, &packages, None);
+        assert!(
+            !without_pin.iter().any(|arg| arg == "--constraint"),
+            "no --constraint expected when nothing to pin: {without_pin:?}"
+        );
     }
 
     #[test]

--- a/apps/rocm/src/comfyui.rs
+++ b/apps/rocm/src/comfyui.rs
@@ -1442,8 +1442,9 @@ const TORCH_STACK_VERSION_PROBE: &str = "import json,sys\n\
 /// Constraining only the installed packages is safe here because the full
 /// torch/torchvision/torchaudio trio is an invariant of a managed runtime:
 /// `therock` installs all three atomically and refuses to install unless it finds
-/// a mutually-compatible set (see `select_compatible_stack` — it bails with "no
-/// mutually compatible ... torch, torchvision, and torchaudio versions"), and
+/// a mutually-compatible set (see `select_matching_pip_package_versions` — it
+/// bails with "no mutually compatible ... torch, torchvision, and torchaudio
+/// versions"), and
 /// ComfyUI install only ever targets such a runtime (`select_runtime` requires a
 /// managed wheel install). So there is no "torch present, torchvision/torchaudio
 /// absent" runtime in which an unpinned CUDA `torchvision` could resolve against


### PR DESCRIPTION
## Summary

`rocm comfyui install` installs ComfyUI's dependencies into the machine's managed ROCm runtime. It already filters `torch`/`torchvision`/`torchaudio` out of ComfyUI's *direct* requirement specs, but nothing scopes package resolution — so a **transitive** ComfyUI dependency can still resolve `torch` from PyPI, pull a CUDA build plus `nvidia-*` wheels, and displace the runtime's ROCm torch. The runtime the whole machine serves models with then becomes a CUDA build with no AMD GPU support: installing an optional app breaks the base runtime (and vLLM serving with it).

This pins the managed runtime's existing torch stack to its exact installed versions so the resolver can never swap in a CUDA build.

## Changes

- Before running `uv pip install` for ComfyUI's deps, probe the managed runtime's currently-installed `torch`/`torchvision`/`torchaudio` versions via `importlib.metadata` (no native import needed).
- Write those as a uv `--constraint` file and pass it to the install. The resolver treats the stack as already satisfied and never replaces it; because ROCm torch has no `nvidia-*` dependencies, none are pulled in.
- A genuine version conflict (a dep needing an incompatible torch) now fails the install loudly instead of silently corrupting the runtime.
- Added unit tests for the constraint-line generation and the `--constraint` argument wiring.

## Test plan

- [x] `cargo test -p rocm` (Linux) — 477 tests pass, including 3 new ComfyUI tests.
- [x] `cargo clippy` / `cargo fmt --check` clean.
- [ ] End-to-end proof is the `@requires-gpu @nightly` scenario `comfyui-install-preserves-the-rocm-runtime` from #291 (EAI-8071), which runs on a GPU host after that contract lands.