### PR TITLE
fix(cli): keep the runtimes-list legend in sync with its markers

### DIFF
--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -6629,6 +6629,14 @@ struct RuntimeUninstallResult {
     was_active: bool,
 }
 
+/// Marker shown beside the active runtime in `rocm runtimes list`. Every
+/// place that renders this glyph MUST use this constant so the rendered
+/// character and the legend text stay in sync.
+const ACTIVE_RUNTIME_MARKER: &str = "*";
+/// Marker shown beside the rollback-target runtime. See
+/// [`ACTIVE_RUNTIME_MARKER`].
+const ROLLBACK_RUNTIME_MARKER: &str = "-";
+
 pub(crate) fn render_runtimes_text(paths: &AppPaths, config: &RocmCliConfig) -> Result<String> {
     recover_setup_runtime_registration(paths, config)?;
     let manifests = therock::load_runtime_manifests(paths)?;
@@ -6708,6 +6716,11 @@ pub(crate) fn render_runtimes_text(paths: &AppPaths, config: &RocmCliConfig) -> 
     drop(default_runtime_matches);
 
     let _ = writeln!(output, "  installed:");
+    let _ = writeln!(
+        output,
+        "    legend: {ACTIVE_RUNTIME_MARKER} = active, {ROLLBACK_RUNTIME_MARKER} = rollback target"
+    );
+    let _ = writeln!(output);
     for manifest in manifests {
         let active = config
             .active_runtime_key
@@ -6719,9 +6732,9 @@ pub(crate) fn render_runtimes_text(paths: &AppPaths, config: &RocmCliConfig) -> 
             .as_deref()
             .is_some_and(|runtime_key| runtime_key == manifest.runtime_key);
         let marker = if active {
-            "*"
+            ACTIVE_RUNTIME_MARKER
         } else if rollback {
-            "-"
+            ROLLBACK_RUNTIME_MARKER
         } else {
             " "
         };
@@ -26462,6 +26475,37 @@ ID_LIKE="suse opensuse"
         assert!(rendered.contains(
             "active_status: missing manifest for active_runtime_key=missing-runtime-key"
         ));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn render_runtimes_text_includes_marker_legend() -> Result<()> {
+        let (root, paths) = test_paths("runtime-marker-legend");
+        write_test_pip_runtime(
+            &paths,
+            "release-pip-gfx120x-all-7-13-0",
+            "therock-release:gfx120X-all",
+            "7.13.0",
+            10,
+        )?;
+        let config = RocmCliConfig {
+            active_runtime_key: Some("release-pip-gfx120x-all-7-13-0".to_owned()),
+            ..RocmCliConfig::default()
+        };
+
+        let rendered = render_runtimes_text(&paths, &config)?;
+        let legend = format!(
+            "legend: {ACTIVE_RUNTIME_MARKER} = active, {ROLLBACK_RUNTIME_MARKER} = rollback target\n\n"
+        );
+        let entry = format!("{ACTIVE_RUNTIME_MARKER} release-pip-gfx120x-all-7-13-0");
+        let legend_pos = rendered.find(&legend).expect("legend line present");
+        let entry_pos = rendered.find(&entry).expect("active entry present");
+        assert!(
+            legend_pos < entry_pos,
+            "legend must appear before the entries it explains:\n{rendered}"
+        );
 
         let _ = fs::remove_dir_all(root);
         Ok(())

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -61,6 +61,16 @@ pub struct RuntimeSummary {
     pub rollback: bool,
 }
 
+/// Marker shown beside the active runtime in the list. Every place *in this
+/// module* that renders this glyph MUST use this constant so it can't drift
+/// out of sync with the legend rendered in `draw_runtime_manager`. Other
+/// modules (e.g. the compact runtime preview in `tabs/pane.rs`) render the
+/// same active/inactive concept independently and are not bound by this.
+const ACTIVE_MARKER: &str = "● ";
+/// Marker shown beside the rollback-target runtime in the list. See
+/// [`ACTIVE_MARKER`].
+const ROLLBACK_MARKER: &str = "↺ ";
+
 /// The mutating lifecycle verbs (everything except the read-only refresh).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeAction {
@@ -355,14 +365,32 @@ pub fn draw_runtime_manager(
         return;
     }
 
+    // No legend row when there's nothing to explain — collapse it to zero
+    // height instead of always reserving it, so the empty-state hint isn't
+    // pushed down by a blank line.
+    let legend_height = u16::from(!runtimes.is_empty());
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
+            Constraint::Length(legend_height),
             Constraint::Min(1),
             Constraint::Length(1),
             Constraint::Length(1),
         ])
         .split(inner);
+
+    if !runtimes.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(ACTIVE_MARKER, Style::default().fg(theme.ok)),
+                Span::styled("= active", Style::default().fg(theme.muted)),
+                Span::styled(" · ", Style::default().fg(theme.muted)),
+                Span::styled(ROLLBACK_MARKER, Style::default().fg(theme.warn)),
+                Span::styled("= rollback target", Style::default().fg(theme.muted)),
+            ])),
+            rows[0],
+        );
+    }
 
     if runtimes.is_empty() {
         f.render_widget(
@@ -371,16 +399,16 @@ pub fn draw_runtime_manager(
                  i to import a manifest, or l to refresh.",
                 Style::default().fg(theme.muted),
             ))),
