### PR TITLE
fix(serve): pick a free port instead of colliding on the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ different settings. If you previously started a service with `--temperature`
 flags — or with different ones — stop the existing service first (`rocm
 services stop`) or match the original flags.
 
+Omit `--port` and the server takes 11435, or the next free port above it when
+11435 is already serving — so a second model starts alongside the first instead
+of colliding with it. The chosen port is reported in the deployment summary and
+by `rocm services`. Pass `--port` explicitly and that exact port is required: if
+something already holds it, `rocm serve` says so and stops before loading the
+model, rather than failing later on the engine's own bind. Reuse follows the
+same rule — when an existing service for this engine and model is reused, its
+own port is what you get, so naming a different one is refused rather than
+quietly ignored.
+
 By default the server runs in the background under rocm-cli's supervision and
 prints a deployment summary — a progress indicator while it starts, then a table
 with the status, the full inference endpoint, the API-qualified model name, and a

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -362,9 +362,13 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         /// Host address to bind.
         #[arg(long, default_value = DEFAULT_LOCAL_HOST)]
         host: String,
-        /// TCP port to bind.
-        #[arg(long, default_value_t = rocm_core::DEFAULT_LOCAL_PORT)]
-        port: u16,
+        /// TCP port to bind [default: 11435, or the next free port when it is taken].
+        // Deliberately not a clap default: an omitted port means "any free port,
+        // starting at 11435", while naming 11435 explicitly means that port and
+        // nothing else, so a busy one is an error rather than a silent move.
+        // Giving it a clap default would erase that distinction.
+        #[arg(long)]
+        port: Option<u16>,
         /// Attach to the server in this terminal and stream its logs (Ctrl-D to
         /// detach and leave it running, Ctrl-C to stop). Same as --verbose.
         #[arg(long, conflicts_with = "managed")]
