### PR TITLE
fix(bench): populate the engine column and keep bench load latency windowed

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -595,6 +595,21 @@ pub fn run_bench(a: BenchLoadArgs) -> Result<()> {
                 report.failed, report.attempted, row.cell
             );
         }
+        // `engine` is a rollup key, so rows this file already holds for the cell
+        // without one — written before the column was populated, or by a run
+        // whose /metrics was unreachable — do not group with the rows written
+        // now. N trials become two smaller groups and the Bench panel has no
+        // `engine` column to explain it, so the run has to say so itself. The
+        // sweep raises this at most once, so it prints once per run.
+        if let Some(notice) = &report.engine_split {
+            eprintln!(
+                "warning: {} already has rows for {} with a blank engine column; `engine` is a rollup key, so those trials group separately from this run's engine=vllm rows",
+                notice.path, notice.cell
+            );
+            eprintln!(
+                "hint: rotate or move that file if you are comparing trials across the change"
+            );
+        }
     }
     println!(
         "note: local saturation smoke-test — client-measured throughput, not an official ROCm/AMD benchmark."

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -22,6 +22,8 @@ use serde_json::Value;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
+use crate::engine_registry::EngineKind;
+
 /// Timeout for /metrics scrapes (short; must never stall the cell sweep).
 const METRICS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
@@ -390,12 +392,25 @@ async fn run_cell_with_clients(
             (Some(running), Some(waiting))
         });
 
-    // TTFT/TPOT deltas come from the before/after histogram scrapes (unchanged).
-    let (_, _, ttft_ms, tpot_ms) = prom_deltas(prom_before.as_ref(), prom_after.as_ref());
+    // TTFT/TPOT latency from the before/after histogram scrapes: the windowed
+    // mean over just the requests this cell issued. A field stays blank when the
+    // window is not measurable (a scrape missing, the counter flat, or a reset)
+    // rather than borrowing the endpoint's lifetime average, which would fold in
+    // traffic from earlier ramp cells or other clients.
+    let (ttft_ms, tpot_ms) = prom_latency(prom_before.as_ref(), prom_after.as_ref());
+
+    // The `/metrics` scraper only understands vLLM's `vllm:` series, so a
+    // recognisable sample is proof the endpoint is vLLM; a non-vLLM endpoint
+    // leaves the column blank rather than guessing. `engine` is a new column:
+    // rows appended before this change have it blank, and since `engine` is a
+    // rollup key, a shared `results.csv` spanning the upgrade splits a cell's
+    // trials into blank and `vllm` groups — rotate the file to regroup them.
+    let engine = detect_engine(prom_before.as_ref(), prom_after.as_ref());
 
     let row = BenchmarkRow {
         cell: format!("bench-c{concurrency}"),
         run: 1,
+        engine,
         model: Some(spec.model.clone()),
         concurrency: Some(concurrency),
         input_len: Some(spec.input_len),
@@ -423,32 +438,85 @@ async fn run_cell_with_clients(
     })
 }
 
-/// Compute latency deltas from two Prometheus samples.
+/// Best-effort engine label for the CSV `engine` column from a scrape pair.
 ///
