### PR TITLE
fix(chat): read a one-shot prompt from piped stdin

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1777,6 +1777,16 @@ fn dispatch(cli: Cli) -> Result<()> {
                     },
                 );
             }
+            // Resolve the prompt from `--prompt` or, when it is omitted and
+            // stdin is not a terminal, from piped standard input — the
+            // documented `echo "…" | rocm chat` path. Only when neither
+            // supplies a prompt do we fall back to the status screen (stdin is
+            // an interactive TTY here, since the piped/interactive branches
+            // above already handled the other cases).
+            let prompt = match prompt {
+                Some(prompt) => Some(prompt),
+                None => read_piped_prompt()?,
+            };
             match prompt {
                 Some(prompt) => print!(
                     "{}",
@@ -9585,6 +9595,31 @@ pub(crate) fn render_launch_summary(paths: &AppPaths, config: &RocmCliConfig) ->
         "  note: launch from an interactive terminal to enter the TUI."
     );
     output
+}
+
+/// Read a one-shot chat prompt from standard input when it is piped in.
+///
+/// Backs the documented `echo "…" | rocm chat` path: when `--prompt` is omitted
+/// and stdin is not a terminal, the piped text becomes the prompt. Returns
+/// `None` when stdin is an interactive TTY or the piped input is empty, so the
+/// caller falls back to the status screen instead of blocking on input nobody
+/// can supply.
+fn read_piped_prompt() -> Result<Option<String>> {
+    use std::io::{IsTerminal, Read};
+
+    if std::io::stdin().is_terminal() {
+        return Ok(None);
+    }
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("failed to read chat prompt from standard input")?;
+    let trimmed = buf.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed.to_owned()))
+    }
 }
 
 pub(crate) fn render_chat_text(paths: &AppPaths, provider: &str) -> Result<String> {
@@ -29863,6 +29898,21 @@ ID_LIKE="suse opensuse"
         assert!(
             body.contains("render_chat_text("),
             "non-interactive no-prompt path must still call render_chat_text; body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn command_chat_reads_prompt_from_piped_stdin() {
+        // Regression for the documented `echo "…" | rocm chat` path: when
+        // `--prompt` is omitted the handler must read stdin via
+        // `read_piped_prompt` and route the piped text through
+        // `render_chat_prompt_text`, rather than dropping straight to the
+        // status screen (`render_chat_text`) and ignoring stdin.
+        let src = main_rs_source();
+        let body = strip_line_comments(&command_chat_handler_body(&src));
+        assert!(
+            body.contains("read_piped_prompt("),
+            "no-prompt path must read piped stdin via read_piped_prompt; body:\n{body}"
         );
     }
 }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -9601,7 +9601,7 @@ pub(crate) fn render_launch_summary(paths: &AppPaths, config: &RocmCliConfig) ->
 ///
 /// Backs the documented `echo "…" | rocm chat` path: when `--prompt` is omitted
 /// and stdin is not a terminal, the piped text becomes the prompt. Returns
-/// `None` when stdin is an interactive TTY or the piped input is empty, so the
+/// `None` when stdin is an interactive TTY or the piped input is blank, so the
 /// caller falls back to the status screen instead of blocking on input nobody
 /// can supply.
 fn read_piped_prompt() -> Result<Option<String>> {
@@ -9614,12 +9614,31 @@ fn read_piped_prompt() -> Result<Option<String>> {
     std::io::stdin()
         .read_to_string(&mut buf)
         .context("failed to read chat prompt from standard input")?;
-    let trimmed = buf.trim();
-    if trimmed.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(trimmed.to_owned()))
+    Ok(piped_prompt_from_input(&buf))
+}
+
+/// Turn raw piped stdin into a chat prompt, or `None` when there is nothing to
+/// send.
+///
+/// `--prompt` reaches the send path verbatim, so a piped prompt must too:
+/// leading indentation and trailing spaces or tabs carry meaning for a model and
+/// are preserved byte for byte. The only thing removed is the line ending the
+/// writer appends — a single trailing `\n`, plus the `\r` in front of it on
+/// Windows — because `echo "…" |` and `printf '…\n' |` add it, not the user.
+/// Further blank lines stay: the second newline of `printf 'a\n\n'` is authored
+/// content, not shell punctuation.
+///
+/// `trim()` is used only to classify the input: whitespace-only stdin (an empty
+/// pipe, or a bare newline) holds no prompt and yields `None`.
+fn piped_prompt_from_input(input: &str) -> Option<String> {
+    if input.trim().is_empty() {
+        return None;
     }
+    let prompt = match input.strip_suffix('\n') {
+        Some(rest) => rest.strip_suffix('\r').unwrap_or(rest),
+        None => input,
+    };
+    Some(prompt.to_owned())
 }
 
 pub(crate) fn render_chat_text(paths: &AppPaths, provider: &str) -> Result<String> {
@@ -29914,5 +29933,58 @@ ID_LIKE="suse opensuse"
             body.contains("read_piped_prompt("),
             "no-prompt path must read piped stdin via read_piped_prompt; body:\n{body}"
         );
