### PR TITLE
fix(chat): tell the assistant which machine it is running on

### DIFF
--- a/apps/rocm/src/chat_host_facts.rs
+++ b/apps/rocm/src/chat_host_facts.rs
@@ -1,0 +1,261 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Host facts injected into the chat assistant's system prompt.
+//!
+//! The assistant used to answer platform questions purely from pretraining —
+//! "ROCm is not compatible with Windows, use CUDA" was the reported result. It
+//! never learned which machine it was running on, even though `rocm-core`
+//! detects all of it. This module turns that detection into a short, plain-text
+//! block the bin appends to the assistant prompt.
+//!
+//! Two constraints shape it:
+//!
+//! - **Cheap.** It is built in [`crate::dash::resolved_args`], on the
+//!   synchronous pre-runtime path, before the dashboard draws. So it uses the
+//!   fast public getters (`runtime_os_name`, `is_wsl_host`,
+//!   `detect_host_gpu_summary`) and never `ExamineSummary::gather()`, whose
+//!   Windows path chains several process-spawning inventory queries.
+//! - **Plain data.** The dash crates carry no `rocm-core` dependency; the bin
+//!   detects and renders, and the rendered `String` rides down through
+//!   `ResolvedArgs`.
+//!
+//! Rendering is separated from detection ([`HostFacts::render`] is pure) so the
+//! wording is unit-testable without a machine.
+
+use rocm_core::{AppPaths, HostGpuSummary, detect_host_gpu_summary, is_wsl_host, runtime_os_name};
+
+/// What the assistant is told about the machine it is answering for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HostFacts {
+    /// `windows` / `linux` (or whatever `std::env::consts::OS` reports).
+    os_name: &'static str,
+    /// Linux running under WSL — a Windows box where the Linux engines apply.
+    wsl: bool,
+    /// Marketing name of the primary AMD adapter, when one was detected.
+    gpu_name: Option<String>,
+    /// LLVM target of that adapter (`gfx1151`, …), when it was detected.
+    gfx_target: Option<String>,
+    /// TheRock family the target maps to, when it differs from the target.
+    therock_family: Option<String>,
+}
+
+impl HostFacts {
+    /// Detect this machine's facts. Fast: one const OS lookup, up to three
+    /// filesystem/env reads for the WSL signal, and the fast GPU summary.
+    pub(crate) fn detect(paths: Option<&AppPaths>) -> Self {
+        Self::from_gpu_summary(
+            runtime_os_name(),
+            is_wsl_host(),
+            detect_host_gpu_summary(paths),
+        )
+    }
+
+    /// The pure half of [`Self::detect`], so the rendering tests can pin every
+    /// host shape (Windows, WSL, bare Linux, no GPU) from one machine.
+    fn from_gpu_summary(os_name: &'static str, wsl: bool, gpu: HostGpuSummary) -> Self {
+        let HostGpuSummary {
+            name,
+            gfx_target,
+            therock_family,
+        } = gpu;
+        // The family is only worth a line when it says something the target
+        // does not (`gfx110X-all` for `gfx1100`, but not `gfx1151` twice).
+        let therock_family = therock_family.filter(|f| Some(f) != gfx_target.as_ref());
+        Self {
+            os_name,
+            wsl,
+            gpu_name: name,
+            gfx_target,
+            therock_family,
+        }
+    }
+
+    /// Whether vLLM can serve here. Mirrors
+    /// [`rocm_core::preferred_serve_engine_for_host_gpu_summary`]: the vLLM
+    /// adapter bails out on native Windows, and WSL builds as Linux.
+    fn vllm_available(&self) -> bool {
+        self.os_name != "windows"
+    }
+
+    /// How to describe the operating system to a non-technical user. WSL is
+    /// called out because it is the case the old prompt got wrong: it asserted
+    /// "on native Windows, vLLM is skipped" at a user who was on WSL, where
+    /// vLLM is the supported path.
+    fn operating_system(&self) -> &'static str {
+        match (self.os_name, self.wsl) {
+            ("windows", _) => "Windows",
+            ("linux", true) => "Linux running under WSL2 on a Windows host",
+            ("linux", false) => "Linux",
+            (other, _) => other,
+        }
+    }
+
+    /// The GPU line's value. `None` renders as an explicit "not detected" so
+    /// the assistant knows the check ran and came back empty, rather than
+    /// filling the silence from pretraining.
+    fn gpu(&self) -> String {
+        match (self.gpu_name.as_deref(), self.gfx_target.as_deref()) {
+            (Some(name), Some(target)) => format!("{name} ({target})"),
+            (Some(name), None) => name.to_owned(),
+            (None, Some(target)) => target.to_owned(),
+            (None, None) => "no AMD GPU detected on this machine".to_owned(),
+        }
+    }
+
+    /// Render the block appended to the assistant's system prompt.
+    ///
+    /// Deliberately short: for the built-in `local` provider the whole system
+    /// prompt is folded into the user turn, and the built-in assistant is a 4B
+    /// model — a long facts block would crowd out the question.
+    pub(crate) fn render(&self) -> String {
+        let family = self
+            .therock_family
+            .as_deref()
+            .map_or_else(String::new, |f| {
+                format!("- ROCm/TheRock family for this GPU: {f}\n")
+            });
+        let engines = if self.vllm_available() {
+            "- Serving engines that run here: Lemonade and vLLM.\n"
+        } else {
+            "- Serving engines that run here: Lemonade. vLLM is skipped on native Windows; \
+             tell the user to use WSL2 or Linux for that ROCm GPU engine.\n"
+        };
+        format!(
+            "Facts about the machine you are running on, detected by ROCm CLI. Trust these \
+             over anything you remember about ROCm:\n\
+             - Operating system: {os}\n\
+             - AMD GPU: {gpu}\n\
+             {family}{engines}\
+             ROCm and ROCm CLI support this operating system. Never tell the user ROCm is \
+             unavailable on their platform, and never suggest CUDA, DirectML, or CPU fallback.",
+            os = self.operating_system(),
+            gpu = self.gpu(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gpu(name: Option<&str>, target: Option<&str>, family: Option<&str>) -> HostGpuSummary {
+        HostGpuSummary {
+            name: name.map(str::to_owned),
+            gfx_target: target.map(str::to_owned),
+            therock_family: family.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn wsl_is_described_as_linux_on_a_windows_host_with_vllm_available() {
+        // The reporter's shape: a Windows box, but the CLI runs as Linux, so
+        // vLLM IS the supported path. The old prompt asserted the opposite.
+        let facts = HostFacts::from_gpu_summary(
+            "linux",
+            true,
+            gpu(
+                Some("AMD Radeon Graphics"),
+                Some("gfx1151"),
+                Some("gfx1151"),
+            ),
+        );
+        let block = facts.render();
+        assert!(
+            block.contains("- Operating system: Linux running under WSL2 on a Windows host"),
+            "WSL must be named, not flattened to bare Linux:\n{block}"
+        );
+        assert!(
+            block.contains("- AMD GPU: AMD Radeon Graphics (gfx1151)"),
+            "the detected adapter and target must both appear:\n{block}"
+        );
+        assert!(
+            block.contains("Lemonade and vLLM"),
+            "vLLM is available under WSL:\n{block}"
+        );
+        assert!(
+            !block.contains("ROCm/TheRock family"),
+            "a family identical to the target adds nothing:\n{block}"
+        );
+    }
+
+    #[test]
+    fn native_windows_keeps_the_vllm_caveat_that_left_the_static_prompt() {
+        let facts = HostFacts::from_gpu_summary(
+            "windows",
+            false,
+            gpu(
+                Some("AMD Radeon RX 9070 XT"),
+                Some("gfx1201"),
+                Some("gfx120X-all"),
+            ),
+        );
+        let block = facts.render();
+        assert!(block.contains("- Operating system: Windows"), "{block}");
+        assert!(
+            block.contains("vLLM is skipped on native Windows"),
+            "the caveat must survive, now stated only where it is true:\n{block}"
+        );
+        assert!(
+            block.contains("- ROCm/TheRock family for this GPU: gfx120X-all"),
+            "a family that differs from the target is worth a line:\n{block}"
+        );
+    }
+
+    #[test]
+    fn bare_linux_is_not_reported_as_wsl() {
+        let facts =
+            HostFacts::from_gpu_summary("linux", false, gpu(None, Some("gfx942"), Some("gfx942")));
+        let block = facts.render();
+        assert!(block.contains("- Operating system: Linux\n"), "{block}");
+        assert!(!block.contains("WSL"), "{block}");
+        assert!(block.contains("- AMD GPU: gfx942"), "{block}");
+    }
+
+    #[test]
+    fn an_undetected_gpu_is_stated_rather_than_omitted() {
+        // A missing line would leave the model free to invent one; an explicit
+        // negative keeps the block's shape stable for every host.
+        let facts = HostFacts::from_gpu_summary("linux", false, gpu(None, None, None));
+        let block = facts.render();
+        assert!(
+            block.contains("- AMD GPU: no AMD GPU detected on this machine"),
+            "{block}"
+        );
+    }
+
+    #[test]
+    fn every_host_is_told_rocm_supports_its_platform() {
+        // The reported defect: the assistant answered "ROCm is not compatible
+        // with Windows; use CUDA/DirectX". Both halves are refused here.
+        for (os, wsl) in [("windows", false), ("linux", true), ("linux", false)] {
+            let block = HostFacts::from_gpu_summary(os, wsl, gpu(None, None, None)).render();
+            assert!(
+                block.contains("Never tell the user ROCm is unavailable on their platform"),
+                "{os} (wsl={wsl}):\n{block}"
+            );
+            assert!(block.contains("never suggest CUDA"), "{os}:\n{block}");
+        }
+    }
+
+    #[test]
+    fn detection_describes_this_machine() {
+        // Not a fixture: this pins that `detect` reads the real host and that
+        // the block it produces is well-formed wherever the suite runs.
+        let facts = HostFacts::detect(None);
+        let block = facts.render();
+        assert!(block.contains("- Operating system: "), "{block}");
+        assert!(block.contains("- AMD GPU: "), "{block}");
+        assert!(
+            block.contains(if cfg!(windows) {
+                "Operating system: Windows"
+            } else if cfg!(target_os = "linux") {
+                "Operating system: Linux"
+            } else {
+                "Operating system: "
+            }),
+            "the OS line must match the machine the test runs on:\n{block}"
+        );
+    }
+}

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -209,6 +209,12 @@ pub fn resolved_args(
         model_recipes: model_recipe_summaries(),
         runtimes: runtime_summaries(paths, config),
         automations: automation_summaries(config),
+        // The dash chat used to send a four-sentence preamble that never said
+        // which machine it was on, so platform questions were answered from
+        // pretraining ("ROCm is not compatible with Windows"). Compose the real
+        // assistant prompt plus this host's facts here — the bin is the only
+        // side with both — and hand the TUI a plain String.
+        chat_system_prompt: Some(crate::rocm_chat_tool_system_prompt_for_host(Some(paths))),
         // The real executor is injected in `run_async` for a live dash; None
         // here keeps demo/replay/mock behaving exactly as today.
         tool_executor: None,

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4,6 +4,7 @@
 
 mod automations;
 mod bootstrap;
+mod chat_host_facts;
 mod comfyui;
 mod dash;
 mod dash_seam;
@@ -9784,7 +9785,7 @@ pub(crate) fn render_chat_prompt_result_with_progress(
     if rocm_tools {
         messages.push(providers::ChatMessage {
             role: "system".to_owned(),
-            content: rocm_chat_tool_system_prompt(),
+            content: rocm_chat_tool_system_prompt_for_host(Some(paths)),
         });
     }
     messages.push(providers::ChatMessage {
@@ -10903,11 +10904,28 @@ fn find_ascii_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
         .position(|window| window.eq_ignore_ascii_case(needle))
 }
 
-const ROCM_CHAT_TOOL_SYSTEM_PROMPT: &str = "You are ROCm CLI's local assistant. Speak in simple English for non-technical Windows users. Use the provided ROCm tools when you need to inspect this machine, preview setup, read service logs, check updates, inspect automations, install or start ROCm-managed apps, or request ROCm/TheRock, config, engine, app, and local model server changes. For simple greetings or thanks like hello, hi, hey, ok, or thank you, reply normally; do not inspect ROCm, do not call tools, and do not launch or propose a model server. Tool-use rules: inspect first with read-only tools; call rocm_command only with argv-style args and no shell text; use natural_language_plan for ROCm requests that do not fit another read-only tool; ask for a mutating tool call only after explaining why it is needed; summarize tool results after they are returned. Read-only tools may run immediately. Tools that install, launch, stop, delete, or change state require user approval; request rocm_command and explain why. For 'is X running?', 'what is running?', status, or port questions, inspect before answering and do not start, stop, install, or serve anything. For ComfyUI or port 8188 use [\"comfyui\",\"status\"] or port_status. For vLLM, Lemonade, qwen, or local model servers use [\"services\",\"list\",\"--all\"] for running state and [\"engines\",\"list\"] for installed/available engine state. Treat ready/running as running, starting/recovering as starting, failed/stopped as not running, and no matching record as unknown or not managed by ROCm CLI. Interpret Examine carefully: active_runtime_status=ready means ROCm CLI has an active managed TheRock/ROCm runtime; legacy_rocm_status=not_detected only means no global system ROCm install was found. If active_runtime_status=ready, tell the user ROCm/TheRock is installed and active for ROCm CLI. For 'is TheRock installed', 'is ROCm installed', or 'which GPU is on this machine', use examine or gpu_snapshot before answering. For 'how do I setup TheRock' or install/setup requests, guide the user to choose an install folder first; do not answer with only a status check. For 'which LLMs can this machine support', use rocm_command args [\"model\"] or natural_language_plan before answering. For TheRock installs, always let the user choose the install folder. If the user names a folder or prefix, preserve that exact folder with [\"--prefix\",\"PATH\"]; you may call path_exists first to check whether that user-provided folder or its parent exists. If the user asks you to install TheRock/ROCm but has not named a folder, ask for the folder or let the guided setup folder picker collect it; do not invent a hidden default folder and do not request an install command without --prefix. Use rocm_command args [\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"wheel\",\"--prefix\",\"PATH\"] only when the user asks you to install it and a folder is known; for a requested build date add [\"--build-date\",\"YYYY-MM-DD\"] and for a requested exact version add [\"--version\",\"VERSION\"]. For config changes, inspect with [\"config\",\"show\"] first when useful, then request config subcommands such as [\"config\",\"set-default-engine\",\"lemonade\"], [\"config\",\"set-default-runtime\",\"RUNTIME_KEY\"], or [\"config\",\"set-telemetry\",\"local\"] only after explaining why. For ComfyUI, use rocm_command with args like [\"comfyui\",\"status\"], [\"comfyui\",\"logs\"], [\"comfyui\",\"install\"], [\"comfyui\",\"start\"], or [\"comfyui\",\"stop\"]. First-time setup is the same thing as bootstrap in ROCm CLI; it is a deterministic ROCm setup flow, not a separate model chat. The built-in local assistant is fixed to qwen, which maps to Qwen3-4B-Instruct-2507-GGUF served by Lemonade with gpu_required. vLLM and Lemonade are the general serving engines; inspect or manage them when the user asks about general model serving, but do not switch the built-in assistant away from Lemonade. Use qwen-smoke only for a quick server smoke test. On native Windows, vLLM is skipped; use WSL/Linux for that ROCm GPU engine. For vLLM management, inspect engines first and use [\"engines\",\"install\",\"vllm\"] or [\"serve\",\"MODEL\",\"--engine\",\"vllm\",\"--device\",\"gpu_required\",\"--managed\"] only where the host supports it. Do not invent shell commands and do not request CPU fallback.";
+/// The host-independent half of the assistant prompt.
+///
+/// Statements that are only true on *some* hosts do not belong here — they used
+/// to, and a WSL user was told "on native Windows, vLLM is skipped" while vLLM
+/// was in fact their supported path. Anything host-dependent now comes from
+/// [`chat_host_facts::HostFacts`], which knows which machine it is describing.
+const ROCM_CHAT_TOOL_SYSTEM_PROMPT: &str = "You are ROCm CLI's local assistant. Speak in simple English for non-technical users. Use the provided ROCm tools when you need to inspect this machine, preview setup, read service logs, check updates, inspect automations, install or start ROCm-managed apps, or request ROCm/TheRock, config, engine, app, and local model server changes. For simple greetings or thanks like hello, hi, hey, ok, or thank you, reply normally; do not inspect ROCm, do not call tools, and do not launch or propose a model server. Tool-use rules: inspect first with read-only tools; call rocm_command only with argv-style args and no shell text; use natural_language_plan for ROCm requests that do not fit another read-only tool; ask for a mutating tool call only after explaining why it is needed; summarize tool results after they are returned. Read-only tools may run immediately. Tools that install, launch, stop, delete, or change state require user approval; request rocm_command and explain why. For 'is X running?', 'what is running?', status, or port questions, inspect before answering and do not start, stop, install, or serve anything. For ComfyUI or port 8188 use [\"comfyui\",\"status\"] or port_status. For vLLM, Lemonade, qwen, or local model servers use [\"services\",\"list\",\"--all\"] for running state and [\"engines\",\"list\"] for installed/available engine state. Treat ready/running as running, starting/recovering as starting, failed/stopped as not running, and no matching record as unknown or not managed by ROCm CLI. Interpret Examine carefully: active_runtime_status=ready means ROCm CLI has an active managed TheRock/ROCm runtime; legacy_rocm_status=not_detected only means no global system ROCm install was found. If active_runtime_status=ready, tell the user ROCm/TheRock is installed and active for ROCm CLI. For 'is TheRock installed', 'is ROCm installed', or 'which GPU is on this machine', use examine or gpu_snapshot before answering. For 'how do I setup TheRock' or install/setup requests, guide the user to choose an install folder first; do not answer with only a status check. For 'which LLMs can this machine support', use rocm_command args [\"model\"] or natural_language_plan before answering. For TheRock installs, always let the user choose the install folder. If the user names a folder or prefix, preserve that exact folder with [\"--prefix\",\"PATH\"]; you may call path_exists first to check whether that user-provided folder or its parent exists. If the user asks you to install TheRock/ROCm but has not named a folder, ask for the folder or let the guided setup folder picker collect it; do not invent a hidden default folder and do not request an install command without --prefix. Use rocm_command args [\"install\",\"sdk\",\"--channel\",\"release\",\"--format\",\"wheel\",\"--prefix\",\"PATH\"] only when the user asks you to install it and a folder is known; for a requested build date add [\"--build-date\",\"YYYY-MM-DD\"] and for a requested exact version add [\"--version\",\"VERSION\"]. For config changes, inspect with [\"config\",\"show\"] first when useful, then request config subcommands such as [\"config\",\"set-default-engine\",\"lemonade\"], [\"config\",\"set-default-runtime\",\"RUNTIME_KEY\"], or [\"config\",\"set-telemetry\",\"local\"] only after explaining why. For ComfyUI, use rocm_command with args like [\"comfyui\",\"status\"], [\"comfyui\",\"logs\"], [\"comfyui\",\"install\"], [\"comfyui\",\"start\"], or [\"comfyui\",\"stop\"]. First-time setup is the same thing as bootstrap in ROCm CLI; it is a deterministic ROCm setup flow, not a separate model chat. The built-in local assistant is fixed to qwen, which maps to Qwen3-4B-Instruct-2507-GGUF served by Lemonade with gpu_required. vLLM and Lemonade are the general serving engines; inspect or manage them when the user asks about general model serving, but do not switch the built-in assistant away from Lemonade. Use qwen-smoke only for a quick server smoke test. For vLLM management, inspect engines first and use [\"engines\",\"install\",\"vllm\"] or [\"serve\",\"MODEL\",\"--engine\",\"vllm\",\"--device\",\"gpu_required\",\"--managed\"] only where the host supports it. Do not invent shell commands and do not request CPU fallback.";
 const ROCM_CHAT_TOOL_SKILL: &str = include_str!("../../../skills/rocm-cli-assistant/SKILL.md");
 
 fn rocm_chat_tool_system_prompt() -> String {
     format!("{ROCM_CHAT_TOOL_SYSTEM_PROMPT}\n\nROCm CLI assistant skill:\n{ROCM_CHAT_TOOL_SKILL}")
+}
+
+/// The assistant prompt grounded in the machine it will answer for.
+///
+/// The single composition point: both chat surfaces (`rocm chat --prompt
+/// --tools` in this bin, and the dashboard chat via
+/// [`crate::dash::resolved_args`]) send this, so neither can drift into
+/// answering platform questions from pretraining alone.
+pub(crate) fn rocm_chat_tool_system_prompt_for_host(paths: Option<&AppPaths>) -> String {
+    let facts = chat_host_facts::HostFacts::detect(paths);
+    format!("{}\n\n{}", rocm_chat_tool_system_prompt(), facts.render())
 }
 
 fn local_provider_missing_service_error(error: &anyhow::Error) -> bool {
@@ -21635,6 +21653,86 @@ mod tests {
             assert!(
                 prompt.contains(expected),
                 "system prompt should mention {expected}"
+            );
+        }
+    }
+
+    /// The reported bug: asked "What can ROCm do on Windows?", the assistant
+    /// answered that ROCm is Windows-incompatible and suggested CUDA/DirectX —
+    /// because nothing ever told it which machine it was on. The prompt the CLI
+    /// actually sends must carry the host.
+    #[test]
+    fn assistant_prompt_states_the_host_it_is_answering_for() {
+        let prompt = rocm_chat_tool_system_prompt_for_host(None);
+
+        // The tool-use rules survive the composition (this is the same prompt,
+        // grounded — not a replacement for it).
+        assert!(
+            prompt.contains("You are ROCm CLI's local assistant"),
+            "the ROCm tool-use prompt must still be there:\n{prompt}"
+        );
+
+        // …and it now names this machine's OS and GPU state.
+        let expected_os = if cfg!(windows) {
+            "- Operating system: Windows"
+        } else {
+            "- Operating system: Linux"
+        };
+        assert!(
+            prompt.contains(expected_os),
+            "the prompt must state this machine's operating system:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("- AMD GPU: "),
+            "the prompt must state what GPU was detected (or that none was):\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Never tell the user ROCm is unavailable on their platform"),
+            "the prompt must refuse the reported answer:\n{prompt}"
+        );
+    }
+
+    /// The static prompt asserted two Windows-only facts at every host, which is
+    /// how a WSL user — where vLLM IS the supported path — was told to go use
+    /// WSL. Platform claims now come from the detected facts instead.
+    #[test]
+    fn assistant_prompt_makes_no_unconditional_windows_claims() {
+        let prompt = rocm_chat_tool_system_prompt();
+        assert!(
+            !prompt.contains("non-technical Windows users"),
+            "the audience is not assumed to be on Windows:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("On native Windows, vLLM is skipped"),
+            "the vLLM caveat belongs in the host facts, not the static prompt:\n{prompt}"
+        );
+
+        // Stated only where it is true: present on Windows, absent elsewhere.
+        let grounded = rocm_chat_tool_system_prompt_for_host(None);
+        assert_eq!(
+            grounded.contains("vLLM is skipped on native Windows"),
+            cfg!(windows),
+            "the vLLM caveat must track the host:\n{grounded}"
+        );
+    }
+
+    /// The prompt tells the model to "use examine … before answering". The dash
+    /// registers its machine check as `doctor`, so before the alias that
+    /// sentence named a tool absent from the dash's schema.
+    #[test]
+    fn every_tool_the_prompt_names_exists_in_the_dash_schema() {
+        let prompt = rocm_chat_tool_system_prompt();
+        for named in [
+            "examine",
+            "gpu_snapshot",
+            "port_status",
+            "natural_language_plan",
+        ] {
+            assert!(prompt.contains(named), "prompt should mention {named}");
+            assert!(
+                rocm_dash_tui::agent::ROCM_READ_TOOL_NAMES.contains(&named),
+                "the prompt names `{named}` but the dash never registers it, so a \
+                 model that obeys the prompt calls a tool the schema does not offer"
             );
         }
     }

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -2355,7 +2355,7 @@ fn normalize_cpu_model(value: &str) -> String {
 /// route-out note, a false negative runs bare-metal driver checks against a
 /// platform that has no amdgpu module and reports nonsense.
 #[must_use]
-pub(crate) fn is_wsl_host() -> bool {
+pub fn is_wsl_host() -> bool {
     runtime_is_linux()
         && wsl_signals_indicate_wsl(
             Path::new("/dev/dxg").exists(),

--- a/crates/rocm-dash-tui/src/agent.rs
+++ b/crates/rocm-dash-tui/src/agent.rs
@@ -102,10 +102,50 @@ fn validate_chatgpt_inference_params(params: &InferenceParams) -> Result<(), Age
 }
 
 /// Default system preamble for the dashboard assistant.
+///
+/// The fallback only — a live dash replaces it via `with_preamble` with the
+/// bin-composed prompt, which carries the ROCm tool-use rules AND this
+/// machine's detected facts. This text stands alone for demo/replay/`--chat-mock`,
+/// which have no bin seam to compose one.
 const DEFAULT_PREAMBLE: &str = "You are the rocm-dash assistant, embedded in a terminal dashboard for AMD \
      Instinct GPU telemetry and benchmarks. Use the provided tools (gpu_status, \
      list_instances, bench_summary, tokens_per_watt) to answer questions about \
      live GPU, serving instance, and benchmark state. Prefer short, direct answers.";
+
+/// Give one backend a `with_preamble` override for its system prompt.
+///
+/// All three backends carry the same `preamble: String`, and all three must
+/// accept the bin's host-grounded prompt or the grounding would depend on which
+/// provider the operator happened to pick. One macro keeps that parity the way
+/// the tool-registration helpers already do.
+///
+/// An override is applied post-construction rather than as a `new` parameter so
+/// the constructors keep their signatures; `None` or a blank string leaves
+/// [`DEFAULT_PREAMBLE`] in place, which is what demo/replay/`--chat-mock` pass.
+macro_rules! impl_with_preamble {
+    ($ty:ident) => {
+        impl $ty {
+            #[must_use]
+            pub fn with_preamble(mut self, preamble: Option<String>) -> Self {
+                if let Some(prompt) = preamble.filter(|p| !p.trim().is_empty()) {
+                    self.preamble = prompt;
+                }
+                self
+            }
+
+            /// The system prompt this client sends. Test-only: it exists so the
+            /// override can be pinned without a network round-trip.
+            #[cfg(test)]
+            pub(crate) fn preamble(&self) -> &str {
+                &self.preamble
+            }
+        }
+    };
+}
+
+impl_with_preamble!(RigAgentClient);
+impl_with_preamble!(ChatGptAgentClient);
+impl_with_preamble!(AnthropicAgentClient);
 
 /// Errors from a chat completion. Public form is string-only so no `rig` type
 /// leaks past this file. Messages never include the api_key (it is a header,
@@ -661,6 +701,19 @@ rocm_read_tool!(
      runtime status, and readiness checks. Read-only.",
     { "type": "object", "properties": {} }
 );
+// The same machine inspection under the name the assistant prompt uses. The
+// bin has exposed it as `examine` since before the dash existed and accepts
+// both names (`validate_chat_tool_call`), but the dash schema advertised only
+// `doctor` — so the shared prompt's "use examine … before answering" named a
+// tool the model could not see here. Registering the alias makes the one prompt
+// valid against both catalogs.
+rocm_read_tool!(
+    ExamineRocmTool,
+    "examine",
+    "Alias of `doctor`: the same read-only environment check (detected AMD \
+     GPU/driver, active ROCm runtime status, readiness). Read-only.",
+    { "type": "object", "properties": {} }
+);
 rocm_read_tool!(
     EnginesRocmTool,
     "engines",
@@ -793,8 +846,9 @@ rocm_read_tool!(
 /// Used for uniqueness/registration checks and the parity map. Mutating tools
 /// are intentionally absent. `natural_language_plan` is read-only: it plans but
 /// never executes (Phase 7).
-pub const ROCM_READ_TOOL_NAMES: [&str; 13] = [
+pub const ROCM_READ_TOOL_NAMES: [&str; 14] = [
     DoctorRocmTool::NAME,
+    ExamineRocmTool::NAME,
     EnginesRocmTool::NAME,
     ServicesRocmTool::NAME,
     ServiceLogsRocmTool::NAME,
@@ -1204,6 +1258,10 @@ where
 {
     builder
         .tool(DoctorRocmTool {
+            executor: executor.cloned(),
+            fired: fired.clone(),
+        })
+        .tool(ExamineRocmTool {
             executor: executor.cloned(),
             fired: fired.clone(),
         })
@@ -2003,6 +2061,9 @@ mod tests {
         // Every expected read-only tool is registered…
         for expected in [
             "doctor",
+            // The prompt's name for the same check; both must be advertised or
+            // the shared assistant prompt names a tool the dash never offers.
+            "examine",
             "engines",
             "services",
             "service_logs",
@@ -2100,6 +2161,64 @@ mod tests {
         let client_default =
             RigAgentClient::new(cfg, InferenceParams::default(), None, None).expect("build");
         assert_eq!(client_default.params, InferenceParams::default());
+    }
+
+    #[test]
+    fn a_bin_composed_prompt_replaces_the_default_preamble() {
+        // Construction is offline, so this pins that the host-grounded prompt
+        // the bin composes actually reaches the field every request's system
+        // message is built from — and that demo/replay/mock, which pass None,
+        // keep the standalone default.
+        let cfg = LlmConfig {
+            base_url: "http://127.0.0.1:8000/v1".to_string(),
+            model: "local-model".to_string(),
+            api_key: None,
+            auth_header: None,
+        };
+        let grounded = "You are ROCm CLI's local assistant. Operating system: Linux.";
+        let client = RigAgentClient::new(cfg.clone(), InferenceParams::default(), None, None)
+            .expect("build rig client")
+            .with_preamble(Some(grounded.to_string()));
+        assert_eq!(client.preamble(), grounded);
+
+        for absent in [None, Some(String::new()), Some("   ".to_string())] {
+            let fallback = RigAgentClient::new(cfg.clone(), InferenceParams::default(), None, None)
+                .expect("build rig client")
+                .with_preamble(absent.clone());
+            assert_eq!(
+                fallback.preamble(),
+                DEFAULT_PREAMBLE,
+                "no usable prompt ({absent:?}) must leave the built-in default"
+            );
+        }
+
+        // Same for the other two backends: grounding must not depend on which
+        // provider the operator picked, so all three accept the override.
+        let chatgpt = ChatGptAgentClient::new(
+            None,
+            InferenceParams::default(),
+            |_url, _code| {},
+            None,
+            None,
+        )
+        .expect("build chatgpt oauth client")
+        .with_preamble(Some(grounded.to_string()));
+        assert_eq!(chatgpt.preamble(), grounded);
+
+        let anthropic = AnthropicAgentClient::new(
+            LlmConfig {
+                base_url: String::new(),
+                model: String::new(),
+                api_key: Some("dummy".to_string()),
+                auth_header: None,
+            },
+            InferenceParams::default(),
+            None,
+            None,
+        )
+        .expect("build anthropic client")
+        .with_preamble(Some(grounded.to_string()));
+        assert_eq!(anthropic.preamble(), grounded);
     }
 
     #[test]
@@ -2321,7 +2440,7 @@ mod tests {
         }
         assert_eq!(
             ROCM_READ_TOOL_NAMES.len(),
-            13,
+            14,
             "canonical read-tool set size"
         );
         assert_eq!(

--- a/crates/rocm-dash-tui/src/app/chat.rs
+++ b/crates/rocm-dash-tui/src/app/chat.rs
@@ -74,6 +74,7 @@ pub(super) fn build_chat_agent(
                 Some(approval_tx),
             )
             .ok()
+            .map(|c| c.with_preamble(args.chat_system_prompt.clone()))
             .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         }
         ChatProvider::Anthropic => {
@@ -92,6 +93,7 @@ pub(super) fn build_chat_agent(
                 Some(approval_tx),
             )
             .ok()
+            .map(|c| c.with_preamble(args.chat_system_prompt.clone()))
             .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         }
     }
@@ -105,13 +107,20 @@ pub(super) fn build_chat_agent(
 /// no network I/O. Returns the [`AgentError`](crate::agent::AgentError) so the
 /// caller can either discard it (`.ok()` at startup) or surface it as an error
 /// turn (the rebuild drain).
+///
+/// `system_prompt` is the bin-composed, host-grounded prompt from
+/// `ResolvedArgs`; `None` (demo/replay/mock) keeps the agent's default preamble.
+/// Both call sites must pass it — the rebuild drain included, or accepting the
+/// detected local endpoint would silently drop the grounding mid-session.
 pub(super) fn build_local_agent(
     cfg: crate::llm::LlmConfig,
     params: crate::agent::InferenceParams,
     executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
     approval_tx: mpsc::UnboundedSender<ClientMsg>,
+    system_prompt: Option<String>,
 ) -> Result<std::sync::Arc<dyn crate::agent::AgentClient>, crate::agent::AgentError> {
     crate::agent::RigAgentClient::new(cfg, params, executor, Some(approval_tx))
+        .map(|c| c.with_preamble(system_prompt))
         .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
 }
 

--- a/crates/rocm-dash-tui/src/app/mod.rs
+++ b/crates/rocm-dash-tui/src/app/mod.rs
@@ -120,6 +120,12 @@ pub struct ResolvedArgs {
     /// Background checks for the automations manager (Phase 3 Wave 3). Adapted
     /// by the bin. Empty when none are available.
     pub automations: Vec<crate::ui::automations_manager::AutomationSummary>,
+    /// System prompt for the chat assistant: the ROCm tool-use prompt plus this
+    /// machine's detected facts (OS, WSL, AMD GPU, available engines). Composed
+    /// by the bin (`apps/rocm`, which has `rocm-core`) so this crate needs no
+    /// `rocm-core` dep. `None` for demo/replay/`--chat-mock`, which have no bin
+    /// seam and keep the agent's built-in default preamble.
+    pub chat_system_prompt: Option<String>,
     /// Bin-injected tool-executor seam; None for demo/replay/mock — dash behaves
     /// as today. Stored here (Phase 2 plumbing); Phase 3 will use it.
     pub tool_executor: Option<crate::tool_exec::SharedRocmToolExecutor>,
@@ -1822,6 +1828,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                 Some(chat_tx.clone()),
             )
             .ok()
+            .map(|c| c.with_preamble(args.chat_system_prompt.clone()))
             .map(|c| std::sync::Arc::new(c) as std::sync::Arc<dyn crate::agent::AgentClient>)
         } else {
             // A build failure leaves `agent` None; a submit surfaces an error turn.
@@ -1831,6 +1838,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                     args.inference_params(),
                     state.tool_executor.clone(),
                     chat_tx.clone(),
+                    args.chat_system_prompt.clone(),
                 )
                 .ok(),
                 None => None,
@@ -2314,6 +2322,7 @@ async fn event_loop(terminal: &mut Tui, args: &ResolvedArgs) -> color_eyre::Resu
                         args.inference_params(),
                         state.tool_executor.clone(),
                         chat_tx.clone(),
+                        args.chat_system_prompt.clone(),
                     ) {
                         Ok(arc) => {
                             agent = Some(arc.clone());
@@ -5556,6 +5565,7 @@ mod tests {
             model_recipes: Vec::new(),
             runtimes: Vec::new(),
             automations: Vec::new(),
+            chat_system_prompt: None,
             tool_executor: None,
             bench_results_dir: None,
         }

--- a/docs/llm-tool-use.md
+++ b/docs/llm-tool-use.md
@@ -27,8 +27,14 @@ rocm-cli local assistants use structured tools, not shell commands.
   general serving engines; the assistant may inspect or manage them for model
   serving, but it should not switch its own built-in chat engine away from
   Lemonade.
-- On native Windows, vLLM live serving/install checks are skipped. The assistant
-  should direct those requests to WSL/Linux and should not suggest CPU fallback.
+- The assistant prompt is grounded in the host. rocm-cli detects the operating
+  system (including WSL), the AMD GPU and its `gfx` target, and which serving
+  engines run there, and appends those facts to the system prompt on every chat
+  surface. Platform statements belong in that block, not in the static prompt: a
+  claim such as "on native Windows, vLLM live checks are skipped" is true only
+  on native Windows, and asserting it unconditionally misinformed WSL users,
+  where vLLM is the supported path. The assistant should answer platform
+  questions from the injected facts and must never suggest CPU fallback.
 
 This follows the same shape described by current tool-use docs: the application
 defines tool schemas, the model requests a tool, the application executes the

--- a/skills/rocm-cli-assistant/SKILL.md
+++ b/skills/rocm-cli-assistant/SKILL.md
@@ -28,7 +28,7 @@ Use this skill when answering ROCm CLI local assistant questions.
 - The built-in assistant is fixed to qwen served by Lemonade with GPU required. Do not switch the built-in assistant to vLLM.
 - Installing an engine and running a model server are different states. Answer each separately when the user asks.
 - `rocm serve` accepts `--gpu auto|<index>` to pick the AMD GPU. `auto` (default) prefers a GPU that looks idle from `amd-smi` VRAM telemetry and is not already used by another rocm-cli server (managed or foreground), falling back to the GPU with the most free memory; a single index pins one GPU. Serving one model across multiple GPUs is not supported. Do not suggest CPU fallback when a GPU is busy or out of range.
-- On native Windows, vLLM serving/install live checks are skipped; tell the user to use WSL/Linux for that ROCm GPU engine and do not suggest CPU fallback.
+- Which engines actually run on the user's machine is stated in the host facts the CLI appends to this prompt. Answer from those facts; do not assume a platform. Never suggest CPU fallback.
 
 ## ComfyUI
 

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -34,8 +34,25 @@ Feature: Chat and endpoint detection
     When the user quits interactive chat
     Then interactive chat exits successfully
 
+  # The reported defect was not a bad model, it was a blind one: the dashboard
+  # assistant was never told which machine it was answering for, so it answered
+  # platform questions from pretraining ("ROCm is not compatible with Windows").
+  # Asserts what the CLI sends, not what the model replies — a 4B model's wording
+  # is not deterministic, but what it is told is entirely ours.
+  @id:chat-assistant-is-told-which-machine-it-is-on @requires-os:linux
+  Scenario: chat-04 - The assistant is told what machine it is running on
+    Given a running managed model is available locally
+    When the user opens interactive chat
+    Then the local endpoint is shown for confirmation
+    When the user accepts the local endpoint
+    And the user sends a message to the managed model
+    Then the assistant is told which operating system this machine runs
+    And the assistant is told which GPU this machine has
+    When the user quits interactive chat
+    Then interactive chat exits successfully
+
   @id:chat-endpoint-shown-in-services
-  Scenario: chat-04 - A served model's endpoint is shown in the services list
+  Scenario: chat-05 - A served model's endpoint is shown in the services list
     Given a model is being served
     And the model is registered with the CLI
     When the user lists running services
@@ -46,18 +63,18 @@ Feature: Chat and endpoint detection
   # assertion (a tools-bearing request is accepted) is engine-agnostic, so no GPU
   # is required — dropping @requires-gpu gives this per-PR mock-lane coverage.
   @id:chat-tool-definitions-accepted
-  Scenario: chat-05 - Chat requests that include tool definitions are accepted
+  Scenario: chat-06 - Chat requests that include tool definitions are accepted
     Given a managed runtime is active
     And a model is served in the background
     When a chat request with tool definitions is sent
     Then the chat response is successful
 
-  # Runs on every lane (see chat-05): real serve on a GPU host, MockServer on
+  # Runs on every lane (see chat-06): real serve on a GPU host, MockServer on
   # the no-GPU mock lane. Asserts only that a served model returns a non-empty
   # reply, which is engine-agnostic — real generation is covered by the
   # @requires-gpu serve-*-inference scenarios.
   @id:chat-end-to-end-local-model
-  Scenario: chat-06 - End-to-end chat through a locally served model
+  Scenario: chat-07 - End-to-end chat through a locally served model
     Given a managed runtime is active
     And a model is served in the background
     And the served model has been detected
@@ -70,7 +87,7 @@ Feature: Chat and endpoint detection
   # reports `rocm chat` as covered. Runs on mock (no GPU): the local provider
   # resolves the planted managed-service record and talks to the mock server.
   @id:chat-cli-oneshot-prompt
-  Scenario: chat-07 - The chat CLI answers a one-shot prompt against a local server
+  Scenario: chat-08 - The chat CLI answers a one-shot prompt against a local server
     Given a model is being served
     And the model is registered with the CLI
     When the user sends a one-shot chat prompt through the CLI

--- a/tests/e2e-cucumber/src/mock_server.rs
+++ b/tests/e2e-cucumber/src/mock_server.rs
@@ -625,6 +625,38 @@ impl MockServer {
         }
     }
 
+    /// Poll for a chat request that satisfies `matches`, so a scenario asserting
+    /// on the user's turn cannot be answered by an earlier unrelated one.
+    ///
+    /// [`Self::wait_for_chat_request`] returns whichever body was recorded
+    /// first, and the local-endpoint detection probe (`Say ok.`, `max_tokens: 2`)
+    /// is itself a chat request that lands before the user has typed anything.
+    /// A scenario with no intervening screen wait therefore sees the probe and
+    /// reports the real turn as missing. Only `last_chat_request` is retained,
+    /// so this narrows to the newest body rather than searching a history.
+    pub async fn wait_for_chat_request_where(
+        &self,
+        timeout: Duration,
+        matches: impl Fn(&Value) -> bool,
+    ) -> Result<Value, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(body) = self.last_chat_request()
+                && matches(&body)
+            {
+                return Ok(body);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for a matching chat request; \
+                     the most recent one was: {:?}",
+                    self.last_chat_request()
+                ));
+            }
+            tokio::time::sleep(CHAT_REQUEST_POLL_INTERVAL).await;
+        }
+    }
+
     /// Shut the server down explicitly. Equivalent to dropping it — the
     /// handle stops the server on drop — but says so at the call site.
     pub fn stop(self) {

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -314,6 +314,131 @@ async fn managed_chat_request_carried_prompt(world: &mut E2eWorld) {
     );
 }
 
+/// The recorded chat request's message contents, in order.
+///
+/// The grounding steps look across every role rather than only `system`: what
+/// matters is that the model was told, not which envelope carried it (the
+/// built-in local provider folds system text into the user turn).
+///
+/// Waits for the request carrying `MANAGED_MODEL_PROMPT` specifically. Accepting
+/// any chat request instead picks up the local-endpoint detection probe, which
+/// is sent before the user types and carries no system prompt at all — the
+/// grounding then looks absent when it was simply asserted against the wrong
+/// request. Unlike `chat-03`, these steps have no screen wait ahead of them to
+/// order the two.
+async fn recorded_chat_messages(world: &mut E2eWorld) -> Vec<String> {
+    let body = world
+        .mock
+        .as_ref()
+        .expect("no mock server running")
+        .wait_for_chat_request_where(default_timeout(), |body| {
+            body.get("messages")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|messages| {
+                    messages.iter().any(|m| {
+                        m.get("role").and_then(serde_json::Value::as_str) == Some("user")
+                            && message_text(m.get("content").unwrap_or(&serde_json::Value::Null))
+                                .contains(MANAGED_MODEL_PROMPT)
+                    })
+                })
+        })
+        .await
+        .unwrap_or_else(|e| panic!("the mock never received the user's chat turn: {e}"));
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("chat request had no messages array:\n{body}"))
+        .iter()
+        .filter_map(|m| m.get("content"))
+        .map(message_text)
+        .collect()
+}
+
+/// The text of one OpenAI-format message. `content` is a bare string on the
+/// turns the TUI builds, but an array of typed parts on the system message the
+/// chat client emits — read both, or the grounding looks absent when it is
+/// simply wrapped.
+fn message_text(content: &serde_json::Value) -> String {
+    content.as_str().map_or_else(
+        || {
+            content
+                .as_array()
+                .map(|parts| {
+                    parts
+                        .iter()
+                        .filter_map(|p| p.get("text").and_then(serde_json::Value::as_str))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default()
+        },
+        str::to_owned,
+    )
+}
+
+/// The single line of the sent prompt that opens with `label`, or a failure
+/// naming what was actually sent. Asserting on the request — never on the
+/// canned reply — is the point: the mock answers identically whatever it is
+/// told, so only the request can show the assistant was grounded.
+fn sent_fact_line(messages: &[String], label: &str) -> String {
+    messages
+        .iter()
+        .flat_map(|m| m.lines())
+        .map(str::trim)
+        .find(|line| line.starts_with(label))
+        .unwrap_or_else(|| {
+            panic!(
+                "the assistant was never told `{label}`; the request carried:\n{}",
+                messages.join("\n---\n")
+            )
+        })
+        .to_owned()
+}
+
+#[then("the assistant is told which operating system this machine runs")]
+async fn assistant_told_the_operating_system(world: &mut E2eWorld) {
+    let messages = recorded_chat_messages(world).await;
+    let line = sent_fact_line(&messages, "- Operating system:");
+    let host = e2e_cucumber::capability::host_capability();
+    let expected = if host.os_family.eq_ignore_ascii_case("windows") {
+        "Windows"
+    } else {
+        "Linux"
+    };
+    assert!(
+        line.contains(expected),
+        "this machine runs {}, but the assistant was told: {line}",
+        host.os_family
+    );
+    // WSL is the case the old prompt got wrong — it told WSL users vLLM was
+    // unavailable — so a WSL host must be named as one, not flattened to Linux.
+    assert_eq!(
+        line.contains("WSL"),
+        host.is_wsl,
+        "WSL must be stated exactly when this machine is WSL (is_wsl={}): {line}",
+        host.is_wsl
+    );
+}
+
+#[then("the assistant is told which GPU this machine has")]
+async fn assistant_told_the_gpu(world: &mut E2eWorld) {
+    let messages = recorded_chat_messages(world).await;
+    let line = sent_fact_line(&messages, "- AMD GPU:");
+    let host = e2e_cucumber::capability::host_capability();
+    match host.gfx_target.as_deref() {
+        // A host with a real GPU must see that GPU named, not a placeholder.
+        Some(target) => assert!(
+            line.contains(target),
+            "this machine's GPU is {target}, but the assistant was told: {line}"
+        ),
+        // A host without one must be told so explicitly, rather than left to
+        // fill the silence from pretraining.
+        None => assert!(
+            line.contains("no AMD GPU detected"),
+            "no GPU is detectable here, so the assistant must be told that: {line}"
+        ),
+    }
+}
+
 #[then("the managed model is shown as loading rather than ready")]
 async fn managed_model_shown_loading(world: &mut E2eWorld) {
     let model = world.model_name.clone().expect("no model name set");


### PR DESCRIPTION
Fixes #287 in substance; see *What this does not fix* before treating the issue as closed.

## The reported bug

Asked "What ROCm can do in windows?", the dashboard assistant replied that ROCm is **not** compatible with Windows and suggested CUDA/DirectX.

## Root cause — not the model being wrong, the CLI telling it nothing

rocm-cli ships **two chat implementations with different grounding**, and the one users reach interactively has almost none. The dashboard's entire system message was:

> You are the rocm-dash assistant, embedded in a terminal dashboard for AMD **Instinct** GPU telemetry and benchmarks. Use the provided tools (gpu_status, list_instances, bench_summary, tokens_per_watt) … Prefer short, direct answers.

Then the raw question. No OS, no WSL flag, no GPU, no runtime, no ROCm product knowledge. A 4B model answering from that is answering from pretraining, where "ROCm is Linux-only" was true for years. The observed reply is the predictable outcome, not an anomaly.

Three things made it worse:

- A ~4000-char ROCm-aware prompt and a bundled `SKILL.md` **already existed**, reachable only from `rocm chat --prompt … --tools`. Nothing under `crates/` could reference them.
- **Interactive `rocm chat` routes into the dashboard chat**, so users who think they are using "the assistant" got the weak preamble.
- **That prompt would have misled this reporter anyway.** It asserted, unconditionally, "Speak in simple English for non-technical **Windows** users" and "On native Windows, vLLM is skipped; use WSL/Linux". The reporter is on WSL — where vLLM *is* the supported path. Wiring it in unchanged would have traded one wrong answer for another.

## What this does

Detect the host and say so, instead of letting either prompt guess. On this machine:

```
Facts about the machine you are running on, detected by ROCm CLI. Trust these over anything you remember about ROCm:
- Operating system: Linux running under WSL2 on a Windows host
- AMD GPU: <detected adapter / gfx target>
- Serving engines that run here: Lemonade and vLLM.
ROCm and ROCm CLI support this operating system. Never tell the user ROCm is unavailable on their platform, and never suggest CUDA, DirectML, or CPU fallback.
```

The bin is the only place holding both the ROCm knowledge and `rocm-core`, so **it composes and the dashboard consumes** — a fourth plain-data field on `ResolvedArgs`, alongside `model_recipes` / `runtimes` / `automations`, which already carry the comment *"Adapted by the bin so this crate needs no `rocm-core` dep."* **No dash crate gained a `rocm-core` dependency**; no dash `Cargo.toml` changed at all.

Also: the two unconditional Windows claims are gone; `rocm chat --prompt --tools` gets the grounded prompt too; and the dashboard gains an `examine` alias, because the prompt named a tool it did not register.

## Non-obvious decisions

- **Detection must be cheap** — it runs in `resolved_args()`, before the dashboard draws. Cheap getters only, never `ExamineSummary::gather()`. Measured here: **1.35 ms cold, 0.59 ms warm**.
- **`is_wsl_host()` promoted `pub(crate)` → `pub`** (three fs/env reads, no subprocess). The only public alternative was `gather()`, whose WSL probe shells out to `ldconfig -p`.
- **`rocm_chat_tool_system_prompt()` is untouched**; the grounded variant is a new function. The 22-substring contract test stays green with every assertion intact.
- **The scenario asserts the request, not the reply.** A 4B model's wording is not deterministic; what broke was the CLI's side of the conversation.

## Verification

`cargo fmt` = 0 · `cargo clippy --workspace --all-targets -D warnings` = 0 · `cargo clippy -p e2e-cucumber --test e2e -D warnings` = 0 · `cargo test --workspace --all-targets` = 0 · `smoke_local.py` = 0 · `cargo xtask e2e` = 0 (70 passed, 2 known WSL diagnose xfail, **0 unexpected**).

`MockAgentClient` ignores the preamble entirely, so a mock-driven test can pass while proving nothing. The coverage was therefore mutation-tested:

| Mutation | Unit test | Scenario |
|---|---|---|
| Facts injection removed from the composer | **FAIL** (exit 101) | **FAIL** — `chat-assistant-is-told-which-machine-it-is-on … a regression` |
| Wiring seam cut (`chat_system_prompt: None`) | passes — correctly, it tests composition | **FAIL** — same regression line |

The second row is the useful one: it shows the scenario, not the unit test, is what covers the seam. I re-ran that mutation independently and confirmed both the failure and a byte-identical restore.

## What this does not fix

**Grounding narrows the failure; it does not cure it.** A 4B model will still get some ROCm platform questions wrong, and **no automated test judges answer quality** — by design, since model wording is not deterministic. The scenario proves the assistant is *told* about the host, not that it answers correctly. Please read the green check accordingly.

**`rocm chat --prompt` without `--tools` still sends no system message at all.** Out of scope here; making the grounded prompt unconditional is a behaviour change affecting scripted callers and deserves its own decision.

## Limitations of local verification

This box turned out **not** to be the gfx1151 Strix Halo host the issue reports: no `/dev/dxg`, no amdgpu sysfs node, a Ryzen 7 PRO 8840U, and `rocm examine` independently reports the WSL GPU plumbing missing. So the WSL/OS half of the block was verified against real detection, but **the GPU-populated form was not** — the e2e step covers both shapes, and the GPU lanes will exercise the second.

One correction to my own design note while implementing: `detect_host_gpu_summary` is **not** unconditionally process-free on native Windows — it shares the pnputil/PowerShell inventory path with `gather()`, just less of it. Still far cheaper, but worth stating rather than implying.