### PR TITLE
fix(therock): cap http_get's connect phase at the request timeout

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -335,10 +335,7 @@ jobs:
     timeout-minutes: 35
     # `native` disambiguates the two Linux Strix runners: the WSL host also
     # carries `strix-halo`, but the paths below exist only on the native one.
-    # TEMPORARY: `ubuntu-26.04` pins this to strix-halo-ubuntu-2 specifically,
-    # to confirm the timeout_connect fix on the runner that actually hit the
-    # egress stall. Revert before merge.
-    runs-on: [self-hosted, linux, strix-halo, native, ubuntu-26.04]
+    runs-on: [self-hosted, linux, strix-halo, native]
     needs: [changes]
     # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-ubuntu.
     if: >-

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -335,7 +335,10 @@ jobs:
     timeout-minutes: 35
     # `native` disambiguates the two Linux Strix runners: the WSL host also
     # carries `strix-halo`, but the paths below exist only on the native one.
-    runs-on: [self-hosted, linux, strix-halo, native]
+    # TEMPORARY: `ubuntu-26.04` pins this to strix-halo-ubuntu-2 specifically,
+    # to confirm the timeout_connect fix on the runner that actually hit the
+    # egress stall. Revert before merge.
+    runs-on: [self-hosted, linux, strix-halo, native, ubuntu-26.04]
     needs: [changes]
     # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-ubuntu.
     if: >-

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -2252,7 +2252,13 @@ fn http_get(
     let timeout = max_time_secs
         .filter(|value| *value > 0)
         .map_or_else(|| Duration::from_mins(10), Duration::from_secs);
-    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
+    let agent = ureq::AgentBuilder::new()
+        // `timeout_connect` takes precedence over `timeout` and defaults to 30s,
+        // so without it a host that blackholes rather than refuses would stall
+        // the request well past the intended ceiling.
+        .timeout_connect(timeout)
+        .timeout(timeout)
+        .build();
     let mut request = agent.get(url).set("User-Agent", "rocm-cli");
     for (name, value) in headers {
         request = request.set(name, value);

--- a/apps/rocm/src/therock.rs
+++ b/apps/rocm/src/therock.rs
@@ -2252,11 +2252,13 @@ fn http_get(
     let timeout = max_time_secs
         .filter(|value| *value > 0)
         .map_or_else(|| Duration::from_mins(10), Duration::from_secs);
+    // Connecting should always be fast if the host is reachable at all, so cap it
+    // independently of the (possibly very generous, e.g. 10-minute default) overall
+    // timeout. Without this, a blackholed host stalls the connect phase for the full
+    // overall timeout on every request instead of failing fast.
+    let connect_timeout = timeout.min(Duration::from_secs(THEROCK_HEAD_PROBE_TIMEOUT_SECS));
     let agent = ureq::AgentBuilder::new()
-        // `timeout_connect` takes precedence over `timeout` and defaults to 30s,
-        // so without it a host that blackholes rather than refuses would stall
-        // the request well past the intended ceiling.
-        .timeout_connect(timeout)
+        .timeout_connect(connect_timeout)
         .timeout(timeout)
         .build();
     let mut request = agent.get(url).set("User-Agent", "rocm-cli");


### PR DESCRIPTION
## Summary
- `http_get` in `apps/rocm/src/therock.rs` only set ureq's overall `.timeout()`, not `.timeout_connect()`. ureq defaults the connect-phase timeout to 30s and it takes precedence over the overall timeout, so a host that blackholes packets (drops silently rather than refusing) stalls `http_get` for ~30s per request regardless of the caller's intended budget.
- This is what timed out job `E2E tests (Strix Halo, Ubuntu)` in run [33730461545](https://github.com/ROCm/rocm-cli/actions/runs/33730461545/job/100569144985): the background "check for updates" call (`STARTUP_UPDATE_CHECK_TIMEOUT_SECS = 2`) fires before nearly every `rocm` subcommand via `dispatch()`, and on the `strix-halo-ubuntu-2` runner each of its up-to-5 sequential requests (index root + rocm/torch/torchvision/torchaudio) stalled ~30s instead of failing fast, adding minutes per CLI invocation across the suite until the job's 35-minute cap was exceeded.
- `head_content_length` in the same file already sets both `timeout_connect` and `timeout` for this reason (added for a similar issue). This mirrors that fix onto `http_get`.

## Test plan
- [x] `cargo check -p rocm` passes
- [ ] Watch this PR's CI, especially the `E2E tests (Strix Halo, Ubuntu)` lane, to confirm the fix holds under real runner conditions