-/// Returns `((), (), ttft_ms, tpot_ms)` — the first two elements are `None`
-/// placeholder for the deprecated peak fields (peaks now come from the
-/// mid-cell poller; this function only computes histogram deltas).
-/// If either sample is `None`, both latency fields are `None`.
-fn prom_deltas(
+/// The load generator's only view of the backend is its Prometheus `/metrics`
+/// endpoint, and [`crate::vllm_prom::parse`] only recognises vLLM's `vllm:`
+/// series. A sample carrying any recognised field is therefore proof the
+/// endpoint is vLLM. Returns `None` when neither scrape produced a recognisable
+/// sample (a non-vLLM endpoint, a 404, or a malformed body), leaving the column
+/// blank rather than guessing.
+fn detect_engine(
     before: Option<&InstanceSample>,
     after: Option<&InstanceSample>,
-) -> (Option<u32>, Option<u32>, Option<f64>, Option<f64>) {
-    let (Some(b), Some(a)) = (before, after) else {
-        return (None, None, None, None);
-    };
-
-    let ttft_ms = latency_delta_ms(b.ttft_sum_s, b.ttft_count, a.ttft_sum_s, a.ttft_count);
-    let tpot_ms = latency_delta_ms(b.tpot_sum_s, b.tpot_count, a.tpot_sum_s, a.tpot_count);
-
-    (None, None, ttft_ms, tpot_ms)
+) -> Option<String> {
+    let recognised = [after, before].into_iter().flatten().any(sample_is_vllm);
+    // Take the label from the registry (`engine_registry.rs`) rather than
+    // respelling it here: `engine` is a rollup key, so a spelling that drifted
+    // from the registry would silently split rollup groups.
+    recognised.then(|| EngineKind::Vllm.label().to_string())
 }
 
-/// Compute `Δsum / Δcount * 1000` (ms).
+/// Whether a parsed sample carries any vLLM-specific field.
 ///
-/// Returns `None` if either input is `None`, if the count delta is not
-/// positive (avoids division by zero and nonsense from stale counters),
-/// or if the sum delta is negative (counter reset).
-fn latency_delta_ms(
+/// `gen_tps` is deliberately excluded: it is the rate-reporting seam other
+/// engines (e.g. Lemonade) populate, not a vLLM signal, and the vLLM parser
+/// never sets it.
+const fn sample_is_vllm(s: &InstanceSample) -> bool {
+    s.kv_cache_usage_pct.is_some()
+        || s.running_reqs.is_some()
+        || s.waiting_reqs.is_some()
+        || s.gen_tokens_total.is_some()
+        || s.ttft_sum_s.is_some()
+        || s.ttft_count.is_some()
+        || s.tpot_sum_s.is_some()
+        || s.tpot_count.is_some()
+}
+
+/// Compute TTFT/TPOT latency (ms) from two Prometheus samples.
+///
+/// Returns `(ttft_ms, tpot_ms)`, each the windowed mean over just the requests
+/// this cell issued (see [`latency_ms`]). Either field is `None` when its
+/// window is not measurable — including a flat TPOT counter, which for vLLM
+/// means no inter-token gap was recorded in the window, i.e. the value is
+/// genuinely unmeasured for this cell rather than zero.
+fn prom_latency(
+    before: Option<&InstanceSample>,
+    after: Option<&InstanceSample>,
+) -> (Option<f64>, Option<f64>) {
+    let ttft_ms = latency_ms(
+        before.and_then(|s| s.ttft_sum_s),
+        before.and_then(|s| s.ttft_count),
+        after.and_then(|s| s.ttft_sum_s),
+        after.and_then(|s| s.ttft_count),
+    );
+    let tpot_ms = latency_ms(
+        before.and_then(|s| s.tpot_sum_s),
+        before.and_then(|s| s.tpot_count),
+        after.and_then(|s| s.tpot_sum_s),
+        after.and_then(|s| s.tpot_count),
+    );
+    (ttft_ms, tpot_ms)
+}
+
+/// Windowed latency (ms) across the cell's two histogram scrapes.
+///
+/// Computes `Δsum/Δcount × 1000` — the mean latency of just the requests this
+/// cell issued between the before- and after-scrape. Returns `None` when the
+/// window cannot be measured: either scrape missing, the observation count did
+/// not advance (`Δcount ≤ 0`, no request recorded this metric in the window),
+/// or the counter reset (`Δsum < 0`, a server restart).
+///
+/// The value is deliberately *not* backfilled from the after-scrape's lifetime
+/// `sum/count` average. That average covers every request the server process
+/// ever handled — earlier ramp cells and other clients included — so writing it
+/// into this cell's immutable CSV row would describe a different population than
+/// the row names, with nothing to flag it. A blank column therefore honestly
+/// means "not measured for this cell". (This is narrower than the telemetry
+/// daemon's `avg_ms_from_histogram`, which *does* fall back: it is a repeated
+/// live poll with a rolling baseline that self-corrects on the next tick and
+/// persists nothing, so the trade-offs differ.)
+fn latency_ms(
     sum_before: Option<f64>,
     count_before: Option<f64>,
     sum_after: Option<f64>,
@@ -456,10 +524,8 @@ fn latency_delta_ms(
 ) -> Option<f64> {
     let delta_sum = sum_after? - sum_before?;
     let delta_count = count_after? - count_before?;
-    if delta_count <= 0.0 || delta_sum < 0.0 {
-        return None;
-    }
-    Some(delta_sum / delta_count * 1000.0)
+    // Guard division by zero (flat counter) and counter resets.
+    (delta_count > 0.0 && delta_sum >= 0.0).then_some(delta_sum / delta_count * 1000.0)
 }
 
 /// Concurrency levels tried by [`run_auto_ramp`] in order.
@@ -1067,6 +1133,10 @@ mod tests {
         );
         assert_eq!(row.ttft_ms, None, "ttft_ms should be None for 404 /metrics");
         assert_eq!(row.tpot_ms, None, "tpot_ms should be None for 404 /metrics");
+        assert_eq!(
+            row.engine, None,
+            "engine should be blank for a non-vLLM (404 /metrics) endpoint"
+        );
         assert!(
             row.gen_tps.unwrap_or(0.0) > 0.0,
             "gen_tps must still be positive"
@@ -1505,5 +1575,224 @@ mod tests {
             reason.contains("usage"),
             "the reason should name the missing field, got: {reason}"
         );
+    }
+
+    // ---------- engine + tpot column population ----------
+
+    fn sample_with_tpot(
+        ttft_sum: Option<f64>,
+        ttft_count: Option<f64>,
+        tpot_sum: Option<f64>,
+        tpot_count: Option<f64>,
+    ) -> InstanceSample {
+        InstanceSample {
+            running_reqs: Some(1),
+            ttft_sum_s: ttft_sum,
+            ttft_count,
+            tpot_sum_s: tpot_sum,
+            tpot_count,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn latency_ms_prefers_the_window_when_the_counter_advanced() {
+        // Δsum=1.0s over Δcount=2 → 500 ms.
+        assert_eq!(
+            latency_ms(Some(1.0), Some(10.0), Some(2.0), Some(12.0)),
+            Some(500.0)
+        );
+    }
+
+    #[test]
+    fn latency_ms_is_none_when_the_counter_did_not_advance() {
+        // A flat window (Δcount = 0) is unmeasured for this cell, not the
+        // endpoint's lifetime average. For vLLM's TPOT this is the load-bearing
+        // case: a flat counter means zero inter-token gaps were recorded here,
+        // so a blank column is the honest answer.
+        assert_eq!(
+            latency_ms(Some(2.0), Some(100.0), Some(2.0), Some(100.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn latency_ms_is_none_when_the_before_scrape_is_missing() {
+        // With no baseline there was never a window over this cell; the row must
+        // not borrow the after-scrape's lifetime average.
+        assert_eq!(latency_ms(None, None, Some(3.0), Some(30.0)), None);
+    }
+
+    #[test]
+    fn latency_ms_is_none_on_a_counter_reset() {
+        // sum dropped (server restart) → the negative window is discarded and
+        // the row stays blank rather than reporting an average from a different
+        // process lifetime.
+        assert_eq!(
+            latency_ms(Some(10.0), Some(100.0), Some(0.2), Some(2.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn latency_ms_is_none_without_any_data() {
+        assert_eq!(latency_ms(None, None, None, None), None);
+        // count == 0 is not divisible → None, never a divide-by-zero number.
+        assert_eq!(latency_ms(None, None, Some(0.0), Some(0.0)), None);
+    }
+
+    #[test]
+    fn prom_latency_computes_ttft_and_tpot_independently() {
+        // ttft advanced (windowed → 500 ms); tpot flat across the window, so it
+        // is genuinely unmeasured for this cell and stays blank rather than
+        // reporting the endpoint's lifetime average.
+        let before = sample_with_tpot(Some(1.0), Some(10.0), Some(2.0), Some(100.0));
+        let after = sample_with_tpot(Some(2.0), Some(12.0), Some(2.0), Some(100.0));
+        let (ttft_ms, tpot_ms) = prom_latency(Some(&before), Some(&after));
+        assert_eq!(ttft_ms, Some(500.0));
+        assert_eq!(tpot_ms, None);
+    }
+
+    #[test]
+    fn prom_latency_reports_tpot_when_the_counter_advances() {
+        // The window advances for both histograms → both populated. ttft:
+        // (2.0-1.0)/(12-10)*1000 = 500 ms; tpot: (2.4-2.0)/(120-100)*1000 = 20 ms.
+        let before = sample_with_tpot(Some(1.0), Some(10.0), Some(2.0), Some(100.0));
+        let after = sample_with_tpot(Some(2.0), Some(12.0), Some(2.4), Some(120.0));
+        let (ttft_ms, tpot_ms) = prom_latency(Some(&before), Some(&after));
+        assert_eq!(ttft_ms, Some(500.0));
+        let tpot = tpot_ms.expect("tpot_ms should be Some when the counter advances");
+        assert!((tpot - 20.0).abs() < 1e-9, "expected tpot≈20 got {tpot}");
+    }
+
+    #[test]
+    fn detect_engine_labels_a_recognised_sample_vllm() {
+        let sample = sample_with_tpot(Some(1.0), Some(10.0), Some(2.0), Some(100.0));
+        assert_eq!(detect_engine(Some(&sample), None).as_deref(), Some("vllm"));
+        assert_eq!(detect_engine(None, Some(&sample)).as_deref(), Some("vllm"));
+    }
+
+    #[test]
+    fn detect_engine_leaves_an_unrecognised_endpoint_blank() {
+        // No scrape at all (404 / non-vLLM), and an all-`None` (malformed body)
+        // sample must both leave the column blank rather than guess "vllm".
+        assert_eq!(detect_engine(None, None), None);
+        let empty = InstanceSample::default();
+        assert_eq!(detect_engine(Some(&empty), Some(&empty)), None);
+    }
+
+    fn prom_body_full(
+        running: u32,
+        waiting: u32,
+        ttft_sum: f64,
+        ttft_count: f64,
+        tpot_sum: f64,
+        tpot_count: f64,
+    ) -> String {
+        format!(
+            "vllm:num_requests_running {running}\n\
+             vllm:num_requests_waiting {waiting}\n\
+             vllm:time_to_first_token_seconds_sum {ttft_sum}\n\
+             vllm:time_to_first_token_seconds_count {ttft_count}\n\
+             vllm:time_per_output_token_seconds_sum {tpot_sum}\n\
+             vllm:time_per_output_token_seconds_count {tpot_count}\n"
+        )
+    }
+
+    // A vLLM endpoint whose TPOT counter did not advance between the before and
+    // after scrapes (while TTFT did): the `engine` column is populated from the
+    // recognised scrape, `ttft_ms` carries its windowed value, and `tpot_ms`
+    // stays blank — a flat TPOT window is unmeasured for this cell, not a value
+    // borrowed from the endpoint's lifetime average.
+    #[tokio::test]
+    async fn bench_row_labels_engine_and_leaves_flat_tpot_blank() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(stub_response(100, 50))
+            .mount(&server)
+            .await;
+
+        // Before scrape: ttft cumulative 1.0s/10, tpot cumulative 2.0s/100.
+        Mock::given(method("GET"))
+            .and(path("/metrics"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(prom_body_full(5, 2, 1.0, 10.0, 2.0, 100.0)),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        // After/poller: ttft advanced (sum 2.0/count 12) but tpot counter is
+        // unchanged (still 2.0/100) — the exact real-vLLM symptom.
+        Mock::given(method("GET"))
+            .and(path("/metrics"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(prom_body_full(8, 1, 2.0, 12.0, 2.0, 100.0)),
+            )
+            .mount(&server)
+            .await;
+
+        let mut spec = make_spec(&server.uri());
+        spec.requests = 2;
+        let row = run_cell(&spec, 1).await.unwrap().row;
+
+        assert_eq!(
+            row.engine.as_deref(),
+            Some("vllm"),
+            "engine must be labelled from the recognised vLLM scrape"
+        );
+        // ttft: windowed (2.0-1.0)/(12-10)*1000 = 500 ms.
+        let ttft = row.ttft_ms.expect("ttft_ms should be Some");
+        assert!((ttft - 500.0).abs() < 0.01, "expected ttft≈500 got {ttft}");
+        // tpot: flat window → genuinely unmeasured for this cell → blank.
+        assert_eq!(
+            row.tpot_ms, None,
+            "a flat TPOT window must stay blank, not borrow the lifetime average"
+        );
+    }
+
+    // When the TPOT counter advances across the cell's scrapes, the windowed
+    // value is populated — the ordinary served case.
+    #[tokio::test]
+    async fn bench_row_populates_tpot_when_the_counter_advances() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(stub_response(100, 50))
+            .mount(&server)
+            .await;
+
+        // Before: tpot cumulative 2.0s/100. After: 2.4s/120 → Δ 0.4s/20 = 20 ms.
+        Mock::given(method("GET"))
+            .and(path("/metrics"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(prom_body_full(5, 2, 1.0, 10.0, 2.0, 100.0)),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/metrics"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(prom_body_full(8, 1, 2.0, 12.0, 2.4, 120.0)),
+            )
+            .mount(&server)
+            .await;
+
+        let mut spec = make_spec(&server.uri());
+        spec.requests = 2;
+        let row = run_cell(&spec, 1).await.unwrap().row;
+
+        assert_eq!(row.engine.as_deref(), Some("vllm"));
+        let tpot = row
+            .tpot_ms
+            .expect("tpot_ms must be populated when the counter advanced");
+        assert!((tpot - 20.0).abs() < 0.01, "expected tpot≈20 got {tpot}");
     }
 }

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -80,6 +80,33 @@ pub struct CellReport {
     pub failed: u32,
     /// Reason from the first failure observed, for the operator-facing warning.
     pub first_error: Option<String>,
+    /// Set on the first cell of a sweep whose append landed in a file that
+    /// already held blank-`engine` rows for that cell; `None` on every other
+    /// report, so the CLI warns once per run rather than once per cell. Always
+    /// `None` from [`run_cell`], which appends nothing.
+    pub engine_split: Option<EngineSplitNotice>,
+}
+
+/// Evidence that the results file being appended to straddles the point at
+/// which the `engine` column started being populated.
+///
+/// `engine` is a rollup key (`RollupKey` in `rocm_dash_core::bench_rollup`), so
+/// a cell's rows written before the column was populated (blank `engine`) do
+/// not group with the rows written after it (`vllm`): one Pass^N over N trials
+/// becomes two smaller groups, and nothing on the dashboard says why — the
+/// Bench rollup table renders `cell/model/tp·dtype/concurrency` and never
+/// `engine`. The same split follows any run whose `/metrics` was unreachable
+/// (a remote endpoint, metrics disabled, a restart mid-series), so this is not
+/// a one-off upgrade notice; it fires whenever the two groups actually exist.
+///
+/// Carried out to the CLI rather than printed here so the collector stays free
+/// of process-wide output.
+#[derive(Debug, Clone)]
+pub struct EngineSplitNotice {
+    /// The cell whose earlier rows in the file carry a blank `engine`.
+    pub cell: String,
+    /// The results file holding both groups.
+    pub path: String,
 }
 
 /// Why a single benchmark request produced no usable measurement.
@@ -401,10 +428,10 @@ async fn run_cell_with_clients(
 
     // The `/metrics` scraper only understands vLLM's `vllm:` series, so a
     // recognisable sample is proof the endpoint is vLLM; a non-vLLM endpoint
-    // leaves the column blank rather than guessing. `engine` is a new column:
-    // rows appended before this change have it blank, and since `engine` is a
-    // rollup key, a shared `results.csv` spanning the upgrade splits a cell's
-    // trials into blank and `vllm` groups — rotate the file to regroup them.
+    // leaves the column blank rather than guessing. `engine` is a new column and
+    // a rollup key, so a shared `results.csv` spanning the upgrade splits a
+    // cell's trials into blank and `vllm` groups; the append path detects that
+    // and the CLI warns about it (see [`EngineSplitNotice`]).
     let engine = detect_engine(prom_before.as_ref(), prom_after.as_ref());
 
     let row = BenchmarkRow {
@@ -435,6 +462,8 @@ async fn run_cell_with_clients(
         succeeded: n_success,
         failed: n_failed,
         first_error,
+        // Filled in by the sweep, which is what knows the target file.
+        engine_split: None,
     })
 }
 
@@ -506,7 +535,7 @@ fn prom_latency(
 /// window cannot be measured: either scrape missing, the observation count did
 /// not advance (`Δcount ≤ 0`, no request recorded this metric in the window),
 /// the counter reset (`Δsum < 0`, a server restart), or either delta is `NaN`
-/// (Prometheus reports an unobserved histogram sum that way).
+/// (defensive: see the guard below).
 ///
 /// The value is deliberately *not* backfilled from the after-scrape's lifetime
 /// `sum/count` average. That average covers every request the server process
@@ -527,7 +556,18 @@ fn latency_ms(
     let delta_count = count_after? - count_before?;
     // Phrased as acceptance, not rejection: every comparison against NaN is
     // false, so this rejects a NaN delta where `if delta_count <= 0.0 || ...`
-    // would fall through and emit Some(NaN).
+    // would fall through and emit Some(NaN) — which `opt_f64` then writes into
+    // the CSV as a literal `NaN` cell.
+    //
+    // A conforming vLLM cannot produce that NaN: `_sum`/`_count` are counters
+    // that `prometheus_client` initialises to `0.0`/`0` and never renders as
+    // NaN (NaN appears in text exposition for summary quantiles with no
+    // observations and for gauges explicitly set to NaN, neither of which is
+    // among the four series `vllm_prom` reads). The guard is therefore
+    // defensive, not a response to an observed exposition: `extract` finishes
+    // with `parse::<f64>()`, which accepts a `NaN` token from a malformed or
+    // non-conforming exporter, and this is the last place to stop it before it
+    // reaches an immutable CSV row.
     (delta_count > 0.0 && delta_sum >= 0.0).then_some(delta_sum / delta_count * 1000.0)
 }
 
@@ -537,13 +577,30 @@ pub const RAMP_SEQUENCE: &[u32] = &[1, 2, 4, 8, 16, 32, 64, 128];
 /// Minimum fractional `gen_tps` improvement to keep ramping.
 pub const PLATEAU_GAIN: f64 = 0.05;
 
+/// Zero-based position of the `cell` column in [`CSV_HEADER`].
+const CELL_COLUMN: usize = 0;
+
+/// Zero-based position of the `engine` column in [`CSV_HEADER`].
+///
+/// Both indexes are only read after the file's header has been validated as
+/// byte-identical to [`CSV_HEADER`], so they cannot address a foreign layout.
+const ENGINE_COLUMN: usize = 4;
+
 /// Open (or create) `csv_path` once, take an exclusive advisory lock, validate
 /// or write the header, then append one newline-terminated row.
 ///
 /// The lock serializes cooperating `rocm bench load` processes so concurrent
 /// first writers cannot both emit the header. `O_APPEND` keeps each row write
 /// at the end of the file.
-fn append_one_row(row: &BenchmarkRow, csv_path: &Path) -> Result<(), BenchLoadError> {
+///
+/// Returns an [`EngineSplitNotice`] when the row carries an `engine` and the
+/// file already holds rows for the same cell without one — the two sets are
+/// separate rollup groups, which the caller reports. Detected under the same
+/// lock as the append so a concurrent writer cannot slip a row in between.
+fn append_one_row(
+    row: &BenchmarkRow,
+    csv_path: &Path,
+) -> Result<Option<EngineSplitNotice>, BenchLoadError> {
     use std::io::{BufRead, Seek};
 
     let mut file = OpenOptions::new()
@@ -553,6 +610,7 @@ fn append_one_row(row: &BenchmarkRow, csv_path: &Path) -> Result<(), BenchLoadEr
         .open(csv_path)?;
     file.lock()?;
 
+    let mut notice = None;
     if file.metadata()?.len() == 0 {
         file.write_all(CSV_HEADER.as_bytes())?;
     } else {
@@ -564,11 +622,59 @@ fn append_one_row(row: &BenchmarkRow, csv_path: &Path) -> Result<(), BenchLoadEr
                 path: csv_path.display().to_string(),
             });
         }
+        if row.engine.is_some() {
+            file.seek(std::io::SeekFrom::Start(0))?;
+            if has_blank_engine_row(&file, &row.cell) {
+                notice = Some(EngineSplitNotice {
+                    cell: row.cell.clone(),
+                    path: csv_path.display().to_string(),
+                });
+            }
+        }
     }
 
+    // `O_APPEND` puts this at the end of the file regardless of where the
+    // scan above left the read cursor.
     let line = serialize_row_to_line(row)?;
     file.write_all(&line)?;
-    Ok(())
+    Ok(notice)
+}
+
+/// Whether `file` already holds a row for `cell` whose `engine` column is blank.
+///
+/// Best-effort by design: an unreadable record is skipped rather than failing
+/// the append, because this only decides whether to print a warning and a
+/// half-written or hand-edited line is not worth refusing a benchmark over.
+/// The reader is `flexible` for the same reason. Stops at the first hit, so the
+/// common case (a file the current build wrote) costs one pass at most.
+fn has_blank_engine_row(file: &std::fs::File, cell: &str) -> bool {
+    csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .from_reader(std::io::BufReader::new(file))
+        .records()
+        .flatten()
+        .any(|record| {
+            record.get(CELL_COLUMN) == Some(cell)
+                && record
+                    .get(ENGINE_COLUMN)
+                    .is_none_or(|engine| engine.trim().is_empty())
+        })
+}
+
+/// Attach `notice` to `report` unless this sweep already raised one.
+///
+/// The notice describes the *file*, so repeating it for every concurrency level
+/// of a ramp would be noise; `already` carries the once-per-sweep state.
+fn attach_engine_split(
+    report: &mut CellReport,
+    notice: Option<EngineSplitNotice>,
+    already: &mut bool,
+) {
+    if !*already && notice.is_some() {
+        report.engine_split = notice;
+        *already = true;
+    }
 }
 
 /// Run a concurrency sweep and append one aggregate row per cell to `csv_path`.
@@ -586,11 +692,13 @@ pub async fn run_and_append_csv(
     let clients = BenchClients::new()?;
 
     let mut reports = Vec::with_capacity(concurrency_levels.len());
+    let mut split_reported = false;
     for &conc in concurrency_levels {
-        let report = run_cell_with_clients(spec, conc, &clients).await?;
+        let mut report = run_cell_with_clients(spec, conc, &clients).await?;
         // A fully-failed cell is still appended: the dashboard tailer expects one
         // row per cell, and the caller reports the failure separately.
-        append_one_row(&report.row, csv_path)?;
+        let notice = append_one_row(&report.row, csv_path)?;
+        attach_engine_split(&mut report, notice, &mut split_reported);
         reports.push(report);
     }
 
@@ -654,10 +762,12 @@ pub async fn run_auto_ramp(
     let mut reports = Vec::new();
     let mut prev_gen_tps: Option<f64> = None;
     let clients = BenchClients::new()?;
+    let mut split_reported = false;
 
     for &conc in RAMP_SEQUENCE {
-        let report = run_cell_with_clients(spec, conc, &clients).await?;
-        append_one_row(&report.row, csv_path)?;
+        let mut report = run_cell_with_clients(spec, conc, &clients).await?;
+        let notice = append_one_row(&report.row, csv_path)?;
+        attach_engine_split(&mut report, notice, &mut split_reported);
 
         let is_last = conc == *RAMP_SEQUENCE.last().unwrap_or(&conc);
         let stop = should_stop_ramp(prev_gen_tps, &report.row, is_last);
@@ -993,7 +1103,9 @@ mod tests {
             .collect();
 
         for handle in handles {
-            handle.join().unwrap().unwrap();
+            // These rows carry no `engine`, so none of them can straddle the
+            // split — a notice here would mean the scan fires on the wrong rows.
+            assert!(handle.join().unwrap().unwrap().is_none());
         }
 
         let content = std::fs::read_to_string(&csv_path).unwrap();
@@ -1646,9 +1758,11 @@ mod tests {
 
     #[test]
     fn latency_ms_is_none_when_a_counter_is_nan() {
-        // Prometheus emits NaN for a histogram sum with no observations, and
-        // `vllm_prom::parse` accepts it verbatim (`parse::<f64>()` parses
-        // "NaN"), so a NaN can reach this arithmetic from a real scrape.
+        // Defensive, not observed: a conforming vLLM never exposes NaN here —
+        // its histogram `_sum`/`_count` are counters `prometheus_client`
+        // initialises to `0.0`/`0`. What makes the guard worth keeping is that
+        // `vllm_prom::extract` ends in `parse::<f64>()`, which accepts a `NaN`
+        // token, so a malformed or non-conforming exporter can still put one in.
         //
         // Every comparison against NaN is false, so a guard phrased as a
         // rejection — `if delta_count <= 0.0 || delta_sum < 0.0 { None }` —
@@ -1826,5 +1940,157 @@ mod tests {
             .tpot_ms
             .expect("tpot_ms must be populated when the counter advanced");
         assert!((tpot - 20.0).abs() < 0.01, "expected tpot≈20 got {tpot}");
+    }
+
+    // ---------- engine-column rollup split ----------
+
+    /// The column positions the blank-`engine` scan reads must be the ones
+    /// [`CSV_HEADER`] actually declares; a reordered header would otherwise send
+    /// the scan looking at `model` or `run` and silently stop warning.
+    #[test]
+    fn scan_column_indexes_match_the_header() {
+        let columns: Vec<&str> = CSV_HEADER.trim().split(',').collect();
+        assert_eq!(columns[CELL_COLUMN], "cell");
+        assert_eq!(columns[ENGINE_COLUMN], "engine");
+    }
+
+    /// A file exactly as a build that never populated `engine` left it: the
+    /// current header (the append is refused otherwise) and a row for the cell
+    /// about to be appended, with the `engine` field empty.
+    fn write_pre_engine_file(csv_path: &Path, cells: &[&str]) {
+        use std::fmt::Write as _;
+
+        let mut content = CSV_HEADER.to_string();
+        for cell in cells {
+            let _ = writeln!(
+                content,
+                "{cell},1,1,test-model,,16,8,4,200,100,10.0,5.0,0.5,rocm bench load (local smoke),1,0,50.0,20.0"
+            );
+        }
+        std::fs::write(csv_path, content).unwrap();
+    }
+
+    fn engine_row(cell: &str, engine: Option<&str>) -> BenchmarkRow {
+        BenchmarkRow {
+            cell: cell.to_string(),
+            run: 1,
+            engine: engine.map(ToString::to_string),
+            concurrency: Some(1),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn append_flags_a_cell_whose_earlier_rows_predate_the_engine_column() {
+        let dir = tempdir();
+        let csv_path = dir.join("results.csv");
+        write_pre_engine_file(&csv_path, &["bench-c1"]);
+
+        let notice = append_one_row(&engine_row("bench-c1", Some("vllm")), &csv_path)
+            .unwrap()
+            .expect("appending a vllm row over blank-engine rows must be flagged");
+        assert_eq!(notice.cell, "bench-c1");
+        assert_eq!(notice.path, csv_path.display().to_string());
+
+        // The row is still appended — this is a warning, not a refusal.
+        let content = std::fs::read_to_string(&csv_path).unwrap();
+        assert_eq!(content.lines().count(), 3);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn append_is_quiet_when_no_group_is_actually_split() {
+        let dir = tempdir();
+
+        // Earlier rows already carry the same engine → one group, no notice.
+        let labelled = dir.join("labelled.csv");
+        std::fs::write(
+            &labelled,
+            format!(
+                "{CSV_HEADER}bench-c1,1,1,test-model,vllm,16,8,4,200,100,10.0,5.0,0.5,l,1,0,50.0,20.0\n"
+            ),
+        )
+        .unwrap();
+        assert!(
+            append_one_row(&engine_row("bench-c1", Some("vllm")), &labelled)
+                .unwrap()
+                .is_none()
+        );
+
+        // Blank-engine rows exist, but for a different cell: different rollup
+        // group either way, so there is nothing to explain.
+        let other_cell = dir.join("other-cell.csv");
+        write_pre_engine_file(&other_cell, &["bench-c8"]);
+        assert!(
+            append_one_row(&engine_row("bench-c1", Some("vllm")), &other_cell)
+                .unwrap()
+                .is_none()
+        );
+
+        // The appended row has no engine either (non-vLLM endpoint), so it lands
+        // in the same group as the earlier rows.
+        let unlabelled = dir.join("unlabelled.csv");
+        write_pre_engine_file(&unlabelled, &["bench-c1"]);
+        assert!(
+            append_one_row(&engine_row("bench-c1", None), &unlabelled)
+                .unwrap()
+                .is_none()
+        );
+
+        // A brand-new file has no earlier rows at all.
+        let fresh = dir.join("fresh.csv");
+        assert!(
+            append_one_row(&engine_row("bench-c1", Some("vllm")), &fresh)
+                .unwrap()
+                .is_none()
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The notice names the file, not the cell, so a multi-cell sweep over a
+    /// file whose every cell predates the column must still warn exactly once.
+    #[tokio::test]
+    async fn engine_split_is_reported_once_per_sweep() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(stub_response(100, 50))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/metrics"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(prom_body_full(5, 2, 1.0, 10.0, 2.0, 100.0)),
+            )
+            .mount(&server)
+            .await;
+
+        let dir = tempdir();
+        let csv_path = dir.join("results.csv");
+        write_pre_engine_file(&csv_path, &["bench-c1", "bench-c2"]);
+
+        let mut spec = make_spec(&server.uri());
+        spec.requests = 2;
+        let reports = run_and_append_csv(&spec, &[1, 2], &csv_path).await.unwrap();
+
+        assert!(
+            reports.iter().all(|r| r.row.engine.as_deref() == Some("vllm")),
+            "the mock exposes vLLM metrics, so every row must be labelled"
+        );
+        let flagged: Vec<&str> = reports
+            .iter()
+            .filter_map(|r| r.engine_split.as_ref())
+            .map(|notice| notice.cell.as_str())
+            .collect();
+        assert_eq!(
+            flagged,
+            ["bench-c1"],
+            "both cells straddle the split, but the warning is about the file and must be raised once"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -2077,7 +2077,9 @@ mod tests {
         let reports = run_and_append_csv(&spec, &[1, 2], &csv_path).await.unwrap();
 
         assert!(
-            reports.iter().all(|r| r.row.engine.as_deref() == Some("vllm")),
+            reports
+                .iter()
+                .all(|r| r.row.engine.as_deref() == Some("vllm")),
             "the mock exposes vLLM metrics, so every row must be labelled"
         );
         let flagged: Vec<&str> = reports

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -534,8 +534,8 @@ fn prom_latency(
 /// cell issued between the before- and after-scrape. Returns `None` when the
 /// window cannot be measured: either scrape missing, the observation count did
 /// not advance (`Δcount ≤ 0`, no request recorded this metric in the window),
-/// the counter reset (`Δsum < 0`, a server restart), or either delta is `NaN`
-/// (defensive: see the guard below).
+/// the counter reset (`Δsum < 0`, a server restart), or either delta is not
+/// finite (defensive: see the guard below).
 ///
 /// The value is deliberately *not* backfilled from the after-scrape's lifetime
 /// `sum/count` average. That average covers every request the server process
@@ -568,7 +568,15 @@ fn latency_ms(
     // with `parse::<f64>()`, which accepts a `NaN` token from a malformed or
     // non-conforming exporter, and this is the last place to stop it before it
     // reaches an immutable CSV row.
-    (delta_count > 0.0 && delta_sum >= 0.0).then_some(delta_sum / delta_count * 1000.0)
+    //
+    // `±Inf` arrives the same way and needs its own conjunct, because the
+    // ordered comparisons above accept it: an infinite `Δsum` satisfies
+    // `>= 0.0` and reaches `opt_f64`, whose `{:.6}` writes a literal `inf` into
+    // a numeric column, while an infinite `Δcount` silently collapses a real
+    // `Δsum` to `0.000000`. Requiring both deltas finite closes both, and makes
+    // the "blank when unmeasurable" contract exact rather than NaN-only.
+    (delta_count > 0.0 && delta_sum >= 0.0 && delta_count.is_finite() && delta_sum.is_finite())
+        .then_some(delta_sum / delta_count * 1000.0)
 }
 
 /// Concurrency levels tried by [`run_auto_ramp`] in order.
@@ -1783,6 +1791,32 @@ mod tests {
         );
         assert_eq!(
             latency_ms(Some(1.0), Some(f64::NAN), Some(2.0), Some(12.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn latency_ms_is_none_when_a_counter_is_infinite() {
+        // Same class as the NaN case and the same entry point: `+Inf`/`-Inf`
+        // are legal exposition tokens that `parse::<f64>()` accepts verbatim.
+        // Unlike NaN they survive the ordered comparisons — an infinite `Δsum`
+        // is `>= 0.0`, so without the `is_finite` conjuncts `opt_f64` would
+        // write a literal `inf` into a numeric CSV column, and an infinite
+        // `Δcount` would report a real window as `0.000000` ms.
+        assert_eq!(
+            latency_ms(Some(1.0), Some(10.0), Some(f64::INFINITY), Some(12.0)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(f64::NEG_INFINITY), Some(10.0), Some(2.0), Some(12.0)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(1.0), Some(10.0), Some(2.0), Some(f64::INFINITY)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(1.0), Some(f64::NEG_INFINITY), Some(2.0), Some(12.0)),
             None
         );
     }

--- a/crates/rocm-dash-collectors/src/bench_load.rs
+++ b/crates/rocm-dash-collectors/src/bench_load.rs
@@ -505,7 +505,8 @@ fn prom_latency(
 /// cell issued between the before- and after-scrape. Returns `None` when the
 /// window cannot be measured: either scrape missing, the observation count did
 /// not advance (`Δcount ≤ 0`, no request recorded this metric in the window),
-/// or the counter reset (`Δsum < 0`, a server restart).
+/// the counter reset (`Δsum < 0`, a server restart), or either delta is `NaN`
+/// (Prometheus reports an unobserved histogram sum that way).
 ///
 /// The value is deliberately *not* backfilled from the after-scrape's lifetime
 /// `sum/count` average. That average covers every request the server process
@@ -524,7 +525,9 @@ fn latency_ms(
 ) -> Option<f64> {
     let delta_sum = sum_after? - sum_before?;
     let delta_count = count_after? - count_before?;
-    // Guard division by zero (flat counter) and counter resets.
+    // Phrased as acceptance, not rejection: every comparison against NaN is
+    // false, so this rejects a NaN delta where `if delta_count <= 0.0 || ...`
+    // would fall through and emit Some(NaN).
     (delta_count > 0.0 && delta_sum >= 0.0).then_some(delta_sum / delta_count * 1000.0)
 }
 
@@ -1639,6 +1642,35 @@ mod tests {
         assert_eq!(latency_ms(None, None, None, None), None);
         // count == 0 is not divisible → None, never a divide-by-zero number.
         assert_eq!(latency_ms(None, None, Some(0.0), Some(0.0)), None);
+    }
+
+    #[test]
+    fn latency_ms_is_none_when_a_counter_is_nan() {
+        // Prometheus emits NaN for a histogram sum with no observations, and
+        // `vllm_prom::parse` accepts it verbatim (`parse::<f64>()` parses
+        // "NaN"), so a NaN can reach this arithmetic from a real scrape.
+        //
+        // Every comparison against NaN is false, so a guard phrased as a
+        // rejection — `if delta_count <= 0.0 || delta_sum < 0.0 { None }` —
+        // falls through and writes Some(NaN) into an immutable CSV row. The
+        // acceptance phrasing used here rejects it instead. This test is what
+        // keeps the guard from being "simplified" back.
+        assert_eq!(
+            latency_ms(Some(1.0), Some(10.0), Some(f64::NAN), Some(12.0)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(1.0), Some(10.0), Some(2.0), Some(f64::NAN)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(f64::NAN), Some(10.0), Some(2.0), Some(12.0)),
+            None
+        );
+        assert_eq!(
+            latency_ms(Some(1.0), Some(f64::NAN), Some(2.0), Some(12.0)),
+            None
+        );
     }
 
     #[test]

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -153,9 +153,10 @@ reason = "Managed runtime path nests recursively (runtimes/wheel/...) on re-prov
 # matches those rows too: which of them pass varies run to run on that lane, and
 # a deterministic-XPASS row would fail the lane on unrelated PRs.
 #
-# This does NOT weaken the coverage the bench fix relies on: the three
-# MockServer-backed bench scenarios run unxfail'd on every lane, including this
-# one, and they are what pin the request path and the failure reporting.
+# This does NOT weaken the coverage the bench fix relies on: the five
+# MockServer-backed bench scenarios (bench-01 to bench-05) run unxfail'd on
+# every lane, including this one, and they are what pin the request path, the
+# failure reporting, the CSV columns, and the rollup-split warning.
 [["bench-load-real-serve"]]
 when = { effective_engine = "lemonade", os = "linux", therock_family = "gfx*", has_amd_gpu = true }
 bug = "EAI-7423"

--- a/tests/e2e-cucumber/features/bench.feature
+++ b/tests/e2e-cucumber/features/bench.feature
@@ -6,9 +6,9 @@ Feature: Benchmarking a served endpoint
   # one of the two 404'd — and every request failure was swallowed, so the run
   # still exited 0 with a row of blanks.
   #
-  # bench-01 to bench-03 run on every lane (MockServer-backed, no GPU needed)
-  # and are what pin the request path and the failure reporting. bench-04 is the
-  # hardware proof against a really served model.
+  # bench-01 to bench-04 run on every lane (MockServer-backed, no GPU needed)
+  # and are what pin the request path, the failure reporting, and the CSV
+  # columns. bench-05 is the hardware proof against a really served model.
 
   # The mock answers chat on BOTH the versioned and unversioned routes, so
   # "the benchmark succeeded" alone would pass even with the bug present. This
@@ -34,6 +34,17 @@ Feature: Benchmarking a served endpoint
     Then the benchmark reports that the requests failed
     And the benchmark does not report a successful run
 
+  # The value of the run is the CSV it writes, and two of its columns had no
+  # coverage: `engine` (which the run now labels from the `/metrics` scrape) and
+  # `tpot_ms` (the windowed per-output-token latency). A unit test on the helper
+  # doesn't prove the columns reach the file, so this asserts the emitted row
+  # against a metrics-backed mock whose histogram counters advance each scrape.
+  @id:bench-load-records-engine-and-tpot
+  Scenario: bench-04 - The recorded CSV row carries the engine and per-output-token latency
+    Given a model is being served with a metrics endpoint
+    When the user benchmarks the served endpoint recording results to a file
+    Then the recorded benchmark row is labelled the vLLM engine with a per-output-token latency
+
   # Hardware proof: a real `rocm serve` on this host (vLLM on Instinct, lemonade
   # on Strix Halo) benchmarked through the endpoint the CLI itself reports.
   #
@@ -42,7 +53,7 @@ Feature: Benchmarking a served endpoint
   # without an active ROCm runtime. Lemonade hosts do not need it, so omitting it
   # fails on Instinct alone — mirror the sibling GPU serve scenarios and keep it.
   @id:bench-load-real-serve @requires-gpu
-  Scenario: bench-04 - Benchmarking a really served model reports throughput
+  Scenario: bench-05 - Benchmarking a really served model reports throughput
     Given a managed runtime is active
     And a model is being served on GPU
     When the user benchmarks the served endpoint

--- a/tests/e2e-cucumber/features/bench.feature
+++ b/tests/e2e-cucumber/features/bench.feature
@@ -6,9 +6,10 @@ Feature: Benchmarking a served endpoint
   # one of the two 404'd — and every request failure was swallowed, so the run
   # still exited 0 with a row of blanks.
   #
-  # bench-01 to bench-04 run on every lane (MockServer-backed, no GPU needed)
-  # and are what pin the request path, the failure reporting, and the CSV
-  # columns. bench-05 is the hardware proof against a really served model.
+  # bench-01 to bench-05 run on every lane (MockServer-backed, no GPU needed)
+  # and are what pin the request path, the failure reporting, the CSV columns,
+  # and the rollup-split warning. bench-06 is the hardware proof against a
+  # really served model.
 
   # The mock answers chat on BOTH the versioned and unversioned routes, so
   # "the benchmark succeeded" alone would pass even with the bug present. This
@@ -45,6 +46,18 @@ Feature: Benchmarking a served endpoint
     When the user benchmarks the served endpoint recording results to a file
     Then the recorded benchmark row is labelled the vLLM engine with a per-output-token latency
 
+  # `engine` is a rollup key, so a results file holding a cell's rows from
+  # before the column was populated groups them apart from the rows written
+  # now: N trials become two smaller groups, and the Bench panel renders no
+  # `engine` column to explain it. Nothing in the file or on screen says why,
+  # so the run itself has to — which is behaviour, not a source comment.
+  @id:bench-load-warns-on-engine-split
+  Scenario: bench-05 - Appending over results that predate the engine column warns about the split
+    Given a model is being served with a metrics endpoint
+    And earlier results for the same cell were recorded without an engine
+    When the user benchmarks the served endpoint recording results to a file
+    Then the benchmark warns that the earlier rows group separately
+
   # Hardware proof: a real `rocm serve` on this host (vLLM on Instinct, lemonade
   # on Strix Halo) benchmarked through the endpoint the CLI itself reports.
   #
@@ -53,7 +66,7 @@ Feature: Benchmarking a served endpoint
   # without an active ROCm runtime. Lemonade hosts do not need it, so omitting it
   # fails on Instinct alone — mirror the sibling GPU serve scenarios and keep it.
   @id:bench-load-real-serve @requires-gpu
-  Scenario: bench-05 - Benchmarking a really served model reports throughput
+  Scenario: bench-06 - Benchmarking a really served model reports throughput
     Given a managed runtime is active
     And a model is being served on GPU
     When the user benchmarks the served endpoint

--- a/tests/e2e-cucumber/tests/e2e/bench_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/bench_steps.rs
@@ -18,9 +18,32 @@ use crate::E2eWorld;
 /// on throughput accuracy, and the GPU lane pays real inference time for each.
 const BENCH_REQUESTS: &str = "2";
 
+/// Deterministic path, inside the scenario's isolated root, that the CSV-content
+/// scenario writes to via `--out` and reads back — so the `then` step can assert
+/// on the emitted row without depending on the default `<data_dir>` layout.
+fn bench_out_path(world: &E2eWorld) -> std::path::PathBuf {
+    world
+        .isolated_root
+        .as_ref()
+        .expect("no isolated root for the benchmark output")
+        .path()
+        .join("bench-results.csv")
+}
+
 #[given("an endpoint that rejects every request")]
 async fn setup_rejecting_endpoint(world: &mut E2eWorld) {
     let mock = MockServer::start_rejecting().await;
+    world.endpoint = Some(mock.base_url());
+    world.model_name = Some("TestModel/E2E-1B".to_string());
+    world.mock = Some(mock);
+}
+
+#[given("a model is being served with a metrics endpoint")]
+async fn setup_model_server_with_metrics(world: &mut E2eWorld) {
+    // `start_with_metrics` exposes a vLLM-flavoured `/metrics` route whose
+    // TTFT/TPOT histograms advance every scrape, so the bench cell's before/
+    // after window measures a real per-output-token latency (not a flat one).
+    let mock = MockServer::start_with_metrics("TestModel/E2E-1B").await;
     world.endpoint = Some(mock.base_url());
     world.model_name = Some("TestModel/E2E-1B".to_string());
     world.mock = Some(mock);
@@ -88,6 +111,88 @@ fn run_bench(world: &mut E2eWorld, endpoint: &str) {
     world.cli_output = Some(stdout);
     world.cli_stderr = Some(stderr);
     world.cli_rc = Some(rc);
+}
+
+/// Benchmark the metrics-backed endpoint, writing the row to a known `--out`
+/// file so the row's `engine`/`tpot_ms` columns can be asserted directly.
+#[when("the user benchmarks the served endpoint recording results to a file")]
+async fn benchmark_recording_results(world: &mut E2eWorld) {
+    let endpoint = world
+        .endpoint
+        .clone()
+        .expect("no endpoint configured for the benchmark");
+    let model = world
+        .model_name
+        .clone()
+        .expect("no model configured for the benchmark");
+    let out = bench_out_path(world);
+    let out = out.to_str().expect("bench output path is not valid UTF-8");
+    let (stdout, stderr, rc) = crate::run_rocm(
+        world,
+        &[
+            "bench",
+            "load",
+            "--endpoint",
+            endpoint.as_str(),
+            "--model",
+            &model,
+            "--concurrency",
+            "1",
+            "--isl",
+            "8",
+            "--osl",
+            "4",
+            "--requests",
+            BENCH_REQUESTS,
+            "--out",
+            out,
+        ],
+    );
+    world.cli_output = Some(stdout);
+    world.cli_stderr = Some(stderr);
+    world.cli_rc = Some(rc);
+}
+
+#[then("the recorded benchmark row is labelled the vLLM engine with a per-output-token latency")]
+async fn assert_row_engine_and_tpot(world: &mut E2eWorld) {
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    let stderr = world.cli_stderr.as_deref().unwrap_or("");
+    let rc = world.cli_rc.expect("no command was run");
+    assert!(
+        rc == 0,
+        "rocm bench load failed (rc={rc}):\n{stdout}{stderr}"
+    );
+
+    let path = bench_out_path(world);
+    let csv = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read bench CSV {}: {e}", path.display()));
+    let mut lines = csv.lines();
+    let header = lines
+        .next()
+        .unwrap_or_else(|| panic!("bench CSV is empty:\n{csv}"));
+    let data = lines
+        .next()
+        .unwrap_or_else(|| panic!("bench CSV has no data row:\n{csv}"));
+
+    let cols: Vec<&str> = header.split(',').collect();
+    let col = |name: &str| {
+        let idx = cols
+            .iter()
+            .position(|c| *c == name)
+            .unwrap_or_else(|| panic!("no `{name}` column in header: {header}"));
+        data.split(',').nth(idx).unwrap_or("")
+    };
+
+    assert_eq!(
+        col("engine"),
+        "vllm",
+        "the emitted row must carry engine=vllm from the recognised /metrics scrape:\n{data}"
+    );
+    let tpot = col("tpot_ms");
+    assert!(
+        tpot.parse::<f64>().is_ok_and(|v| v > 0.0),
+        "the emitted row must carry a positive tpot_ms from the advancing counter, got {tpot:?}:\n{data}"
+    );
 }
 
 #[then("the benchmark reports measured throughput")]

--- a/tests/e2e-cucumber/tests/e2e/bench_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/bench_steps.rs
@@ -57,7 +57,7 @@ async fn benchmark_served_endpoint(world: &mut E2eWorld) {
         .endpoint
         .clone()
         .expect("no endpoint configured for the benchmark");
-    run_bench(world, &endpoint);
+    run_bench(world, &endpoint, None);
 }
 
 /// Benchmark using the bare `scheme://host:port` form, dropping the API-root
@@ -78,36 +78,49 @@ async fn benchmark_plain_host_address(world: &mut E2eWorld) {
         !plain.ends_with("/v1"),
         "the plain form must not keep the API-root suffix: {plain}"
     );
-    run_bench(world, &plain);
+    run_bench(world, &plain, None);
 }
 
-fn run_bench(world: &mut E2eWorld, endpoint: &str) {
+/// Run one `rocm bench load` cell against `endpoint`, optionally recording the
+/// row to `out`, and park the outcome on the world for the `then` steps.
+///
+/// Every scenario here runs the same single-cell shape; only the endpoint form
+/// and whether the row is written to a known path differ, so they share one
+/// argv builder rather than each keeping its own copy to drift.
+fn run_bench(world: &mut E2eWorld, endpoint: &str, out: Option<&std::path::Path>) {
     let model = world
         .model_name
         .clone()
         .expect("no model configured for the benchmark");
-    // `--out` lands inside the scenario's isolated data dir by default; the
-    // explicit model avoids depending on the endpoint's model-listing route,
-    // which the rejecting server deliberately fails.
-    let (stdout, stderr, rc) = crate::run_rocm(
-        world,
-        &[
-            "bench",
-            "load",
-            "--endpoint",
-            endpoint,
-            "--model",
-            &model,
-            "--concurrency",
-            "1",
-            "--isl",
-            "8",
-            "--osl",
-            "4",
-            "--requests",
-            BENCH_REQUESTS,
-        ],
-    );
+    // Without `--out` the row lands inside the scenario's isolated data dir by
+    // default; the explicit model avoids depending on the endpoint's
+    // model-listing route, which the rejecting server deliberately fails.
+    let mut args = vec![
+        "bench",
+        "load",
+        "--endpoint",
+        endpoint,
+        "--model",
+        &model,
+        "--concurrency",
+        "1",
+        "--isl",
+        "8",
+        "--osl",
+        "4",
+        "--requests",
+        BENCH_REQUESTS,
+    ];
+    let out = out.map(|path| {
+        path.to_str()
+            .expect("bench output path is not valid UTF-8")
+            .to_string()
+    });
+    if let Some(out) = out.as_deref() {
+        args.extend_from_slice(&["--out", out]);
+    }
+
+    let (stdout, stderr, rc) = crate::run_rocm(world, &args);
     world.cli_output = Some(stdout);
     world.cli_stderr = Some(stderr);
     world.cli_rc = Some(rc);
@@ -125,36 +138,8 @@ fn run_bench_recording(world: &mut E2eWorld) {
         .endpoint
         .clone()
         .expect("no endpoint configured for the benchmark");
-    let model = world
-        .model_name
-        .clone()
-        .expect("no model configured for the benchmark");
     let out = bench_out_path(world);
-    let out = out.to_str().expect("bench output path is not valid UTF-8");
-    let (stdout, stderr, rc) = crate::run_rocm(
-        world,
-        &[
-            "bench",
-            "load",
-            "--endpoint",
-            endpoint.as_str(),
-            "--model",
-            &model,
-            "--concurrency",
-            "1",
-            "--isl",
-            "8",
-            "--osl",
-            "4",
-            "--requests",
-            BENCH_REQUESTS,
-            "--out",
-            out,
-        ],
-    );
-    world.cli_output = Some(stdout);
-    world.cli_stderr = Some(stderr);
-    world.cli_rc = Some(rc);
+    run_bench(world, &endpoint, Some(&out));
 }
 
 /// Leave behind the results file a build that never populated `engine` would
@@ -281,10 +266,17 @@ async fn assert_row_engine_and_tpot(world: &mut E2eWorld) {
         "vllm",
         "the emitted row must carry engine=vllm from the recognised /metrics scrape:\n{data}"
     );
+    // The mock's TPOT histogram adds 0.4 s of `_sum` per 20 `_count` on every
+    // scrape, so Δsum/Δcount is exactly 0.020 s however many scrapes the window
+    // spans: 20 ms. Asserting the value rather than just its sign is what makes
+    // this pin the windowed arithmetic — a lifetime `sum/count` backfill or a
+    // unit slip would also be "positive".
+    const EXPECTED_TPOT_MS: f64 = 20.0;
     let tpot = col("tpot_ms");
     assert!(
-        tpot.parse::<f64>().is_ok_and(|v| v > 0.0),
-        "the emitted row must carry a positive tpot_ms from the advancing counter, got {tpot:?}:\n{data}"
+        tpot.parse::<f64>()
+            .is_ok_and(|v| (v - EXPECTED_TPOT_MS).abs() < 0.5),
+        "the emitted row must carry the mock's windowed tpot_ms of {EXPECTED_TPOT_MS} ms, got {tpot:?}:\n{data}"
     );
 }
 

--- a/tests/e2e-cucumber/tests/e2e/bench_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/bench_steps.rs
@@ -18,6 +18,15 @@ use crate::E2eWorld;
 /// on throughput accuracy, and the GPU lane pays real inference time for each.
 const BENCH_REQUESTS: &str = "2";
 
+/// Windowed `tpot_ms` the metrics mock is built to produce, in milliseconds.
+///
+/// Its TPOT histogram adds 0.4 s of `_sum` per 20 `_count` on every scrape, so
+/// `Δsum/Δcount` is exactly 0.020 s however many scrapes the cell's window
+/// spans. Asserting the value rather than just its sign is what makes the CSV
+/// scenario pin the windowed arithmetic — a lifetime `sum/count` backfill or a
+/// unit slip would also be "positive".
+const EXPECTED_TPOT_MS: f64 = 20.0;
+
 /// Deterministic path, inside the scenario's isolated root, that the CSV-content
 /// scenario writes to via `--out` and reads back — so the `then` step can assert
 /// on the emitted row without depending on the default `<data_dir>` layout.
@@ -266,12 +275,6 @@ async fn assert_row_engine_and_tpot(world: &mut E2eWorld) {
         "vllm",
         "the emitted row must carry engine=vllm from the recognised /metrics scrape:\n{data}"
     );
-    // The mock's TPOT histogram adds 0.4 s of `_sum` per 20 `_count` on every
-    // scrape, so Δsum/Δcount is exactly 0.020 s however many scrapes the window
-    // spans: 20 ms. Asserting the value rather than just its sign is what makes
-    // this pin the windowed arithmetic — a lifetime `sum/count` backfill or a
-    // unit slip would also be "positive".
-    const EXPECTED_TPOT_MS: f64 = 20.0;
     let tpot = col("tpot_ms");
     assert!(
         tpot.parse::<f64>()

--- a/tests/e2e-cucumber/tests/e2e/bench_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/bench_steps.rs
@@ -117,6 +117,10 @@ fn run_bench(world: &mut E2eWorld, endpoint: &str) {
 /// file so the row's `engine`/`tpot_ms` columns can be asserted directly.
 #[when("the user benchmarks the served endpoint recording results to a file")]
 async fn benchmark_recording_results(world: &mut E2eWorld) {
+    run_bench_recording(world);
+}
+
+fn run_bench_recording(world: &mut E2eWorld) {
     let endpoint = world
         .endpoint
         .clone()
@@ -151,6 +155,95 @@ async fn benchmark_recording_results(world: &mut E2eWorld) {
     world.cli_output = Some(stdout);
     world.cli_stderr = Some(stderr);
     world.cli_rc = Some(rc);
+}
+
+/// Leave behind the results file a build that never populated `engine` would
+/// have written for this same cell.
+///
+/// Produced by running the benchmark once and then blanking the `engine` column
+/// of the row it wrote, rather than by pasting a fixture: an append whose header
+/// does not match byte-for-byte is refused outright, so a hand-written file
+/// would decay into a header-mismatch failure that proves nothing about the
+/// warning. Blanking is also exactly how a run against an endpoint with no
+/// reachable `/metrics` leaves the column, which is the other way the split
+/// happens.
+#[given("earlier results for the same cell were recorded without an engine")]
+async fn seed_results_recorded_without_an_engine(world: &mut E2eWorld) {
+    run_bench_recording(world);
+    let rc = world.cli_rc.expect("no command was run");
+    assert!(
+        rc == 0,
+        "the seeding benchmark run failed (rc={rc}):\n{}{}",
+        world.cli_output.as_deref().unwrap_or(""),
+        world.cli_stderr.as_deref().unwrap_or("")
+    );
+
+    let path = bench_out_path(world);
+    let csv = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read bench CSV {}: {e}", path.display()));
+    let blanked = blank_engine_column(&csv);
+    assert_ne!(
+        blanked, csv,
+        "the seeding run wrote no engine value to blank:\n{csv}"
+    );
+    std::fs::write(&path, blanked).expect("could not rewrite the seeded bench CSV");
+}
+
+/// Empty the `engine` field of every data row, locating it by header name so a
+/// column reorder cannot silently blank the wrong one.
+fn blank_engine_column(csv: &str) -> String {
+    let mut lines = csv.lines();
+    let header = lines.next().unwrap_or_else(|| panic!("bench CSV is empty"));
+    let idx = header
+        .split(',')
+        .position(|c| c == "engine")
+        .unwrap_or_else(|| panic!("no `engine` column in header: {header}"));
+
+    let mut out = format!("{header}\n");
+    for line in lines {
+        let mut fields: Vec<&str> = line.split(',').collect();
+        if let Some(field) = fields.get_mut(idx) {
+            *field = "";
+        }
+        out.push_str(&fields.join(","));
+        out.push('\n');
+    }
+    out
+}
+
+#[then("the benchmark warns that the earlier rows group separately")]
+async fn assert_engine_split_warning(world: &mut E2eWorld) {
+    let stdout = world.cli_output.as_deref().unwrap_or("");
+    let stderr = world.cli_stderr.as_deref().unwrap_or("");
+    let rc = world.cli_rc.expect("no command was run");
+    // A split is worth saying out loud, but the run still measured what it was
+    // asked to: warn, do not fail.
+    assert!(
+        rc == 0,
+        "rocm bench load failed (rc={rc}):\n{stdout}{stderr}"
+    );
+
+    let warning = stderr
+        .lines()
+        .find(|line| line.contains("blank engine column"))
+        .unwrap_or_else(|| {
+            panic!("the run did not warn about the pre-existing blank-engine rows:\n{stderr}")
+        });
+    // Naming the cell and the file is what makes the warning actionable: the
+    // Bench panel renders no `engine` column, so without them there is nothing
+    // to connect a halved group to.
+    assert!(
+        warning.contains("bench-c1"),
+        "the warning must name the affected cell:\n{warning}"
+    );
+    assert!(
+        warning.contains("bench-results.csv"),
+        "the warning must name the file holding both groups:\n{warning}"
+    );
+    assert!(
+        stderr.contains("rotate"),
+        "the warning must say what to do about it:\n{stderr}"
+    );
 }
 
 #[then("the recorded benchmark row is labelled the vLLM engine with a per-output-token latency")]


### PR DESCRIPTION
## Summary

`bench load` writes a CSV whose header includes `engine` and `tpot_ms`, but the
`engine` field was always blank in the data row, and `tpot_ms` was frequently
blank too (while `ttft_ms` was populated). Since the CSV feeds the dashboard
Bench panel, `engine` was missing there as well.

- **`engine` — the behaviour fix.** The load generator's only view of the
  backend is its Prometheus `/metrics` endpoint, and the scraper only
  understands vLLM's `vllm:` series. A scrape carrying any recognised vLLM field
  now labels the row, taking the string from the engine registry itself
  (`EngineKind::Vllm.label()`) rather than respelling it, so the CSV value cannot
  drift from the registry. A non-vLLM / 404 endpoint leaves the column blank
  rather than guessing.
- **`tpot_ms` — semantics kept, now documented and covered.** A blank `tpot_ms`
  is not an arithmetic bug. Latency stays strictly windowed —
  `Δsum/Δcount × 1000` over the cell's before/after scrapes — and a missing
  scrape, a flat counter, or a counter reset each leave the column blank. It is
  deliberately *not* backfilled from the endpoint's lifetime `sum/count`
  average: that average covers earlier ramp cells and other clients, so writing
  it into this cell's immutable row would describe a different population than
  the row names, with nothing to flag it. A blank column therefore honestly
  means "not measured for this cell". The helpers are renamed
  (`prom_deltas`/`latency_delta_ms` → `prom_latency`/`latency_ms`, dropping the
  unused placeholder return values). The docstring now records where this
  deliberately *differs* from the telemetry daemon's `avg_ms_from_histogram`,
  which does fall back because it is a repeated live poll with a rolling
  baseline that persists nothing.
- **One CSV cell changes value, not only its name.** The guard on the deltas is
  now phrased as an acceptance (`Δcount > 0 && Δsum >= 0`) rather than a
  rejection (`if Δcount <= 0.0 || Δsum < 0.0 { return None }`). Every comparison
  against NaN is false, so the old form let a NaN delta fall through and return
  `Some(NaN)`, which `opt_f64` wrote into `results.csv` as a literal `NaN` cell;
  the new form returns `None`, so that cell is blank. Blank is the honest
  answer, and a `NaN` token in a numeric column is a downstream hazard — but it
  is a change to what lands in the file, not a pure rename. (An earlier revision
  of this PR body claimed the computed values were unchanged. That was wrong.)
- **Non-finite deltas are rejected too.** `±Inf` reaches the arithmetic by the
  same route as NaN — they are legal exposition tokens that `parse::<f64>()`
  accepts verbatim — but unlike NaN they survive the ordered comparisons: an
  infinite `Δsum` satisfies `>= 0.0` and reached `opt_f64`, whose `{:.6}` wrote
  a literal `inf` into a numeric column, while an infinite `Δcount` collapsed a
  real `Δsum` to `0.000000`. Both deltas must now be finite, which makes the
  "blank when unmeasurable" contract exact rather than NaN-only.

## Reproduce

```
rocm bench load --endpoint http://127.0.0.1:11435/v1 --requests 2 --concurrency 1 --out /tmp/b.csv
head -2 /tmp/b.csv
```

Before: `engine` empty.
After: `engine` populated (`vllm`). `tpot_ms` carries the windowed value when the
endpoint's TPOT counter advanced across the two scrapes, and stays blank when it
did not.

## Migration: a shared `results.csv` written across this change

**`engine` is a rollup key**, and `rocm bench load` appends to one shared
`<data_dir>/bench/results.csv` by default. Trials of a cell are rows differing
only by `run`, so a file spanning this change holds two groups for the same
cell: the pre-change trials (blank `engine`) and the post-change ones (`vllm`).
N trials become two smaller groups — a Pass^N over N trials becomes two N=1
groups, which `at_n_mark` renders as a muted dash. Nothing on screen explains
it: the Bench rollup table renders `cell/model/tp·dtype/concurrency` and never
`engine`, so the two groups look identical, and the table caps at 8 data rows,
so doubling the group count can push cells off it entirely.

This is not only an upgrade artefact — the same split follows any two runs of a
cell where `/metrics` was reachable for one and not the other (a remote
endpoint, metrics disabled, a restart mid-series).

**Rotate or move `results.csv` if you compare trials across the change.** The
run now says so itself rather than leaving it to a source comment: while holding
the append lock, a row that carries an `engine` scans the target file for
earlier rows of the same cell without one, and the CLI warns once per run,
naming the file, the cell, and the fix. The row is still appended — this is a
warning, not a refusal:

```
warning: /home/u/.rocm/bench/results.csv already has rows for bench-c1 with a blank engine
column; `engine` is a rollup key, so those trials group separately from this run's
engine=vllm rows
hint: rotate or move that file if you are comparing trials across the change
```

Rendering `engine` in the Bench rollup table would also make a split group
explicable rather than mysterious. That is a TUI change interacting with the
8-row height cap, so it is deliberately not in this PR.

## The NaN guard: corrected rationale

Commit `163224ad`'s message, and the code comments it added, justified the guard
by claiming Prometheus reports an unobserved histogram sum as NaN. **That is
wrong.** A histogram's `_sum`/`_count` are counters that `prometheus_client` —
which is what vLLM uses for `vllm:time_to_first_token_seconds` and
`vllm:time_per_output_token_seconds` — initialises to `0.0` and `0`; NaN appears
in text exposition for *summary quantiles* with no observations and for gauges
explicitly set to NaN, neither of which is among the four series `vllm_prom`
reads.

The guard stays, on accurate ground: `vllm_prom::extract` ends in
`parse::<f64>()`, which accepts `NaN` and `±Inf` tokens alike, so a malformed or
non-conforming exporter can still put one into the arithmetic, and this is the
last place to stop it before an immutable CSV row. **The guard is therefore defensive, not a
response to an observed exposition.** That is also why it is covered by a unit
test rather than a Gherkin scenario (AGENTS.md §3): the path is unreachable from
any conforming endpoint, so there is no user-observable behaviour to script
against — bench-04's mock counters always advance and never reach it, and a mock
that emitted `NaN` would be asserting on a fixture nobody can produce in the
field. The blank-vs-`NaN` cell change above is the user-visible part, and it is
stated here rather than left in a commit message.

The code comments carrying the wrong claim are corrected in this PR. `163224ad`'s
message cannot be corrected without rewriting a pushed branch, so it stands as
superseded by the paragraph above.

## Tests

The user-observable behaviour — the columns the CLI writes into the CSV, and the
warning it prints — is covered by two Gherkin scenarios in
`tests/e2e-cucumber/features/bench.feature`, both ungated, so they run on every
lane:

- `@id:bench-load-records-engine-and-tpot` (`bench-04`) benchmarks a mock
  endpoint whose vLLM-flavoured `/metrics` histograms advance on every scrape,
  reads the `--out` CSV back, and asserts the emitted row carries `engine=vllm`
  and a `tpot_ms` of 20 ms. The mock's TPOT histogram adds 0.4 s of `_sum` per
  20 `_count` on every scrape, so `Δsum/Δcount` is exactly 0.020 s however many
  scrapes the window spans; asserting the value rather than merely its sign is
  what makes the scenario pin the windowed arithmetic, since a lifetime
  `sum/count` backfill or a unit slip would also be "positive".
- `@id:bench-load-warns-on-engine-split` (`bench-05`, new) runs the benchmark
  once, blanks the `engine` column of the row it wrote — exactly what a
  pre-change build, or a run with no reachable `/metrics`, leaves behind — then
  benchmarks again and asserts the run warns, names the cell and the file, and
  still exits 0. The fixture is produced by the CLI rather than pasted so it
  cannot drift from `CSV_HEADER` (a mismatched header is refused outright).

The pre-existing GPU scenario is renumbered `bench-06`, otherwise unchanged. The
sentence in `tests/e2e-cucumber/expectations.toml` that justifies the
`bench-load-real-serve` xfail is updated to match: it still said "the three
MockServer-backed bench scenarios ... pin the request path and the failure
reporting", which undercounted them and omitted the CSV columns.

Unit tests cover `latency_ms` (windowed value; blank on a flat counter, on a
missing before-scrape, on a counter reset, on a NaN delta, on an infinite
delta, and with no data at all), `detect_engine` (recognised sample → `vllm`; absent or empty sample →
blank), the split detection (flagged for the same cell; quiet when the earlier
rows already carry the engine, when they belong to another cell, when the new
row has no engine, and on a fresh file; raised once per sweep, not once per
cell; and a guard that the scanned column indexes still match `CSV_HEADER`), and
two bench-row tests over a mock endpoint: one reproducing the real symptom (TPOT
counter flat while TTFT advances), asserting `engine` is populated and `tpot_ms`
stays blank, and one where the counter advances, asserting `tpot_ms` is
populated. The existing `t7` non-vLLM test is extended to assert `engine` stays
blank.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --all-targets` — passed
- `cargo xtask e2e` — bench feature green (bench-01 … bench-06)
- Every added test was falsified: each was confirmed red against a deliberate
  break of the code it covers, and green again after restoring it.