+    }
+
+    #[test]
+    fn piped_prompt_keeps_everything_but_the_trailing_line_ending() {
+        // A piped prompt must reach the send path byte-identical to the same
+        // text passed with `--prompt`, which is forwarded verbatim. Only the
+        // line ending the writer appends is dropped; indentation and trailing
+        // spaces or tabs are content and have to survive.
+        assert_eq!(
+            piped_prompt_from_input("    indented line\n"),
+            Some("    indented line".to_owned()),
+            "leading indentation must survive; only the trailing newline goes"
+        );
+        assert_eq!(
+            piped_prompt_from_input("trailing spaces matter   \n"),
+            Some("trailing spaces matter   ".to_owned()),
+            "trailing spaces must survive the trailing-newline strip"
+        );
+        assert_eq!(
+            piped_prompt_from_input("\tleading tab"),
+            Some("\tleading tab".to_owned()),
+            "input without a trailing newline must pass through unchanged"
+        );
+        assert_eq!(
+            piped_prompt_from_input("crlf line\r\n"),
+            Some("crlf line".to_owned()),
+            "a Windows line ending must be stripped as one unit"
+        );
+        assert_eq!(
+            piped_prompt_from_input("fn main() {\n    body\n}\n"),
+            Some("fn main() {\n    body\n}".to_owned()),
+            "interior newlines and indentation must survive"
+        );
+        assert_eq!(
+            piped_prompt_from_input("blank line below\n\n"),
+            Some("blank line below\n".to_owned()),
+            "only one trailing line ending is shell punctuation; the rest is content"
+        );
+    }
+
+    #[test]
+    fn piped_prompt_treats_whitespace_only_input_as_no_prompt() {
+        // The fallback that keeps the no-argument behavior intact: an empty
+        // pipe, a bare newline, or blank padding carries no prompt, so the
+        // caller must see `None` and render the status screen instead of
+        // sending whitespace to a model.
+        for input in ["", "\n", "\r\n", "   ", "  \t \n\n", "\n\n\n"] {
+            assert_eq!(
+                piped_prompt_from_input(input),
+                None,
+                "whitespace-only stdin must yield no prompt; input: {input:?}"
+            );
+        }
     }
 }

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -1781,9 +1781,11 @@ fn dispatch(cli: Cli) -> Result<()> {
             // Resolve the prompt from `--prompt` or, when it is omitted and
             // stdin is not a terminal, from piped standard input — the
             // documented `echo "…" | rocm chat` path. Only when neither
-            // supplies a prompt do we fall back to the status screen (stdin is
-            // an interactive TTY here, since the piped/interactive branches
-            // above already handled the other cases).
+            // supplies a prompt do we fall back to the status screen, which
+            // two kinds of invocation reach: stdin is a TTY that the
+            // interactive branch above declined (it also requires stdout to be
+            // one), or stdin was redirected and carried nothing but whitespace
+            // — an empty pipe or `< /dev/null`.
             let prompt = match prompt {
                 Some(prompt) => Some(prompt),
                 None => read_piped_prompt()?,
@@ -9742,8 +9744,18 @@ pub(crate) fn render_launch_summary(paths: &AppPaths, config: &RocmCliConfig) ->
 /// `None` when stdin is an interactive TTY or the piped input is blank, so the
 /// caller falls back to the status screen instead of blocking on input nobody
 /// can supply.
+///
+/// The read runs to EOF — the conventional filter contract that
+/// `read_provider_key_from_user` already follows. A caller that hands us a pipe
+/// it never writes to and never closes therefore waits, exactly as `cat` would;
+/// the TTY guard is what keeps that off an interactive user, and a
+/// non-interactive caller with no prompt to send should pass `/dev/null` (as
+/// `scripts/smoke_local.py` does) rather than an idle pipe. A read error — a
+/// closed or non-UTF-8 fd 0 — is reported instead of being folded into "no
+/// prompt", so text that was piped but could not be decoded fails loudly rather
+/// than silently becoming a status screen and a zero exit.
 fn read_piped_prompt() -> Result<Option<String>> {
-    use std::io::{IsTerminal, Read};
+    use std::io::IsTerminal as _;
 
     if std::io::stdin().is_terminal() {
         return Ok(None);
@@ -9767,7 +9779,12 @@ fn read_piped_prompt() -> Result<Option<String>> {
 /// content, not shell punctuation.
 ///
 /// `trim()` is used only to classify the input: whitespace-only stdin (an empty
-/// pipe, or a bare newline) holds no prompt and yields `None`.
+/// pipe, or a bare newline) holds no prompt and yields `None`. That is the one
+/// deliberate divergence from `--prompt`, which forwards `"   "` as written: a
+/// bare `rocm chat` under any redirect — `< /dev/null`, a closed heredoc, a CI
+/// step with no stdin — has to keep printing the status screen rather than send
+/// a blank turn to a model, and a caller who really means to send whitespace
+/// can still say so with `--prompt`.
 fn piped_prompt_from_input(input: &str) -> Option<String> {
     if input.trim().is_empty() {
         return None;
@@ -30607,16 +30624,33 @@ ID_LIKE="suse opensuse"
 
     #[test]
     fn command_chat_reads_prompt_from_piped_stdin() {
-        // Regression for the documented `echo "…" | rocm chat` path: when
-        // `--prompt` is omitted the handler must read stdin via
-        // `read_piped_prompt` and route the piped text through
-        // `render_chat_prompt_text`, rather than dropping straight to the
-        // status screen (`render_chat_text`) and ignoring stdin.
+        // A structural guard on the wiring, not a behavioral test: the handler
+        // reads the real fd 0, which an in-process test cannot pipe. The
+        // behavior — piped text reaching the model unaltered — is covered end
+        // to end by the `chat-09` scenario (`@id:chat-cli-stdin-prompt`); what
+        // is checked here is that the `--prompt`-less arm still resolves the
+        // prompt from `read_piped_prompt`, with the result feeding the dispatch
+        // rather than being discarded or read after the send decision is
+        // already made.
         let src = main_rs_source();
         let body = strip_line_comments(&command_chat_handler_body(&src));
         assert!(
             body.contains("read_piped_prompt("),
             "no-prompt path must read piped stdin via read_piped_prompt; body:\n{body}"
+        );
+        assert!(
+            body.contains("None => read_piped_prompt()?"),
+            "the piped read must supply the prompt that is dispatched (and \
+             propagate its error), not be a discarded call; body:\n{body}"
+        );
+        let read_at = body.find("read_piped_prompt(").expect("asserted above");
+        let send_at = body
+            .find("render_chat_prompt_text(")
+            .unwrap_or_else(|| panic!("chat handler no longer sends a prompt; body:\n{body}"));
+        assert!(
+            read_at < send_at,
+            "stdin must be read before the send/status-screen decision, or a \
+             piped prompt cannot influence it; body:\n{body}"
         );
     }
 

--- a/scripts/smoke_local.py
+++ b/scripts/smoke_local.py
@@ -52,6 +52,12 @@ def run(
     completed = subprocess.run(
         argv,
         cwd=repo_root(),
+        # No smoke command takes input, and `rocm chat` without `--prompt` now
+        # reads a piped stdin to EOF: inheriting this script's stdin would make
+        # it hang whenever the harness running the smoke keeps a pipe open.
+        # Hand every child /dev/null so the gate does not depend on how it was
+        # launched (same reason as `vllm_therock_gpu_test.py`).
+        stdin=subprocess.DEVNULL,
         env=env,
         text=True,
         stdout=subprocess.PIPE,

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -79,10 +79,14 @@ Feature: Chat and endpoint detection
   # `rocm chat --help` documents `echo "…" | rocm chat` — the prompt is read
   # from stdin when `--prompt` is omitted. This drives that path (piped stdin,
   # no `--prompt`) and asserts the assistant reply is produced, proving stdin is
-  # consumed and routed through the same send path as `--prompt`.
+  # consumed and routed through the same send path as `--prompt`. The piped text
+  # is indented and trailing-spaced, so the second assertion also proves it
+  # reaches the model unaltered apart from the newline the shell appends —
+  # indentation is meaningful to a model and must not be trimmed away.
   @id:chat-cli-stdin-prompt
   Scenario: chat-08 - The chat CLI reads a one-shot prompt from stdin
     Given a model is being served
     And the model is registered with the CLI
     When the user pipes a one-shot chat prompt through the CLI
     Then the CLI prints the assistant's reply
+    And the model receives the piped prompt with its whitespace intact

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -75,3 +75,14 @@ Feature: Chat and endpoint detection
     And the model is registered with the CLI
     When the user sends a one-shot chat prompt through the CLI
     Then the CLI prints the assistant's reply
+
+  # `rocm chat --help` documents `echo "…" | rocm chat` — the prompt is read
+  # from stdin when `--prompt` is omitted. This drives that path (piped stdin,
+  # no `--prompt`) and asserts the assistant reply is produced, proving stdin is
+  # consumed and routed through the same send path as `--prompt`.
+  @id:chat-cli-stdin-prompt
+  Scenario: chat-08 - The chat CLI reads a one-shot prompt from stdin
+    Given a model is being served
+    And the model is registered with the CLI
+    When the user pipes a one-shot chat prompt through the CLI
+    Then the CLI prints the assistant's reply

--- a/tests/e2e-cucumber/features/chat.feature
+++ b/tests/e2e-cucumber/features/chat.feature
@@ -101,7 +101,7 @@ Feature: Chat and endpoint detection
   # reaches the model unaltered apart from the newline the shell appends —
   # indentation is meaningful to a model and must not be trimmed away.
   @id:chat-cli-stdin-prompt
-  Scenario: chat-08 - The chat CLI reads a one-shot prompt from stdin
+  Scenario: chat-09 - The chat CLI reads a one-shot prompt from stdin
     Given a model is being served
     And the model is registered with the CLI
     When the user pipes a one-shot chat prompt through the CLI

--- a/tests/e2e-cucumber/tests/e2e/chat_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/chat_steps.rs
@@ -80,6 +80,23 @@ async fn user_sends_oneshot_chat(world: &mut E2eWorld) {
     world.cli_output = Some(stdout);
 }
 
+#[when("the user pipes a one-shot chat prompt through the CLI")]
+async fn user_pipes_oneshot_chat(world: &mut E2eWorld) {
+    // Drive `rocm chat` with the prompt on stdin and no `--prompt`, matching the
+    // documented `echo "…" | rocm chat` path. `run_rocm_with_stdin` pipes stdin,
+    // so the child sees a non-terminal stdin and must read the prompt from it.
+    // Passing the served model id avoids depending on default-model resolution.
+    let model = world.model_name.clone().expect("no model name set");
+    let (stdout, stderr, rc) = crate::run_rocm_with_stdin(
+        world,
+        &["chat", "--provider", "local", "--model", &model],
+        "Hello",
+        &[],
+    );
+    assert!(rc == 0, "rocm chat failed (rc={rc}):\n{stdout}\n{stderr}");
+    world.cli_output = Some(stdout);
+}
+
 // ── Then ───────────────────────────────────────────────────────────
 
 #[then("the served model is listed")]

--- a/tests/e2e-cucumber/tests/e2e/chat_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/chat_steps.rs
@@ -7,6 +7,17 @@ use e2e_cucumber::mock_server::MockServer;
 
 use crate::E2eWorld;
 
+/// The exact bytes `user_pipes_oneshot_chat` writes to the CLI's stdin. The
+/// leading indentation and the trailing space are content — a model reads them,
+/// the same as it would from `--prompt` — while the final newline is what
+/// `echo "…" |` appends, so only that may be stripped.
+const PIPED_PROMPT_STDIN: &str = "    Hello, indented and trailing-spaced \n";
+
+/// `PIPED_PROMPT_STDIN` minus the one line ending the writer appended: what the
+/// CLI must send byte for byte, so a piped prompt equals the same text passed
+/// with `--prompt`. Kept next to the input so the two cannot drift apart.
+const PIPED_PROMPT_SENT: &str = "    Hello, indented and trailing-spaced ";
+
 // ── Given ──────────────────────────────────────────────────────────
 
 #[given("a model is being served")]
@@ -86,11 +97,13 @@ async fn user_pipes_oneshot_chat(world: &mut E2eWorld) {
     // documented `echo "…" | rocm chat` path. `run_rocm_with_stdin` pipes stdin,
     // so the child sees a non-terminal stdin and must read the prompt from it.
     // Passing the served model id avoids depending on default-model resolution.
+    // The prompt carries indentation, a trailing space, and the newline `echo`
+    // adds, so the `Then` step can prove which of those the CLI forwards.
     let model = world.model_name.clone().expect("no model name set");
     let (stdout, stderr, rc) = crate::run_rocm_with_stdin(
         world,
         &["chat", "--provider", "local", "--model", &model],
-        "Hello",
+        PIPED_PROMPT_STDIN,
         &[],
     );
     assert!(rc == 0, "rocm chat failed (rc={rc}):\n{stdout}\n{stderr}");
@@ -144,6 +157,38 @@ async fn assert_cli_prints_reply(world: &mut E2eWorld) {
     assert!(
         output.contains("mock response"),
         "chat CLI output does not contain the assistant reply:\n{output}"
+    );
+}
+
+#[then("the model receives the piped prompt with its whitespace intact")]
+async fn piped_chat_request_kept_whitespace(world: &mut E2eWorld) {
+    // The canned reply never varies with the prompt, so printing it proves only
+    // that stdin reached the send path, not that it arrived unaltered — trimming
+    // the piped text would still pass. Assert on the request the mock recorded:
+    // the model must see the piped prompt byte for byte, minus the single line
+    // ending the writer appended. The CLI process has already exited by now and
+    // the mock records the body before it answers, so the snapshot is final and
+    // needs no polling.
+    let body = world
+        .mock
+        .as_ref()
+        .expect("no mock server running")
+        .last_chat_request()
+        .unwrap_or_else(|| panic!("the mock never received a chat request"));
+    let messages = body
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("chat request had no messages array:\n{body}"));
+    let last_user_content = messages
+        .iter()
+        .rev()
+        .find(|m| m.get("role").and_then(serde_json::Value::as_str) == Some("user"))
+        .and_then(|m| m.get("content"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("no user message found in chat request:\n{body}"));
+    assert_eq!(
+        last_user_content, PIPED_PROMPT_SENT,
+        "the piped prompt reached the model altered; full request:\n{body}"
     );
 }
 


### PR DESCRIPTION
## Summary

`rocm chat --help` documents the `echo "…" | rocm chat` form and states the
prompt is read from stdin when `--prompt` is omitted, but stdin was never
consumed. The interactive branch requires a TTY, so piped input fell through to
the non-interactive `None` arm, which rendered the static status screen via
`render_chat_text` and ignored stdin entirely. Only `--prompt` ever sent a
request.

## Fix

Resolve the prompt from `--prompt` or, when it is omitted and stdin is not a
terminal, from piped standard input, then route it through the same
`render_chat_prompt_text` send path as `--prompt`. A new `read_piped_prompt`
helper reads stdin to EOF only when it is not a TTY, returning `None` for an
interactive terminal or empty input so the no-argument behavior (status
screen / interactive dash) is unchanged.

## Reproduce

Before this change:

```
$ printf 'Summarize: the sky is blue.\n' | rocm chat --provider local
Chat assistant

Assistant source: local model on this computer
...
```

The piped prompt was dropped and the status screen printed. After this change
the same command routes the stdin text through the `--prompt` send path
(identical output to `rocm chat --provider local --prompt "Summarize: the sky is blue."`).

## Tests

- Unit test `command_chat_reads_prompt_from_piped_stdin` asserting the no-prompt
  path reads stdin via `read_piped_prompt`.
- Gherkin scenario `@id:chat-cli-stdin-prompt` (`tests/e2e-cucumber/features/chat.feature`)
  that pipes a prompt with no `--prompt` and asserts the assistant reply is
  produced. Runs on the no-GPU mock lane.

Verified locally: reproduced before the fix, confirmed fixed after; the new and
existing one-shot chat scenarios pass, chat unit tests pass, and
`cargo clippy --workspace --all-targets -- -D warnings` is clean.


## Review follow-ups (b2a0770)

Non-blocking points from the automated review of `48f2718a`:

- `scripts/smoke_local.py` — its `run()` inherited the script's own stdin, so the
  `rocm chat --provider local` step is only safe when the harness happens to
  leave fd 0 a TTY or empty. Confirmed on Linux that the built binary waits
  indefinitely with an idle pipe on fd 0 and exits immediately with `/dev/null`,
  so every smoke child now gets `stdin=subprocess.DEVNULL` (matching
  `scripts/vllm_therock_gpu_test.py`). `python scripts/smoke_local.py` passes.
- The comment above the prompt resolution wrongly claimed the status-screen
  fallback is only reached on an interactive TTY; `interactive_terminal()` also
  requires stdout to be a TTY, and an empty pipe lands there too. Corrected.
- Documented as deliberate: reading to EOF (the usual filter contract, same as
  `read_provider_key_from_user`), surfacing a read error rather than treating it
  as "no prompt", and dropping whitespace-only stdin even though `--prompt "   "`
  is forwarded verbatim.
- `command_chat_reads_prompt_from_piped_stdin` now also pins that the read's
  result supplies the dispatched prompt and happens before the send decision,
  and its docstring no longer implies it covers the behavior — `chat-09` does.
