### PR TITLE
ci(e2e): close two self-hosted lane divergences, and guard them

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -509,6 +509,10 @@ jobs:
       # Raise the wait budget rather than let that read as a product failure; a
       # genuine hang still fails, just later.
       E2E_TUI_TIMEOUT_SECS: "90"
+      # Same cold-start budget as every other lane and as this lane's own nightly
+      # twin: a first serve on shared hardware loads the model before it answers,
+      # and the default is short enough to read that as a product failure.
+      E2E_SERVE_TIMEOUT_SECS: "300"
       # Match the Linux Strix dispatch path: opt into the platform-adaptive
       # large-model scenario only when the manual input is enabled.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -363,6 +363,46 @@ jobs:
           rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
           echo "reclaimed"
 
+      # GPU preflight: fail fast (~90s) instead of hanging to the job cap when the
+      # GPU is missing, the driver is wedged, or VRAM is still saturated by a
+      # leftover serve. A BOUNDED POLL, not a one-shot check: transient contention
+      # (e.g. the reclaim step's kills still draining VRAM) self-heals within
+      # seconds, so we retry up to a ceiling and succeed the moment the GPU is both
+      # responsive AND has enough free VRAM. Only a genuinely absent/wedged/held
+      # GPU reaches the ceiling and fails — with a per-reason message.
+      - name: GPU preflight (bounded wait for an available GPU)
+        run: |
+          # A serve here needs most of the card; require a generous free-VRAM
+          # floor so a leftover serve (which the reclaim step should have killed)
+          # is caught, while normal baseline (~300 MB used) passes immediately.
+          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
+          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
+          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
+          deadline=$(( SECONDS + CEILING_SECS ))
+          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            # rocm-smi itself can hang on a wedged driver — bound it with timeout.
+            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
+            # Parse the byte value AFTER the colon; the line prefix "GPU[0]" would
+            # otherwise make a naive first-number match pick up the "0".
+            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
+            if [ -z "$total" ] || [ -z "$used" ]; then
+              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
+              sleep 5; continue
+            fi
+            free=$(( total - used ))
+            if [ "$free" -ge "$min_free" ]; then
+              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
+              exit 0
+            fi
+            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
+            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
+            sleep 5
+          done
+          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
+          exit 1
+
       # cache: false — this self-hosted runner persists the build cache itself via
       # CARGO_TARGET_DIR (below), so the action's rust-cache is pure overhead.
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -789,6 +789,57 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
         }
     }
 