-            rows[0],
+            rows[1],
         );
     } else {
         let items: Vec<ListItem> = runtimes
             .iter()
             .map(|rt| {
                 let marker = if rt.active {
-                    "● "
+                    ACTIVE_MARKER
                 } else if rt.rollback {
-                    "↺ "
+                    ROLLBACK_MARKER
                 } else {
                     "  "
                 };
@@ -418,9 +446,9 @@ pub fn draw_runtime_manager(
         );
         let list_area = panel::vertical_scrollbar(
             f,
-            rows[0],
+            rows[1],
             runtimes.len(),
-            rows[0].height as usize,
+            rows[1].height as usize,
             r.selected,
             theme,
         );
@@ -433,7 +461,7 @@ pub fn draw_runtime_manager(
             msg.to_string(),
             Style::default().fg(theme.err),
         ))),
-        rows[1],
+        rows[2],
     );
 
     f.render_widget(
@@ -441,7 +469,7 @@ pub fn draw_runtime_manager(
             "↑↓ select · Enter/a activate · r rollback · x uninstall · o adopt · i import · l refresh · Esc close",
             Style::default().fg(theme.muted),
         ))),
-        rows[2],
+        rows[3],
     );
 
     if let Some(fb) = &r.browser {
@@ -772,6 +800,35 @@ mod tests {
         assert!(out.contains("Runtimes"));
         assert!(out.contains("therock-release-gfx94"));
         assert!(out.contains("activate"));
+        assert!(out.contains("= active"));
+        assert!(out.contains("= rollback target"));
+    }
+
+    #[test]
+    fn snapshot_legend_markers_are_color_matched() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let theme = Theme::from_name("default-dark");
+        let backend = TestBackend::new(120, 22);
+        let mut term = Terminal::new(backend).unwrap();
+        let r = RuntimeManagerState::default();
+        let rts = runtimes();
+        let jobs = State::default();
+        term.draw(|f| draw_runtime_manager(f, f.area(), &r, &rts, &jobs, &theme))
+            .unwrap();
+        let buffer = term.backend().buffer();
+        let active_cell = buffer
+            .content()
+            .iter()
+            .find(|cell| cell.symbol() == ACTIVE_MARKER.trim())
+            .expect("active marker glyph should render");
+        assert_eq!(active_cell.fg, theme.ok);
+        let rollback_cell = buffer
+            .content()
+            .iter()
+            .find(|cell| cell.symbol() == ROLLBACK_MARKER.trim())
+            .expect("rollback marker glyph should render");
+        assert_eq!(rollback_cell.fg, theme.warn);
     }
 
     #[test]
@@ -793,5 +850,30 @@ mod tests {
             .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("No runtimes registered"));
+    }
+
+    #[test]
+    fn draws_without_panicking_at_minimum_height_with_runtimes() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        // A non-empty runtime list now needs 4 inner rows (legend + list +
+        // message + footer), one more than before the legend row existed. At
+        // height 6 the bento border/padding leaves only 3 inner rows, so the
+        // layout must shrink gracefully instead of panicking.
+        let theme = Theme::from_name("default-dark");
+        let backend = TestBackend::new(40, 6);
+        let mut term = Terminal::new(backend).unwrap();
+        let r = RuntimeManagerState::default();
+        let rts = runtimes();
+        let jobs = State::default();
+        term.draw(|f| draw_runtime_manager(f, f.area(), &r, &rts, &jobs, &theme))
+            .unwrap();
+    }
+
+    #[test]
+    fn runtime_markers_are_non_empty_and_distinct() {
+        assert!(!ACTIVE_MARKER.trim().is_empty());
+        assert!(!ROLLBACK_MARKER.trim().is_empty());
+        assert_ne!(ACTIVE_MARKER, ROLLBACK_MARKER);
     }
 }

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -367,8 +367,11 @@ pub fn draw_runtime_manager(
 
     // No legend row when there's nothing to explain — collapse it to zero
     // height instead of always reserving it, so the empty-state hint isn't
-    // pushed down by a blank line.
-    let legend_height = u16::from(!runtimes.is_empty());
+    // pushed down by a blank line. "Nothing to explain" means no row actually
+    // carries a marker yet (mirrors the HELD_LEGEND/any_held precedent in
+    // format.rs / tabs/observe.rs), not merely a non-empty list.
+    let any_marked = runtimes.iter().any(|rt| rt.active || rt.rollback);
+    let legend_height = u16::from(any_marked);
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -379,7 +382,7 @@ pub fn draw_runtime_manager(
         ])
         .split(inner);
 
