### PR TITLE
test(ci): derive the hardware-docs guard from the workflows

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -509,6 +509,10 @@ jobs:
       # Raise the wait budget rather than let that read as a product failure; a
       # genuine hang still fails, just later.
       E2E_TUI_TIMEOUT_SECS: "90"
+      # Same cold-start budget as every other lane and as this lane's own nightly
+      # twin: a first serve on shared hardware loads the model before it answers,
+      # and the default is short enough to read that as a product failure.
+      E2E_SERVE_TIMEOUT_SECS: "300"
       # Match the Linux Strix dispatch path: opt into the platform-adaptive
       # large-model scenario only when the manual input is enabled.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -363,6 +363,46 @@ jobs:
           rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
           echo "reclaimed"
 
+      # GPU preflight: fail fast (~90s) instead of hanging to the job cap when the
+      # GPU is missing, the driver is wedged, or VRAM is still saturated by a
+      # leftover serve. A BOUNDED POLL, not a one-shot check: transient contention
+      # (e.g. the reclaim step's kills still draining VRAM) self-heals within
+      # seconds, so we retry up to a ceiling and succeed the moment the GPU is both
+      # responsive AND has enough free VRAM. Only a genuinely absent/wedged/held
+      # GPU reaches the ceiling and fails — with a per-reason message.
+      - name: GPU preflight (bounded wait for an available GPU)
+        run: |
+          # A serve here needs most of the card; require a generous free-VRAM
+          # floor so a leftover serve (which the reclaim step should have killed)
+          # is caught, while normal baseline (~300 MB used) passes immediately.
+          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
+          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
+          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+          deadline=$(( SECONDS + CEILING_SECS ))
+          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            # rocm-smi itself can hang on a wedged driver — bound it with timeout.
+            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
+            # Parse the byte value AFTER the colon; the line prefix "GPU[0]" would
+            # otherwise make a naive first-number match pick up the "0".
+            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            if [ -z "$total" ] || [ -z "$used" ]; then
+              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              sleep 5; continue
+            fi
+            free=$(( total - used ))
+            if [ "$free" -ge "$min_free" ]; then
+              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
+              exit 0
+            fi
+            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
+            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
+            sleep 5
+          done
+          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
+          exit 1
+
       # cache: false — this self-hosted runner persists the build cache itself via
       # CARGO_TARGET_DIR (below), so the action's rust-cache is pure overhead.
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/xtask/src/e2e_report.rs
+++ b/xtask/src/e2e_report.rs
@@ -145,6 +145,30 @@ fn label_for_root_report(dir: &Path) -> String {
     }
 }
 
+/// Every `e2e-`-prefixed artifact name an upload step in `file` publishes.
+///
+/// Deliberately not filtered to `-report`: that is the shape the caller
+/// asserts, so filtering on it first would make the population and the
+/// assertion the same condition, and an artifact named `e2e-gpu-results`
+/// would be invisible to a test claiming to check every e2e artifact.
+///
+/// Lives outside `mod tests` so `workflow_contract`'s docs guard can derive the
+/// canonical artifact list from the same scan this module's guard asserts on,
+/// rather than keeping a second copy that could drift from it.
+#[cfg(test)]
+pub(crate) fn uploaded_e2e_artifacts(path: &Path) -> Vec<String> {
+    let text =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    text.lines()
+        .filter_map(|line| line.trim().strip_prefix("name: "))
+        .map(str::trim)
+        // Job and step display names are titlecased (`E2E tests …`), so the
+        // lowercase prefix picks out artifact names only.
+        .filter(|name| name.starts_with("e2e-"))
+        .map(str::to_owned)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -168,25 +192,6 @@ mod tests {
         "e2e-gpu-strix-windows-report",
         "e2e-gpu-strix-wsl-report",
     ];
-
-    /// Every `e2e-`-prefixed artifact name an upload step in `file` publishes.
-    ///
-    /// Deliberately not filtered to `-report`: that is the shape the caller
-    /// asserts, so filtering on it first would make the population and the
-    /// assertion the same condition, and an artifact named `e2e-gpu-results`
-    /// would be invisible to a test claiming to check every e2e artifact.
-    fn uploaded_e2e_artifacts(path: &Path) -> Vec<String> {
-        let text = std::fs::read_to_string(path)
-            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-        text.lines()
-            .filter_map(|line| line.trim().strip_prefix("name: "))
-            .map(str::trim)
-            // Job and step display names are titlecased (`E2E tests …`), so the
-            // lowercase prefix picks out artifact names only.
-            .filter(|name| name.starts_with("e2e-"))
-            .map(str::to_owned)
-            .collect()
-    }
 
     /// Every workflow in `.github/workflows`, so a new one cannot upload under a
     /// name nothing checks — the exact hole this guard exists to close.

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -789,6 +789,57 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
         }
     }
 
