### PR TITLE
build(deps): bump rocm-docs-core to 1.40.2

### DIFF
--- a/docs/rocm-docs/sphinx/requirements.txt
+++ b/docs/rocm-docs/sphinx/requirements.txt
@@ -1,1 +1,1 @@
-rocm-docs-core==1.40.1
+rocm-docs-core==1.40.2


### PR DESCRIPTION
## Summary
- Bump `rocm-docs-core` pin from 1.40.1 to 1.40.2 in `docs/rocm-docs/sphinx/requirements.txt`

## Test plan
- [ ] Docs build succeeds with the new pin