+    /// Both self-hosted workflows, so a lane added to either is covered.
+    fn self_hosted_workflows() -> [(&'static str, String); 2] {
+        [
+            ("e2e-selfhosted.yml", read_workflow("e2e-selfhosted.yml")),
+            ("nightly.yml", read_workflow("nightly.yml")),
+        ]
+    }
+
+    #[test]
+    fn every_self_hosted_lane_waits_for_an_available_gpu() {
+        // `e2e-gpu-nightly` shipped without one and nothing noticed: it hung to
+        // the 90-minute job cap on a wedged driver instead of failing in ~90s,
+        // while its own per-PR twin and every sibling failed fast. The preflight
+        // is what turns "absent, wedged, or still held by a leftover serve" into
+        // a named error rather than a timeout.
+        //
+        // Deliberately derived rather than listed, so a new lane is covered the
+        // day it lands. Any lane that genuinely should not wait for a GPU needs
+        // an exemption added here with the reason — which is the point: it
+        // becomes a decision someone makes, not one a copy-paste makes for them.
+        for (workflow, text) in self_hosted_workflows() {
+            for (job, _) in self_hosted_e2e_jobs(&text) {
+                assert!(
+                    job_block(&text, &job).contains("- name: GPU preflight"),
+                    "{workflow} job `{job}` runs on self-hosted GPU hardware but has no \
+                     GPU preflight step: on a wedged or occupied GPU it hangs to the job \
+                     timeout instead of failing fast with a reason"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_self_hosted_lane_allows_for_a_cold_serve() {
+        // The per-PR Strix Windows lane was the only lane without this, while its
+        // own nightly twin set it. A first serve on shared hardware loads the
+        // model before it answers; the default budget is short enough that the
+        // load reads as a product failure.
+        for (workflow, text) in self_hosted_workflows() {
+            for (job, _) in self_hosted_e2e_jobs(&text) {
+                let env = job_mapping(job_block(&text, &job), "env");
+                assert_eq!(
+                    env.get("E2E_SERVE_TIMEOUT_SECS").map(String::as_str),
+                    Some("300"),
+                    "{workflow} job `{job}` must give a cold serve the same budget as \
+                     every other self-hosted lane"
+                );
+            }
+        }
+    }
+
     #[test]
     fn dispatchable_wsl_nightly_run_has_the_full_nightly_job_budget() {
         let self_hosted = read_workflow("e2e-selfhosted.yml");


### PR DESCRIPTION
Part of #294 — acceptance criterion "the drift instances are resolved or deliberately documented".

**Stacked on #319** (base is `ci/derive-hardware-docs-guard`), because both new tests derive the lane list using the `self_hosted_e2e_jobs` helper that PR adds. Retarget to `main` once #319 lands.

## Summary

- `e2e-gpu-nightly` gains the GPU preflight step it never had — byte-identical to its per-PR twin's, verified programmatically.
- Per-PR `e2e-gpu-strix-windows` gains `E2E_SERVE_TIMEOUT_SECS: "300"`.
- Two contract tests so neither can re-drift, and so a lane added tomorrow is covered without anyone remembering.

## What was wrong

**`e2e-gpu-nightly` had no preflight.** Its step list was checkout → Reclaim → toolchain → Run → Upload. It was the only one of the ten self-hosted lanes across both files without one. The consequence is not cosmetic: on a wedged driver, or a GPU still held by a leftover serve, the lane hangs to its 90-minute cap instead of failing in ~90s with a named reason. Its own per-PR twin (`e2e-selfhosted.yml:200`, `MIN_FREE_GIB` 16) and its sibling `e2e-gpu-nightly-rad3` (`nightly.yml:446`) both fail fast.

**Per-PR `e2e-gpu-strix-windows` had no `E2E_SERVE_TIMEOUT_SECS`.** The other four per-PR lanes set `"300"`, as does its own nightly twin. A first serve on shared hardware loads the model before it answers, and the default is short enough that the load reads as a product failure.

Both are one-line divergences inside blocks that are otherwise identical five ways over, and nothing existed that would have caught either.

## Why tests, not just fixes

The fixes are trivial; the guards are the point. Both derive the lane list from the workflows rather than restating it, so:

- a lane added tomorrow is covered the day it lands, without anyone remembering to extend a list;
- a lane that genuinely should *not* wait for a GPU needs an exemption written into the test **with its reason** — which makes it a decision someone makes, rather than one a copy-paste makes for them.

This is the same shape as #319's docs guard: derive from the workflow, don't restate it in the test.

## Verification

`cargo fmt --all -- --check` = 0 · `cargo clippy --workspace --all-targets -- -D warnings` = 0 · `cargo test --workspace --all-targets` = 0 · `python scripts/smoke_local.py` = 0.

Both guards mutation-tested — reverting each fix makes its test fail, naming the lane, and the tree restores byte-identical:

| Mutation | Result |
|---|---|
| Remove the preflight from `e2e-gpu-nightly` | FAIL — ``nightly.yml job `e2e-gpu-nightly` runs on self-hosted GPU hardware but has no GPU preflight step`` |
| Remove `E2E_SERVE_TIMEOUT_SECS` from `e2e-gpu-strix-windows` | FAIL — ``e2e-selfhosted.yml job `e2e-gpu-strix-windows` must give a cold serve the same budget as every other self-hosted lane`` |

Also verified programmatically that the inserted preflight is byte-identical to `e2e-gpu`'s (including `MIN_FREE_GIB` 16, the Instinct floor — not the 8 used by the Strix lanes), and that all ten self-hosted lanes now carry one.

## Scope

CI-only; no CLI-observable behaviour changes, so no Gherkin scenario is required (AGENTS.md §3 exempts CI plumbing).

The other two drift instances listed in #294 do not reproduce — `e2e-gpu-rad3` does set `E2E_MERGE_QUEUE` (`e2e-selfhosted.yml:848`) and `e2e-gpu-nightly-rad3` drops only comment prose. Evidence is in [this issue comment](https://github.com/ROCm/rocm-cli/issues/294#issuecomment-5436472995).