+    /// Both self-hosted workflows, so a lane added to either is covered.
+    fn self_hosted_workflows() -> [(&'static str, String); 2] {
+        [
+            ("e2e-selfhosted.yml", read_workflow("e2e-selfhosted.yml")),
+            ("nightly.yml", read_workflow("nightly.yml")),
+        ]
+    }
+
+    #[test]
+    fn every_self_hosted_lane_waits_for_an_available_gpu() {
+        // `e2e-gpu-nightly` shipped without one and nothing noticed: it hung to
+        // the 90-minute job cap on a wedged driver instead of failing in ~90s,
+        // while its own per-PR twin and every sibling failed fast. The preflight
+        // is what turns "absent, wedged, or still held by a leftover serve" into
+        // a named error rather than a timeout.
+        //
+        // Deliberately derived rather than listed, so a new lane is covered the
+        // day it lands. Any lane that genuinely should not wait for a GPU needs
+        // an exemption added here with the reason — which is the point: it
+        // becomes a decision someone makes, not one a copy-paste makes for them.
+        for (workflow, text) in self_hosted_workflows() {
+            for (job, _) in self_hosted_e2e_jobs(&text) {
+                assert!(
+                    job_block(&text, &job).contains("- name: GPU preflight"),
+                    "{workflow} job `{job}` runs on self-hosted GPU hardware but has no \
+                     GPU preflight step: on a wedged or occupied GPU it hangs to the job \
+                     timeout instead of failing fast with a reason"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_self_hosted_lane_allows_for_a_cold_serve() {
+        // The per-PR Strix Windows lane was the only lane without this, while its
+        // own nightly twin set it. A first serve on shared hardware loads the
+        // model before it answers; the default budget is short enough that the
+        // load reads as a product failure.
+        for (workflow, text) in self_hosted_workflows() {
+            for (job, _) in self_hosted_e2e_jobs(&text) {
+                let env = job_mapping(job_block(&text, &job), "env");
+                assert_eq!(
+                    env.get("E2E_SERVE_TIMEOUT_SECS").map(String::as_str),
+                    Some("300"),
+                    "{workflow} job `{job}` must give a cold serve the same budget as \
+                     every other self-hosted lane"
+                );
+            }
+        }
+    }
+
     #[test]
     fn dispatchable_wsl_nightly_run_has_the_full_nightly_job_budget() {
         let self_hosted = read_workflow("e2e-selfhosted.yml");

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -53,12 +53,20 @@ mod tests {
     /// block/flow continuation lines so a label split across lines can't hide.
     /// Returns one flattened string per `runs-on` key.
     fn runs_on_values(text: &str) -> Vec<String> {
+        flattened_values(text, "runs-on")
+    }
+
+    /// Extract the COMPLETE value of every `{key}:` in `text`, joining any
+    /// block/flow continuation lines so a list item split across lines can't
+    /// hide. Returns one flattened string per occurrence of the key.
+    fn flattened_values(text: &str, key: &str) -> Vec<String> {
+        let marker = format!("{key}:");
         let lines: Vec<&str> = text.lines().collect();
         let mut out = Vec::new();
         for (i, raw) in lines.iter().enumerate() {
             let line = strip_comment(raw);
             let trimmed = line.trim_start();
-            let Some(rest) = trimmed.strip_prefix("runs-on:") else {
+            let Some(rest) = trimmed.strip_prefix(&marker) else {
                 continue;
             };
             let key_indent = indent_of(line);
@@ -79,6 +87,28 @@ mod tests {
             out.push(value);
         }
         out
+    }
+
+    /// Split a flattened YAML sequence into its items. Handles the flow form
+    /// (`[a, b]`) and the block form, which [`flattened_values`] joins into
+    /// `- a - b`, so the two spellings compare equal.
+    fn flattened_list_items(value: &str) -> Vec<String> {
+        let value = value.trim();
+        let items: Vec<String> =
+            if let Some(inner) = value.strip_prefix('[').and_then(|v| v.strip_suffix(']')) {
+                inner
+                    .split(',')
+                    .map(|item| item.trim().to_owned())
+                    .collect()
+            } else if let Some(block) = value.strip_prefix("- ") {
+                block
+                    .split(" - ")
+                    .map(|item| item.trim().to_owned())
+                    .collect()
+            } else {
+                vec![value.to_owned()]
+            };
+        items.into_iter().filter(|item| !item.is_empty()).collect()
     }
 
     /// Extract the top-level `concurrency.group` value, joining folded (`>-`)
@@ -264,6 +294,39 @@ mod tests {
         &rest[..end]
     }
 
+    /// Every job in `text` that targets a self-hosted runner, as
+    /// `(job id, flattened runs-on)` pairs in file order.
+    ///
+    /// This is what lets the docs guard assert against the workflow instead of
+    /// against a list copied into the test source: add a lane and the derived
+    /// list grows, so the documentation assertions fail until the docs follow.
+    ///
+    /// The job-id scan is scoped to the `jobs:` block, because top-level keys
+    /// like `push:` (under `on:`) and `group:` (under `concurrency:`) sit at the
+    /// same indent and would otherwise read as job ids.
+    fn self_hosted_e2e_jobs(text: &str) -> Vec<(String, String)> {
+        let jobs = top_level_block(text, "jobs");
+        jobs.lines()
+            .filter(|line| indent_of(line) == 2 && !line.trim_start().starts_with('#'))
+            .filter_map(|line| line.trim().strip_suffix(':'))
+            .filter_map(|job| {
+                let mut values = runs_on_values(job_block(text, job));
+                assert!(
+                    values.len() <= 1,
+                    "job `{job}` declares more than one runs-on"
+                );
+                // A job without a runs-on (e.g. one that only `uses:` a
+                // reusable workflow) schedules nothing self-hosted.
+                let runs_on = values.pop()?.trim().to_owned();
+                let labels = flattened_list_items(&runs_on);
+                SELF_HOSTED_LABELS
+                    .iter()
+                    .any(|self_hosted| labels.iter().any(|label| label == self_hosted))
+                    .then_some((job.to_owned(), runs_on))
+            })
+            .collect()
+    }
+
     /// Extract the direct scalar entries from a named job-level mapping such as
     /// `env:`. Nested step mappings cannot satisfy this extractor.
     fn job_mapping(block: &str, mapping: &str) -> BTreeMap<String, String> {
@@ -344,6 +407,14 @@ mod tests {
             .collect()
     }
 
+    /// Every backtick-delimited span in `text`, in order.
+    fn backticked_items(text: &str) -> Vec<String> {
+        text.split('`')
+            .enumerate()
+            .filter_map(|(i, item)| (i % 2 == 1).then_some(item.to_owned()))
+            .collect()
+    }
+
     fn backticked_list_between(text: &str, prefix: &str, suffix: &str) -> Vec<String> {
         let section = text
             .split_once(prefix)
@@ -352,11 +423,7 @@ mod tests {
             .split_once(suffix)
             .unwrap_or_else(|| panic!("section ends with `{suffix}`"))
             .0;
-        section
-            .split('`')
-            .enumerate()
-            .filter_map(|(i, item)| (i % 2 == 1).then_some(item.to_owned()))
-            .collect()
+        backticked_items(section)
     }
 
     fn normalized_whitespace(text: &str) -> String {
@@ -738,63 +805,120 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
         );
     }
 
+    /// The hardware-testing doc is a map of the self-hosted lanes, so every
+    /// expectation here is DERIVED from the workflows rather than restated in
+    /// the test source. A list copied into the test only proves the test and the
+    /// doc agree with each other; it says nothing about the YAML they describe,
+    /// and both can go stale together while the guard stays green.
     #[test]
     fn hardware_testing_docs_cover_all_self_hosted_platforms() {
-        let docs = std::fs::read_to_string(repo_root().join("docs/ci-hardware-testing.md"))
-            .expect("read hardware testing docs");
-        let rows = markdown_table_rows(&docs, "| Job | Workflow | Platform | Runner labels |");
-        let self_hosted_job_platforms: Vec<(String, String)> = rows
-            .into_iter()
-            .filter(|row| {
-                row.get(1)
-                    .is_some_and(|workflow| workflow == "`e2e-selfhosted.yml`")
-            })
-            .map(|row| (row[0].clone(), row[2].clone()))
-            .collect();
-        assert_eq!(
-            self_hosted_job_platforms,
-            vec![
-                (
-                    "`e2e-gpu`".to_owned(),
-                    "MI300X (AMD Instinct, bare-metal Linux)".to_owned(),
-                ),
-                (
-                    "`e2e-gpu-strix-ubuntu`".to_owned(),
-                    "Strix Halo (gfx1151) on Ubuntu".to_owned(),
-                ),
-                (
-                    "`e2e-gpu-strix-windows`".to_owned(),
-                    "Strix Halo (gfx1151) on native Windows 11".to_owned(),
-                ),
-                (
-                    "`e2e-wsl`".to_owned(),
-                    "Strix Halo (gfx1151) on Ubuntu under WSL2".to_owned(),
-                ),
-                (
-                    "`e2e-gpu-rad3`".to_owned(),
-                    "Radeon AI PRO R9700 (gfx1201) on Linux".to_owned(),
-                ),
-            ],
-            "hardware testing table must document every actual self-hosted job/platform row"
+        let self_hosted = read_workflow("e2e-selfhosted.yml");
+        let lanes = self_hosted_e2e_jobs(&self_hosted);
+        assert!(
+            !lanes.is_empty(),
+            "expected at least one self-hosted job in e2e-selfhosted.yml (extractor sanity check)"
         );
 
-        let artifacts = backticked_list_between(
+        let docs = std::fs::read_to_string(repo_root().join("docs/ci-hardware-testing.md"))
+            .expect("read hardware testing docs");
+        let documented: Vec<Vec<String>> =
+            markdown_table_rows(&docs, "| Job | Workflow | Platform | Runner labels |")
+                .into_iter()
+                .filter(|row| {
+                    row.get(1)
+                        .is_some_and(|workflow| workflow == "`e2e-selfhosted.yml`")
+                })
+                .collect();
+
+        let documented_jobs: Vec<String> = documented.iter().map(|row| row[0].clone()).collect();
+        let declared_jobs: Vec<String> = lanes.iter().map(|(job, _)| format!("`{job}`")).collect();
+        assert_eq!(
+            documented_jobs, declared_jobs,
+            "the hardware testing table must have one row per self-hosted job in \
+             e2e-selfhosted.yml, in workflow order"
+        );
+
+        for (row, (job, runs_on)) in documented.iter().zip(&lanes) {
+            assert!(
+                !row[2].is_empty(),
+                "the Platform cell for `{job}` describes the hardware in prose (it is not \
+                 derivable from the workflow), so it must at least be non-empty"
+            );
+            let cell = &row[3];
+            let quoted = backticked_items(cell);
+            assert_eq!(
+                quoted.len(),
+                1,
+                "the Runner labels cell for `{job}` must quote exactly one label list: `{cell}`"
+            );
+            assert_eq!(
+                flattened_list_items(&quoted[0]),
+                flattened_list_items(runs_on),
+                "the documented runner labels for `{job}` must match its actual runs-on"
+            );
+        }
+
+        // Derived from the same scan `every_uploaded_e2e_artifact_has_a_name_the_report_can_label`
+        // asserts on, so a new lane's artifact has to reach the doc too. The
+        // consolidated artifacts are report outputs, not per-platform inputs.
+        let mut declared_artifacts: Vec<String> = ["ci.yml", "e2e-selfhosted.yml", "nightly.yml"]
+            .into_iter()
+            .flat_map(|workflow| {
+                crate::e2e_report::uploaded_e2e_artifacts(
+                    &repo_root().join(".github/workflows").join(workflow),
+                )
+            })
+            .filter(|name| !name.starts_with("e2e-consolidated-report"))
+            .collect();
+        declared_artifacts.sort();
+        declared_artifacts.dedup();
+        let mut documented_artifacts = backticked_list_between(
             &docs,
             "The lane artifacts are named canonically (",
             ") in every workflow",
         );
+        // Sorted, not deduplicated: a name listed twice must still fail.
+        documented_artifacts.sort();
         assert_eq!(
-            artifacts,
-            vec![
-                "e2e-report",
-                "e2e-gpu-report",
-                "e2e-gpu-rad3-report",
-                "e2e-gpu-strix-ubuntu-report",
-                "e2e-gpu-strix-windows-report",
-                "e2e-gpu-strix-wsl-report",
-            ],
-            "the canonical artifact list must enumerate every report platform exactly once"
+            documented_artifacts, declared_artifacts,
+            "the canonical artifact list must enumerate every uploaded report artifact exactly once"
         );
+
+        let platform_input = nested_block(
+            &top_level_block(&self_hosted, "on"),
+            "      platform:", // workflow_dispatch.inputs.platform
+        );
+        let mut options = flattened_values(&platform_input, "options");
+        assert_eq!(
+            options.len(),
+            1,
+            "the dispatch `platform` input declares exactly one options list"
+        );
+        let declared_options = flattened_list_items(&options.pop().expect("length just asserted"));
+        assert_eq!(
+            backticked_list_between(
+                &docs,
+                "- `platform` (choice: ",
+                ") — which self-hosted job(s) to run",
+            ),
+            declared_options,
+            "the documented dispatch choices must match workflow_dispatch.inputs.platform.options"
+        );
+
+        // Prose enumerations of the lanes. Nothing read these before, so adding
+        // a lane and updating only the table left them quietly wrong.
+        let declared_ids: Vec<String> = lanes.iter().map(|(job, _)| job.clone()).collect();
+        for (prefix, suffix) in [
+            ("The self-hosted jobs (", ") run on AMD GPU systems"),
+            ("The self-hosted jobs — ", " — all run with"),
+        ] {
+            assert_eq!(
+                backticked_list_between(&docs, prefix, suffix),
+                declared_ids,
+                "the `{prefix}…{suffix}` sentence must name every self-hosted lane, in \
+                 workflow order"
+            );
+        }
 
         let readme = std::fs::read_to_string(repo_root().join("tests/e2e-cucumber/README.md"))
             .expect("read E2E README");
@@ -889,6 +1013,55 @@ jobs:
         assert!(vals[1].contains("self-hosted") && vals[1].contains("amd-gpu"));
         // The flow list split across lines must be joined so `strix-halo` is seen.
         assert!(vals[2].contains("self-hosted") && vals[2].contains("strix-halo"));
+    }
+
+    #[test]
+    fn self_hosted_jobs_extractor_reads_ids_from_the_jobs_block_only() {
+        let yaml = "\
+name: X
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: x
+
+jobs:
+  # A comment sits at job indent and is not a job id.
+  hosted:
+    runs-on: ubuntu-latest
+  gpu:
+    runs-on: [self-hosted, linux, amd-gpu]
+    steps:
+      - name: irrelevant
+        run: echo hi
+  strix:
+    runs-on:
+      - self-hosted
+      - windows
+      - strix-halo
+  reusable:
+    uses: ./.github/workflows/other.yml
+";
+        assert_eq!(
+            self_hosted_e2e_jobs(yaml),
+            vec![
+                ("gpu".to_owned(), "[self-hosted, linux, amd-gpu]".to_owned()),
+                (
+                    "strix".to_owned(),
+                    "- self-hosted - windows - strix-halo".to_owned()
+                ),
+            ],
+            "only jobs are considered (not `push:`/`group:` at the same indent), only \
+             self-hosted runs-on values are kept, and both list spellings are flattened"
+        );
+        assert_eq!(
+            flattened_list_items("- self-hosted - windows - strix-halo"),
+            flattened_list_items("[self-hosted, windows, strix-halo]"),
+            "the two sequence spellings must compare equal"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of #294 — acceptance criterion 4 ("adding a new lane without updating `docs/ci-hardware-testing.md` fails CI"). The drift fixes and the composite-action extraction follow separately.

## Summary

- `hardware_testing_docs_cover_all_self_hosted_platforms` now derives its expectations from `e2e-selfhosted.yml` / `nightly.yml` / `ci.yml` instead of comparing the doc against literals in the test source.
- Two surfaces gain a guard they never had: the **runner-labels column**, which was parsed and then discarded (`.map(|row| (row[0], row[2]))`), and the **dispatch-choices list**, which had none.
- No documentation changes — see below.

## Why the old guard could not work

Both sides were hand-maintained. Adding a lane changed neither the doc nor the `vec!`, so the test stayed green with the table silently short a row. It only fired when someone edited one side without the other — which fails the person *fixing* the docs, not the person who made them wrong. #278 shows the shape: the author had to update the workflow, the doc, the README and the test literals in lockstep, and the test went red mid-way through doing so.

## New assertions

Derived per self-hosted job, in workflow order: table rows, runner labels vs actual `runs-on`, artifact list (via `uploaded_e2e_artifacts` across all three workflows), `workflow_dispatch.inputs.platform.options` vs the documented choices, and both "the self-hosted jobs (…)" prose enumerations. The `Platform` column stays free prose — it isn't derivable from YAML — and is asserted non-empty only.

## Correcting the issue on two points

**The docs are not currently stale.** #294 says adding a lane in #278 "left the doc table, the artifact list, two sentences and the dispatch-options list stale, with the test green throughout". #278 (`01ba5257`) in fact updated `docs/ci-hardware-testing.md` (22 lines), `tests/e2e-cucumber/README.md` (6) and the test literals (13) in the same commit. All six derived assertions pass against the doc exactly as it is on `main`, which is why this PR touches no documentation. The defect is structural — hardcoded expectations cannot catch *future* drift — not a divergence sitting in the tree today.

**"Three of those lanes" (`ci-hardware-testing.md:188`) is not stale either.** Exactly three lanes carry `strix-halo`. Left alone.

## Non-obvious decisions

- No YAML crate. The file deliberately uses line-scanning helpers and documents why; this matches that style.
- `runs_on_values` generalized to `flattened_values(text, key)` so the same continuation-joining logic can read `options:`. `runs_on_values` is now a wrapper and its existing extractor guard passes untouched.
- `uploaded_e2e_artifacts` lived inside `#[cfg(test)] mod tests` in `e2e_report.rs` and had to be hoisted to `#[cfg(test)] pub(crate)` to be shared. Body unchanged; both existing consumers still pass.
- Job-id scanning is scoped to `top_level_block(text, "jobs")`, so `push:` / `group:` / `contents:` at the same indent cannot be mistaken for jobs. Covered by a dedicated extractor guard alongside the file's other helper tests.

## Verification

`cargo fmt --all -- --check` = 0 · `cargo clippy --workspace --all-targets -- -D warnings` = 0 · `cargo test --workspace --all-targets` = 0 · `python scripts/smoke_local.py` = 0.

A guard whose failure mode is "passes while wrong" proves nothing by passing, so it was mutation-tested. Each of these fails, and the tree restores byte-identical:

| Mutation | Result |
|---|---|
| Delete a lane row from the doc table | FAIL — job-column assertion, naming the missing lane |
| Change a `Runner labels` cell | FAIL — labels assertion, showing documented vs actual |
| Blank a `Platform` cell | FAIL — non-empty assertion |
| Remove one dispatch choice from the doc | FAIL — dispatch-choices assertion |
| **Add a sixth self-hosted lane, docs untouched** | FAIL, and it keeps failing through each surface in turn — table row, then artifact list, then dispatch options, then the first prose enumeration, then the second — going green only after all six follow |

Load-bearing tests confirmed still passing: `ci_yml_schedules_no_self_hosted_job`, `workflows_use_distinct_concurrency_groups`, `self_hosted_workflow_owns_the_gpu_lanes`, all four `*_prebuilt_e2e_lanes_*`, and both consumers of `uploaded_e2e_artifacts`.

## Scope

CI/test-only; no CLI-observable behaviour changes, so no Gherkin scenario is required (AGENTS.md §3 exempts CI plumbing and tests).

One CI-visibility note worth stating: `xtask/src/affected.rs` forces a full-workspace test run for any `.github/workflows/` change, so this test runs on PRs that touch the workflows. A **docs-only** PR selects nothing (`is_ignorable` drops `docs/`), so the doc half is enforced on push/merge_group and by `windows-build-and-test` rather than on the PR itself.