### PR TITLE
fix(examine): read the KFD gfx target from the node properties file

### DIFF
--- a/crates/rocm-core/src/lib.rs
+++ b/crates/rocm-core/src/lib.rs
@@ -4685,15 +4685,16 @@ pub(crate) fn detect_kfd_gfx_target_in(nodes_dir: &Path) -> Option<String> {
         .ok()?
         .flatten()
         .filter_map(|entry| {
-            let value = fs::read_to_string(entry.path().join("gfx_target_version")).ok()?;
+            let value = kfd_node_gfx_target_version(&entry.path())?;
             let token = parse_linux_kfd_gfx_target(value.trim())?;
             Some((entry.file_name().to_string_lossy().into_owned(), token))
         })
         .collect();
     // `read_dir` order is filesystem-defined, so a multi-node box could report a
-    // different GPU run to run. Node names are `node0`, `node1`, ...; sorting by
-    // name makes the answer stable and picks the lowest-numbered node, which is
-    // the one HIP ordinal 0 refers to.
+    // different GPU run to run. Node directories are numbered (`0`, `1`, ... on
+    // a real KFD; `node0`, `node1`, ... in planted fixtures), so sorting on the
+    // trailing number makes the answer stable and picks the lowest-numbered
+    // node, which is the one HIP ordinal 0 refers to.
     targets.sort_by_key(|(name, _)| natural_node_order(name));
     targets.into_iter().next().map(|(_, token)| token)
 }
