### PR TITLE
fix(release): reuse an existing release instead of creating a duplicate draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,15 @@ jobs:
             --asset "${DIST}.tar.gz" \
             --asset rocm-cli-linux-amd64.tar.gz
 
-      - name: Create release
+      - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.value }}"
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            gh release upload "${VERSION}" dist/*.tar.gz dist/*.tar.gz.sha256 dist/*.sig --clobber
+            exit 0
+          fi
           gh release create "${VERSION}" \
             --draft \
             --title "rocm-cli ${VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,15 @@ jobs:
           EOF
           )"
           if gh release view "${VERSION}" >/dev/null 2>&1; then
-            gh release edit "${VERSION}" --notes "${NOTES}"
+            EXISTING_BODY="$(gh release view "${VERSION}" --json body -q .body)"
+            if [[ "${EXISTING_BODY}" != *"Install the latest stable release on Linux x86_64"* ]]; then
+              if [ -n "${EXISTING_BODY}" ]; then
+                COMBINED_NOTES="${EXISTING_BODY}"$'\n\n'"${NOTES}"
+                gh release edit "${VERSION}" --notes "${COMBINED_NOTES}"
+              else
+                gh release edit "${VERSION}" --notes "${NOTES}"
+              fi
+            fi
             gh release upload "${VERSION}" dist/*.tar.gz dist/*.tar.gz.sha256 dist/*.sig --clobber
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,14 +149,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.version.outputs.value }}"
-          if gh release view "${VERSION}" >/dev/null 2>&1; then
-            gh release upload "${VERSION}" dist/*.tar.gz dist/*.tar.gz.sha256 dist/*.sig --clobber
-            exit 0
-          fi
-          gh release create "${VERSION}" \
-            --draft \
-            --title "rocm-cli ${VERSION}" \
-            --notes "$(cat <<EOF
+          NOTES="$(cat <<EOF
           Install the latest stable release on Linux x86_64:
 
           \`\`\`bash
@@ -175,7 +168,16 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | sh -s -- ${VERSION}
           \`\`\`
           EOF
-          )" \
+          )"
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            gh release edit "${VERSION}" --notes "${NOTES}"
+            gh release upload "${VERSION}" dist/*.tar.gz dist/*.tar.gz.sha256 dist/*.sig --clobber
+            exit 0
+          fi
+          gh release create "${VERSION}" \
+            --draft \
+            --title "rocm-cli ${VERSION}" \
+            --notes "${NOTES}" \
             dist/*.tar.gz dist/*.tar.gz.sha256 dist/*.sig
 
   windows-release:


### PR DESCRIPTION
## Summary
- When you create a release manually via GitHub's UI, the new tag push re-triggers this workflow.
- The Linux job's `gh release create` step ran unconditionally, and GitHub allows multiple draft releases per tag, so it created a second draft holding the Linux assets while Windows assets and the publish step landed on the release you created.
- The job now checks `gh release view "$VERSION"` first; if a release already exists for the tag, it uploads assets to it (`--clobber`) instead of creating a new draft.

## Test plan
- [ ] Manually create a release via the GitHub UI for a test tag and confirm the workflow uploads Linux + Windows assets to that single release with no duplicate draft.