### PR TITLE
fix(dash): validate --replay path before entering the TUI

### DIFF
--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -294,8 +294,54 @@ fn prune_stale_demo_sessions(dir: &Path, keep: &Path) {
     }
 }
 
+/// Validate a user-supplied `--replay` path before the dashboard takes over the
+/// terminal. Fails fast with a clear error (and, via the returned `Err`, a
+/// non-zero exit) when the file is missing, is a directory, or is not readable —
+/// rather than entering the alt-screen and only then surfacing a disconnect
+/// inside the TUI. Pure filesystem check → unit-testable without a terminal.
+///
+/// Only a *directory* is rejected on shape, not "not a regular file": the replay
+/// reader is `std::fs::read_to_string`, which happily reads FIFOs, `/dev/stdin`,
+/// and process-substitution paths (`--replay <(zcat rec.ndjson.gz)`), all of
+/// which `metadata().is_file()` would reject. A missing-vs-unreadable distinction
+/// is made by matching the `metadata` error kind, so a permission-denied parent
+/// is not mislabelled "not found".
+fn validate_replay_path(path: &Path) -> Result<()> {
+    let meta = std::fs::metadata(path).map_err(|err| match err.kind() {
+        std::io::ErrorKind::NotFound => {
+            anyhow::anyhow!("replay file not found: {}", path.display())
+        }
+        _ => anyhow::anyhow!("cannot read replay file: {}: {err}", path.display()),
+    })?;
+    if meta.is_dir() {
+        anyhow::bail!(
+            "replay path is a directory, not a recording: {}",
+            path.display()
+        );
+    }
+    // Confirm a *regular* file actually opens for reading — a successful `stat`
+    // only needs a traversable parent, not a readable file — so a mode-0
+    // recording fails here instead of after the alt-screen has taken over. Only
+    // regular files are pre-opened: opening a FIFO / `/dev/stdin` / process
+    // substitution would block on, or consume, the one-shot stream the replay
+    // reader (`read_to_string`) is about to read, so those are left to the reader.
+    if meta.is_file() {
+        std::fs::File::open(path)
+            .with_context(|| format!("replay file is not readable: {}", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Entry point for `rocm dash`. Builds a tokio runtime and runs the dashboard.
 pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
+    // Validate a user-supplied `--replay` path up front — before building the
+    // runtime or entering the alt-screen — so a missing/unreadable file fails
+    // fast with a clear error and non-zero exit instead of silently taking over
+    // the terminal and surfacing a disconnect inside the TUI. `--demo` writes
+    // its own session below, so it is exempt.
+    if !demo && let Some(path) = replay.as_deref() {
+        validate_replay_path(path)?;
+    }
     let paths = AppPaths::discover()?;
     let config = RocmCliConfig::load(&paths)?;
     // `--demo` writes a synthetic session and replays it, so the dashboard shows
@@ -1018,5 +1064,111 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// EAI-8366 regression: `rocm dash --replay <missing>` must fail the upfront
+    /// validation with a clear "not found" error (→ non-zero exit) instead of
+    /// entering the alt-screen and surfacing a disconnect inside the TUI.
+    #[test]
+    fn validate_replay_path_rejects_missing_file() {
+        let missing = std::env::temp_dir().join(format!(
+            "rocm-cli-replay-missing-{}-{}.ndjson",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        // Guard against a pre-existing file from a prior crashed run.
+        let _ = std::fs::remove_file(&missing);
+
+        let err = validate_replay_path(&missing).expect_err("missing file must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("replay file not found"),
+            "error must name the missing replay file: {msg}"
+        );
+    }
+
+    /// A directory passed to `--replay` is present but is not a replayable
+    /// recording; validation must reject it up front rather than in the TUI.
+    #[test]
+    fn validate_replay_path_rejects_directory() {
+        let dir = std::env::temp_dir().join(format!(
+            "rocm-cli-replay-dir-{}-{}",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let err = validate_replay_path(&dir).expect_err("a directory must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("is a directory"),
+            "error must explain the path is a directory: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// EAI-8366 regression for the readability branch the PR advertises but did
+    /// not cover: a present, regular recording that cannot be opened (mode 0o000)
+    /// must be rejected up front — not after the alt-screen has taken over. Unix
+    /// only (Windows has no equivalent open-time read bit) and skipped as root,
+    /// where the mode is not enforced.
+    #[cfg(unix)]
+    #[test]
+    fn validate_replay_path_rejects_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if rocm_core::openmpi::running_as_root() {
+            // Mode 0o000 is not enforced for uid 0, so the open would succeed and
+            // the branch under test cannot be exercised.
+            return;
+        }
+
+        let file = std::env::temp_dir().join(format!(
+            "rocm-cli-replay-unreadable-{}-{}.ndjson",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        std::fs::write(&file, "{}\n").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let err = validate_replay_path(&file).expect_err("an unreadable file must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not readable") || msg.contains("Permission denied"),
+            "error must explain the file is not readable: {msg}"
+        );
+
+        // Restore permissions so cleanup can remove the file.
+        let _ = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600));
+        let _ = std::fs::remove_file(&file);
+    }
+
+    /// EAI-8366 regression: a readable *non-regular* input (here `/dev/null`, a
+    /// character device — a stand-in for the FIFO / `/dev/stdin` / process-
+    /// substitution paths the replay reader handles) must NOT be rejected on
+    /// shape. Only a directory is a shape error; requiring a regular file would
+    /// break streaming replays.
+    #[cfg(unix)]
+    #[test]
+    fn validate_replay_path_accepts_non_regular_readable_input() {
+        validate_replay_path(Path::new("/dev/null"))
+            .expect("a readable non-regular input must pass validation");
+    }
+
+    /// A present, readable recording passes validation so the normal replay
+    /// flow proceeds into the dashboard unchanged.
+    #[test]
+    fn validate_replay_path_accepts_readable_file() {
+        let file = std::env::temp_dir().join(format!(
+            "rocm-cli-replay-ok-{}-{}.ndjson",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        std::fs::write(&file, "{}\n").unwrap();
+
+        validate_replay_path(&file).expect("a readable file must pass validation");
+
+        let _ = std::fs::remove_file(&file);
     }
 }

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -338,7 +338,11 @@ pub fn run(replay: Option<PathBuf>, demo: bool, chat_mock: bool) -> Result<()> {
     // runtime or entering the alt-screen — so a missing/unreadable file fails
     // fast with a clear error and non-zero exit instead of silently taking over
     // the terminal and surfacing a disconnect inside the TUI. `--demo` writes
-    // its own session below, so it is exempt.
+    // its own session below, so it is exempt: `--demo` overwrites `replay` with
+    // that generated path, so a caller-supplied one is never read in demo mode
+    // and must not be rejected. `conflicts_with` rules the pair out on the CLI,
+    // but this is a `pub fn` whose two flags arrive independently, so the guard
+    // is a real precondition at this boundary rather than dead code.
     if !demo && let Some(path) = replay.as_deref() {
         validate_replay_path(path)?;
     }
@@ -1158,6 +1162,11 @@ mod tests {
     ///
     /// A readable character device such as `/dev/null` cannot stand in here: it
     /// opens instantly, so it passes with or without the narrowing.
+    ///
+    /// Unix only: `mkfifo` has no Windows equivalent, and Windows named pipes
+    /// live in the `\\.\pipe\` namespace rather than on the filesystem, so the
+    /// blocking-open behaviour this pins cannot be staged there. The narrowing
+    /// under test is platform-independent, so this covers it for every target.
     #[cfg(unix)]
     #[allow(unsafe_code)] // libc FFI: mkfifo has no std equivalent
     #[test]

--- a/apps/rocm/src/dash.rs
+++ b/apps/rocm/src/dash.rs
@@ -1144,16 +1144,56 @@ mod tests {
         let _ = std::fs::remove_file(&file);
     }
 
-    /// EAI-8366 regression: a readable *non-regular* input (here `/dev/null`, a
-    /// character device — a stand-in for the FIFO / `/dev/stdin` / process-
-    /// substitution paths the replay reader handles) must NOT be rejected on
-    /// shape. Only a directory is a shape error; requiring a regular file would
-    /// break streaming replays.
+    /// EAI-8366 regression covering *both* halves of the non-regular-file
+    /// contract, on a real one-shot stream rather than a stand-in:
+    ///
+    /// 1. a FIFO must not be rejected on shape — only a directory is a shape
+    ///    error, and requiring a regular file would break `--replay <(...)`;
+    /// 2. validation must not *pre-open* it. `open(2)` on a writer-less FIFO
+    ///    blocks until a writer arrives, so dropping the `is_file()` narrowing
+    ///    around the readability probe hangs `rocm dash` before the TUI starts
+    ///    (and, with a writer, would consume the stream the replay reader is
+    ///    about to read). The validation therefore runs on a worker thread and
+    ///    must report back well inside the timeout below.
+    ///
+    /// A readable character device such as `/dev/null` cannot stand in here: it
+    /// opens instantly, so it passes with or without the narrowing.
     #[cfg(unix)]
+    #[allow(unsafe_code)] // libc FFI: mkfifo has no std equivalent
     #[test]
-    fn validate_replay_path_accepts_non_regular_readable_input() {
-        validate_replay_path(Path::new("/dev/null"))
-            .expect("a readable non-regular input must pass validation");
+    fn validate_replay_path_accepts_a_fifo_without_opening_it() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let fifo = std::env::temp_dir().join(format!(
+            "rocm-cli-replay-fifo-{}-{}",
+            std::process::id(),
+            rocm_core::unix_time_millis()
+        ));
+        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the
+        // call, and `mkfifo` only reads it.
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+
+        // No writer is ever opened for this FIFO, so any `open` of it blocks
+        // indefinitely. The worker thread is deliberately not joined: if the
+        // validation regresses it stays parked in `open` until the test process
+        // exits, and the timeout below is what fails the test.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let probe = fifo.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(validate_replay_path(&probe).map_err(|err| format!("{err:#}")));
+        });
+        let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
+
+        let _ = std::fs::remove_file(&fifo);
+        let validation = outcome.unwrap_or_else(|err| {
+            panic!(
+                "validate_replay_path never returned for a writer-less FIFO ({err}): \
+                 non-regular replay paths must not be pre-opened"
+            )
+        });
+        validation.expect("a FIFO must pass validation, not be rejected on shape");
     }
 
     /// A present, readable recording passes validation so the normal replay

--- a/tests/e2e-cucumber/features/dash.feature
+++ b/tests/e2e-cucumber/features/dash.feature
@@ -123,3 +123,14 @@ Feature: Interactive dashboard
     Then the launcher shows the model serving
     When the user quits the launcher
     Then the launcher exits successfully
+
+  # EAI-8366: `--replay <missing>` must fail fast — validate the path BEFORE the
+  # dashboard takes over the terminal, printing a clear error and exiting
+  # non-zero. Driven through a PTY (like the rest of this file): the fail-fast
+  # property is unobservable through a pipe, and under a real terminal the pre-fix
+  # binary enters the alt-screen and hangs, which this scenario pins.
+  @id:dash-replay-missing-file-fails-fast @requires-os:linux
+  Scenario: dash-11 - Replaying a missing recording fails before entering the dashboard
+    When the user replays a recording that does not exist
+    Then the dashboard is refused before taking over the terminal
+    And the user is told the replay file was not found

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -80,6 +80,26 @@ async fn running_managed_model(world: &mut E2eWorld) {
 
 // ── When ───────────────────────────────────────────────────────────
 
+#[when("the user replays a recording that does not exist")]
+async fn replay_missing_recording(world: &mut E2eWorld) {
+    // Drive this under a real pseudo-terminal, not a pipe. The point of the fix is
+    // fail-fast *before the terminal takeover*, and that property is unobservable
+    // through a pipe: a piped `dash` can't enter the alt-screen either way (and
+    // the pre-fix binary already exits non-zero through a pipe when raw-mode
+    // fails, so a piped run detects nothing). Under a PTY the pre-fix binary
+    // enters the alt-screen (`ESC[?1049h`) and hangs — that is the regression this
+    // scenario pins.
+    let missing = std::env::temp_dir().join(format!(
+        "rocm-cli-e2e-no-such-recording-eai-8366-{}.ndjson",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&missing);
+    let path = missing.to_string_lossy().to_string();
+    let session = TuiSession::spawn(world, &["dash", "--replay", &path])
+        .unwrap_or_else(|e| panic!("failed to spawn dash under a pty: {e}"));
+    world.tui = Some(session);
+}
+
 #[when("the user opens the dashboard with demo data")]
 async fn open_dashboard_demo(world: &mut E2eWorld) {
     // `--demo` replays a deterministic synthetic session, so the dashboard
@@ -241,6 +261,39 @@ async fn quit_launcher(world: &mut E2eWorld) {
 }
 
 // ── Then ───────────────────────────────────────────────────────────
+
+#[then("the dashboard is refused before taking over the terminal")]
+async fn dashboard_refused_before_takeover(world: &mut E2eWorld) {
+    // Fail-fast contract: the child must exit non-zero *promptly*. Under a PTY the
+    // pre-fix binary takes over the terminal and hangs, so `wait_for_refusal`
+    // times out there — the timeout IS the regression, not a flake.
+    let tui = session(world);
+    tui.wait_for_refusal(default_timeout())
+        .await
+        .unwrap_or_else(|e| panic!("{e}"));
+    // And it never entered the alt-screen: the refusal happened before the
+    // dashboard could take over the terminal.
+    assert!(
+        !tui.in_alternate_screen(),
+        "dash entered the alt-screen before refusing a missing replay file:\n{}",
+        tui.screen_text(),
+    );
+    // Snapshot the drained final frame for the sibling message assertion.
+    let screen = tui.drain_final_screen().await;
+    world.cli_output = Some(screen);
+}
+
+#[then("the user is told the replay file was not found")]
+async fn told_replay_file_not_found(world: &mut E2eWorld) {
+    let output = world
+        .cli_output
+        .as_deref()
+        .expect("no dash screen captured");
+    assert!(
+        output.to_lowercase().contains("replay file not found"),
+        "expected a clear 'replay file not found' error on screen, got:\n{output}"
+    );
+}
 
 #[then("the dashboard home view is displayed")]
 async fn home_view_displayed(world: &mut E2eWorld) {

--- a/tests/e2e-cucumber/tests/e2e/dash_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/dash_steps.rs
@@ -278,20 +278,18 @@ async fn dashboard_refused_before_takeover(world: &mut E2eWorld) {
         "dash entered the alt-screen before refusing a missing replay file:\n{}",
         tui.screen_text(),
     );
-    // Snapshot the drained final frame for the sibling message assertion.
-    let screen = tui.drain_final_screen().await;
-    world.cli_output = Some(screen);
 }
 
 #[then("the user is told the replay file was not found")]
 async fn told_replay_file_not_found(world: &mut E2eWorld) {
-    let output = world
-        .cli_output
-        .as_deref()
-        .expect("no dash screen captured");
+    // Read the screen from the PTY session itself rather than stashing it in
+    // `world.cli_output`, which carries piped stdout for the non-PTY steps.
+    // Draining first lets the reader thread commit the final buffered frame, so
+    // this does not race the PTY being drained after the child exits.
+    let screen = session(world).drain_final_screen().await;
     assert!(
-        output.to_lowercase().contains("replay file not found"),
-        "expected a clear 'replay file not found' error on screen, got:\n{output}"
+        screen.to_lowercase().contains("replay file not found"),
+        "expected a clear 'replay file not found' error on screen, got:\n{screen}"
     );
 }
 

--- a/tests/e2e-cucumber/tests/e2e/tui_driver.rs
+++ b/tests/e2e-cucumber/tests/e2e/tui_driver.rs
@@ -495,6 +495,80 @@ impl TuiSession {
         }
     }
 
+    /// Whether the emulated terminal is currently in the alternate screen — the
+    /// full-screen buffer a TUI switches to with `ESC[?1049h`. For a fail-fast
+    /// refusal that never takes over the terminal this must stay `false`.
+    #[must_use]
+    pub fn in_alternate_screen(&self) -> bool {
+        self.parser
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .screen()
+            .alternate_screen()
+    }
+
+    /// Poll until the child exits, asserting a *non-zero* exit code — the fail-
+    /// fast refusal contract. Unlike [`wait_for_exit`](Self::wait_for_exit) (which
+    /// requires success), this fails if the child exits 0, and — crucially — if it
+    /// does not exit within `timeout`: the pre-fix `dash --replay <missing>`
+    /// enters the alt-screen and hangs under a real PTY, so a timeout here is the
+    /// regression, not an infrastructure flake.
+    pub async fn wait_for_refusal(&mut self, timeout: Duration) -> Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    self.finished = true;
+                    self.record_once(i32::try_from(status.exit_code()).unwrap_or(-1));
+                    return if status.success() {
+                        Err(format!(
+                            "expected `dash --replay <missing>` to be refused, but it exited 0.\n{}",
+                            self.framed_screen()
+                        ))
+                    } else {
+                        Ok(())
+                    };
+                }
+                Ok(None) => {}
+                Err(e) => return Err(format!("failed to poll TUI child: {e}")),
+            }
+            if let Some(panic_message) = self.take_reader_panic() {
+                return Err(format!(
+                    "pty reader thread panicked while waiting for refusal: {panic_message}\n{}",
+                    self.framed_screen()
+                ));
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for `dash --replay <missing>` to be \
+                     refused — it did not exit (pre-fix regression: the dashboard took over the \
+                     terminal and hung).\n{}",
+                    self.framed_screen()
+                ));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    /// After the child has exited (e.g. via [`wait_for_refusal`](Self::wait_for_refusal)),
+    /// wait a bounded time for the reader thread to commit the final buffered
+    /// frame, then return the visible screen. Lets a sibling assertion read the
+    /// last error line without racing the reader draining the PTY after exit.
+    pub async fn drain_final_screen(&mut self) -> String {
+        let drain_deadline = Instant::now() + DRAIN_TIMEOUT;
+        while Instant::now() < drain_deadline {
+            if self
+                .reader
+                .as_ref()
+                .is_some_and(std::thread::JoinHandle::is_finished)
+            {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+        self.screen_text()
+    }
+
     /// Record this invocation once for the command-coverage report (so `rocm
     /// dash` / `rocm chat` count as covered), tied to the scenario for the
     /// pass/fail join. Best-effort and idempotent.


### PR DESCRIPTION
## Summary

`rocm dash --replay <path>` did no upfront validation of the replay path. A missing or unreadable recording was passed straight into the dashboard, so the failure only surfaced as a disconnect inside the TUI *after* the alt-screen had already taken over the terminal (EAI-8366).

This validates the user-supplied replay path in `dash::run` before building the runtime or entering the alt-screen. A missing file, a directory, or an unreadable regular file now fails fast with a clear error and a non-zero exit. `--demo` generates its own session and is exempt.

**Before:** under a real terminal, `rocm dash --replay /nonexistent/file` enters the alt-screen and hangs there.
**After:** it prints `replay file not found: /nonexistent/file` and exits non-zero without taking over the terminal.

## Changes

- `apps/rocm/src/dash.rs`: add `validate_replay_path()` and call it first in `run()`.
  - Failure kinds are distinguished off `io::Error::kind()`, so a permission-denied `stat` reports `cannot read replay file: …` rather than being mislabelled "not found".
  - Only a *directory* is rejected on shape. Requiring a regular file would break inputs the replay reader (`std::fs::read_to_string`) handles today — FIFOs, `/dev/stdin`, process substitution (`--replay <(zcat rec.ndjson.gz)`).
  - The readability probe (`File::open`) runs only for regular files, so it never blocks on or consumes a one-shot stream.
- Unit tests for the missing / directory / readable-file cases, plus — on unix — the unreadable (mode `0o000`, skipped as root) and non-regular-input cases. Five tests, one per documented rejection/acceptance branch.
  - The non-regular case uses a **writer-less FIFO** (`libc::mkfifo`), validated on a worker thread that must report back inside a 10s timeout. It pins both halves of the contract: a FIFO is not a shape error, *and* validation does not pre-open it. An earlier `/dev/null` version could not do the latter — a character device opens instantly, so it passed with or without the `is_file()` narrowing.
- E2E scenario `@id:dash-replay-missing-file-fails-fast` (`dash-11`) + steps, driven through a **real pseudo-terminal** via `TuiSession`, matching the rest of `dash.feature`. It asserts the process exits non-zero *without* ever entering the alt-screen, and that the "replay file not found" message reaches the screen.
- `tests/e2e-cucumber/tests/e2e/tui_driver.rs`: `in_alternate_screen()`, `wait_for_refusal()` and `drain_final_screen()` helpers backing the scenario.

## Testing

Verified on Linux (the fail-fast property is unobservable through a pipe — a piped `dash` cannot enter the alt-screen either way — so the scenario has to run under a PTY):

- `cargo test --workspace --all-targets` — green; the five `dash::tests::validate_replay_path_*` tests pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo xtask e2e -- -n "Replaying a missing recording"` — 1 scenario, 3 steps, passed.
- **Regression proof (scenario):** with the `validate_replay_path` call neutralised (pre-fix behaviour) the same scenario fails: `timed out after 30s waiting for 'dash --replay <missing>' to be refused — it did not exit`. So it genuinely pins the bug rather than passing either way.
- **Regression proof (`is_file()` narrowing):** with the `if meta.is_file()` guard removed so `File::open` runs unconditionally, `validate_replay_path_accepts_a_fifo_without_opening_it` fails after 10s (`validate_replay_path never returned for a writer-less FIFO (timed out waiting on channel)`) while the other four tests still pass; restored, all five pass.

**Gated lane:** the scenario is tagged `@requires-os:linux`, like every other scenario in `dash.feature` (portable-pty compiles on Windows via ConPTY but that path is not yet a blocking contract). It is exercised by the Linux E2E lanes, not by the Windows ones.

The author's local machine is macOS, an unsupported platform for this repo, so all gates above were run on a Linux host rather than locally; CI on Linux is authoritative.