@@ -4769,9 +4770,12 @@ fn probe_usable_amd_gpu_indices() -> Option<Vec<u32>> {
 /// Combine the KFD-topology and DRM-card AMD GPU counts into one "GPUs present"
 /// figure. KFD counts *compute* nodes and is authoritative for HIP ordinals, so
 /// it wins whenever it reports at least one GPU. DRM is used only as the
-/// zero-KFD fallback: some hosts (e.g. Strix Halo APUs) enumerate the GPU only
-/// via DRM ip-discovery and report zero KFD GPU nodes, so relying on KFD alone
-/// would wrongly conclude there is no GPU and block serving.
+/// zero-KFD fallback, so that a host KFD does not account for is not wrongly
+/// told it has no GPU and blocked from serving. The fallback was added when the
+/// KFD count read a node file that no kernel exposes and so came back zero
+/// everywhere; how often a correctly-read KFD still reports zero has not been
+/// surveyed, so treat this as a hedge rather than a description of known
+/// hardware.
 ///
 /// DRM must not *raise* a nonzero KFD count: a display/render-only AMD DRM card
 /// with no KFD compute node (e.g. KFD=1, DRM=2) would otherwise invent a usable
@@ -4783,7 +4787,7 @@ fn combine_amd_gpu_counts(kfd: Option<usize>, drm: Option<usize>) -> Option<usiz
     match kfd {
         // KFD is compute-authoritative: prefer it whenever it sees a GPU.
         Some(k) if k > 0 => Some(k),
-        // Zero KFD compute nodes: fall back to DRM for the APU shape.
+        // Zero KFD compute nodes: let DRM answer rather than block serving.
         Some(_) => Some(drm.unwrap_or(0)),
         // KFD unreadable: use DRM if it could be read, else availability unknown.
         None => drm,
@@ -4817,7 +4821,17 @@ fn linux_drm_amdgpu_card_count() -> Option<usize> {
 /// availability is unknown and must not be treated as zero.
 #[cfg(target_os = "linux")]
 fn linux_kfd_gpu_node_count() -> Option<usize> {
-    let nodes_dir = Path::new("/sys/class/kfd/kfd/topology/nodes");
+    linux_kfd_gpu_node_count_in(Path::new("/sys/class/kfd/kfd/topology/nodes"))
+}
+
+/// The KFD GPU-node count, against a caller-supplied nodes directory.
+///
+/// Split out for the same reason as [`detect_kfd_gfx_target_in`]: the hosts
+/// where this matters are the ones a test cannot run on. Only the readable
+/// branch is driven by tests -- the unreadable branches key off the real
+/// `/dev/kfd`, which a planted directory cannot stand in for.
+#[cfg(any(target_os = "linux", test))]
+fn linux_kfd_gpu_node_count_in(nodes_dir: &Path) -> Option<usize> {
     match fs::read_dir(nodes_dir) {
         Ok(entries) => Some(
             entries
@@ -4832,11 +4846,48 @@ fn linux_kfd_gpu_node_count() -> Option<usize> {
 
 /// A KFD topology node is a GPU (not the CPU node) when its
 /// `gfx_target_version` is a nonzero value; CPU nodes report `0`.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
 fn kfd_node_is_gpu(node_dir: &Path) -> bool {
+    kfd_node_gfx_target_version(node_dir)
+        .is_some_and(|value| kfd_gfx_target_version_is_gpu(value.trim()))
+}
+
+/// A KFD topology node's `gfx_target_version`, or `None` when the node does not
+/// state one.
+///
+/// The kernel exposes it as a **line inside the node's `properties` file**
+/// (`gfx_target_version 90402`), not as a standalone file. Reading only the
+/// standalone path found nothing on every real KFD host, so target detection
+/// silently fell through to the DRM ip-discovery route, which decodes a GC IP
+/// version and is wrong-but-plausible on the GC 9.4.x line: an MI300X reported
+/// `gfx943` where KFD plainly said `90402` (gfx942). Hosts whose ip-discovery
+/// route also came up empty got `<unknown>` instead.
+///
+/// The standalone file is still read as a fallback, so any layout that does
+/// expose it keeps working.
+#[cfg(any(target_os = "linux", test))]
+fn kfd_node_gfx_target_version(node_dir: &Path) -> Option<String> {
+    let from_properties = fs::read_to_string(node_dir.join("properties"))
+        .ok()
+        .and_then(|text| kfd_property_value(&text, "gfx_target_version"));
+    if from_properties.is_some() {
+        return from_properties;
+    }
     fs::read_to_string(node_dir.join("gfx_target_version"))
         .ok()
-        .is_some_and(|value| kfd_gfx_target_version_is_gpu(value.trim()))
+        .map(|value| value.trim().to_owned())
+}
+
+/// The value of one `key value` line in a KFD `properties` body.
+#[cfg(any(target_os = "linux", test))]
+fn kfd_property_value(text: &str, key: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        if parts.next()? != key {
+            return None;
+        }
+        parts.next().map(str::to_owned)
+    })
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -9979,7 +10030,9 @@ Class Name:                Display
 
     #[test]
     fn kfd_topology_names_the_gpu_when_no_tooling_is_installed() -> Result<()> {
-        // The MI300X case. `Examination` enumerates GPUs by shelling out to
+        // Covers the standalone-file fallback; see
+        // `kfd_topology_reads_the_target_from_the_properties_file` for the
+        // layout a real KFD host has. `Examination` enumerates GPUs by shelling out to
         // lspci and rocminfo; where neither is reachable it reported no AMD GPU
         // on a machine that has one, while the human report -- which reads this
         // topology instead -- named the target correctly. Planted here because
@@ -10031,6 +10084,122 @@ Class Name:                Display
 
         assert_eq!(found.as_deref(), Some("gfx1100"));
         Ok(())
+    }
+
+    #[test]
+    fn kfd_topology_reads_the_target_from_the_properties_file() -> Result<()> {
+        // The layout every real KFD host actually has: the value is a line in
+        // the node's `properties`, and there is no standalone file. Reading only
+        // the standalone path found nothing here, so an MI300X fell through to
+        // ip-discovery and was reported as `gfx943` while KFD said `90402`.
+        // Node directories are bare integers on real hardware, not `nodeN`.
+        let (root, _) = temp_app_paths("kfd-topology-properties");
+        let nodes = root.join("nodes");
+        // Trimmed from a live MI300X; ordering and neighbours are as found.
+        for (node, properties) in [
+            (
+                "0",
+                "cpu_cores_count 56\nsimd_count 0\ngfx_target_version 0\n",
+            ),
+            (
+                "5",
+                "cpu_cores_count 0\nsimd_count 1216\nmax_waves_per_simd 8\ngfx_target_version 90402\n",
+            ),
+        ] {
+            fs::create_dir_all(nodes.join(node))?;
+            fs::write(nodes.join(node).join("properties"), properties)?;
+        }
+
+        let found = detect_kfd_gfx_target_in(&nodes);
+        fs::remove_dir_all(&root).ok();
+
+        assert_eq!(found.as_deref(), Some("gfx942"));
+        Ok(())
+    }
+
+    #[test]
+    fn kfd_gpu_node_count_reads_properties_and_skips_cpu_nodes() -> Result<()> {
+        // The count used the same phantom standalone file, so it saw zero GPUs
+        // on every real host and let the DRM card count stand in for it. Two
+        // CPU nodes and two GPU nodes, shaped like a live Instinct topology.
+        let (root, _) = temp_app_paths("kfd-node-count-properties");
+        let nodes = root.join("nodes");
+        for (node, properties) in [
+            ("0", "cpu_cores_count 56\ngfx_target_version 0\n"),
+            ("1", "cpu_cores_count 56\ngfx_target_version 0\n"),
+            ("5", "simd_count 1216\ngfx_target_version 90402\n"),
+            ("6", "simd_count 1216\ngfx_target_version 90402\n"),
+        ] {
+            fs::create_dir_all(nodes.join(node))?;
+            fs::write(nodes.join(node).join("properties"), properties)?;
+        }
+
+        let count = linux_kfd_gpu_node_count_in(&nodes);
+        fs::remove_dir_all(&root).ok();
+
+        assert_eq!(count, Some(2));
+        Ok(())
+    }
+
+    #[test]
+    fn kfd_properties_win_over_a_standalone_file() -> Result<()> {
+        // Both present: `properties` is what the kernel maintains, so it decides.
+        let (root, _) = temp_app_paths("kfd-topology-properties-precedence");
+        let nodes = root.join("nodes");
+        fs::create_dir_all(nodes.join("0"))?;
+        fs::write(
+            nodes.join("0").join("properties"),
+            "gfx_target_version 90402\n",
+        )?;
+        fs::write(nodes.join("0").join("gfx_target_version"), "110000\n")?;
+
+        let found = detect_kfd_gfx_target_in(&nodes);
+        fs::remove_dir_all(&root).ok();
+
+        assert_eq!(found.as_deref(), Some("gfx942"));
+        Ok(())
+    }
+
+    #[test]
+    fn kfd_topology_bare_integer_node_order_is_numeric_not_lexical() -> Result<()> {
+        // Real KFD node directories are bare integers, and the only ordering that
+        // separates numeric from lexical sorting is a multi-digit one: `10` must
+        // not come before `2`. The other topology tests use single digits, which
+        // sort the same either way, so this is the case that pins the behaviour.
+        let (root, _) = temp_app_paths("kfd-topology-bare-integer-order");
+        let nodes = root.join("nodes");
+        for (node, version) in [("10", "110100\n"), ("2", "90402\n")] {
+            fs::create_dir_all(nodes.join(node))?;
+            fs::write(
+                nodes.join(node).join("properties"),
+                format!("gfx_target_version {version}"),
+            )?;
+        }
+
+        let found = detect_kfd_gfx_target_in(&nodes);
+        fs::remove_dir_all(&root).ok();
+
+        // Node 2 is the lowest-numbered GPU node, so it is the one HIP ordinal 0
+        // refers to.
+        assert_eq!(found.as_deref(), Some("gfx942"));
+        Ok(())
+    }
+
+    #[test]
+    fn kfd_property_value_reads_only_its_own_key() {
+        let body = "simd_count 1216\ngfx_target_version 90402\nnum_gws 64\n";
+        assert_eq!(
+            kfd_property_value(body, "gfx_target_version").as_deref(),
+            Some("90402")
+        );
+        assert_eq!(
+            kfd_property_value(body, "simd_count").as_deref(),
+            Some("1216")
+        );
+        // A key that only appears as a prefix of another must not match, and an
+        // absent key yields nothing rather than an empty string.
+        assert_eq!(kfd_property_value(body, "gfx_target"), None);
+        assert_eq!(kfd_property_value(body, "vram_size"), None);
     }
 
     #[test]

--- a/tests/e2e-cucumber/features/examine.feature
+++ b/tests/e2e-cucumber/features/examine.feature
@@ -17,11 +17,18 @@ Feature: GPU detection and system inspection
     When the user asks for help
     Then the subcommands are listed in alphabetical order
 
+  # The target assertion is a cross-check, not a tautology: the expectation comes
+  # from the KFD topology in sysfs, while `examine` reaches its answer through the
+  # CLI's own probe. Detection used to look for `gfx_target_version` as a standalone
+  # file, which no kernel exposes, and silently fell back to decoding a GC IP
+  # version -- naming an MI300X `gfx943` instead of `gfx942`. Only the GPU lane can
+  # exercise this; there is no KFD topology to read on the mock lane.
   @id:examine-detects-gpu-and-driver @requires-gpu
   Scenario: examine-04 - System inspection detects the GPU and driver
     Given a machine with an AMD GPU
     When the user inspects the system
     Then the inspection reports which GPU is installed
+    And the inspection names the GPU target that the kernel reports
     And the inspection reports that the driver is available
 
   # `examine` used to report a hardcoded platform constant as the default engine,

--- a/tests/e2e-cucumber/tests/e2e/examine_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/examine_steps.rs
@@ -502,3 +502,80 @@ async fn assert_still_states_a_verdict(world: &mut E2eWorld) {
     // Skipping the frameworks must narrow the probe, not hollow out the report.
     assert_states_a_verdict(world).await;
 }
+
+/// The `gfx_target_version` of the lowest-numbered KFD GPU node, read straight
+/// from sysfs.
+///
+/// `None` when the topology is unreadable or names no GPU node, which is the
+/// normal case off Linux and on hosts whose GPU is visible only through DRM.
+/// CPU nodes report `0` and are skipped.
+fn lowest_kfd_gpu_node_gfx_target_version() -> Option<u32> {
+    let mut lowest: Option<(u64, u32)> = None;
+    for entry in std::fs::read_dir("/sys/class/kfd/kfd/topology/nodes")
+        .ok()?
+        .flatten()
+    {
+        let Ok(properties) = std::fs::read_to_string(entry.path().join("properties")) else {
+            continue;
+        };
+        let version = properties.lines().find_map(|line| {
+            let mut parts = line.split_whitespace();
+            if parts.next()? != "gfx_target_version" {
+                return None;
+            }
+            parts.next()?.parse::<u32>().ok()
+        });
+        let Some(version) = version.filter(|value| *value != 0) else {
+            continue;
+        };
+        // Real node directories are bare integers, so order them numerically:
+        // node 10 must not sort ahead of node 2.
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let order = name
+            .trim_start_matches(|ch: char| !ch.is_ascii_digit())
+            .parse::<u64>()
+            .unwrap_or(u64::MAX);
+        if lowest.is_none_or(|(seen, _)| order < seen) {
+            lowest = Some((order, version));
+        }
+    }
+    lowest.map(|(_, version)| version)
+}
+
+/// Cross-check the reported GPU target against KFD's own answer.
+///
+/// `examine` used to read `gfx_target_version` as a standalone file under each
+/// KFD topology node. No kernel exposes it there -- it is a line inside the
+/// node's `properties` -- so detection found nothing and fell through to the
+/// DRM ip-discovery route, which decodes a GC IP version and is
+/// wrong-but-plausible on the GC 9.4.x line: an MI300X whose KFD reports
+/// `gfx_target_version 90402` was named `gfx943` instead of `gfx942`. Asserting
+/// only that the target starts with `gfx` cannot see that.
+///
+/// The expectation is derived from `/sys/class/kfd` rather than from the CLI,
+/// so this is a cross-check and not a tautology. It re-derives only the
+/// unambiguous half of the decode: a revision below 10 renders as its own digit
+/// (9.4.2 -> gfx942). Revisions from 10 up use a lettered form (9.0.10 ->
+/// gfx90a) whose mapping belongs to the CLI, and copying it here would just
+/// restate the code under test, so those hosts keep the looser assertion above.
+#[then("the inspection names the GPU target that the kernel reports")]
+async fn assert_gpu_target_matches_kfd(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no command was run");
+    let reported = field_value(output, "detected_gfx_target")
+        .expect("no detected_gfx_target in examine output");
+
+    let Some(packed) = lowest_kfd_gpu_node_gfx_target_version() else {
+        return;
+    };
+    let (major, minor, revision) = (packed / 10_000, (packed / 100) % 100, packed % 100);
+    if revision >= 10 {
+        return;
+    }
+
+    let expected = format!("gfx{major}{minor}{revision}");
+    assert_eq!(
+        reported, expected,
+        "examine reported {reported}, but KFD reports gfx_target_version {packed} \
+         ({major}.{minor}.{revision} = {expected})\n{output}"
+    );
+}


### PR DESCRIPTION
`rocm examine` names the wrong GPU on AMD Instinct hardware. On an MI300X it
reports `detected_gfx_target: gfx943`; the card is `gfx942`, which is what
`amd-smi` reports as its `TARGET_GRAPHICS_VERSION`.

## Cause

KFD publishes `gfx_target_version` as a line inside each topology node's
`properties` file:

```
$ grep gfx_target_version /sys/class/kfd/kfd/topology/nodes/4/properties
gfx_target_version 90402
```

Detection read it as a standalone `<node>/gfx_target_version` file instead. No
kernel version creates that file, so the read never succeeded on any real host
and detection fell through to decoding a GC IP version from DRM ip-discovery.
That decode is wrong-but-plausible on the GC 9.4.x line, which is how `90402`
(gfx942) surfaced as `gfx943`. Where ip-discovery also came up empty the target
was reported as unknown, and `--family` had to be passed by hand to install a
runtime.

The same phantom path decided whether a topology node is a GPU, so the KFD
count was always zero and the DRM card count silently stood in for it. That
count bounds which `--gpu N` values `serve` accepts and is printed when one is
rejected. Nothing regresses, because DRM was already supplying a correct number
on the common shapes, but the KFD-authoritative guard was inert: a display-only
DRM card with no KFD compute node invented a usable HIP ordinal, and a host with
KFD compute nodes and no visible amdgpu DRM card would wrongly be told it has no
usable GPU.

## Fix

Read `properties` first and keep the standalone file as a fallback. Both
`detect_kfd_gfx_target_in` and `kfd_node_is_gpu` route through one helper.

## Verified on hardware

On an MI300X (amdgpu 6.16.13, ROCm 6.4.1):

| | |
|---|---|
| `amd-smi` `TARGET_GRAPHICS_VERSION` | `gfx942` |
| KFD node `properties` | `gfx_target_version 90402` |
| `ls .../nodes/*/gfx_target_version` | `No such file or directory` |
| `rocm examine` before | `detected_gfx_target: gfx943` |
| `rocm examine` after | `detected_gfx_target: gfx942` |
| `compatible_therock_family` | `gfx94X-dcgpu` before and after |
| `serve --gpu 40` | `1 GPU(s) detected` before and after |

The last row is the count change in practice: on a single-GPU host the
KFD-sourced count matches the DRM-sourced one it replaces, so `--gpu`
validation is unchanged.

## Tests

The existing unit tests planted the standalone layout, which is why this
survived; the added ones use a node layout captured from a live MI300X, plus a
case pinning numeric node ordering (`10` must not sort before `2`, since real
node directories are bare integers).

`examine`'s reported target is user-visible, so scenario
`@id:examine-detects-gpu-and-driver` now cross-checks it against the KFD
topology in sysfs rather than only asserting it starts with `gfx`. That
assertion runs on the **`@requires-gpu`** lane only: there is no KFD topology to
read on the mock lane.

Refs #266 — same root cause as the MI210 report there, which surfaces as
`<unknown>` rather than a wrong-but-plausible target. That issue raises several
other items, so this does not close it.

---

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. (No rows keyed to gfx-target detection.)
