### PR TITLE
test(e2e): drive the Lemonade recovery scenario with a planted runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,12 +388,40 @@ jobs:
 
       - name: Acceptance install lifecycle
         if: needs.changes.outputs.heavy == 'true'
+        shell: pwsh
         # Windows install lifecycle (packaging + native-crypto verify + user-PATH
         # + loopback HTTP + isolated smoke + uninstall) as opt-in @lifecycle E2E.
+        #
+        # Hand the suite the binaries the Build step already produced. Without
+        # this `cargo xtask e2e` builds `rocm`/`rocmd` for itself, and because it
+        # adds `--features rocm/e2e-test-hooks` the feature resolution differs
+        # from the Build step's — so cargo recompiles the whole release graph
+        # rather than reusing it. That second release build cost 3-4 minutes on
+        # every run, on the job that alone determines when CI goes green.
+        #
+        # Deliberately NOT built with `rocm/e2e-test-hooks`, unlike the prebuilt
+        # lanes in e2e-selfhosted.yml / nightly.yml. Those run the full suite,
+        # whose scripted failure seams are compiled out without the feature.
+        # `E2E_ONLY_LIFECYCLE` restricts this lane to @lifecycle scenarios, none
+        # of which touch a seam — and this lane packages and installs the binary
+        # through the real installer, so it should ship exactly what a release
+        # ships rather than a build carrying test hooks.
         env:
           E2E_INCLUDE_LIFECYCLE: "1"
           E2E_ONLY_LIFECYCLE: "1"
-        run: cargo xtask e2e
+        run: |
+          $env:ROCM_CLI_BINARY = "$PWD\target\release\rocm.exe"
+          $env:ROCM_CLI_ROCMD_BINARY = "$PWD\target\release\rocmd.exe"
+          # Fail here, naming the missing binary, rather than letting a scenario
+          # die on a "failed to run" deep in the suite. These paths assume the
+          # default target dir; if a future change sets CARGO_TARGET_DIR they
+          # must follow it.
+          foreach ($bin in $env:ROCM_CLI_BINARY, $env:ROCM_CLI_ROCMD_BINARY) {
+            if (-not (Test-Path $bin)) {
+              throw "expected the Build step to have produced $bin"
+            }
+          }
+          cargo xtask e2e
 
   prek:
     # The fast lint gate: every toolchain-light lint/hygiene check, run from the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,14 +410,17 @@ jobs:
           E2E_INCLUDE_LIFECYCLE: "1"
           E2E_ONLY_LIFECYCLE: "1"
         run: |
-          $env:ROCM_CLI_BINARY = "$PWD\target\release\rocm.exe"
-          $env:ROCM_CLI_ROCMD_BINARY = "$PWD\target\release\rocmd.exe"
+          # Derive from CARGO_TARGET_DIR when it is set, falling back to the
+          # default target dir — the same form the PowerShell prebuilt lanes in
+          # nightly.yml and e2e-selfhosted.yml use, so a future job-level
+          # CARGO_TARGET_DIR cannot leave this lane pointing at a stale path.
+          $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
+          $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
+          $env:ROCM_CLI_ROCMD_BINARY = "$targetDir\release\rocmd.exe"
           # Fail here, naming the missing binary, rather than letting a scenario
