### PR TITLE
fix(cli): accept negative float flag values in space form (EAI-8243)

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -257,16 +257,19 @@ echo \"Summarize this\" | rocm chat --provider anthropic")]
         #[arg(long)]
         prompt: Option<String>,
         /// Sampling temperature to send with the request (>= 0.0). Higher is more random.
-        // `allow_negative_numbers` lets the space form (`--temperature -1`) reach
-        // `parse_non_negative_temperature` for a clear range error, instead of clap
-        // rejecting `-1` as an unexpected argument.
+        // `allow_negative_numbers` on the numeric value flags below (`--temperature`,
+        // `--top-p`, `--max-tokens`) lets their space form (e.g. `--temperature -1`) reach
+        // the value parser for a clear range error, instead of clap rejecting the token as
+        // an unexpected argument. clap only treats a `-…` token as a number when the whole
+        // remainder parses as one, so a missing value (`--temperature --top-p 0.5`) or a
+        // malformed token (`--temperature -0.5abc`) still errors at parse time.
         #[arg(long, allow_negative_numbers = true, value_parser = parse_non_negative_temperature)]
         temperature: Option<f32>,
         /// Nucleus sampling probability to send with the request (0.0-1.0).
         #[arg(long = "top-p", allow_negative_numbers = true, value_parser = parse_unit_interval)]
         top_p: Option<f32>,
         /// Maximum number of tokens to generate in the response.
-        #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
+        #[arg(long = "max-tokens", allow_negative_numbers = true, value_parser = parse_positive_u32)]
         max_tokens: Option<u32>,
         #[arg(
             long,
@@ -401,16 +404,19 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         #[arg(long, value_name = "FRACTION", allow_hyphen_values = true)]
         gpu_memory_utilization: Option<String>,
         /// Default sampling temperature for generation (>= 0.0).
-        // `allow_negative_numbers` lets the space form (`--temperature -1`) reach
-        // `parse_non_negative_temperature` for a clear range error, instead of clap
-        // rejecting `-1` as an unexpected argument.
+        // `allow_negative_numbers` on the numeric value flags below (`--temperature`,
+        // `--top-p`, `--max-tokens`) lets their space form (e.g. `--temperature -1`) reach
+        // the value parser for a clear range error, instead of clap rejecting the token as
+        // an unexpected argument. clap only treats a `-…` token as a number when the whole
+        // remainder parses as one, so a missing value (`--temperature --top-p 0.5`) or a
+        // malformed token (`--temperature -0.5abc`) still errors at parse time.
         #[arg(long, allow_negative_numbers = true, value_parser = parse_non_negative_temperature)]
         temperature: Option<f32>,
         /// Default nucleus sampling probability for generation (0.0-1.0).
         #[arg(long = "top-p", allow_negative_numbers = true, value_parser = parse_unit_interval)]
         top_p: Option<f32>,
         /// Default maximum number of tokens to generate per response.
-        #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
+        #[arg(long = "max-tokens", allow_negative_numbers = true, value_parser = parse_positive_u32)]
         max_tokens: Option<u32>,
         /// API key that clients must present to a public (non-loopback) endpoint.
         /// When binding a public interface and this is omitted, a strong key is