@@ -4709,7 +4713,9 @@ struct ServeArgs {
     runtime_id: Option<String>,
     env_id: Option<String>,
     host: String,
-    port: u16,
+    /// `None` when the user did not name a port, which licenses the automatic
+    /// selection in [`resolve_serve_port`].
+    port: Option<u16>,
     foreground: bool,
     managed: bool,
     verbose: bool,
@@ -4732,7 +4738,7 @@ fn serve(args: ServeArgs) -> Result<()> {
         runtime_id,
         env_id,
         host,
-        port,
+        port: requested_port,
         foreground,
         managed,
         verbose,
@@ -4912,6 +4918,21 @@ fn serve(args: ServeArgs) -> Result<()> {
     )?;
     let service_id = generate_service_id(&selected_engine, &resolve.canonical_model_id);
 
+    // Settle the address before anything is announced or launched: the plan below
+    // must print the port this server will actually bind, and an explicitly
+    // requested port that is taken must fail here — while no model has been
+    // loaded and no service record exists — rather than as an engine bind error.
+    let ServePortChoice {
+        port,
+        note: port_note,
+    } = resolve_serve_port(
+        &paths,
+        &host,
+        requested_port,
+        &selected_engine,
+        &resolve.canonical_model_id,
+    )?;
+
     // Attached foreground streaming is the debugging path, selected by `--verbose`
     // or `--foreground`. Everything else backgrounds the server and, when writing
     // to an interactive terminal, shows a progress spinner + deployment summary
@@ -4929,6 +4950,11 @@ fn serve(args: ServeArgs) -> Result<()> {
         println!("{}", serve_engine_selection_line(&serve_engine));
         println!("  host: {host}");
         println!("  port: {port}");
+        // Kept next to the port it explains rather than with the trailing notes,
+        // so a reader scanning for the address sees why it is not the usual one.
+        if let Some(note) = &port_note {
+            println!("  note: {note}");
+        }
         if let Some(runtime_id) = resolved_selection.runtime_id.as_deref() {
             println!("  runtime_id: {runtime_id}");
         }
@@ -5059,6 +5085,7 @@ fn serve(args: ServeArgs) -> Result<()> {
                 &gpu_indices,
                 gpu_vram.as_deref(),
                 gpu_memory_utilization_note.as_deref(),
+                port_note.as_deref(),
                 host_gpu_summary.as_ref(),
             );
             let summary = serve_summary::DeploymentSummary {
@@ -5097,6 +5124,7 @@ fn serve(args: ServeArgs) -> Result<()> {
 
 /// GPU/device warnings folded into the interactive deployment summary. Mirrors the
 /// inline warnings printed in the plain serve plan, in the same order.
+#[allow(clippy::too_many_arguments)]
 fn collect_serve_notes(
     cpu_only: bool,
     gpu_selection: &GpuSelection,
@@ -5104,6 +5132,7 @@ fn collect_serve_notes(
     gpu_indices: &[u32],
     gpu_vram: Option<&[GpuVramUsage]>,
     engine_flag_note: Option<&str>,
+    port_note: Option<&str>,
     host_gpu_summary: Option<&rocm_core::HostGpuSummary>,
 ) -> Vec<String> {
     let mut notes = Vec::new();
@@ -5111,6 +5140,11 @@ fn collect_serve_notes(
     // too: the summary path is what an interactive `rocm serve` actually prints, so
     // a note only emitted on the plan path would never reach that user.
     if let Some(note) = engine_flag_note {
+        notes.push(note.to_owned());
+    }
+    // The summary shows an endpoint, not a plan, so without this an interactive
+    // user would see a port they never asked for and no reason for it.
+    if let Some(note) = port_note {
         notes.push(note.to_owned());
     }
     if cpu_only {
@@ -14763,6 +14797,187 @@ fn existing_live_managed_service(
         })
 }
 
+/// A bind host reduced to the form two records can be compared in: unbracketed,
+/// lowercased, and with the loopback spellings folded together.
+fn normalize_bind_host(host: &str) -> String {
+    let host = host.trim();
+    let host = host
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_ascii_lowercase();
+    match host.as_str() {
+        "localhost" => rocm_core::DEFAULT_LOCAL_HOST.to_owned(),
+        _ => host,
+    }
+}
+
+/// Whether a server on `left` and a server on `right` would contend for the same
+/// port. A wildcard bind covers every interface, so it collides with all of them.
+fn bind_hosts_can_collide(left: &str, right: &str) -> bool {
+    let is_wildcard = |host: &str| matches!(host, "" | "0.0.0.0" | "::");
+    let left = normalize_bind_host(left);
+    let right = normalize_bind_host(right);
+    left == right || is_wildcard(&left) || is_wildcard(&right)
+}
+
+/// Ports live managed services have claimed on `host`, each paired with the
+/// service holding it.
+///
+/// Read from the manifests rather than the network because that is the half a
+/// bind probe cannot see: a service in `starting` has already been promised its
+/// port but has not listened on it yet, which is precisely the window a second
+/// `rocm serve` walks into.
+fn managed_service_port_claims(paths: &AppPaths, host: &str) -> Vec<(u16, String)> {
+    load_managed_services(paths)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|record| {
+            managed_service_is_live(record) && bind_hosts_can_collide(&record.host, host)
+        })
+        .map(|record| (record.port, record.service_id))
+        .collect()
+}
+
+/// The port a serve will bind, plus anything the user needs told about it.
+#[derive(Debug)]
+struct ServePortChoice {
+    port: u16,
+    /// Set only when the search had to move off the default, so silence means
+    /// "you got the port you would have expected".
+    note: Option<String>,
+}
+
+/// How far above the default the automatic search will look before giving up.
+/// Bounded so a machine full of servers fails with an explanation rather than
+/// scanning tens of thousands of ports.
+const SERVE_PORT_SEARCH_SPAN: u16 = 100;
+
+/// First port at or above `base` that no live service has claimed and nothing is
+/// listening on. `base` is a parameter rather than a constant so tests can drive
+/// the search from a port they actually hold.
+///
+/// An address that cannot be bound at all — an unresolvable host, an interface
+/// this machine does not own — aborts the search with that reason instead of
+/// being counted as "taken": no other port in the range would work either, and
+/// retrying all of them would turn one clear error into a misleading one.
+fn select_free_serve_port(host: &str, base: u16, claimed: &[u16]) -> Result<Option<u16>> {
+    for port in base..=base.saturating_add(SERVE_PORT_SEARCH_SPAN) {
+        if claimed.contains(&port) {
+            continue;
+        }
+        match rocm_core::local_port_status(host, port) {
+            rocm_core::LocalPortStatus::Free => return Ok(Some(port)),
+            // Taken: keep looking. Every other port in the range is still a
+            // candidate, which is exactly what an unusable host is not.
+            rocm_core::LocalPortStatus::InUse => {}
+            rocm_core::LocalPortStatus::Unusable(error) => {
+                return Err(anyhow::Error::new(error).context(format!(
+                    "cannot serve on host {host}: it is not bindable here"
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Decide the port this serve will bind, before anything is launched.
+///
+/// The two cases are deliberately different. An omitted `--port` is a request
+/// for *a* server, so a taken default moves to the next free port and says so.
+/// An explicit `--port` names one address and nothing else, so a taken one is an
+/// error raised here — before the model is loaded and before any service record
+/// exists — instead of an engine bind failure minutes later that still leaves a
+/// dead service behind.
+///
+/// CONCURRENCY: this reads the claims and probes the ports, then returns; the
+/// manifest that reserves the chosen port is not written until the spawn further
+/// down `serve()`. Two `rocm serve` commands racing inside that window can still
+/// choose the same port. Closing it needs a lock held across read-select-launch,
+/// which is owned by the separate concurrency-hardening work on the managed
+/// launch path — deliberately not attempted here, so the two changes do not
+/// fight over the same critical section. Note for whoever does it: the section
+/// starts at the claim *read* below, not at the spawn.
+fn resolve_serve_port(
+    paths: &AppPaths,
+    host: &str,
+    requested: Option<u16>,
+    engine: &str,
+    canonical_model_id: &str,
+) -> Result<ServePortChoice> {
+    // Port 0 means "assign me any port" to the kernel, so the probe succeeds and
+    // the engine then binds something else entirely — every port this command
+    // reports would be a lie. Refuse it rather than announce a wrong address.
+    if requested == Some(0) {
+        bail!("--port 0 is not a port a server can be found on; name a port, or omit --port");
+    }
+
+    // An equivalent service is already live, so `spawn_managed_engine_child`'s
+    // idempotency guard will surface that service and spawn nothing. Whatever
+    // this returns is what the plan announces, so it has to be that service's
+    // real address — not the one that was asked for.
+    if let Some(existing) = existing_live_managed_service(paths, engine, canonical_model_id) {
+        // A named port is a requirement, not a preference. Serving the existing
+        // service's address instead would quietly hand back a port the user did
+        // not ask for, so say why nothing was started.
+        if let Some(port) = requested
+            && port != existing.port
+        {
+            bail!(
+                "managed service `{}` is already serving {} on port {}, so port {port} would not \
+                 be used; stop it with `rocm services stop {}`, or drop --port to reuse it",
+                existing.service_id,
+                canonical_model_id,
+                existing.port,
+                existing.service_id
+            );
+        }
+        return Ok(ServePortChoice {
+            port: existing.port,
+            note: None,
+        });
+    }
+
+    let claims = managed_service_port_claims(paths, host);
+
+    if let Some(port) = requested {
+        if let Some((_, service_id)) = claims.iter().find(|(claimed, _)| *claimed == port) {
+            bail!(
+                "port {port} on {host} is already taken by managed service `{service_id}`; \
+                 stop it with `rocm services stop {service_id}`, or serve on a different --port"
+            );
+        }
+        match rocm_core::local_port_status(host, port) {
+            rocm_core::LocalPortStatus::Free => {}
+            rocm_core::LocalPortStatus::InUse => bail!(
+                "port {port} on {host} is already in use by another process; \
+                 free it, or serve on a different --port"
+            ),
+            // Not a collision: a privileged port, an unresolvable host, or an
+            // interface this machine does not own. Quote the reason rather than
+            // blame a server that is not there.
+            rocm_core::LocalPortStatus::Unusable(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("cannot bind {}", format_host_port(host, port))));
+            }
+        }
+        return Ok(ServePortChoice { port, note: None });
+    }
+
+    let base = rocm_core::DEFAULT_LOCAL_PORT;
+    let claimed: Vec<u16> = claims.iter().map(|(port, _)| *port).collect();
+    let Some(port) = select_free_serve_port(host, base, &claimed)? else {
+        bail!(
+            "no free port on {host} between {base} and {last}; stop a server you no longer need \
+             with `rocm services stop <service-id>`, or name a port with --port",
+            last = base.saturating_add(SERVE_PORT_SEARCH_SPAN)
+        );
+    };
+    let note = (port != base)
+        .then(|| format!("port {base} is already in use; serving on port {port} instead"));
+    Ok(ServePortChoice { port, note })
+}
+
 fn managed_service_running_state(status: &str) -> &'static str {
     match status {
         "ready" | "running" => "running",
@@ -23451,19 +23666,248 @@ install therock";
             None,
             Some(note),
             None,
+            None,
         );
         assert!(
             notes.iter().any(|entry| entry == note),
             "the ignored-flag note must reach the summary: {notes:?}"
         );
 
-        let quiet = collect_serve_notes(false, &GpuSelection::Auto, false, &[0], None, None, None);
+        let quiet = collect_serve_notes(
+            false,
+            &GpuSelection::Auto,
+            false,
+            &[0],
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(
             !quiet
                 .iter()
                 .any(|entry| entry.contains("--gpu-memory-utilization")),
             "nothing to report when the flag was honored: {quiet:?}"
         );
+    }
+
+    /// A `starting` service with no tracked pid: `load_managed_services` leaves
+    /// such a record's status alone, so it stays live for the claim scan — which
+    /// is the state the bug's second `rocm serve` actually walks into.
+    fn write_claiming_service(paths: &AppPaths, service_id: &str, host: &str, port: u16) {
+        let record = ManagedServiceRecord::new(
+            paths,
+            service_id,
+            "vllm",
+            "Qwen/Qwen3.5-0.8B",
+            "Qwen/Qwen3.5-0.8B",
+            host,
+            port,
+            "managed",
+            0,
+            None,
+            None,
+            None,
+        );
+        fs::create_dir_all(paths.services_dir()).unwrap();
+        record.write().unwrap();
+    }
+
+    #[test]
+    fn serve_port_search_takes_the_base_when_it_is_free() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let free = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        assert_eq!(
+            select_free_serve_port(DEFAULT_LOCAL_HOST, free, &[]).unwrap(),
+            Some(free)
+        );
+    }
+
+    #[test]
+    fn serve_port_search_steps_over_a_live_listener() {
+        // The reported collision in miniature: something already holds the port a
+        // second server would take, and it is holding it on the socket, not in a
+        // manifest — so only a bind probe can see it.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let taken = listener.local_addr().unwrap().port();
+
+        let chosen = select_free_serve_port(DEFAULT_LOCAL_HOST, taken, &[])
+            .expect("a bindable host must not error")
+            .expect("a free port above the taken one");
+        assert!(
+            chosen > taken,
+            "the search must move past the port that is in use, got {chosen}"
+        );
+    }
+
+    #[test]
+    fn serve_port_search_steps_over_a_port_only_a_manifest_claims() {
+        // Nothing is listening yet — a service that is still starting has been
+        // promised this port but has not bound it. The bind probe would call it
+        // free; the claim list is what keeps the second server off it.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let claimed = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let chosen = select_free_serve_port(DEFAULT_LOCAL_HOST, claimed, &[claimed])
+            .expect("a bindable host must not error")
+            .expect("a free port above the claimed one");
+        assert!(
+            chosen > claimed,
+            "a claimed port must be skipped even when nothing is listening, got {chosen}"
+        );
+    }
+
+    #[test]
+    fn serve_port_search_reports_an_unbindable_host_instead_of_scanning() {
+        // The whole range is unusable for the same reason, so the search must say
+        // what that reason is rather than report every port as taken.
+        let error = select_free_serve_port("host.invalid", rocm_core::DEFAULT_LOCAL_PORT, &[])
+            .expect_err("an unresolvable host must be an error, not an exhausted search")
+            .to_string();
+        assert!(
+            error.contains("host.invalid") && !error.contains("no free port"),
+            "the error must name the host and not blame port exhaustion: {error}"
+        );
+    }
+
+    #[test]
+    fn serve_port_resolution_moves_off_a_claimed_default() {
+        let (root, paths) = test_paths("serve-port-moves-off-claimed");
+        // The claim is on the real default, because that is the port the automatic
+        // search starts from and the whole question is whether it moves.
+        write_claiming_service(
+            &paths,
+            "svc-holding-default",
+            DEFAULT_LOCAL_HOST,
+            rocm_core::DEFAULT_LOCAL_PORT,
+        );
+
+        let choice =
+            resolve_serve_port(&paths, DEFAULT_LOCAL_HOST, None, "vllm", "Qwen/Qwen3-0.6B")
+                .expect("an omitted port must resolve, not fail");
+
+        assert_ne!(choice.port, rocm_core::DEFAULT_LOCAL_PORT);
+        let note = choice.note.expect("a moved port must be explained");
+        assert!(
+            note.contains(&rocm_core::DEFAULT_LOCAL_PORT.to_string())
+                && note.contains(&choice.port.to_string()),
+            "the note must name both the taken port and the chosen one: {note}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn serve_port_resolution_refuses_an_explicitly_requested_claimed_port() {
+        let (root, paths) = test_paths("serve-port-explicit-claimed");
+        write_claiming_service(
+            &paths,
+            "svc-holding-8000",
+            DEFAULT_LOCAL_HOST,
+            rocm_core::DEFAULT_LOCAL_PORT,
+        );
+
+        let error = resolve_serve_port(
+            &paths,
+            DEFAULT_LOCAL_HOST,
+            Some(rocm_core::DEFAULT_LOCAL_PORT),
+            "vllm",
+            "Qwen/Qwen3-0.6B",
+        )
+        .expect_err("a port the user named and that is taken must fail, not move")
+        .to_string();
+
+        assert!(
+            error.contains("svc-holding-8000"),
+            "the error must name what holds the port: {error}"
+        );
+        assert!(
+            error.contains(&rocm_core::DEFAULT_LOCAL_PORT.to_string()),
+            "the error must name the port: {error}"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn serve_port_resolution_reports_the_live_services_own_port() {
+        // Re-serving the same engine+model is satisfied by the running service, so
+        // resolution must announce that service's real address — not the default,
+        // which is not where it is listening.
+        let (root, paths) = test_paths("serve-port-equivalent-live");
+        let live_port = rocm_core::DEFAULT_LOCAL_PORT + 7;
+        write_claiming_service(&paths, "svc-same-model", DEFAULT_LOCAL_HOST, live_port);
+
+        let choice = resolve_serve_port(
+            &paths,
+            DEFAULT_LOCAL_HOST,
+            None,
+            "vllm",
+            "Qwen/Qwen3.5-0.8B",
+        )
+        .expect("re-serving a live model must not fail");
+
+        assert_eq!(choice.port, live_port);
+        assert_eq!(choice.note, None);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn serve_port_resolution_refuses_a_named_port_the_live_service_is_not_on() {
+        // The service that would be reused is on another port, so honouring the
+        // request is impossible. Silently serving its address would hand back a
+        // port the user did not ask for.
+        let (root, paths) = test_paths("serve-port-live-elsewhere");
+        let live_port = rocm_core::DEFAULT_LOCAL_PORT + 7;
+        write_claiming_service(&paths, "svc-elsewhere", DEFAULT_LOCAL_HOST, live_port);
+
+        let error = resolve_serve_port(
+            &paths,
+            DEFAULT_LOCAL_HOST,
+            Some(rocm_core::DEFAULT_LOCAL_PORT),
+            "vllm",
+            "Qwen/Qwen3.5-0.8B",
+        )
+        .expect_err("a named port the reused service is not on must fail")
+        .to_string();
+
+        assert!(
+            error.contains("svc-elsewhere") && error.contains(&live_port.to_string()),
+            "the error must name the service and the port it is really on: {error}"
+        );
+
+        // Asking for the port it is actually on is satisfiable, so it must not fail.
+        let choice = resolve_serve_port(
+            &paths,
+            DEFAULT_LOCAL_HOST,
+            Some(live_port),
+            "vllm",
+            "Qwen/Qwen3.5-0.8B",
+        )
+        .expect("asking for the port the service already uses must be accepted");
+        assert_eq!(choice.port, live_port);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn serve_port_resolution_rejects_port_zero() {
+        // The kernel would assign some other port, so every address this command
+        // printed would be wrong.
+        let (root, paths) = test_paths("serve-port-zero");
+        let error = resolve_serve_port(&paths, DEFAULT_LOCAL_HOST, Some(0), "vllm", "some/model")
+            .expect_err("port 0 must be refused")
+            .to_string();
+        assert!(error.contains("--port 0"), "{error}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn bind_hosts_collide_across_spellings_and_wildcards() {
+        assert!(bind_hosts_can_collide("127.0.0.1", "localhost"));
+        assert!(bind_hosts_can_collide("0.0.0.0", "127.0.0.1"));
+        assert!(bind_hosts_can_collide("[::1]", "::1"));
+        assert!(!bind_hosts_can_collide("127.0.0.1", "192.168.1.10"));
     }
 
     #[test]

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -11,7 +11,7 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{IsTerminal, Read, Write, stdin, stdout};
-use std::net::{IpAddr, TcpStream, ToSocketAddrs};
+use std::net::{IpAddr, TcpListener, TcpStream, ToSocketAddrs};
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -102,6 +102,57 @@ pub fn format_host_port(host: &str, port: u16) -> String {
 
 pub fn format_http_base_url(host: &str, port: u16) -> String {
     format!("http://{}", format_host_port(host, port))
+}
+
+/// What a bind attempt says about `host:port`.
+///
+/// Three outcomes, not two: "something else is serving here" and "this address
+/// cannot be served at all" call for different messages and different handling.
+/// Collapsing them tells a user whose real problem is a permission or a typo'd
+/// hostname that the port is busy, and sends an automatic port search scanning a
+/// whole range that was never going to work.
+#[derive(Debug)]
+pub enum LocalPortStatus {
+    /// The bind succeeded, so a server can take this address.
+    Free,
+    /// Something already holds this address.
+    InUse,
+    /// The address itself is unusable — the host does not resolve, is not one of
+    /// this machine's, or the port is privileged. Carries the reason so the
+    /// caller can quote it instead of guessing.
+    Unusable(std::io::Error),
+}
+
+/// Whether `host:port` can still be listened on, answered by attempting the bind
+/// a server would attempt and immediately releasing it.
+///
+/// A bind is the only honest answer here: a connect probe cannot distinguish a
+/// free port from one held by a listener that refuses connections, and it says
+/// nothing about the `0.0.0.0` / `127.0.0.1` overlap that actually makes two
+/// servers collide. `host` is the same string the engine will bind, so the probe
+/// sees the same conflicts the engine would.
+///
+/// On Unix std sets `SO_REUSEADDR`, so a socket merely lingering in `TIME_WAIT`
+/// reads as free (correct — a server can bind it), while a live listener still
+/// rejects the bind (also correct). Windows has no such option set and fails the
+/// same way against a live listener.
+pub fn local_port_status(host: &str, port: u16) -> LocalPortStatus {
+    // `format_host_for_url` brackets IPv6 for URLs; the socket API wants the bare
+    // address, so undo that here rather than making callers remember which form
+    // they are holding.
+    let host = host.trim();
+    let host = host
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host);
+    match TcpListener::bind((host, port)) {
+        Ok(_) => LocalPortStatus::Free,
+        // `AddrInUse` is the only kind that means "taken"; `AddrNotAvailable`
+        // means the address is not this machine's to bind, which no other port
+        // will fix, so it belongs with the unusable cases.
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => LocalPortStatus::InUse,
+        Err(error) => LocalPortStatus::Unusable(error),
+    }
 }
 
 pub fn parse_http_endpoint(endpoint_url: &str) -> Option<(String, u16)> {
@@ -11108,6 +11159,55 @@ Class Name:                Display
         assert_eq!(format_host_port("::1", 11435), "[::1]:11435");
         assert_eq!(format_http_base_url("::1", 11435), "http://[::1]:11435");
         assert_eq!(format_host_port("[::1]", 11435), "[::1]:11435");
+    }
+
+    #[test]
+    fn port_status_follows_a_live_listener() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().expect("read bound address").port();
+        assert!(
+            matches!(local_port_status("127.0.0.1", port), LocalPortStatus::InUse),
+            "a port held by a live listener must read as in use"
+        );
+        drop(listener);
+        assert!(
+            matches!(local_port_status("127.0.0.1", port), LocalPortStatus::Free),
+            "the port must read as free again once the listener is gone"
+        );
+    }
+
+    #[test]
+    fn port_status_accepts_a_bracketed_ipv6_host() {
+        // The URL-facing form is bracketed; the socket API is not. Callers holding
+        // either form must get the same answer.
+        let Ok(listener) = std::net::TcpListener::bind("[::1]:0") else {
+            // No IPv6 loopback on this host; the bracket handling is unobservable.
+            return;
+        };
+        let port = listener.local_addr().expect("read bound address").port();
+        assert!(matches!(
+            local_port_status("[::1]", port),
+            LocalPortStatus::InUse
+        ));
+        assert!(matches!(
+            local_port_status("::1", port),
+            LocalPortStatus::InUse
+        ));
+    }
+
+    #[test]
+    fn port_status_separates_an_unusable_address_from_a_taken_one() {
+        // A host that cannot be bound at all is not a port collision: reporting it
+        // as one would send the caller looking for a server that is not there, and
+        // would make an automatic search retry every port in its range.
+        assert!(matches!(
+            local_port_status("host.invalid", 11_435),
+            LocalPortStatus::Unusable(_)
+        ));
+        assert!(matches!(
+            local_port_status("203.0.113.1", 11_435),
+            LocalPortStatus::Unusable(_)
+        ));
     }
 
     fn temp_app_paths(name: &str) -> (PathBuf, AppPaths) {

--- a/crates/rocm-dash-tui/src/ui/serve_wizard.rs
+++ b/crates/rocm-dash-tui/src/ui/serve_wizard.rs
@@ -49,10 +49,16 @@ pub const DEVICES: &[&str] = &[
     "cpu_only",
 ];
 
-/// Mirrors `rocm-core::DEFAULT_LOCAL_HOST` / `DEFAULT_LOCAL_PORT` (TUI-local to
-/// avoid the dep; the CLI re-applies its own defaults if these are cleared).
+/// Mirrors `rocm-core::DEFAULT_LOCAL_HOST` (TUI-local to avoid the dep; the CLI
+/// re-applies its own default if this is cleared).
+///
+/// The port has no counterpart on purpose. Prefilling it would make every wizard
+/// launch an *explicit* port request, and `rocm serve` treats a named port that
+/// is already taken as an error rather than moving off it — so a prefill would
+/// turn "start a second server" into a hard failure. Left empty, the field reads
+/// as `(engine default)` and no `--port` is emitted, which is what lets the CLI
+/// pick a free one.
 const DEFAULT_HOST: &str = "127.0.0.1";
-const DEFAULT_PORT: &str = "11435";
 
 /// The form fields, in vertical order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,7 +125,7 @@ impl Default for ServeWizardState {
             engine_idx: 0,
             device_idx: 0,
             host: DEFAULT_HOST.to_string(),
-            port: DEFAULT_PORT.to_string(),
+            port: String::new(),
             managed: true,
             browser: None,
             picker: None,
@@ -571,7 +577,9 @@ mod tests {
         assert_eq!(ENGINES[w.engine_idx], "lemonade");
         assert_eq!(w.device_idx, 0); // engine default → no --device
         assert_eq!(w.host, "127.0.0.1");
-        assert_eq!(w.port, "11435");
+        // Empty on purpose: an unset port lets `rocm serve` pick a free one, so a
+        // second launch from the wizard does not collide with the first.
+        assert_eq!(w.port, "");
     }
 
     #[test]
@@ -587,6 +595,8 @@ mod tests {
             ..Default::default()
         };
         let args = w.build_args().unwrap();
+        // No `--port`: naming one would make the CLI treat the address as
+        // mandatory and fail when it is taken, instead of choosing a free one.
         assert_eq!(
             args,
             vec![
@@ -596,10 +606,23 @@ mod tests {
                 "lemonade",
                 "--host",
                 "127.0.0.1",
-                "--port",
-                "11435",
                 "--managed",
             ]
+        );
+    }
+
+    #[test]
+    fn build_args_emits_the_port_the_user_typed() {
+        let w = ServeWizardState {
+            model: "qwen".into(),
+            port: "8000".into(),
+            ..Default::default()
+        };
+        let args = w.build_args().unwrap();
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--port".to_string(), "8000".to_string()]),
+            "a typed port must still be passed through: {args:?}"
         );
     }
 

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -154,3 +154,22 @@ Feature: Model serving
     When the user serves a model pinned to a GPU index that does not exist
     Then serving is refused before any engine starts
     And the user is told that GPU index is unavailable
+
+  # An address the user names is a requirement, not a preference. When something
+  # else already holds it, the serve has to stop there — before the model is
+  # loaded and before a service is recorded — instead of letting the engine
+  # discover the collision on its own bind, which fails minutes later and leaves
+  # a dead service behind. Runs on GPU hardware for the same reason as scenario
+  # 13: on a no-GPU host the GPU-required pre-flight refuses before the address
+  # is ever examined, so the address-specific refusal is unobservable there.
+  # Not @merge-queue despite needing a GPU — that tag is for heavy real serves,
+  # and this one never launches an engine: it is refused at the address check,
+  # so it costs a process start and belongs on the per-PR path.
+  @id:serve-named-address-already-taken @requires-gpu
+  Scenario: 14 - Serving on an address something else holds is refused
+    Given a managed runtime is active
+    And another process holds the address the user is going to name
+    When the user serves a model on that address
+    Then serving is refused before any engine starts
+    And the user is told the address is already in use
+    And no service is recorded for the refused launch

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -85,6 +85,10 @@ pub struct E2eWorld {
     /// dir, captured logs). `Some` only for `@lifecycle` scenarios; all its paths
     /// are rooted in `isolated_root` so teardown removes them with the temp dir.
     pub lifecycle: Option<e2e::lifecycle_steps::LifecycleState>,
+    /// A listener a scenario is deliberately holding, so the address stays taken
+    /// for the whole scenario rather than only for the step that took it. Dropped
+    /// with the World, which releases the port.
+    pub held_listener: Option<std::net::TcpListener>,
 }
 
 /// Resolve a CI-provided shared-directory env var to a validated, existing path.
@@ -191,6 +195,7 @@ impl Default for E2eWorld {
             tui: None,
             chat_use_mock: false,
             lifecycle: None,
+            held_listener: None,
         }
     }
 }

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -742,6 +742,34 @@ async fn user_serves_absent_gpu_index(world: &mut E2eWorld) {
     world.cli_rc = Some(rc);
 }
 
+#[given("another process holds the address the user is going to name")]
+async fn given_named_address_taken(world: &mut E2eWorld) {
+    // An ephemeral port rather than the default: the point is that a *named*
+    // address which is taken is refused, and borrowing the default would make the
+    // scenario indistinguishable from the automatic-selection one — and would
+    // fight it for the same port when both run on the same host.
+    let listener =
+        std::net::TcpListener::bind(("127.0.0.1", 0)).expect("could not take an address to hold");
+    // Held on the World so it stays taken across the serve, not just this step.
+    world.held_listener = Some(listener);
+}
+
+#[when("the user serves a model on that address")]
+async fn user_serves_on_held_address(world: &mut E2eWorld) {
+    let port = held_port(world).to_string();
+    let (model, engine, _) = host_serve_target();
+    // The serve is expected to stop at the address check, so nothing here waits
+    // for readiness — a refusal that took a model download would be a failure of
+    // this scenario, not a pass.
+    let (stdout, stderr, rc) = crate::run_rocm(
+        world,
+        &["serve", model, "--engine", engine, "--port", &port],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
 #[when("the CLI reports the service as ready")]
 async fn when_cli_reports_ready(world: &mut E2eWorld) {
     // Read readiness from the CLI's own view (`services list`), not a direct
@@ -753,6 +781,18 @@ async fn when_cli_reports_ready(world: &mut E2eWorld) {
         "CLI does not report any service ready:\n{stdout}"
     );
     world.cli_output = Some(stdout);
+}
+
+/// The port of the address this scenario is holding, for the steps that have to
+/// name it in a command or look for it in output.
+fn held_port(world: &E2eWorld) -> u16 {
+    world
+        .held_listener
+        .as_ref()
+        .expect("no address is being held by this scenario")
+        .local_addr()
+        .expect("held listener has no address")
+        .port()
 }
 
 // ── Then ───────────────────────────────────────────────────────────
@@ -800,6 +840,30 @@ async fn assert_no_gpu_message(world: &mut E2eWorld) {
     assert!(
         output.to_lowercase().contains("no usable amd gpu"),
         "expected a no-AMD-GPU message, got:\n{output}"
+    );
+}
+
+#[then("the user is told the address is already in use")]
+async fn assert_address_in_use_message(world: &mut E2eWorld) {
+    let port = held_port(world).to_string();
+    let output = serve_output(world);
+    let lowered = output.to_lowercase();
+    assert!(
+        lowered.contains(&port) && lowered.contains("in use"),
+        "expected the refusal to name the taken address, got:\n{output}"
+    );
+}
+
+#[then("no service is recorded for the refused launch")]
+async fn assert_no_service_recorded(world: &mut E2eWorld) {
+    // The defect this pins left a dead entry behind: the engine was launched, hit
+    // the bind failure, and its manifest stayed in the list. A refusal that stops
+    // before the record is written leaves nothing to clean up.
+    let port = held_port(world).to_string();
+    let (listed, _, _) = crate::run_rocm(world, &["services", "list", "--all"]);
+    assert!(
+        !listed.contains(&port),
+        "a refused launch must not leave a service behind, but one is listed on {port}:\n{listed}"
     );
 }
 


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — no row exists on `main`; see Coordination below.

## Summary

A second managed service started without `--port` was handed 11435 unconditionally, so it collided with a server already holding it. Both manifests recorded the same address, the engine only discovered the clash when it tried to bind — minutes later, after the model had loaded — and the failed service stayed in `rocm services list --all`. Because the CLI advertises managing several background servers and spreads models across devices, the shared default defeated a capability the product otherwise has.

**Root cause:** there was no port-availability check anywhere on the serve path. The default was applied by clap and passed straight through to the engine.

What changed:

- The address is resolved before anything is announced or launched. An omitted `--port` takes the first free port at or above 11435 and reports the move; a named port is treated as a requirement, so a taken one fails up front — before the model loads and before a service record exists, which is also what stops the dead record being left behind.
- Ports claimed by live service manifests count as taken alongside a live bind probe. The manifest half covers a service that is still starting and has not listened yet — the exact state the second serve walks into.
- Reusing an already-running service now reports that service's own port rather than the one that was asked for, and refuses a named port it is not on. Previously the plan could announce a port the reused service was not listening on.
- Bind failures are classified rather than all read as collisions. A privileged port or an unresolvable host is quoted as itself and does not send the automatic search scanning a range that was never going to work.
- The dash serve wizard no longer prefills the port. Prefilling made every wizard launch an explicit request, which under the new rule would turn a second server into a hard failure.

**Why `--port` became `Option<u16>`:** the two branches have to be distinguishable. `--port 11435` against a busy 11435 must fail, while the *implicit* 11435 must move; a clap default erases that distinction. Help text carries the default instead.

**Risk: low.** No change to the launch path itself — only which port reaches it, and a new pre-flight refusal. The single user-visible behaviour change beyond the fix is that an explicitly named busy port is now an error rather than a late engine crash.

## Scope

Concurrent `rocm serve` invocations can still race between the claim read and the manifest write. Closing that needs a lock held across read-select-launch, which is owned by separate in-progress concurrency work on the managed launch path; adding one here would fight it for the same critical section. The window is documented in `resolve_serve_port`, including the fact that the critical section starts at the claim read rather than the spawn. This is a narrowing, not a regression — the collision was previously deterministic.

## Test plan

- 13 new unit tests: automatic selection over a live listener and over a manifest-only claim, explicit-port refusal naming the holder, reuse reporting the live service's own port, refusal of a named port the reused service is not on, `--port 0` rejection, unbindable-host classification, and wizard argument construction.
- `cargo test` green for `rocm`, `rocm-core`, `rocm-dash-tui`; `cargo clippy --workspace --all-targets` and `cargo fmt` clean.
- New e2e scenario `serve-named-address-already-taken` pins the explicit-busy-port refusal and asserts no service is recorded for it.

**Not verified locally, stated rather than skipped:** I have no GPU on this machine, so `rocm serve` exits at the GPU pre-flight before port resolution is ever reached. The original defect was reproduced on GPU hardware by the reporter, but I could not re-run that reproduction myself; the fix is verified by unit tests and by review against the reported behaviour. The new e2e scenario is `@requires-gpu` for the same reason scenario 13 is — on a host with no usable device the pre-flight refuses before the address is examined — so it is verified on the GPU lane, not here.

## Coordination

An e2e scenario for this bug is already pending in #241, along with an `expectations.toml` xfail row citing it. Neither is on `main` yet, so there is no stale row for this PR to remove. Whichever merges second must reconcile: if this one lands first, #241 needs to drop that row, or the merge queue will fail on the XPASS.