-          # die on a "failed to run" deep in the suite. These paths assume the
-          # default target dir; if a future change sets CARGO_TARGET_DIR they
-          # must follow it.
+          # die on a "failed to run" deep in the suite.
           foreach ($bin in $env:ROCM_CLI_BINARY, $env:ROCM_CLI_ROCMD_BINARY) {
-            if (-not (Test-Path $bin)) {
+            if (-not (Test-Path -LiteralPath $bin)) {
               throw "expected the Build step to have produced $bin"
             }
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,20 +392,16 @@ jobs:
         # Windows install lifecycle (packaging + native-crypto verify + user-PATH
         # + loopback HTTP + isolated smoke + uninstall) as opt-in @lifecycle E2E.
         #
-        # Hand the suite the binaries the Build step already produced. Without
-        # this `cargo xtask e2e` builds `rocm`/`rocmd` for itself, and because it
-        # adds `--features rocm/e2e-test-hooks` the feature resolution differs
-        # from the Build step's — so cargo recompiles the whole release graph
-        # rather than reusing it. That second release build cost 3-4 minutes on
-        # every run, on the job that alone determines when CI goes green.
+        # Hand the suite the binaries the Build step already produced, so
+        # `cargo xtask e2e` skips its own build entirely. Relying on cargo to
+        # notice the artifacts are fresh is not enough: any divergence between
+        # the two invocations (profile, package set, RUSTFLAGS, target dir)
+        # re-resolves the graph and recompiles it. That is what happened here —
+        # a feature-set mismatch cost a second 3-4 minute release build on every
+        # run, on the job that alone determines when CI goes green.
         #
-        # Deliberately NOT built with `rocm/e2e-test-hooks`, unlike the prebuilt
-        # lanes in e2e-selfhosted.yml / nightly.yml. Those run the full suite,
-        # whose scripted failure seams are compiled out without the feature.
-        # `E2E_ONLY_LIFECYCLE` restricts this lane to @lifecycle scenarios, none
-        # of which touch a seam — and this lane packages and installs the binary
-        # through the real installer, so it should ship exactly what a release
-        # ships rather than a build carrying test hooks.
+        # This lane packages and installs the binary through the real installer,
+        # so it ships exactly what a release ships.
         env:
           E2E_INCLUDE_LIFECYCLE: "1"
           E2E_ONLY_LIFECYCLE: "1"

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -280,14 +280,11 @@ jobs:
           # pre-warm and suite so xtask does not rebuild. Honors
           # CARGO_TARGET_DIR set above.
           #
-          # `--features rocm/e2e-test-hooks` must match what `cargo xtask e2e`
-          # builds when it builds for itself. The suite's deterministic failure
-          # seams (e.g. the scripted Lemonade backend-install failure) are
-          # compiled out without it, so a pre-built binary that omits the feature
-          # leaves those scenarios unable to reach their premise — they then fail
-          # as regressions on whichever lane happens to select them. Every lane
-          # that pre-builds and exports ROCM_CLI_BINARY must pass it.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # Keep this invocation identical to the one `cargo xtask e2e` runs when
+          # it builds for itself. Any divergence (profile, package set, features)
+          # re-resolves the graph and makes xtask recompile everything instead of
+          # reusing what this step just built.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -452,9 +449,9 @@ jobs:
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane for why this must match what `cargo xtask e2e`
+          # would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -605,9 +602,9 @@ jobs:
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
           # This job does not set CARGO_TARGET_DIR, so the binaries land in
           # the default target\release (fall back to it when the env var is unset).
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane for why this must match what `cargo xtask e2e`
+          # would build for itself.
+          cargo build --release -p rocm -p rocmd
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
@@ -792,9 +789,9 @@ jobs:
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane for why this must match what `cargo xtask e2e`
+          # would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -921,9 +918,9 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane for why this must match what `cargo xtask e2e`
+          # would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -425,9 +425,9 @@ jobs:
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
           # Build both binaries once; reuse them for pre-warm + suite.
-          # See the e2e-gpu lane in e2e-selfhosted.yml for why the
-          # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane in e2e-selfhosted.yml for why this must match
+          # what `cargo xtask e2e` would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -526,9 +526,9 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # See the e2e-gpu lane in e2e-selfhosted.yml for why the
-          # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane in e2e-selfhosted.yml for why this must match
+          # what `cargo xtask e2e` would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -622,9 +622,9 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # See the e2e-gpu lane in e2e-selfhosted.yml for why the
-          # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane in e2e-selfhosted.yml for why this must match
+          # what `cargo xtask e2e` would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 
@@ -718,9 +718,9 @@ jobs:
           $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm"
           $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
 
-          # See the e2e-gpu lane in e2e-selfhosted.yml for why the
-          # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane in e2e-selfhosted.yml for why this must match
+          # what `cargo xtask e2e` would build for itself.
+          cargo build --release -p rocm -p rocmd
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $targetDir = if ($env:CARGO_TARGET_DIR) { $env:CARGO_TARGET_DIR } else { "target" }
           $env:ROCM_CLI_BINARY = "$targetDir\release\rocm.exe"
@@ -872,9 +872,9 @@ jobs:
           prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
-          # See the e2e-gpu lane in e2e-selfhosted.yml for why the
-          # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
+          # See the e2e-gpu lane in e2e-selfhosted.yml for why this must match
+          # what `cargo xtask e2e` would build for itself.
+          cargo build --release -p rocm -p rocmd
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
           export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
 

--- a/apps/rocm/Cargo.toml
+++ b/apps/rocm/Cargo.toml
@@ -10,9 +10,6 @@ publish.workspace = true
 [lints]
 workspace = true
 
-[features]
-e2e-test-hooks = ["rocm-engine-lemonade/e2e-test-hooks"]
-
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/apps/rocm/src/main.rs
+++ b/apps/rocm/src/main.rs
@@ -4999,13 +4999,8 @@ fn serve(args: ServeArgs) -> Result<()> {
     // BEFORE preparing or launching any engine (no wasted engine download, and an
     // actionable message instead of a late engine crash). The engine enforces the
     // same rule as a backstop. Skipped for cpu_only; permissive when availability
-    // cannot be probed on this platform (probe returns `None`). The E2E-only
-    // backend-failure scenario bypasses this host precondition so the black-box
-    // test reaches Lemonade's backend boundary without real GPU hardware.
-    let scripted_backend_failure = cfg!(feature = "e2e-test-hooks")
-        && std::env::var_os("ROCM_E2E_LEMONADE_BACKEND_INSTALL_FAILURE").is_some();
+    // cannot be probed on this platform (probe returns `None`).
     if !cpu_only
-        && !scripted_backend_failure
         && let Some(usable) = rocm_core::usable_amd_gpu_indices()
         && usable.is_empty()
     {

--- a/engines/lemonade/Cargo.toml
+++ b/engines/lemonade/Cargo.toml
@@ -10,9 +10,6 @@ publish.workspace = true
 [lints]
 workspace = true
 
-[features]
-e2e-test-hooks = []
-
 [[bin]]
 name = "rocm-engine-lemonade"
 path = "src/main.rs"

--- a/engines/lemonade/src/lib.rs
+++ b/engines/lemonade/src/lib.rs
@@ -40,8 +40,6 @@ const DEFAULT_MODEL_REPO_DIR: &str = "models--unsloth--Qwen3-4B-Instruct-2507-GG
 const DEFAULT_MODEL_GGUF: &str = "Qwen3-4B-Instruct-2507-Q4_K_M.gguf";
 const LLAMACPP_RECIPE: &str = "llamacpp";
 const ROCM_BACKEND_NAME: &str = "rocm";
-#[cfg(feature = "e2e-test-hooks")]
-const BACKEND_INSTALL_FAILURE_TEST_ENV: &str = "ROCM_E2E_LEMONADE_BACKEND_INSTALL_FAILURE";
 /// Preferred llama.cpp backends, best first. Lemonade reports per-GPU support;
 /// we pick the highest-priority backend it considers supported on this host.
 /// GPU backends only — `cpu` is intentionally excluded so the router path never
@@ -428,14 +426,6 @@ fn detect_response() -> DetectResponse {
 fn install_response(request: InstallRequest) -> Result<InstallResponse> {
     let paths = AppPaths::discover()?;
     paths.ensure()?;
-    // Debug builds expose a deterministic failure seam for the black-box CLI
-    // scenario that pins retry count and terminal recovery guidance. Keep it at
-    // the backend phase: the real defect happens after the embeddable is ready,
-    // and exercising it must not download or alter a runtime on the test host.
-    #[cfg(feature = "e2e-test-hooks")]
-    if std::env::var_os(BACKEND_INSTALL_FAILURE_TEST_ENV).is_some() {
-        install_llamacpp_backend_with_retry(|| bail!("scripted Lemonade backend install failure"))?;
-    }
     eprintln!(
         "Preparing Lemonade embeddable {}...",
         rocm_deps::LEMONADE_VERSION
@@ -5099,6 +5089,41 @@ vllm                rocm        unsupported     Requires Linux                  
                 ("system".to_owned(), "unsupported".to_owned()),
                 ("vulkan".to_owned(), "installable".to_owned()),
             ]
+        );
+    }
+
+    /// The E2E fake runtime's `lemonade backends` table must drive this engine to
+    /// attempt a `llamacpp:rocm` install — that attempt is the whole premise of
+    /// `@id:serve-lemonade-preparation-recovery`.
+    ///
+    /// That scenario is `@requires-gpu`, so nothing on a GPU-less lane would
+    /// notice if a parser change stopped accepting the fixture's table: the
+    /// scenario would quietly stop reaching the failure it asserts, and only a
+    /// GPU lane would report it. Pin the coupling here, where every lane runs it.
+    /// Keep this table byte-identical to the one printed by
+    /// `tests/e2e-cucumber/src/bin/fake-lemonade.rs`.
+    #[test]
+    fn e2e_fake_runtime_table_drives_a_rocm_backend_install() {
+        let output = "\
+Recipe    Backend   Status
+--------  --------  -----------
+llamacpp  rocm      installable
+llamacpp  vulkan    unsupported
+";
+        let backends = parse_llamacpp_backend_statuses(output);
+        assert_eq!(
+            backends,
+            vec![
+                ("rocm".to_owned(), "installable".to_owned()),
+                ("vulkan".to_owned(), "unsupported".to_owned()),
+            ]
+        );
+        // `false` = not already installed, which is what makes the engine run the
+        // install the fixture then refuses. Reporting `installed` instead would
+        // skip the install and the scenario would never see a failure.
+        assert_eq!(
+            select_best_llamacpp_backend(&backends),
+            Some(("rocm".to_owned(), false))
         );
     }
 

--- a/tests/e2e-cucumber/Cargo.toml
+++ b/tests/e2e-cucumber/Cargo.toml
@@ -16,6 +16,16 @@ workspace = true
 name = "rocm-demo-env"
 path = "src/bin/rocm-demo-env.rs"
 
+# Stand-in for a Lemonade runtime's `lemonade`/`lemond` executables, planted by
+# the serve-preparation-recovery scenario. A bin target of this package so the
+# suite can reach it through `CARGO_BIN_EXE_fake-lemonade`, which cargo sets when
+# it builds the `e2e` test target — no xtask plumbing and no second copy of the
+# path to keep in step. It must be a real executable, not a script: the engine
+# spawns it by exact path, and Windows `CreateProcess` needs a PE image.
+[[bin]]
+name = "fake-lemonade"
+path = "src/bin/fake-lemonade.rs"
+
 [dependencies]
 axum.workspace = true
 cucumber = { version = "0.23", features = ["output-json", "output-junit"] }

--- a/tests/e2e-cucumber/features/model_serving.feature
+++ b/tests/e2e-cucumber/features/model_serving.feature
@@ -176,12 +176,15 @@ Feature: Model serving
     Then serving is refused before any engine starts
     And the user is told the two selectors cannot be combined
 
-  # The failure is injected at Lemonade's backend-install boundary in debug/test
-  # builds, after the CLI has selected Lemonade but before any runtime download or
-  # machine mutation. That makes the user-visible retry and final recovery command
-  # deterministic on the blocking no-GPU lane rather than relying on a real 3 GiB
-  # transfer to fail at just the right moment.
-  @id:serve-lemonade-preparation-recovery @requires-no-gpu
+  # The harness plants a Lemonade runtime whose `lemonade backends install` always
+  # exits non-zero, so the failure happens at the real boundary — a non-zero child
+  # process, after the CLI has selected Lemonade but before any runtime download or
+  # machine mutation — and the user-visible retry and recovery command are
+  # deterministic without a real multi-gigabyte transfer failing at just the right
+  # moment. Needs a GPU because `rocm serve` enforces its GPU-required policy
+  # before it resolves the runtime, so a GPU-less host stops at the pre-flight and
+  # never reaches preparation.
+  @id:serve-lemonade-preparation-recovery @requires-gpu
   Scenario: serve-18 - Repeated Lemonade preparation failure gives the user a recovery path
     Given Lemonade preparation cannot complete
     When the user serves a model with Lemonade

--- a/tests/e2e-cucumber/src/bin/fake-lemonade.rs
+++ b/tests/e2e-cucumber/src/bin/fake-lemonade.rs
@@ -1,0 +1,100 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier: MIT
+
+//! A stand-in for the two executables a Lemonade runtime installs: the `lemonade`
+//! CLI and the `lemond` server.
+//!
+//! `@id:serve-lemonade-preparation-recovery` needs Lemonade's llama.cpp backend
+//! install to fail deterministically, twice, so the scenario can pin the retry
+//! count and the terminal recovery guidance. That failure used to be a
+//! `#[cfg(feature = "e2e-test-hooks")]` seam compiled into `rocm` itself, which
+//! meant every full-suite CI lane shipped a binary that differed from a release
+//! build. Driving it from here keeps `rocm` identical to what users run: the CLI
+//! spawns these as real subprocesses over the same interface it uses for a real
+//! runtime, and only the runtime is fake.
+//!
+//! The harness copies this one binary into a planted runtime directory under
+//! both names, so the role is taken from `argv[0]`:
+//!
+//! - `lemond` — the server `rocm serve` spawns. It only has to stay alive; the
+//!   CLI's readiness check polls the `lemonade` CLI, not this process.
+//! - `lemonade` — the CLI the engine shells out to. Three calls matter, and the
+//!   real binary's contract for each is what this reproduces:
+//!   - `--host H --port P status` → exit 0, which is how
+//!     `wait_for_lemonade_cli_status` decides the server came up.
+//!   - `backends` → the recipe/backend/status table
+//!     `parse_llamacpp_backend_statuses` scrapes. Reporting `llamacpp rocm` as
+//!     `installable` (not `installed`) is what makes the engine attempt an
+//!     install rather than reuse one.
+//!   - `--host H --port P backends install llamacpp:rocm` → non-zero, the
+//!     failure the scenario is about.
+
+use std::path::Path;
+use std::process::ExitCode;
+use std::time::Duration;
+
+fn main() -> ExitCode {
+    // Copied rather than symlinked (self-hosted Windows runners commonly lack
+    // SeCreateSymbolicLinkPrivilege), so the file name is the only role signal.
+    let argv0 = std::env::args_os().next().unwrap_or_default();
+    let role = Path::new(&argv0)
+        .file_stem()
+        .map(|stem| stem.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    match role.as_str() {
+        "lemond" => run_lemond(),
+        "lemonade" => run_lemonade_cli(&args),
+        other => {
+            eprintln!(
+                "fake-lemonade: copied to an unexpected name {other:?}; expected `lemond` or \
+                 `lemonade`"
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Stay alive until the parent kills us. `rocm serve` spawns `lemond`, writes its
+/// pid into the running state, and terminates it when the serve fails — so
+/// exiting on our own would race that teardown and turn the scenario's expected
+/// backend-install failure into a spurious "server exited" diagnosis.
+fn run_lemond() -> ExitCode {
+    loop {
+        std::thread::sleep(Duration::from_mins(1));
+    }
+}
+
+fn run_lemonade_cli(args: &[String]) -> ExitCode {
+    if let Some(index) = args.iter().position(|arg| arg == "backends") {
+        if args.get(index + 1).map(String::as_str) == Some("install") {
+            // Fail loudly on stderr: the engine surfaces the child's output, and
+            // a scenario that somehow ran against a real runtime should be
+            // obvious in the log rather than look like a genuine install bug.
+            eprintln!(
+                "fake-lemonade: refusing to install a backend; this runtime was planted by the \
+                 E2E harness for @id:serve-lemonade-preparation-recovery"
+            );
+            return ExitCode::FAILURE;
+        }
+        // Only the `llamacpp` rows are read, but print a plausible table rather
+        // than a single row so a parser change that starts depending on the
+        // header or on other recipes fails here instead of silently selecting
+        // nothing.
+        println!("Recipe    Backend   Status");
+        println!("--------  --------  -----------");
+        println!("llamacpp  rocm      installable");
+        println!("llamacpp  vulkan    unsupported");
+        return ExitCode::SUCCESS;
+    }
+
+    if args.iter().any(|arg| arg == "status") {
+        return ExitCode::SUCCESS;
+    }
+
+    // Any other subcommand: succeed quietly. The scenario never reaches model
+    // load, and failing here would mask the failure it is actually asserting.
+    ExitCode::SUCCESS
+}

--- a/tests/e2e-cucumber/tests/e2e.rs
+++ b/tests/e2e-cucumber/tests/e2e.rs
@@ -446,6 +446,74 @@ impl E2eWorld {
         self.legacy_rocm_path = Some(rocm);
     }
 
+    /// Plant a Lemonade runtime whose llama.cpp backend install always fails, so
+    /// `@id:serve-lemonade-preparation-recovery` can pin the retry count and the
+    /// terminal recovery guidance without downloading a real multi-gigabyte
+    /// runtime.
+    ///
+    /// This replaces a `#[cfg(feature = "e2e-test-hooks")]` seam that used to be
+    /// compiled into `rocm`. The seam made every full-suite lane test a binary
+    /// that differed from a release build; planting a runtime instead leaves
+    /// `rocm` byte-identical to what ships and moves the fake behind the
+    /// subprocess boundary the engine already talks to.
+    ///
+    /// Black-box, like [`Self::register_mock_service`]: the manifest is plain
+    /// JSON matching the engine's on-disk schema, not a typed import from the
+    /// engine crate. `resolve_runtime` accepts it as installed because it checks
+    /// only that the manifest parses and that `lemond` is a file — no checksum,
+    /// version, or signature is involved on this path, so nothing here weakens a
+    /// verification the product performs.
+    pub fn plant_failing_lemonade_runtime(&mut self) {
+        let root = self.isolated_root.as_ref().expect("no isolated root");
+        let engine = root.path().join("data").join("engines").join("lemonade");
+        let runtime_dir = engine.join("runtime");
+        // `serve` writes running state and a startup log beside the manifest and
+        // does not create these itself outside the install path.
+        for dir in [
+            &runtime_dir,
+            &engine.join("manifests"),
+            &engine.join("state"),
+            &engine.join("logs"),
+        ] {
+            std::fs::create_dir_all(dir)
+                .unwrap_or_else(|e| panic!("failed to create {}: {e}", dir.display()));
+        }
+
+        let exe = |name: &str| {
+            runtime_dir.join(if cfg!(windows) {
+                format!("{name}.exe")
+            } else {
+                name.to_owned()
+            })
+        };
+        let (lemond, lemonade) = (exe("lemond"), exe("lemonade"));
+        // One fixture, copied under both names — it takes its role from argv[0].
+        // Copied rather than linked so it works without the symlink privilege
+        // self-hosted Windows runners lack; `fs::copy` carries the Unix mode
+        // bits, so the copies stay executable.
+        for dest in [&lemond, &lemonade] {
+            std::fs::copy(env!("CARGO_BIN_EXE_fake-lemonade"), dest)
+                .unwrap_or_else(|e| panic!("failed to plant {}: {e}", dest.display()));
+        }
+
+        let manifest = serde_json::json!({
+            "env_id": "e2e-planted",
+            "version": "0.0.0-e2e",
+            "runtime_dir": runtime_dir,
+            "lemond": lemond,
+            "lemonade": lemonade,
+            "backend_recipe": "llamacpp",
+            "backend_name": "rocm",
+            "installed_at_unix_ms": 0,
+        });
+        let path = engine.join("manifests").join("runtime.json");
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&manifest).expect("manifest json"),
+        )
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
+    }
+
     /// Register the running mock server with the CLI by writing a managed-service
     /// record into the isolated services directory (`<data>/services/`), exactly
     /// as `rocm serve --managed` would. This lets `rocm services list` and the

--- a/tests/e2e-cucumber/tests/e2e/serving_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/serving_steps.rs
@@ -792,15 +792,17 @@ async fn user_serves_vllm_capable_default(world: &mut E2eWorld) {
 
 #[given("Lemonade preparation cannot complete")]
 async fn lemonade_preparation_cannot_complete(world: &mut E2eWorld) {
-    world.command_env.push((
-        "ROCM_E2E_LEMONADE_BACKEND_INSTALL_FAILURE",
-        "repeated".into(),
-    ));
+    // Plant a runtime whose `lemonade backends install` always exits non-zero,
+    // rather than compiling a failure seam into `rocm`. The CLI then fails at the
+    // same boundary a real broken install fails at — a non-zero child process —
+    // so what the scenario asserts is the product's real retry and recovery
+    // handling, not a test-only branch.
+    world.plant_failing_lemonade_runtime();
 }
 
 #[when("the user serves a model with Lemonade")]
 async fn user_serves_with_failing_lemonade_preparation(world: &mut E2eWorld) {
-    let (stdout, stderr, rc) = crate::run_rocm_with_scenario_env(
+    let (stdout, stderr, rc) = crate::run_rocm(
         world,
         &[
             "serve",
@@ -951,17 +953,16 @@ async fn assert_lemonade_preparation_retry_is_bounded(world: &mut E2eWorld) {
         Some(0),
         "serve unexpectedly succeeded:\n{output}"
     );
-    // The scripted failure seam also waives serve's no-GPU pre-flight, so this
-    // refusal can only appear when the seam is compiled out. Name that cause:
-    // otherwise a lane that pre-builds `rocm` without the feature reports a
+    // Serve enforces its GPU-required policy before it touches the runtime, so a
+    // host without a usable device never reaches Lemonade preparation at all.
+    // Name that cause: the scenario is `@requires-gpu` precisely because of this
+    // pre-flight, and a lane that runs it anyway would otherwise report a
     // baffling "no retry announcement" instead of its real misconfiguration.
     assert!(
         !output.contains("no usable AMD GPU detected"),
-        "serve stopped at the no-GPU pre-flight, so the binary under test was \
-         built without the `rocm/e2e-test-hooks` feature and never reached \
-         Lemonade preparation. E2E lanes that pre-build `rocm` and export \
-         ROCM_CLI_BINARY must pass `--features rocm/e2e-test-hooks`, matching \
-         what `cargo xtask e2e` builds for itself:\n{output}"
+        "serve stopped at the no-GPU pre-flight, so it never reached Lemonade \
+         preparation. This scenario is tagged @requires-gpu and needs a host with \
+         a usable AMD GPU:\n{output}"
     );
     assert_eq!(
         output.matches("retrying once").count(),

--- a/xtask/src/e2e.rs
+++ b/xtask/src/e2e.rs
@@ -85,16 +85,7 @@ pub fn run(args: &[String]) -> Result<()> {
 
     if binaries.build_release {
         let status = Command::new(&cargo)
-            .args([
-                "build",
-                "--release",
-                "-p",
-                "rocm",
-                "-p",
-                "rocmd",
-                "--features",
-                "rocm/e2e-test-hooks",
-            ])
+            .args(["build", "--release", "-p", "rocm", "-p", "rocmd"])
             .current_dir(&root)
             .status()
             .context("failed to run `cargo build --release -p rocm -p rocmd`")?;

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -1041,6 +1041,58 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
         assert_prebuilt_e2e_lanes_enable_test_hooks("nightly.yml", &workflow);
     }
 
+    /// The Windows lane must hand its lifecycle E2E run the release binaries the
+    /// Build step already produced.
+    ///
+    /// Without `ROCM_CLI_BINARY`, `cargo xtask e2e` builds `rocm`/`rocmd` for
+    /// itself WITH `--features rocm/e2e-test-hooks`. That is a different feature
+    /// resolution than the Build step's, so cargo rebuilds the entire release
+    /// graph instead of reusing it — a second 3-4 minute release build on the one
+    /// job that alone determines total CI wall clock.
+    ///
+    /// Note this is the mirror image of
+    /// [`assert_prebuilt_e2e_lanes_enable_test_hooks`]: lanes running the FULL
+    /// suite must build WITH the hooks, while this lifecycle-only lane must build
+    /// WITHOUT them. `E2E_ONLY_LIFECYCLE` keeps it to @lifecycle scenarios, none
+    /// of which use a scripted seam, and the lane packages and installs the
+    /// binary through the real installer — so it must ship what a release ships.
+    #[test]
+    fn ci_windows_lifecycle_lane_reuses_the_binaries_it_built() {
+        let ci = read_workflow("ci.yml");
+        let windows = job_block(&ci, "windows-build-and-test");
+
+        assert!(
+            windows.contains("cargo build --release -p rocm -p rocmd"),
+            "the Windows lane must pre-build the release binaries"
+        );
+
+        assert!(
+            windows.contains("cargo xtask e2e"),
+            "the Windows lane must run the lifecycle E2E suite"
+        );
+
+        // A bare `run: cargo xtask e2e` is exactly the regression this guards:
+        // no run block can export the binaries, so xtask rebuilds them itself.
+        let lifecycle = multiline_run_blocks(windows)
+            .into_iter()
+            .find(|block| invokes_e2e(block))
+            .unwrap_or_default();
+
+        for var in ["ROCM_CLI_BINARY", "ROCM_CLI_ROCMD_BINARY"] {
+            assert!(
+                lifecycle.contains(var),
+                "the Windows lifecycle lane must export {var} so `cargo xtask e2e` \
+                 reuses the already-built release binaries instead of recompiling \
+                 the whole release graph under a different feature set:\n{lifecycle}"
+            );
+        }
+        assert!(
+            !lifecycle.contains("e2e-test-hooks"),
+            "the lifecycle-only lane packages and installs what a release ships, \
+             so it must NOT carry the test hooks:\n{lifecycle}"
+        );
+    }
+
     // Extractor guards: prove the helpers actually parse multiline forms, so the
     // contract tests above can't silently false-pass on a shape they don't handle.
     #[test]

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -1076,7 +1076,7 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
         let lifecycle = multiline_run_blocks(windows)
             .into_iter()
             .find(|block| invokes_e2e(block))
-            .unwrap_or_default();
+            .unwrap_or_else(|| "<no multiline run block invoking `cargo xtask e2e`>".to_owned());
 
         for var in ["ROCM_CLI_BINARY", "ROCM_CLI_ROCMD_BINARY"] {
             assert!(
@@ -1086,6 +1086,17 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
                  the whole release graph under a different feature set:\n{lifecycle}"
             );
         }
+
+        // Naming the variables is not enough: pointing them at `target\debug\`
+        // would satisfy the check above while defeating the reuse this test is
+        // named for. Pin the whole assignment, exactly as
+        // `assert_prebuilt_e2e_lanes_export_rocmd` pins it for the other
+        // PowerShell prebuilt lanes.
+        assert!(
+            lifecycle.contains("$env:ROCM_CLI_ROCMD_BINARY = \"$targetDir\\release\\rocmd.exe\""),
+            "the Windows lifecycle lane must export the RELEASE rocmd.exe path — the \
+             binaries the Build step produced, not a debug or stale target dir:\n{lifecycle}"
+        );
         assert!(
             !lifecycle.contains("e2e-test-hooks"),
             "the lifecycle-only lane packages and installs what a release ships, \

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -242,17 +242,17 @@ mod tests {
     }
 
     /// Every lane that pre-builds `rocm` and hands it to the suite via
-    /// `ROCM_CLI_BINARY` must enable the same test-hook feature `cargo xtask e2e`
-    /// enables when it builds for itself.
+    /// `ROCM_CLI_BINARY` must build it with exactly the invocation `cargo xtask
+    /// e2e` uses when it builds for itself.
     ///
-    /// The suite's deterministic failure seams (e.g. the scripted Lemonade
-    /// backend-install failure) are `#[cfg(feature = "e2e-test-hooks")]`. A lane
-    /// that omits the feature ships a binary in which those seams do not exist,
-    /// so the scenarios relying on them cannot reach their premise and fail as
-    /// regressions — but only on whichever lane happens to select them, which is
-    /// what made this divergence so hard to read the first time. Pin it here so a
-    /// new lane copying an existing block cannot silently reintroduce it.
-    fn assert_prebuilt_e2e_lanes_enable_test_hooks(workflow: &str, text: &str) {
+    /// Exporting the binaries only saves the second build if cargo would have
+    /// produced the same artifacts. Any divergence — package set, profile,
+    /// features — re-resolves the graph, and the lane silently pays a full
+    /// release rebuild on top of the one it already did. That is exactly the
+    /// regression #342 fixed on the Windows lane, where the two invocations had
+    /// drifted apart by one feature flag. Pin it here so a new lane copying an
+    /// existing block cannot reintroduce the drift.
+    fn assert_prebuilt_e2e_lanes_match_xtask_build(workflow: &str, text: &str) {
         let blocks: Vec<_> = multiline_run_blocks(text)
             .into_iter()
             .filter(|block| block.contains("ROCM_CLI_BINARY") && invokes_e2e(block))
@@ -262,14 +262,16 @@ mod tests {
             "{workflow} must contain prebuilt E2E run blocks"
         );
         for block in blocks {
+            // Whole-line, not `contains`: a trailing `--features …` would
+            // satisfy a substring check while being exactly the drift this pins.
             assert!(
-                block.contains(
-                    "cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks"
-                ),
-                "{workflow} prebuilt E2E lane must build with \
-                 `--features rocm/e2e-test-hooks`, matching what `cargo xtask e2e` \
-                 builds for itself; without it the suite's scripted failure seams \
-                 are compiled out:\n{block}"
+                block
+                    .lines()
+                    .any(|line| line.trim() == "cargo build --release -p rocm -p rocmd"),
+                "{workflow} prebuilt E2E lane must build exactly \
+                 `cargo build --release -p rocm -p rocmd`, matching what `cargo xtask \
+                 e2e` builds for itself; anything else re-resolves the graph and the \
+                 lane pays a second full release build:\n{block}"
             );
         }
     }
@@ -1030,32 +1032,30 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
     }
 
     #[test]
-    fn self_hosted_prebuilt_e2e_lanes_enable_test_hooks() {
+    fn self_hosted_prebuilt_e2e_lanes_match_xtask_build() {
         let workflow = read_workflow("e2e-selfhosted.yml");
-        assert_prebuilt_e2e_lanes_enable_test_hooks("e2e-selfhosted.yml", &workflow);
+        assert_prebuilt_e2e_lanes_match_xtask_build("e2e-selfhosted.yml", &workflow);
     }
 
     #[test]
-    fn nightly_prebuilt_e2e_lanes_enable_test_hooks() {
+    fn nightly_prebuilt_e2e_lanes_match_xtask_build() {
         let workflow = read_workflow("nightly.yml");
-        assert_prebuilt_e2e_lanes_enable_test_hooks("nightly.yml", &workflow);
+        assert_prebuilt_e2e_lanes_match_xtask_build("nightly.yml", &workflow);
     }
 
     /// The Windows lane must hand its lifecycle E2E run the release binaries the
     /// Build step already produced.
     ///
     /// Without `ROCM_CLI_BINARY`, `cargo xtask e2e` builds `rocm`/`rocmd` for
-    /// itself WITH `--features rocm/e2e-test-hooks`. That is a different feature
-    /// resolution than the Build step's, so cargo rebuilds the entire release
-    /// graph instead of reusing it — a second 3-4 minute release build on the one
-    /// job that alone determines total CI wall clock.
+    /// itself. Cargo reusing the Build step's artifacts then depends on the two
+    /// invocations agreeing on profile, package set, features and target dir; a
+    /// one-flag drift cost this job a second 3-4 minute release build on every
+    /// run — the one job that alone determines total CI wall clock. Exporting the
+    /// paths removes the dependence on that agreement instead of restating it.
     ///
-    /// Note this is the mirror image of
-    /// [`assert_prebuilt_e2e_lanes_enable_test_hooks`]: lanes running the FULL
-    /// suite must build WITH the hooks, while this lifecycle-only lane must build
-    /// WITHOUT them. `E2E_ONLY_LIFECYCLE` keeps it to @lifecycle scenarios, none
-    /// of which use a scripted seam, and the lane packages and installs the
-    /// binary through the real installer — so it must ship what a release ships.
+    /// [`assert_prebuilt_e2e_lanes_match_xtask_build`] pins the same invariant
+    /// from the other side for the self-hosted and nightly lanes, which pre-build
+    /// and must therefore match `xtask`'s own invocation.
     #[test]
     fn ci_windows_lifecycle_lane_reuses_the_binaries_it_built() {
         let ci = read_workflow("ci.yml");
@@ -1096,11 +1096,6 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
             lifecycle.contains("$env:ROCM_CLI_ROCMD_BINARY = \"$targetDir\\release\\rocmd.exe\""),
             "the Windows lifecycle lane must export the RELEASE rocmd.exe path — the \
              binaries the Build step produced, not a debug or stale target dir:\n{lifecycle}"
-        );
-        assert!(
-            !lifecycle.contains("e2e-test-hooks"),
-            "the lifecycle-only lane packages and installs what a release ships, \
-             so it must NOT carry the test hooks:\n{lifecycle}"
         );
     }
 


### PR DESCRIPTION
Depends on #342 — this rewrites the contract test #342 adds, so it stays in draft until that merges. Closes #349.

## Problem

`e2e-test-hooks` is a cargo feature that compiles two scripted-failure seams into `rocm`, and it exists to serve exactly one scenario: `@id:serve-lemonade-preparation-recovery` (serve-18).

- `engines/lemonade/src/lib.rs` — makes the llama.cpp backend install fail on demand
- `apps/rocm/src/main.rs` — waives `rocm serve`'s no-GPU pre-flight, so the scenario can reach the install phase on a GPU-less host

The cost is spread across the repo: 2 feature declarations, 3 `cfg` sites, 10 `--features` lines across `nightly.yml` and `e2e-selfhosted.yml`, `xtask`'s own build, and 3 contract tests.

Two consequences follow from the feature existing at all.

**Binaries under test are not the binaries shipped.** Every lane that pre-builds with the feature installs a binary that differs from a release build. #342 fixed this for the Windows lifecycle lane; it was still true on Linux, where the release build happens inside `cargo xtask e2e` — with the feature — so the Linux lifecycle lane packaged and installed a hook-carrying binary through the real installer.

**The contract tests encoded the asymmetry instead of removing it.** One test asserted the Windows lane must be hook-free, two asserted self-hosted and nightly must be hook-ful, and `ci.yml`'s Linux lane was asserted by neither — the same blind spot that hid the duplicate-build drift #342 fixed, one lane over.

## Fix

Delete the feature and drive the failure from a planted runtime instead.

`tests/e2e-cucumber/src/bin/fake-lemonade.rs` is a fixture binary copied into an isolated runtime directory under both `lemonade` and `lemond` (it takes its role from `argv[0]`), alongside a hand-written install manifest. It reproduces the three calls the engine makes: `status` exits 0, `backends` prints a table reporting `llamacpp:rocm` as *installable*, and `backends install` exits non-zero.

The CLI then fails where a genuinely broken install fails — at a non-zero child process — and `rocm` stays byte-identical to what ships.

A bin target of `e2e-cucumber` rather than an xtask-built artifact, so the suite reaches it through `CARGO_BIN_EXE_fake-lemonade` with no path to keep in step. It has to be a real executable, not a script: the engine spawns it by exact path and Windows `CreateProcess` needs a PE image.

## Why this doesn't weaken verification

`resolve_runtime` accepts the planted manifest because it checks only that the manifest parses and that `lemond` is a file. No checksum, version, or signature is involved on this path — the SHA-pinned archive download lives in `prepare_embeddable`, which the serve path does not go through. Nothing here bypasses a check the product performs.

Approaches ruled out are recorded in #349 (mocking the request — the boundary is a subprocess, not HTTP; prewarming — ephemeral on hosted lanes, already installed on prewarmed ones; dropping the network; mocking `verify_sha256` — a fail-open seam inside supply-chain verification).

## The tradeoff, explicitly

Seam #2 was what let serve-18 run without a GPU. Without it, `rocm serve` reaches its GPU-required pre-flight first, so **the scenario is retagged `@requires-gpu` and moves off the blocking every-PR lane onto a gated one.**

That is a real loss of coverage cadence and it is the reviewer's call, not a cleanup side effect. The counter-argument is that what it covered on the every-PR lane was a code path that only existed in test builds.

To limit what that move gives up, a unit test in `engines/lemonade` pins the coupling a GPU-less lane would otherwise silently lose: the fixture's `backends` table must still parse into a `llamacpp:rocm` install *attempt*. If a parser change stopped accepting it, the scenario would quietly stop reaching the failure it asserts and only a GPU lane would notice. That test runs everywhere.

## Contract tests

`assert_prebuilt_e2e_lanes_enable_test_hooks` is repurposed, not deleted: "match the feature `xtask` uses" becomes "match the invocation `xtask` uses", which is the invariant that actually prevents the duplicate release build. It asserts whole-line, so a trailing `--features …` cannot satisfy it — verified by re-adding the flag and watching it fail.

#342's `!contains("e2e-test-hooks")` assertion is dropped; its reuse assertions stay.

## Test plan

Verified locally:

- The fixture's four behaviours, driven directly: `backends` table, `status` → 0, `backends install` → non-zero, `lemond` stays alive until killed.
- The new lemonade unit test, and the reworked contract tests (24/24). Re-adding `--features rocm/e2e-test-hooks` to a lane makes `nightly_prebuilt_e2e_lanes_match_xtask_build` fail.
- `cargo check --workspace --all-targets`, plus `cargo check -p e2e-cucumber --test e2e` explicitly (the `e2e` target is `test = false`, so `--all-targets` skips it).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.
- `cargo test --workspace --all-targets`: two failures in `rocm-dash-tui` (`chatgpt_oauth_client_*`, "cannot create token cache dir: Permission denied"). Confirmed pre-existing — they fail identically on `origin/main` in this environment, and this diff does not touch that crate.

**Not verified locally, stated per AGENTS.md §8:** serve-18 itself. This host has no usable AMD GPU, so `rocm serve` stops at the pre-flight — which is exactly why the scenario is now `@requires-gpu`. I confirmed the CLI reaches and reports that pre-flight against a planted runtime, but the retry-count and recovery-guidance assertions past it need a GPU host. **The self-hosted GPU lane is what will exercise them, and this PR should not merge until that lane has run it green.**