### PR TITLE
test(core): stop env-mutating tests racing on a shared process global

### DIFF
--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -981,11 +981,30 @@ fn ps_env_scope(var: &str, scope: &str) -> String {
 /// It now asks the same resolver as `examine`, which also means `$ROCM_PATH` is
 /// honoured here for the first time.
 fn newest_rocm_install_dir() -> String {
-    crate::discover_rocm_installs()
+    first_install_path(crate::discover_rocm_installs())
+}
+
+/// The best install's path, or empty when there is none.
+fn first_install_path(installs: Vec<crate::RocmInstall>) -> String {
+    installs
         .into_iter()
         .next()
         .map(|install| install.path.to_string_lossy().into_owned())
         .unwrap_or_default()
+}
+
+/// [`newest_rocm_install_dir`] against a caller-supplied `$ROCM_PATH` and
+/// search roots, so a test can drive it without touching the process
+/// environment. Same seam as [`crate::discover_rocm_installs_in`].
+#[cfg(test)]
+fn newest_rocm_install_dir_in(
+    search_dirs: &[std::path::PathBuf],
+    env_override: Option<&std::path::Path>,
+) -> String {
+    first_install_path(crate::discover_rocm_installs_on_host_in(
+        search_dirs,
+        env_override,
+    ))
 }
 
 #[cfg(test)]
@@ -1001,7 +1020,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn the_path_fix_finds_the_install_the_rest_of_the_cli_found() {
         // Discriminating on purpose: the scanner this replaces looked only in
         // two hardcoded `C:\Program Files` directories and ignored $ROCM_PATH
@@ -1016,17 +1034,12 @@ mod tests {
         let install = root.join("rocm-6.10.0");
         plant_install(&install);
 
-        let previous = std::env::var_os("ROCM_PATH");
-        unsafe {
-            std::env::set_var("ROCM_PATH", &install);
-        }
-        let found = newest_rocm_install_dir();
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("ROCM_PATH", value),
-                None => std::env::remove_var("ROCM_PATH"),
-            }
-        }
+        // The override goes in as an argument rather than through
+        // `std::env::set_var`: the environment is process-global, so a sibling
+        // test mutating $ROCM_PATH between this set and its read used to make
+        // this assertion fail on whichever test lost the race.
+        let found = newest_rocm_install_dir_in(&[], Some(&install));
+
         std::fs::remove_dir_all(&root).ok();
 
         assert_eq!(
@@ -1037,7 +1050,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn the_path_fix_reports_nothing_rather_than_a_directory_with_no_install_in_it() {
         // The old scan accepted any directory whose name started with a digit,
         // so an empty leftover could be put on PATH. The resolver requires a
@@ -1050,17 +1062,8 @@ mod tests {
         let empty = root.join("6.10");
         std::fs::create_dir_all(&empty).expect("create empty dir");
 
-        let previous = std::env::var_os("ROCM_PATH");
-        unsafe {
-            std::env::set_var("ROCM_PATH", &empty);
-        }
-        let found = newest_rocm_install_dir();
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("ROCM_PATH", value),
-                None => std::env::remove_var("ROCM_PATH"),
-            }
-        }
+        let found = newest_rocm_install_dir_in(&[], Some(&empty));
+
         std::fs::remove_dir_all(&root).ok();
 
         assert!(

--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -1670,14 +1670,31 @@ impl AppPaths {
     }
 
     pub fn engine_envs_root(&self) -> PathBuf {
-        env_path_override("ROCM_CLI_ENGINE_ENVS_ROOT").map_or_else(
+        self.engine_envs_root_from(env_path_override("ROCM_CLI_ENGINE_ENVS_ROOT").as_deref())
+    }
+
+    /// [`Self::engine_envs_root`] against a caller-supplied override.
+    ///
+    /// Lets a test drive the override without `std::env::set_var`, which is
+    /// process-global and races other tests under a threaded runner. Same seam
+    /// as [`discover_rocm_installs_in_layout`].
+    fn engine_envs_root_from(&self, override_root: Option<&Path>) -> PathBuf {
+        override_root.map_or_else(
             || self.data_dir.join("engines"),
-            |root| normalize_runtime_path_for_host(&root),
+            normalize_runtime_path_for_host,
         )
     }
 
     pub fn engine_envs_dir(&self, engine: &str) -> PathBuf {
         self.engine_envs_root().join(engine).join("envs")
+    }
+
+    /// [`Self::engine_envs_dir`] against a caller-supplied override.
+    #[cfg(test)]
+    fn engine_envs_dir_from(&self, engine: &str, override_root: Option<&Path>) -> PathBuf {
+        self.engine_envs_root_from(override_root)
+            .join(engine)
+            .join("envs")
     }
 
     pub fn engine_locks_dir(&self, engine: &str) -> PathBuf {
@@ -2543,19 +2560,42 @@ pub(crate) struct RocmInstall {
     pub(crate) version: Option<String>,
 }
 
+/// The search roots and layout this host's installs use.
+fn host_rocm_search() -> (Vec<PathBuf>, RocmLayout) {
+    let (dirs, layout) = if runtime_is_windows() {
+        (WINDOWS_ROCM_SEARCH_DIRS, RocmLayout::Children)
+    } else {
+        (LINUX_ROCM_SEARCH_DIRS, RocmLayout::Siblings)
+    };
+    (dirs.iter().map(PathBuf::from).collect(), layout)
+}
+
 /// Every unmanaged ROCm install on this host, best candidate first.
 ///
 /// Supplies the platform's search roots, layout, and `$ROCM_PATH` to
 /// [`discover_rocm_installs_in_layout`].
 pub(crate) fn discover_rocm_installs() -> Vec<RocmInstall> {
     let env_override = std::env::var_os("ROCM_PATH").map(PathBuf::from);
-    let (dirs, layout) = if runtime_is_windows() {
-        (WINDOWS_ROCM_SEARCH_DIRS, RocmLayout::Children)
-    } else {
-        (LINUX_ROCM_SEARCH_DIRS, RocmLayout::Siblings)
-    };
-    let search_dirs: Vec<PathBuf> = dirs.iter().map(PathBuf::from).collect();
+    let (search_dirs, layout) = host_rocm_search();
     discover_rocm_installs_in_layout(&search_dirs, env_override.as_deref(), layout)
+}
+
+/// [`discover_rocm_installs`] with the host's `$ROCM_PATH` and search roots
+/// supplied by the caller instead of read from the process.
+///
+/// Reading `$ROCM_PATH` inside [`discover_rocm_installs`] is what forced its
+/// callers' tests to mutate the process environment, and two of them racing on
+/// that global is what made the Windows lane flake — that lane runs `cargo test`
+/// (threads in one process) where the Linux lanes run `cargo nextest` (a process
+/// per test), so only Windows could ever observe it. Passing the override in
+/// keeps those tests hermetic. Same seam as [`discover_rocm_installs_in`], but
+/// keeps the host's layout so the caller under test is the real one.
+#[cfg(test)]
+pub(crate) fn discover_rocm_installs_on_host_in(
+    search_dirs: &[PathBuf],
+    env_override: Option<&Path>,
+) -> Vec<RocmInstall> {
+    discover_rocm_installs_in_layout(search_dirs, env_override, host_rocm_search().1)
 }
 
 /// [`discover_rocm_installs_in_layout`] for the Linux sibling layout.
@@ -11020,28 +11060,35 @@ Class Name:                Display
     }
 
     #[test]
-    #[allow(unsafe_code)] // std::env::set_var is unsafe in edition 2024
     fn engine_envs_dir_honors_dedicated_root_override() {
         let (root, paths) = temp_app_paths("engine-envs-root-override");
         let override_root = root.join("runtime").join("engines");
-        let previous = std::env::var_os("ROCM_CLI_ENGINE_ENVS_ROOT");
-        unsafe {
-            std::env::set_var("ROCM_CLI_ENGINE_ENVS_ROOT", &override_root);
-        }
 
+        // Passed in rather than set via `std::env::set_var`: the environment is
+        // process-global, so mutating it here would race any concurrent test
+        // that reads the same key under a threaded runner.
         assert_eq!(
-            paths.engine_envs_dir("vllm"),
+            paths.engine_envs_dir_from("vllm", Some(&override_root)),
             normalize_runtime_path_for_host(&override_root)
                 .join("vllm")
                 .join("envs")
         );
 
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("ROCM_CLI_ENGINE_ENVS_ROOT", value),
-                None => std::env::remove_var("ROCM_CLI_ENGINE_ENVS_ROOT"),
-            }
-        }
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn engine_envs_dir_falls_back_to_the_data_dir_without_an_override() {
+        // The other half of the override contract: with nothing supplied the
+        // root is the data dir, which is what the unset-environment production
+        // path resolves to.
+        let (root, paths) = temp_app_paths("engine-envs-root-default");
+
+        assert_eq!(
+            paths.engine_envs_dir_from("vllm", None),
+            paths.data_dir.join("engines").join("vllm").join("envs")
+        );
+
         fs::remove_dir_all(root).ok();
     }
 

--- a/xtask/src/env_mutation_contract.rs
+++ b/xtask/src/env_mutation_contract.rs
@@ -1,0 +1,271 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! Static contract test: a test that mutates the process environment must
+//! serialize itself.
+//!
+//! Regression guard for EAI-8397. `std::env::set_var`/`remove_var` change state
+//! shared by every thread in the process, so two tests touching the same key
+//! race — one reads the other's value and fails an assertion that has nothing
+//! to do with what it is testing.
+//!
+//! This is invisible on most of CI. `ci.yml` runs the Linux lanes under
+//! `cargo nextest` (a process per test, so the mutation cannot escape), but
+//! `windows-build-and-test` runs `cargo test --workspace --all-targets` — all
+//! tests as threads in ONE process. So the Windows lane, a required check, was
+//! the only place the race could fire, and it read as "your change broke
+//! Windows" on branches that never touched the crate. Nothing about the bug is
+//! Windows-specific; it is a property of the runner.
+//!
+//! The repo already had two ways of handling this — `ScopedTestEnv` in
+//! `apps/rocm/src/main.rs` and `PROCESS_ENV_TEST_LOCK` in
+//! `apps/rocm/src/therock.rs`, both of which take a process-wide lock — and the
+//! `fix.rs` tests that flaked were simply the ones that skipped the discipline.
+//! This guard makes the omission a build failure rather than an intermittent
+//! red on a required check.
+//!
+//! Best is to not touch the environment at all: pass the value in through a
+//! test seam, as `discover_rocm_installs_on_host_in` and
+//! `newest_rocm_install_dir_in` do. Where a test must exercise the real
+//! env-reading path, holding one of the shared locks above is the accepted
+//! alternative and satisfies this guard.
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    fn repo_root() -> PathBuf {
+        // CARGO_MANIFEST_DIR is the xtask/ crate dir; its parent is the repo
+        // root (same idiom as workflow_contract::repo_root).
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask crate has a parent directory")
+            .to_path_buf()
+    }
+
+    /// Every `.rs` file in the repository.
+    ///
+    /// A whole-tree walk rather than a list of source directories, so a crate
+    /// added under a new top-level directory is covered without anyone
+    /// remembering to extend this. Two kinds of directory are skipped:
+    /// `target/`, which holds generated and vendored code we do not own, and
+    /// dot-directories, which include the `.claude/worktrees` checkouts of
+    /// other branches — scanning either would make the guard's verdict depend
+    /// on state outside the commit under test.
+    fn workspace_rust_sources() -> Vec<PathBuf> {
+        let mut found = Vec::new();
+        collect_rust_files(&repo_root(), &mut found);
+        assert!(
+            !found.is_empty(),
+            "found no Rust sources to scan -- the walk is broken, not the tree"
+        );
+        found.sort();
+        found
+    }
+
+    fn collect_rust_files(dir: &Path, found: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let skip = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_none_or(|name| name == "target" || name.starts_with('.'));
+                if skip {
+                    continue;
+                }
+                collect_rust_files(&path, found);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                found.push(path);
+            }
+        }
+    }
+
+    /// The mutating calls that need serializing.
+    const MUTATIONS: [&str; 2] = ["env::set_var", "env::remove_var"];
+
+    /// Markers that show a file already serializes its env mutations behind a
+    /// process-wide lock. Both are existing repo mechanisms; a file using
+    /// either has opted into the discipline this guard enforces.
+    const SERIALIZERS: [&str; 2] = ["ScopedTestEnv", "PROCESS_ENV_TEST_LOCK"];
+
+    /// Line numbers (1-based) inside a `#[cfg(test)]` module or a `#[test]`
+    /// function that call one of [`MUTATIONS`].
+    ///
+    /// Brace-depth tracking rather than a whole-file substring match: production
+    /// code in the same file may legitimately set an environment variable (it
+    /// owns the process), and a file-level match could not tell the two apart.
+    fn env_mutations_in_test_code(text: &str) -> Vec<(usize, String)> {
+        let mut hits = Vec::new();
+        let mut depth: usize = 0;
+        // Depth at which the enclosing test block opened, if we are inside one.
+        let mut test_block: Option<usize> = None;
+        let mut pending_test_attr = false;
+
+        for (index, raw) in text.lines().enumerate() {
+            let line = raw.trim();
+            let code = line.split("//").next().unwrap_or(line);
+
+            if test_block.is_none() && (line.contains("#[cfg(test)]") || line.contains("#[test]")) {
+                pending_test_attr = true;
+            }
+
+            if test_block.is_some()
+                && let Some(found) = MUTATIONS.iter().find(|needle| code.contains(*needle))
+            {
+                hits.push((index + 1, (*found).to_owned()));
+            }
+
+            let opens = code.matches('{').count();
+            let closes = code.matches('}').count();
+            if pending_test_attr {
+                if opens > 0 {
+                    test_block.get_or_insert(depth);
+                    pending_test_attr = false;
+                } else if code.trim_end().ends_with(';') {
+                    // The attribute belonged to a braceless item -- a
+                    // `#[cfg(test)] use ...;` import, say. Disarm, or the next
+                    // brace anywhere in the file would be mistaken for the
+                    // start of a test block and production code below it would
+                    // be scanned as test code.
+                    pending_test_attr = false;
+                }
+            }
+            // Saturating: a brace inside a string or macro can make a line look
+            // unbalanced, and the scan should degrade rather than panic.
+            depth = (depth + opens).saturating_sub(closes);
+            if let Some(open_depth) = test_block
+                && depth <= open_depth
+            {
+                test_block = None;
+            }
+        }
+        hits
+    }
+
+    /// Whether `text` serializes its env mutations behind a process-wide lock.
+    ///
+    /// File-level on purpose: both existing mechanisms declare the lock once and
+    /// take it in each test that needs it, so the guard asks whether the file
+    /// has opted in rather than trying to prove each call site is covered.
+    fn serializes_env_mutations(text: &str) -> bool {
+        SERIALIZERS.iter().any(|marker| text.contains(marker))
+    }
+
+    #[test]
+    fn a_test_mutating_the_environment_serializes_itself() {
+        let root = repo_root();
+        let mut offenders: Vec<String> = Vec::new();
+
+        for path in workspace_rust_sources() {
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+            if serializes_env_mutations(&text) {
+                continue;
+            }
+            let relative = path.strip_prefix(&root).unwrap_or(&path).display();
+            for (line, call) in env_mutations_in_test_code(&text) {
+                offenders.push(format!("{relative}:{line}: {call}"));
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "a test that mutates the process environment must serialize itself \
+             -- env is shared by every thread, so an unguarded mutation races \
+             any test reading the same key and fails only under a threaded \
+             runner (the Windows lane, a required check). Prefer passing the \
+             value in through a seam (see `newest_rocm_install_dir_in`); \
+             otherwise hold `ScopedTestEnv` or `PROCESS_ENV_TEST_LOCK`. \
+             Offenders:\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    /// A mutating call, assembled at runtime.
+    ///
+    /// Spelling `env::set_var` literally in a fixture below would make this
+    /// file's own test code match the scan it defines, so the fixtures build
+    /// the needle instead of containing it.
+    fn mutation_call(kind: &str) -> String {
+        format!("unsafe {{ std::env::{kind}(\"KEY\", \"value\") }}")
+    }
+
+    #[test]
+    fn the_scanner_sees_a_mutation_inside_a_test_module() {
+        let call = mutation_call("set_var");
+        let source = format!(
+            "fn production() {{\n    {call}\n}}\n\
+             #[cfg(test)]\nmod tests {{\n    #[test]\n    fn t() {{\n        {call}\n    }}\n}}\n"
+        );
+        let hits = env_mutations_in_test_code(&source);
+        assert_eq!(hits.len(), 1, "expected exactly the in-test hit: {hits:?}");
+        assert_eq!(hits[0].0, 8, "should flag the line inside the test module");
+    }
+
+    #[test]
+    fn the_scanner_ignores_production_mutations() {
+        // Production code owns the process and may legitimately set a variable;
+        // the hazard is specific to tests sharing one process under `cargo test`.
+        let source = format!("fn production() {{\n    {}\n}}\n", mutation_call("set_var"));
+        assert!(
+            env_mutations_in_test_code(&source).is_empty(),
+            "a mutation outside test code is not an offense"
+        );
+    }
+
+    #[test]
+    fn the_scanner_stops_flagging_after_the_test_module_closes() {
+        let source = format!(
+            "#[cfg(test)]\nmod tests {{\n    #[test]\n    fn t() {{\n        let _ = 1;\n    }}\n}}\n\
+             fn later_production() {{\n    {}\n}}\n",
+            mutation_call("remove_var")
+        );
+        assert!(
+            env_mutations_in_test_code(&source).is_empty(),
+            "the test module ended; the later mutation is production code"
+        );
+    }
+
+    #[test]
+    fn the_scanner_ignores_a_cfg_test_attribute_on_a_braceless_item() {
+        // `#[cfg(test)] use ...;` gates an import, not a block. Treating it as
+        // the opening of a test block would make every brace after it -- the
+        // whole rest of the file -- read as test code. Several files in this
+        // repo (crates/rocm-dash-tui/src/ui/dock.rs, apps/rocmd/src/lib.rs) do
+        // exactly this above production code that sets an env var.
+        let source = format!(
+            "#[cfg(test)]\nuse foo::Bar;\n\nfn production() {{\n    {}\n}}\n",
+            mutation_call("set_var")
+        );
+        assert!(
+            env_mutations_in_test_code(&source).is_empty(),
+            "the attribute gated an import; nothing below it is test code"
+        );
+    }
+
+    #[test]
+    fn a_serialized_file_is_exempt_but_an_unguarded_one_is_not() {
+        let unguarded = format!(
+            "#[cfg(test)]\nmod tests {{\n    #[test]\n    fn t() {{\n        {}\n    }}\n}}\n",
+            mutation_call("set_var")
+        );
+        assert!(
+            !serializes_env_mutations(&unguarded),
+            "nothing in this source takes a process-wide lock"
+        );
+
+        let guarded = unguarded.replace(
+            "    #[test]",
+            "    static PROCESS_ENV_TEST_LOCK: Mutex<()> = Mutex::new(());\n    #[test]",
+        );
+        assert!(
+            serializes_env_mutations(&guarded),
+            "declaring the shared lock opts the file into the discipline"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@ mod demos;
 mod e2e;
 mod e2e_prewarm;
 mod e2e_report;
+mod env_mutation_contract;
 mod manifest;
 mod package;
 mod paths;


### PR DESCRIPTION
Fixes #336.

## Problem

The required `windows-build-and-test` check fails intermittently in `rocm-core`, on branches that never touched the crate — e.g. [run 33616465846](https://github.com/ROCm/rocm-cli/actions/runs/33616465846/job/100223046621):

```
---- fix::tests::the_path_fix_finds_the_install_the_rest_of_the_cli_found stdout ----
assertion `left == right` failed: fix-6-path must resolve installs the same way examine does
  left: ""
```

Two tests in `fix.rs` each drove `newest_rocm_install_dir()` by setting the process-global `$ROCM_PATH`, calling, then restoring it. Neither took a lock, so interleaved they read each other's planted value: the test expecting a real install path saw the sibling's empty directory and got `""`.

Only the Windows lane can observe this. The Linux lanes run `cargo nextest` (a process per test, so the mutation cannot escape); `windows-build-and-test` runs `cargo test --workspace --all-targets`, which runs tests as threads in one process. The bug is a property of the runner, not of Windows.

## Fix

Pass the override in as an argument rather than through the environment, using the seam the crate already has (`discover_rocm_installs_in`). `newest_rocm_install_dir_in` takes `$ROCM_PATH` and the search roots from the caller, so the two tests are hermetic and no longer touch process state. This removes the race rather than serializing it.

The same latent pattern in `lib.rs` (`ROCM_CLI_ENGINE_ENVS_ROOT`) gets the same treatment via `engine_envs_root_from`, plus a test for the no-override branch that was previously uncovered.

## Regression guard

`xtask/src/env_mutation_contract.rs` is a static contract test: it walks the repo's Rust sources and fails the build if a test mutates the environment without serializing itself. The repo already had the discipline in two forms — `ScopedTestEnv` and `PROCESS_ENV_TEST_LOCK`, both process-wide locks — and `fix.rs` was simply the omission, so files using either are exempt.

Efficacy verified by reverting the source fix with the guard in place: it fails naming the exact offending lines, and passes once restored.

## Verification

- Pre-fix, the two tests fail within ~10 iterations under `--test-threads=2`; post-fix, 40/40 clean runs.
- `cargo test -p rocm-core --lib` (324 passed), `cargo test -p xtask` (137 passed), `cargo fmt --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings` all clean.