@@ -18261,15 +18267,19 @@ mod tests {
 
     #[test]
     fn serve_negative_sampling_space_form_reaches_range_validator() {
-        // The space form (`--temperature -1`) must reach the range validator and
-        // report a range error, not be rejected by clap as an unexpected argument.
+        // The space form (`--temperature -1`) must reach the value parser and
+        // report a value error, not be rejected by clap as an unexpected argument.
         // This is the classic negative-number-as-flag gotcha; `allow_negative_numbers`
-        // makes both forms validate identically.
+        // makes both forms validate identically. `--max-tokens` shares the gotcha even
+        // though it is a positive integer: the ambiguity is at the tokenizer, before the
+        // value parser runs, so the space form must reach `parse_positive_u32` too.
         for args in [
             &["--temperature", "-1"][..],
             &["--temperature=-1"][..],
             &["--top-p", "-0.5"][..],
             &["--top-p=-0.5"][..],
+            &["--max-tokens", "-1"][..],
+            &["--max-tokens=-1"][..],
         ] {
             assert_eq!(
                 parse_serve(args)
@@ -18283,11 +18293,16 @@ mod tests {
 
     #[test]
     fn chat_negative_sampling_space_form_reaches_range_validator() {
+        // Mirrors `serve_negative_sampling_space_form_reaches_range_validator`: the
+        // same numeric value flags carry `allow_negative_numbers` on `chat`, so the
+        // space form reaches the value parser instead of clap's unexpected-argument path.
         for args in [
             &["--temperature", "-1"][..],
             &["--temperature=-1"][..],
             &["--top-p", "-0.5"][..],
             &["--top-p=-0.5"][..],
+            &["--max-tokens", "-1"][..],
+            &["--max-tokens=-1"][..],
         ] {
             let mut argv = vec!["rocm", "chat", "--prompt", "hi"];
             argv.extend_from_slice(args);

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -257,10 +257,13 @@ echo \"Summarize this\" | rocm chat --provider anthropic")]
         #[arg(long)]
         prompt: Option<String>,
         /// Sampling temperature to send with the request (>= 0.0). Higher is more random.
-        #[arg(long, value_parser = parse_non_negative_temperature)]
+        // `allow_negative_numbers` lets the space form (`--temperature -1`) reach
+        // `parse_non_negative_temperature` for a clear range error, instead of clap
+        // rejecting `-1` as an unexpected argument.
+        #[arg(long, allow_negative_numbers = true, value_parser = parse_non_negative_temperature)]
         temperature: Option<f32>,
         /// Nucleus sampling probability to send with the request (0.0-1.0).
-        #[arg(long = "top-p", value_parser = parse_unit_interval)]
+        #[arg(long = "top-p", allow_negative_numbers = true, value_parser = parse_unit_interval)]
         top_p: Option<f32>,
         /// Maximum number of tokens to generate in the response.
         #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
@@ -398,10 +401,13 @@ rocm serve qwen2.5-7b-instruct --verbose --device gpu_required")]
         #[arg(long, value_name = "FRACTION", allow_hyphen_values = true)]
         gpu_memory_utilization: Option<String>,
         /// Default sampling temperature for generation (>= 0.0).
-        #[arg(long, value_parser = parse_non_negative_temperature)]
+        // `allow_negative_numbers` lets the space form (`--temperature -1`) reach
+        // `parse_non_negative_temperature` for a clear range error, instead of clap
+        // rejecting `-1` as an unexpected argument.
+        #[arg(long, allow_negative_numbers = true, value_parser = parse_non_negative_temperature)]
         temperature: Option<f32>,
         /// Default nucleus sampling probability for generation (0.0-1.0).
-        #[arg(long = "top-p", value_parser = parse_unit_interval)]
+        #[arg(long = "top-p", allow_negative_numbers = true, value_parser = parse_unit_interval)]
         top_p: Option<f32>,
         /// Default maximum number of tokens to generate per response.
         #[arg(long = "max-tokens", value_parser = parse_positive_u32)]
@@ -18251,6 +18257,48 @@ mod tests {
                 .kind(),
             clap::error::ErrorKind::ValueValidation
         );
+    }
+
+    #[test]
+    fn serve_negative_sampling_space_form_reaches_range_validator() {
+        // The space form (`--temperature -1`) must reach the range validator and
+        // report a range error, not be rejected by clap as an unexpected argument.
+        // This is the classic negative-number-as-flag gotcha; `allow_negative_numbers`
+        // makes both forms validate identically.
+        for args in [
+            &["--temperature", "-1"][..],
+            &["--temperature=-1"][..],
+            &["--top-p", "-0.5"][..],
+            &["--top-p=-0.5"][..],
+        ] {
+            assert_eq!(
+                parse_serve(args)
+                    .expect_err("negative sampling value is rejected")
+                    .kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "expected range validation for {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn chat_negative_sampling_space_form_reaches_range_validator() {
+        for args in [
+            &["--temperature", "-1"][..],
+            &["--temperature=-1"][..],
+            &["--top-p", "-0.5"][..],
+            &["--top-p=-0.5"][..],
+        ] {
+            let mut argv = vec!["rocm", "chat", "--prompt", "hi"];
+            argv.extend_from_slice(args);
+            assert_eq!(
+                Cli::try_parse_from(argv)
+                    .expect_err("negative sampling value is rejected")
+                    .kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "expected range validation for {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -135,6 +135,16 @@ Feature: Model serving
     Then serving is refused before any engine starts
     And the user is told no AMD GPU was detected
 
+  # Parse-time refusal: `--temperature -1` (space form) must reach the value
+  # parser and report the range error, not clap's "unexpected argument". The
+  # check runs inside argument parsing, before engine selection or any GPU
+  # pre-flight, so it needs no GPU and no engine and gates every PR (ungated).
+  @id:serve-negative-temperature-rejected
+  Scenario: Serving with a temperature below zero is refused with a clear reason
+    When the user serves a model with a negative sampling temperature
+    Then serving is refused before any engine starts
+    And the CLI explains that temperature cannot be negative
+
   # The masked-device path: on a real GPU host where every device is hidden, the
   # GPU-required serve must treat it as "no GPU" and refuse, not fall back. Runs on
   # GPU hardware (Strix Halo / Instinct).

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -140,7 +140,7 @@ Feature: Model serving
   # check runs inside argument parsing, before engine selection or any GPU
   # pre-flight, so it needs no GPU and no engine and gates every PR (ungated).
   @id:serve-negative-temperature-rejected
-  Scenario: Serving with a temperature below zero is refused with a clear reason
+  Scenario: 15 - Serving with a temperature below zero is refused with a clear reason
     When the user serves a model with a negative sampling temperature
     Then serving is refused before any engine starts
     And the CLI explains that temperature cannot be negative

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -715,6 +715,21 @@ async fn user_serves_gpu_required(world: &mut E2eWorld) {
     world.cli_rc = Some(rc);
 }
 
+/// Serve with a negative `--temperature` in the space form. The value parser
+/// runs inside argument parsing, before engine selection or any GPU pre-flight,
+/// so a bogus model name never gets that far — the refusal needs no GPU and no
+/// engine, which is what lets this scenario gate every PR.
+#[when("the user serves a model with a negative sampling temperature")]
+async fn user_serves_negative_temperature(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(
+        world,
+        &["serve", "sampling-check-model", "--temperature", "-1"],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
 /// Serve with every GPU hidden from the CLI and engine via an empty
 /// `HIP_VISIBLE_DEVICES`, so a GPU host presents as having no usable device.
 #[when("the user serves a model with every GPU masked from view")]
@@ -800,6 +815,17 @@ async fn assert_no_gpu_message(world: &mut E2eWorld) {
     assert!(
         output.to_lowercase().contains("no usable amd gpu"),
         "expected a no-AMD-GPU message, got:\n{output}"
+    );
+}
+
+#[then("the CLI explains that temperature cannot be negative")]
+async fn assert_negative_temperature_message(world: &mut E2eWorld) {
+    let output = serve_output(world);
+    assert!(
+        output
+            .to_lowercase()
+            .contains("temperature must be a finite value >= 0.0"),
+        "expected a temperature range explanation, got:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

`rocm serve --temperature -1` (space-separated form) was rejected by clap with the
confusing error `unexpected argument '-1'`, because clap parsed the leading-dash
token as a flag rather than a value. Only the equals form (`--temperature=-1`)
reached the value validator that reports the valid range.

This is the classic negative-number-as-flag gotcha. It is a **tokenizer-level**
ambiguity that fires before any value parser runs, so it is not float-specific —
it affected every numeric value flag: `--temperature` and `--top-p` (float) **and
`--max-tokens` (positive integer)** on both `chat` and `serve`.

## Fix

Enable clap's `allow_negative_numbers` on the affected numeric flags so the space
form reaches the value parser. Both forms now validate identically and surface a
clear range/parse message instead of an unexpected-argument error.

`allow_negative_numbers` is preferred over `allow_hyphen_values` here: it only
accepts leading-dash tokens that parse as numbers, so it does not swallow the next
flag when a value is missing (the tradeoff called out for `--gpu-memory-utilization`).

## Testing

- **Gherkin scenario (AGENTS.md §3):** `@id:serve-negative-temperature-rejected`
  in `tests/e2e-cucumber/features/model_serving.feature` covers the user-observable
  stderr change end-to-end. It is ungated — the value parser runs inside argument
  parsing before engine selection or GPU pre-flight, so it needs no GPU and no
  engine and gates every PR (mirrors the ungated `@id:fix-position-argument-rejected`
  precedent). The scenario is now numbered (`Scenario: 15 - ...`) for consistency
  with the rest of the suite.
- Extended the space-form regression tests (`serve`/`chat`) to cover
  `--temperature`, `--top-p`, **and `--max-tokens`** in both space and equals
  forms, asserting they reach `ValueValidation` (the value parser) rather than
  being rejected as an unexpected argument.
- `cargo test -p rocm --bin rocm` (touched sampling tests pass); `cargo clippy -p
  rocm --all-targets -- -D warnings`; `cargo fmt -p rocm`.

## Deliberate scope-out (follow-up)

`rocm fix --device-index -1` has the same gotcha with its own dedicated
`--device-index must be >= 0` message (`crates/rocm-core/src/fix.rs`), but it is
**not the only remaining instance**. The same negative-as-flag rejection still
fires on a wider class of single-value numeric flags across the tree — for
example `rocm serve --port -1`, `rocm bench load --isl -1` (and
`--osl`/`--requests`/`--batch-sizes`/`--keep`), `rocm diagnose --top -5`, and
`rocm comfyui logs --lines -5` — roughly eight flags, not one. These are left to
a follow-up to keep this PR one logical change. The durable fix for the recurring
class is a whole-tree guard test walking `Cli::command()` to assert every
single-value numeric arg sets `allow_negative_numbers`/`allow_hyphen_values`; it
belongs with that follow-up, which is "fix the class" rather than "fix
`--device-index`".
