### PR TITLE
fix(install): resolve driver repo version and package release in plans

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -2820,7 +2820,7 @@ struct DriverInstallPlan {
     os_id: String,
     version_id: String,
     codename: String,
-    repo_version_expr: String,
+    repo_version: String,
     reason: String,
     preflight_checks: Vec<String>,
     commands: Vec<DriverPlanCommand>,
@@ -2900,7 +2900,17 @@ fn build_driver_install_plan(
     os_release_text: &str,
     dkms: bool,
 ) -> DriverInstallPlan {
-    let repo_version_expr = "${ROCM_CLI_AMDGPU_VERSION:-7.2.4}".to_owned();
+    // Resolve the AMD graphics version and amdgpu-install package release once,
+    // here at plan-build time, so the concrete values are baked into both the
+    // human-readable summary and every command the plan runs. Keeping shell
+    // `${VAR:-default}` templates in the commands used to be load-bearing, but
+    // AMD's apt `sources.list` line embeds the template inside POSIX single
+    // quotes, which suppress all expansion — so the literal `${...}` would land
+    // in the repo file. Resolving up front fixes that and keeps the summary and
+    // the executed commands in agreement.
+    let repo_version = resolve_shell_default_template("${ROCM_CLI_AMDGPU_VERSION:-7.2.4}");
+    let package_release =
+        resolve_shell_default_template("${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}");
     if examine.os == "windows" {
         return DriverInstallPlan {
             supported: false,
@@ -2909,7 +2919,7 @@ fn build_driver_install_plan(
             os_id: "windows".to_owned(),
             version_id: String::new(),
             codename: String::new(),
-            repo_version_expr,
+            repo_version,
             reason: "Windows driver install is validate-only in rocm-cli; use `rocm examine` to inspect the AMD display driver.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
@@ -2924,7 +2934,7 @@ fn build_driver_install_plan(
             os_id: "wsl".to_owned(),
             version_id: String::new(),
             codename: String::new(),
-            repo_version_expr,
+            repo_version,
             reason: "WSL uses the Windows host driver plus ROCDXG; run `scripts/wsl_setup_rocdxg.sh` inside WSL instead of installing Linux DKMS.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
@@ -2945,7 +2955,7 @@ fn build_driver_install_plan(
             os_id,
             version_id,
             codename,
-            repo_version_expr,
+            repo_version,
             dkms,
             true,
         ),
@@ -2955,7 +2965,7 @@ fn build_driver_install_plan(
                 os_id,
                 version_id,
                 repo_codename.to_owned(),
-                repo_version_expr,
+                repo_version,
                 dkms,
                 false,
             );
@@ -2974,7 +2984,8 @@ fn build_driver_install_plan(
             os_id,
             version_id,
             codename,
-            repo_version_expr,
+            repo_version,
+            package_release,
             dkms,
             DnfDriverDistro::Rhel,
         ),
@@ -2982,7 +2993,8 @@ fn build_driver_install_plan(
             os_id,
             version_id,
             codename,
-            repo_version_expr,
+            repo_version,
+            package_release,
             dkms,
             DnfDriverDistro::Oracle,
         ),
@@ -2990,19 +3002,21 @@ fn build_driver_install_plan(
             os_id,
             version_id,
             codename,
-            repo_version_expr,
+            repo_version,
+            package_release,
             dkms,
             DnfDriverDistro::Rocky,
         ),
         ("sles" | "sle", "15.7") => {
-            sles_driver_plan(os_id, version_id, codename, repo_version_expr, dkms)
+            sles_driver_plan(os_id, version_id, codename, repo_version, package_release, dkms)
         }
         _ => driver_plan_via_id_like(
             &os_id,
             &version_id,
             &id_like,
             &codename,
-            &repo_version_expr,
+            &repo_version,
+            &package_release,
             dkms,
         )
         .unwrap_or_else(|| DriverInstallPlan {
@@ -3012,7 +3026,7 @@ fn build_driver_install_plan(
             os_id,
             version_id,
             codename,
-            repo_version_expr,
+            repo_version,
             reason: "Linux DKMS driver install is currently planned only for AMD-documented Ubuntu, Debian, RHEL, Oracle Linux, SLES, and Rocky versions; no commands were guessed for this distro.".to_owned(),
             preflight_checks: Vec::new(),
             commands: Vec::new(),
@@ -3035,7 +3049,8 @@ fn driver_plan_via_id_like(
     version_id: &str,
     id_like: &str,
     codename: &str,
-    repo_version_expr: &str,
+    repo_version: &str,
+    package_release: &str,
     dkms: bool,
 ) -> Option<DriverInstallPlan> {
     let likes: Vec<String> = id_like
@@ -3061,7 +3076,7 @@ fn driver_plan_via_id_like(
             os_id.to_owned(),
             version_id.to_owned(),
             codename,
-            repo_version_expr.to_owned(),
+            repo_version.to_owned(),
             dkms,
             true,
         ));
@@ -3075,7 +3090,7 @@ fn driver_plan_via_id_like(
             os_id.to_owned(),
             version_id.to_owned(),
             repo_codename.to_owned(),
-            repo_version_expr.to_owned(),
+            repo_version.to_owned(),
             dkms,
             false,
         ));
@@ -3095,7 +3110,8 @@ fn driver_plan_via_id_like(
             os_id.to_owned(),
             version_id.to_owned(),
             codename.to_owned(),
-            repo_version_expr.to_owned(),
+            repo_version.to_owned(),
+            package_release.to_owned(),
             dkms,
             DnfDriverDistro::Generic,
         ));
@@ -3129,7 +3145,7 @@ fn apt_driver_plan(
     os_id: String,
     version_id: String,
     codename: String,
-    repo_version_expr: String,
+    repo_version: String,
     dkms: bool,
     include_linux_modules_extra: bool,
 ) -> DriverInstallPlan {
@@ -3160,7 +3176,7 @@ fn apt_driver_plan(
             driver_command(
                 DriverCommandPhase::Prepare,
                 &format!(
-                    "printf '%s\\n' 'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/{repo_version_expr}/ubuntu {codename} main' | sudo tee /etc/apt/sources.list.d/amdgpu.list >/dev/null"
+                    "printf '%s\\n' 'deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/{repo_version}/ubuntu {codename} main' | sudo tee /etc/apt/sources.list.d/amdgpu.list >/dev/null"
                 ),
             ),
             driver_command(
@@ -3190,7 +3206,7 @@ fn apt_driver_plan(
         os_id,
         version_id,
         codename,
-        repo_version_expr,
+        repo_version,
         reason: if dkms {
             "Plan uses AMD's package-manager DKMS flow and requires explicit approval before execution."
         } else {
@@ -3222,7 +3238,8 @@ fn dnf_driver_plan(
     os_id: String,
     version_id: String,
     codename: String,
-    repo_version_expr: String,
+    repo_version: String,
+    package_release: String,
     dkms: bool,
     distro: DnfDriverDistro,
 ) -> DriverInstallPlan {
@@ -3253,7 +3270,7 @@ fn dnf_driver_plan(
             DriverCommandPhase::Prepare,
             &format!(
                 "sudo dnf install -y {}",
-                amdgpu_install_rpm_url(&repo_version_expr, &version_id, distro)
+                amdgpu_install_rpm_url(&repo_version, &package_release, &version_id, distro)
             ),
         ));
         commands.push(driver_command(
@@ -3281,7 +3298,7 @@ fn dnf_driver_plan(
         os_id,
         version_id,
         codename,
-        repo_version_expr,
+        repo_version,
         reason: if dkms {
             "Plan uses AMD's documented DNF DKMS flow and requires explicit approval before execution."
         } else {
@@ -3316,7 +3333,8 @@ fn sles_driver_plan(
     os_id: String,
     version_id: String,
     codename: String,
-    repo_version_expr: String,
+    repo_version: String,
+    package_release: String,
     dkms: bool,
 ) -> DriverInstallPlan {
     let mut commands = Vec::new();
@@ -3343,7 +3361,7 @@ fn sles_driver_plan(
                 DriverCommandPhase::Prepare,
                 &format!(
                     "sudo zypper --no-gpg-checks install -y {}",
-                    amdgpu_install_sles_rpm_url(&repo_version_expr, &version_id)
+                    amdgpu_install_sles_rpm_url(&repo_version, &package_release, &version_id)
                 ),
             ),
             driver_command(DriverCommandPhase::Prepare, "sudo zypper refresh"),
@@ -3367,7 +3385,7 @@ fn sles_driver_plan(
         os_id,
         version_id,
         codename,
-        repo_version_expr,
+        repo_version,
         reason: if dkms {
             "Plan uses AMD's documented SLES DKMS flow and requires explicit approval before execution."
         } else {
@@ -3413,7 +3431,8 @@ fn rhel_kernel_prepare_commands(version_id: &str) -> Vec<&'static str> {
 }
 
 fn amdgpu_install_rpm_url(
-    repo_version_expr: &str,
+    repo_version: &str,
+    package_release: &str,
     version_id: &str,
     distro: DnfDriverDistro,
 ) -> String {
@@ -3421,16 +3440,20 @@ fn amdgpu_install_rpm_url(
         DnfDriverDistro::Rhel => "rhel",
         DnfDriverDistro::Oracle | DnfDriverDistro::Rocky | DnfDriverDistro::Generic => "el",
     };
-    let repo_version = dnf_repo_version_path(version_id);
+    let repo_version_path = dnf_repo_version_path(version_id);
     let el_major = linux_major_version(version_id);
     format!(
-        "https://repo.radeon.com/amdgpu-install/{repo_version_expr}/{repo_family}/{repo_version}/amdgpu-install-{repo_version_expr}.${{ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}}-1.el{el_major}.noarch.rpm"
+        "https://repo.radeon.com/amdgpu-install/{repo_version}/{repo_family}/{repo_version_path}/amdgpu-install-{repo_version}.{package_release}-1.el{el_major}.noarch.rpm"
     )
 }
 
-fn amdgpu_install_sles_rpm_url(repo_version_expr: &str, version_id: &str) -> String {
+fn amdgpu_install_sles_rpm_url(
+    repo_version: &str,
+    package_release: &str,
+    version_id: &str,
+) -> String {
     format!(
-        "https://repo.radeon.com/amdgpu-install/{repo_version_expr}/sle/{version_id}/amdgpu-install-{repo_version_expr}.${{ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}}-1.noarch.rpm"
+        "https://repo.radeon.com/amdgpu-install/{repo_version}/sle/{version_id}/amdgpu-install-{repo_version}.{package_release}-1.noarch.rpm"
     )
 }
 
@@ -3457,6 +3480,38 @@ fn driver_command(phase: DriverCommandPhase, command: &str) -> DriverPlanCommand
     }
 }
 
+/// Resolve a `${VAR:-default}` shell parameter-expansion template to its
+/// effective value: the value of `VAR` when it is set and non-empty (matching
+/// the shell `:-` semantics), otherwise the literal default. This is resolved
+/// once at plan-build time so the concrete value is baked into both the
+/// human-readable summary and the commands the plan runs, rather than leaking an
+/// unexpanded `${...}` placeholder into user-facing output or depending on the
+/// runtime shell — which, for the single-quoted apt `sources.list` line, would
+/// never expand it at all.
+///
+/// Only a single, flat `${VAR:-default}` template is recognized. Anything else —
+/// a bare `${VAR}`, a `${VAR:=x}`/`${VAR-x}` form, or a nested default such as
+/// `${A:-${B:-x}}` whose default itself contains `${` — is returned unchanged, so
+/// an unresolvable shape degrades to its literal input rather than to a
+/// half-resolved string.
+fn resolve_shell_default_template(expr: &str) -> String {
+    let Some(inner) = expr.strip_prefix("${").and_then(|s| s.strip_suffix('}')) else {
+        return expr.to_owned();
+    };
+    let Some((var, default)) = inner.split_once(":-") else {
+        return expr.to_owned();
+    };
+    if default.contains("${") {
+        // Nested or embedded templates are beyond this flat matcher; return the
+        // input untouched rather than emitting a partially resolved string.
+        return expr.to_owned();
+    }
+    std::env::var(var)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.to_owned())
+}
+
 fn render_driver_install_plan(plan: &DriverInstallPlan, yes: bool, dry_run: bool) -> String {
     let mut output = String::new();
     let _ = writeln!(output, "driver install plan");
@@ -3476,7 +3531,7 @@ fn render_driver_install_plan(plan: &DriverInstallPlan, yes: bool, dry_run: bool
         empty_as_unknown(&plan.version_id)
     );
     let _ = writeln!(output, "  codename: {}", empty_as_unknown(&plan.codename));
-    let _ = writeln!(output, "  repo_version: {}", plan.repo_version_expr);
+    let _ = writeln!(output, "  repo_version: {}", plan.repo_version);
     let _ = writeln!(output, "  reason: {}", plan.reason);
     if !plan.preflight_checks.is_empty() {
         let _ = writeln!(output, "  preflight_checks:");
@@ -17825,6 +17880,80 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Serializes and isolates tests that read or mutate process-global env vars.
+    ///
+    /// `std::env::set_var`/`remove_var` are `unsafe` in edition 2024 because
+    /// concurrent env mutation races with any concurrent `env::var` read anywhere
+    /// in the process, and `cargo test` runs these functions multi-threaded in one
+    /// binary. A unique variable name does not make a mutation safe — the hazard is
+    /// the mutation racing a read, not a name collision. Every test that touches
+    /// env therefore holds this one process-wide lock, and each mutation is saved
+    /// and restored on drop so it cannot leak into another test.
+    struct ScopedTestEnv {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(String, Option<String>)>,
+    }
+
+    impl ScopedTestEnv {
+        fn new() -> Self {
+            static LOCK: Mutex<()> = Mutex::new(());
+            let lock = LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Self {
+                _lock: lock,
+                saved: Vec::new(),
+            }
+        }
+
+        /// Clear the two AMD driver-install override vars for the duration of the
+        /// test, so a value exported in the developer's or runner's shell cannot
+        /// leak into a plan and make its resolved `repo_version`/package release
+        /// disagree with the assertion.
+        fn with_amd_overrides_cleared() -> Self {
+            let mut env = Self::new();
+            env.clear("ROCM_CLI_AMDGPU_VERSION");
+            env.clear("ROCM_CLI_AMDGPU_PACKAGE_RELEASE");
+            env
+        }
+
+        fn save(&mut self, key: &str) {
+            if !self.saved.iter().any(|(saved_key, _)| saved_key == key) {
+                self.saved.push((key.to_owned(), std::env::var(key).ok()));
+            }
+        }
+
+        #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
+        fn set(&mut self, key: &str, value: &str) {
+            self.save(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+
+        #[allow(unsafe_code)] // std::env::remove_var is unsafe in edition 2024
+        fn clear(&mut self, key: &str) {
+            self.save(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for ScopedTestEnv {
+        #[allow(unsafe_code)] // std::env::set_var/remove_var are unsafe in edition 2024
+        fn drop(&mut self) {
+            for (key, previous) in self.saved.iter().rev() {
+                unsafe {
+                    match previous {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
+        }
+    }
+
     // The previous `daemon_run_argv_targets_rocmd_run_with_automations` unit test
     // only re-asserted the literals `daemon_run_argv()` returns, so it tested
     // nothing real. The intended real behavior — that this argv actually drives
@@ -23972,6 +24101,7 @@ install therock";
 
     #[test]
     fn driver_plan_ubuntu_2404_uses_official_dkms_commands() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=ubuntu
 VERSION_ID="24.04"
@@ -24138,6 +24268,7 @@ VERSION_CODENAME=noble
 
     #[test]
     fn driver_plan_default_linux_preflight_has_no_execution_commands() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=ubuntu
 VERSION_ID="24.04"
@@ -24156,7 +24287,84 @@ VERSION_CODENAME=noble
     }
 
     #[test]
+    fn resolve_shell_default_template_uses_default_when_env_unset() {
+        let _env = ScopedTestEnv::new();
+        // A made-up variable name that nothing else sets, cleared under the lock,
+        // isolates the default path.
+        assert_eq!(
+            resolve_shell_default_template("${ROCM_CLI_TEST_UNSET_REPO_VERSION:-7.2.4}"),
+            "7.2.4"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_default_template_prefers_env_value_when_set() {
+        let mut env = ScopedTestEnv::new();
+        let var = "ROCM_CLI_TEST_REPO_VERSION_OVERRIDE";
+        env.set(var, "9.9.9");
+        assert_eq!(
+            resolve_shell_default_template(&format!("${{{var}:-7.2.4}}")),
+            "9.9.9"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_default_template_treats_empty_env_as_unset() {
+        let mut env = ScopedTestEnv::new();
+        let var = "ROCM_CLI_TEST_REPO_VERSION_EMPTY";
+        env.set(var, "");
+        assert_eq!(
+            resolve_shell_default_template(&format!("${{{var}:-7.2.4}}")),
+            "7.2.4"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_default_template_passes_through_non_template() {
+        assert_eq!(resolve_shell_default_template("7.2.4"), "7.2.4");
+    }
+
+    #[test]
+    fn resolve_shell_default_template_leaves_bare_var_untouched() {
+        let _env = ScopedTestEnv::new();
+        // No `:-default`, so there is nothing to resolve to; the input must pass
+        // through unchanged rather than being partially rewritten.
+        assert_eq!(
+            resolve_shell_default_template("${ROCM_CLI_TEST_UNSET_REPO_VERSION}"),
+            "${ROCM_CLI_TEST_UNSET_REPO_VERSION}"
+        );
+    }
+
+    #[test]
+    fn resolve_shell_default_template_leaves_nested_default_untouched() {
+        let _env = ScopedTestEnv::new();
+        // A nested default is beyond the flat matcher; returning the literal
+        // input keeps a `${B:-x}` fragment from leaking as a "resolved" value.
+        assert_eq!(
+            resolve_shell_default_template("${ROCM_CLI_TEST_UNSET_A:-${ROCM_CLI_TEST_UNSET_B:-x}}"),
+            "${ROCM_CLI_TEST_UNSET_A:-${ROCM_CLI_TEST_UNSET_B:-x}}"
+        );
+    }
+
+    #[test]
+    fn driver_plan_dry_run_repo_version_line_is_resolved() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
+        // Regression for the dry-run output leaking the raw shell placeholder on
+        // the `repo_version:` line instead of the effective version.
+        let os_release = r#"
+ID=rhel
+VERSION_ID="9.7"
+"#;
+        let plan = build_driver_install_plan(&test_examine("linux", false), os_release, true);
+        let rendered = render_driver_install_plan(&plan, false, true);
+
+        assert!(rendered.contains("repo_version: 7.2.4"));
+        assert!(!rendered.contains("repo_version: ${ROCM_CLI_AMDGPU_VERSION:-7.2.4}"));
+    }
+
+    #[test]
     fn driver_plan_debian_12_omits_linux_modules_extra() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=debian
 VERSION_ID="12"
@@ -24175,6 +24383,7 @@ VERSION_CODENAME=bookworm
 
     #[test]
     fn driver_plan_rhel_97_uses_documented_dnf_commands() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=rhel
 VERSION_ID="9.7"
@@ -24189,16 +24398,15 @@ VERSION_ID="9.7"
         assert!(rendered.contains("kernel-headers-$(uname -r)"));
         assert!(rendered.contains("kernel-devel-$(uname -r)"));
         assert!(rendered.contains("kernel-devel-matched-$(uname -r)"));
-        assert!(rendered.contains(
-            "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/rhel/9.7/"
-        ));
-        assert!(rendered.contains("amdgpu-install-${ROCM_CLI_AMDGPU_VERSION:-7.2.4}.${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}-1.el9.noarch.rpm"));
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/rhel/9.7/"));
+        assert!(rendered.contains("amdgpu-install-7.2.4.70204-1.el9.noarch.rpm"));
         assert!(rendered.contains("Execute: sudo dnf install -y amdgpu-dkms"));
         assert!(rendered.contains("approval: required"));
     }
 
     #[test]
     fn driver_plan_oracle_linux_101_uses_el_10_uek_flow() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=ol
 VERSION_ID="10.1"
@@ -24209,17 +24417,14 @@ VERSION_ID="10.1"
         assert!(plan.supported);
         assert!(rendered.contains("approval: not required"));
         assert!(rendered.contains("kernel-uek-devel-$(uname -r)"));
-        assert!(
-            rendered.contains(
-                "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/el/10/"
-            )
-        );
-        assert!(rendered.contains("amdgpu-install-${ROCM_CLI_AMDGPU_VERSION:-7.2.4}.${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}-1.el10.noarch.rpm"));
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/el/10/"));
+        assert!(rendered.contains("amdgpu-install-7.2.4.70204-1.el10.noarch.rpm"));
         assert!(rendered.contains("dry run only"));
     }
 
     #[test]
     fn driver_plan_rocky_97_uses_el_dnf_flow() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=rocky
 VERSION_ID="9.7"
@@ -24232,16 +24437,13 @@ VERSION_ID="9.7"
             rendered
                 .contains("sudo dnf install -y kernel-headers kernel-devel kernel-devel-matched")
         );
-        assert!(
-            rendered.contains(
-                "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/el/9.7/"
-            )
-        );
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/el/9.7/"));
         assert!(rendered.contains("Execute: sudo dnf install -y amdgpu-dkms"));
     }
 
     #[test]
     fn driver_plan_rocky_94_uses_el_dnf_flow() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // Rocky 9.x point releases must resolve like RHEL 9.x, not just 9.7.
         let os_release = r#"
 ID=rocky
@@ -24252,17 +24454,14 @@ VERSION_ID="9.4"
 
         assert!(plan.supported);
         assert!(plan.mutating);
-        assert!(
-            rendered.contains(
-                "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/el/9.4/"
-            )
-        );
-        assert!(rendered.contains("amdgpu-install-${ROCM_CLI_AMDGPU_VERSION:-7.2.4}.${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}-1.el9.noarch.rpm"));
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/el/9.4/"));
+        assert!(rendered.contains("amdgpu-install-7.2.4.70204-1.el9.noarch.rpm"));
         assert!(rendered.contains("Execute: sudo dnf install -y amdgpu-dkms"));
     }
 
     #[test]
     fn driver_plan_rocky_8_and_10_remain_unsupported() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // AMD documents Rocky Linux 9 only; keep the driver matrix scoped to 9.x.
         for version in ["8.10", "10.0"] {
             let os_release = format!("\nID=rocky\nVERSION_ID=\"{version}\"\n");
@@ -24278,6 +24477,7 @@ VERSION_ID="9.4"
 
     #[test]
     fn driver_plan_debian_uses_intended_ubuntu_suite() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // AMD's documented Debian install deliberately serves Debian from the
         // Ubuntu-suite graphics tree (Debian 12 -> jammy). Lock that in and
         // ensure the plan explains the mapping is intentional.
@@ -24291,9 +24491,7 @@ VERSION_CODENAME=bookworm
 
         assert!(plan.supported);
         assert_eq!(plan.codename, "jammy");
-        assert!(rendered.contains(
-            "https://repo.radeon.com/graphics/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/ubuntu jammy main"
-        ));
+        assert!(rendered.contains("https://repo.radeon.com/graphics/7.2.4/ubuntu jammy main"));
         assert!(
             plan.reason
                 .contains("intentionally uses AMD's Ubuntu-suite repository")
@@ -24302,6 +24500,7 @@ VERSION_CODENAME=bookworm
 
     #[test]
     fn driver_plan_sles_157_uses_documented_zypper_commands() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=sles
 VERSION_ID="15.7"
@@ -24314,9 +24513,7 @@ VERSION_ID="15.7"
         assert!(rendered.contains("SUSEConnect"));
         assert!(rendered.contains("sle-module-desktop-applications/15.7/x86_64"));
         assert!(rendered.contains("sudo zypper install -y kernel-default-devel"));
-        assert!(rendered.contains(
-            "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/sle/15.7/"
-        ));
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/sle/15.7/"));
         assert!(rendered.contains("sudo zypper --no-gpg-checks install -y"));
         assert!(rendered.contains("Execute: sudo zypper install -y amdgpu-dkms"));
         assert!(rendered.contains("approval: required"));
@@ -24324,6 +24521,7 @@ VERSION_ID="15.7"
 
     #[test]
     fn driver_plan_unsupported_linux_is_non_mutating() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=fedora
 VERSION_ID="41"
@@ -24375,6 +24573,7 @@ VERSION_ID="41"
 
     #[test]
     fn driver_plan_ubuntu_derivative_via_id_like_matches_ubuntu_plan() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // Pop!_OS reports its own ID but reuses Ubuntu's version + repositories.
         let os_release = r#"
 ID=pop
@@ -24390,14 +24589,13 @@ ID_LIKE="ubuntu debian"
         assert_eq!(plan.policy, "linux_official_amd_dkms_wrapper");
         // Ubuntu-family derivatives ship the Ubuntu kernel, so linux-modules-extra applies.
         assert!(rendered.contains("linux-modules-extra-$(uname -r)"));
-        assert!(rendered.contains(
-            "https://repo.radeon.com/graphics/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/ubuntu jammy main"
-        ));
+        assert!(rendered.contains("https://repo.radeon.com/graphics/7.2.4/ubuntu jammy main"));
         assert!(rendered.contains("Execute: sudo apt-get install -y amdgpu-dkms"));
     }
 
     #[test]
     fn driver_plan_debian_derivative_via_id_like_matches_debian_plan() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // A Debian derivative (e.g. LMDE) that shares Debian's version scheme.
         let os_release = r#"
 ID=lmde
@@ -24409,15 +24607,14 @@ ID_LIKE=debian
 
         assert!(plan.supported);
         // Debian-family maps to the Ubuntu jammy repo and omits linux-modules-extra.
-        assert!(rendered.contains(
-            "https://repo.radeon.com/graphics/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/ubuntu jammy main"
-        ));
+        assert!(rendered.contains("https://repo.radeon.com/graphics/7.2.4/ubuntu jammy main"));
         assert!(!rendered.contains("linux-modules-extra-$(uname -r)"));
         assert!(rendered.contains("amdgpu-dkms"));
     }
 
     #[test]
     fn driver_plan_almalinux_via_id_like_uses_el_9_flow() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // AlmaLinux is a RHEL rebuild: standard kernel, served from the el/ path.
         let os_release = r#"
 ID=almalinux
@@ -24431,13 +24628,9 @@ ID_LIKE="rhel centos fedora"
         assert!(plan.mutating);
         assert_eq!(plan.policy, "linux_official_amd_dkms_wrapper");
         // EL rebuilds use the vendor-neutral el/ repo path, not rhel/.
-        assert!(
-            rendered.contains(
-                "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/el/9.6/"
-            )
-        );
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/el/9.6/"));
         assert!(!rendered.contains("/rhel/9.6/"));
-        assert!(rendered.contains("amdgpu-install-${ROCM_CLI_AMDGPU_VERSION:-7.2.4}.${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}-1.el9.noarch.rpm"));
+        assert!(rendered.contains("amdgpu-install-7.2.4.70204-1.el9.noarch.rpm"));
         // el9 uses the version-aware standard-kernel prepare commands.
         assert!(rendered.contains("kernel-devel-matched-$(uname -r)"));
         assert!(rendered.contains("Execute: sudo dnf install -y amdgpu-dkms"));
@@ -24445,6 +24638,7 @@ ID_LIKE="rhel centos fedora"
 
     #[test]
     fn driver_plan_almalinux_8_via_id_like_uses_el_major_path() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let os_release = r#"
 ID=almalinux
 VERSION_ID="8.10"
@@ -24455,10 +24649,7 @@ ID_LIKE="rhel centos fedora"
 
         assert!(plan.supported);
         // EL 8 is served from the major-version path (el/8), matching AMD docs.
-        assert!(
-            rendered
-                .contains("repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/el/8/")
-        );
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/el/8/"));
         assert!(rendered.contains("-1.el8.noarch.rpm"));
         // el8 has no kernel-devel-matched package.
         assert!(!rendered.contains("kernel-devel-matched"));
@@ -24467,6 +24658,7 @@ ID_LIKE="rhel centos fedora"
 
     #[test]
     fn driver_plan_id_like_with_unsupported_version_stays_unsupported() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // A Debian-family derivative whose VERSION_ID does not align with any
         // AMD-documented Debian version must not fabricate a plan.
         let os_release = r#"
@@ -24485,6 +24677,7 @@ ID_LIKE=debian
 
     #[test]
     fn driver_plan_exact_id_takes_precedence_over_id_like() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // An exact RHEL match must keep the rhel/ path even though ID_LIKE=fedora.
         let os_release = r#"
 ID=rhel
@@ -24495,14 +24688,13 @@ ID_LIKE=fedora
         let rendered = render_driver_install_plan(&plan, false, false);
 
         assert!(plan.supported);
-        assert!(rendered.contains(
-            "repo.radeon.com/amdgpu-install/${ROCM_CLI_AMDGPU_VERSION:-7.2.4}/rhel/9.7/"
-        ));
+        assert!(rendered.contains("repo.radeon.com/amdgpu-install/7.2.4/rhel/9.7/"));
         assert!(!rendered.contains("/el/9.7/"));
     }
 
     #[test]
     fn driver_plan_oracle_linux_off_arm_version_stays_unsupported() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // Oracle Linux reports `ID_LIKE=fedora` (not rhel) and boots UEK. An OL
         // version outside the exact `ol` arm must NOT be captured by the EL
         // fallback, which would emit non-UEK kernel commands that cannot install.
@@ -24523,6 +24715,7 @@ ID_LIKE=fedora
 
     #[test]
     fn driver_plan_opensuse_leap_stays_unsupported() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         // openSUSE Leap shares SLES's version scheme but has no SUSEConnect/SCC
         // entitlement, so it must not be matched to the SLES plan.
         let os_release = r#"

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -24539,6 +24539,7 @@ VERSION_ID="41"
 
     #[test]
     fn windows_install_driver_is_validate_only() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let plan = build_driver_install_plan(&test_examine("windows", false), "", true);
         let rendered = render_driver_install_plan(&plan, false, true);
 
@@ -24555,6 +24556,7 @@ VERSION_ID="41"
 
     #[test]
     fn wsl_install_driver_uses_rocdxg_guidance_without_dkms() {
+        let _env = ScopedTestEnv::with_amd_overrides_cleared();
         let plan = build_driver_install_plan(&test_examine("linux", true), "", true);
         let rendered = render_driver_install_plan(&plan, false, false);
 

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -111,3 +111,14 @@ Feature: GPU detection and system inspection
     When the user inspects the system
     Then the inspection reports Linux as the operating system
     And the inspection reports that the host is WSL
+
+  # The dry-run plan used to print the raw `${ROCM_CLI_AMDGPU_VERSION:-...}` shell
+  # placeholder on its `repo_version:` line instead of the effective version, so
+  # the preview a user reviews before approving disagreed with what the install
+  # would actually pull. The plan is rendered on every Linux host regardless of
+  # GPU (the driver is not yet installed when you preview it), so the mock lane
+  # pins this without hardware.
+  @id:install-driver-dry-run-resolves-repo-version @requires-os:linux
+  Scenario: 12 - The driver install dry-run shows the effective repo version
+    When the user previews the driver install plan
+    Then the plan's repo version is a concrete version, not a shell placeholder

--- a/tests/e2e-cucumber/tests/e2e/examine_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/examine_steps.rs
@@ -63,12 +63,39 @@ async fn user_asks_help(world: &mut E2eWorld) {
     world.cli_output = Some(stdout);
 }
 
+#[when("the user previews the driver install plan")]
+async fn user_previews_driver_install_plan(world: &mut E2eWorld) {
+    // `--dry-run` renders the plan and returns before touching the system, so
+    // this is safe to run on any Linux host including the no-GPU mock lane.
+    let (stdout, _, rc) = crate::run_rocm(world, &["install", "driver", "--dry-run"]);
+    world.cli_output = Some(stdout);
+    world.cli_rc = Some(rc);
+}
+
 #[then("a version string is returned")]
 async fn assert_version_returned(world: &mut E2eWorld) {
     let output = world.cli_output.as_ref().expect("no command was run");
     assert!(
         output.trim().starts_with("rocm "),
         "expected version string starting with 'rocm ': {output}"
+    );
+}
+
+#[then("the plan's repo version is a concrete version, not a shell placeholder")]
+async fn assert_driver_plan_repo_version_resolved(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    let repo_version = field_value(output, "repo_version")
+        .unwrap_or_else(|| panic!("no repo_version line in driver install plan:\n{output}"));
+    assert!(
+        !repo_version.contains("${"),
+        "repo_version still shows an unresolved shell placeholder: {repo_version:?}\n{output}"
+    );
+    assert!(
+        repo_version
+            .chars()
+            .next()
+            .is_some_and(|first| first.is_ascii_digit()),
+        "repo_version is not a concrete version string: {repo_version:?}\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

`rocm install driver --dry-run` printed an unexpanded shell-style placeholder on
the `repo_version:` line, and the same unresolved template would have been
written into the apt sources list on Debian/Ubuntu:

```
repo_version: ${ROCM_CLI_AMDGPU_VERSION:-7.2.4}
```

The driver install plan stored the repo version and package release as raw shell
parameter-expansion templates (`${ROCM_CLI_AMDGPU_VERSION:-7.2.4}` and
`${ROCM_CLI_AMDGPU_PACKAGE_RELEASE:-70204}`). Two problems followed:

1. **Cosmetic leak** — the human-readable plan summary printed the version
   template verbatim on its `repo_version:` line, showing an unexpanded shell
   placeholder in user-facing dry-run output.
2. **Install-breaking bug (a real behavior change to fix)** — the Debian/Ubuntu
   apt source line wrapped the template in single quotes, so the shell never
   expanded it and the literal placeholder would have been written into
   `/etc/apt/sources.list.d/amdgpu.list`.

## Fix

Resolve both templates once, at plan-build time in `build_driver_install_plan`,
to their effective values (the env var when set and non-empty — matching shell
`:-` default semantics — otherwise the documented default) and bake the concrete
values into every rendered URL, repo path, and command. The apt sources-list
line now interpolates in Rust before the string is embedded in the single-quoted
shell literal, so it no longer depends on an expansion that could never happen.

The resolver is generalized to `resolve_shell_default_template` and hardened to
pass bare `${VAR}` and nested-default shapes through unchanged rather than
emitting a partially rewritten value.

### Behavioral note

This is **not** a display-only change. A user who previews the plan and later
copy-pastes the printed commands into a different shell now gets the version
baked in from the previewing process's environment rather than resolved by the
pasting shell. That is more predictable than before, and it is what the apt fix
requires, but it is a genuine behavior change to the emitted commands.

## Environment variables

The effective version/release are controlled by `ROCM_CLI_AMDGPU_VERSION` and
`ROCM_CLI_AMDGPU_PACKAGE_RELEASE`; both fall back to the documented defaults when
unset or empty.

## Testing

- Unit tests for the resolver: default, env override, empty-as-unset,
  non-template pass-through, bare-var and nested-default pass-through.
- Every distro plan test updated to assert the concrete resolved values.
- A render-level regression test asserting the dry-run summary shows the
  resolved version rather than the raw placeholder.
- End-to-end scenario **`@id:install-driver-dry-run-resolves-repo-version`**
  (`tests/e2e-cucumber/features/examine.feature`, tagged `@requires-os:linux`).
  `install driver --dry-run` short-circuits before any mutation and prints
  `repo_version:` unconditionally, so the scenario runs on the no-GPU mock lane
  and exits 0 on any Linux host. The assertion is discriminating: the old
  `${ROCM_CLI_AMDGPU_VERSION:-7.2.4}` output fails both the `!contains("${")`
  and the leading-ascii-digit checks.
- Tests that read these process env vars serialize on a shared lock and
  save/restore prior values so they stay deterministic under edition-2024 env
  semantics.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p rocm --bin rocm driver` — 26 passed
- `cargo xtask e2e -- -n "The driver install dry-run shows the effective repo version"` — exit 0
- diff leak scan — clean