-    if !runtimes.is_empty() {
+    if any_marked {
         f.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled(ACTIVE_MARKER, Style::default().fg(theme.ok)),
@@ -805,6 +808,39 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_legend_collapses_when_no_runtime_is_marked() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let theme = Theme::from_name("default-dark");
+        let backend = TestBackend::new(120, 22);
+        let mut term = Terminal::new(backend).unwrap();
+        let r = RuntimeManagerState::default();
+        // Non-empty list, but nothing active or rollback-marked — the legend
+        // has nothing to explain, so it must collapse just like the empty case.
+        let rts: Vec<RuntimeSummary> = runtimes()
+            .into_iter()
+            .map(|mut rt| {
+                rt.active = false;
+                rt.rollback = false;
+                rt
+            })
+            .collect();
+        let jobs = State::default();
+        term.draw(|f| draw_runtime_manager(f, f.area(), &r, &rts, &jobs, &theme))
+            .unwrap();
+        let out: String = term
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(out.contains("therock-release-gfx94"));
+        assert!(!out.contains("= active"));
+        assert!(!out.contains("= rollback target"));
+    }
+
+    #[test]
     fn snapshot_legend_markers_are_color_matched() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
@@ -817,17 +853,23 @@ mod tests {
         term.draw(|f| draw_runtime_manager(f, f.area(), &r, &rts, &jobs, &theme))
             .unwrap();
         let buffer = term.backend().buffer();
+        // `Buffer::content()` is row-major (index = y*width + x) and the legend
+        // renders above the list, so a plain `.find()` always hits the legend's
+        // own glyph first and never actually reaches the list row — making this
+        // assertion tautological. Take the LAST match instead: since the list
+        // is laid out below the legend, the last occurrence in iteration order
+        // is guaranteed to come from a list row, not the legend.
         let active_cell = buffer
             .content()
             .iter()
-            .find(|cell| cell.symbol() == ACTIVE_MARKER.trim())
-            .expect("active marker glyph should render");
+            .rfind(|cell| cell.symbol() == ACTIVE_MARKER.trim())
+            .expect("active marker glyph should render in the list");
         assert_eq!(active_cell.fg, theme.ok);
         let rollback_cell = buffer
             .content()
             .iter()
-            .find(|cell| cell.symbol() == ROLLBACK_MARKER.trim())
-            .expect("rollback marker glyph should render");
+            .rfind(|cell| cell.symbol() == ROLLBACK_MARKER.trim())
+            .expect("rollback marker glyph should render in the list");
         assert_eq!(rollback_cell.fg, theme.warn);
     }
 
@@ -850,6 +892,10 @@ mod tests {
             .map(ratatui::buffer::Cell::symbol)
             .collect();
         assert!(out.contains("No runtimes registered"));
+        // The legend explains markers that don't exist yet on an empty list —
+        // it must be collapsed away entirely, not merely scrolled off.
+        assert!(!out.contains("= active"));
+        assert!(!out.contains("= rollback target"));
     }
 
     #[test]

--- a/tests/e2e-cucumber/features/runtime_lifecycle.feature
+++ b/tests/e2e-cucumber/features/runtime_lifecycle.feature
@@ -42,8 +42,8 @@ Feature: Runtime lifecycle state machine
   # rollback-target, and neither, with nothing else on the page explaining what
   # they mean. This asserts the printed legend actually names both glyphs, so the
   # rendered marker and its explanation can't drift apart silently.
-  @id:runtime-list-shows-marker-legend
-  Scenario: 5 - Listing runtimes explains the active and rollback markers
+  @id:runtime-lifecycle-list-shows-marker-legend
+  Scenario: runtime-lifecycle-05 - Listing runtimes explains the active and rollback markers
     Given two registered runtimes with the second active after the first
     When the user rolls back
     And the user lists the registered runtimes

--- a/tests/e2e-cucumber/features/runtime_lifecycle.feature
+++ b/tests/e2e-cucumber/features/runtime_lifecycle.feature
@@ -37,3 +37,16 @@ Feature: Runtime lifecycle state machine
     Then the CLI refuses because it already exists
     When the user imports it again allowing replacement
     Then the import succeeds
+
+  # `rocm runtimes list` prefixes each row with `*`/`-`/a blank to mark active,
+  # rollback-target, and neither, with nothing else on the page explaining what
+  # they mean. This asserts the printed legend actually names both glyphs, so the
+  # rendered marker and its explanation can't drift apart silently.
+  @id:runtime-list-shows-marker-legend
+  Scenario: 5 - Listing runtimes explains the active and rollback markers
+    Given two registered runtimes with the second active after the first
+    When the user rolls back
+    And the user lists the registered runtimes
+    Then the listing explains the active and rollback markers
+    And the first runtime is marked active
+    And the second runtime is marked as the rollback target

--- a/tests/e2e-cucumber/tests/e2e/runtime_lifecycle_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/runtime_lifecycle_steps.rs
@@ -140,6 +140,12 @@ async fn rollback(world: &mut E2eWorld) {
     record(world, stdout, stderr, rc);
 }
 
+#[when("the user lists the registered runtimes")]
+async fn list_runtimes(world: &mut E2eWorld) {
+    let (stdout, stderr, rc) = crate::run_rocm(world, &["runtimes", "list"]);
+    record(world, stdout, stderr, rc);
+}
+
 #[when("the user uninstalls that runtime")]
 async fn uninstall(world: &mut E2eWorld) {
     let (stdout, stderr, rc) = crate::run_rocm(world, &["runtimes", "uninstall", FIRST_KEY]);
@@ -269,6 +275,33 @@ async fn import_succeeds(world: &mut E2eWorld) {
     assert!(
         out.contains("runtime imported"),
         "expected the replace import to succeed, got:\n{out}"
+    );
+}
+
+#[then("the listing explains the active and rollback markers")]
+async fn listing_explains_markers(world: &mut E2eWorld) {
+    let out = ok_output(world);
+    assert!(
+        out.contains("legend: * = active, - = rollback target"),
+        "expected the marker legend, got:\n{out}"
+    );
+}
+
+#[then("the first runtime is marked active")]
+async fn first_marked_active(world: &mut E2eWorld) {
+    let out = ok_output(world);
+    assert!(
+        out.contains(&format!("* {FIRST_KEY}")),
+        "expected {FIRST_KEY} marked active, got:\n{out}"
+    );
+}
+
+#[then("the second runtime is marked as the rollback target")]
+async fn second_marked_rollback(world: &mut E2eWorld) {
+    let out = ok_output(world);
+    assert!(
+        out.contains(&format!("- {SECOND_KEY}")),
+        "expected {SECOND_KEY} marked as rollback target, got:\n{out}"
     );
 }
 

--- a/xtask/src/e2e_prewarm.rs
+++ b/xtask/src/e2e_prewarm.rs
@@ -822,6 +822,8 @@ registered ROCm runtimes
   registry: /w/e2e-prewarm/data/runtimes/registry
   marker: /w/e2e-prewarm/data/runtimes/active.json
   installed:
+    legend: * = active, - = rollback target
+
     adopted-external-env runtime_id=external-adopted version=7.14.0 format=wheel family=gfx94X-dcgpu mode=read-only status=unusable (pip runtime manifest is missing rocm_sdk probe data)
       install_root: /opt/external-rocm
     release-wheel-gfx94x-dcgpu-7-15-0 runtime_id=therock-release-gfx94x-dcgpu version=7.15.0 format=wheel family=gfx94X-dcgpu mode=managed status=unusable (pip runtime manifest is missing rocm_sdk probe data)
@@ -859,6 +861,8 @@ registered ROCm runtimes
   marker: /w/e2e-prewarm/data/runtimes/active.json
   active_status: missing manifest for active_runtime_key=release-wheel-gfx94x-dcgpu-7-14-0
   installed:
+    legend: * = active, - = rollback target
+
     adopted-external-env runtime_id=external-adopted version=7.14.0 format=wheel family=gfx94X-dcgpu mode=read-only status=usable
       install_root: /opt/external-rocm
     release-wheel-gfx94x-dcgpu-7-13-0 runtime_id=therock-release-gfx94x-dcgpu version=7.13.0 format=wheel family=gfx94X-dcgpu mode=managed status=usable


### PR DESCRIPTION
## Summary
- Keep the runtimes-list marker legend in sync with the markers actually printed (CLI)
- Collapse the legend row in the dash TUI's runtime manager when the runtime list is empty
- Add e2e coverage for the runtimes-list marker legend scenario
- Refresh e2e-prewarm fixtures for the new legend line

## Test plan
- [x] `cargo test` for `rocm`, `rocm-dash-tui`, and `xtask` crates (all green)
- [x] New e2e scenario covering the marker legend added and passing