### PR TITLE
ci: pin the MI300X E2E lanes to the mi300x runner label and name them for it

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -135,7 +135,11 @@ jobs:
   e2e-gpu:
     name: E2E tests (GPU)
     timeout-minutes: 90
-    runs-on: [self-hosted, linux, amd-gpu]
+    # `mi300x`, not `amd-gpu`: every AMD GPU runner carries `amd-gpu`, including
+    # the Strix Halo hosts, so `[self-hosted, linux, amd-gpu]` let this lane land
+    # on gfx1151 — red on the WSL host, and (worse) a silent pass published as
+    # `e2e-gpu-report`, which the consolidated grid renders as MI300X.
+    runs-on: [self-hosted, linux, mi300x]
     needs: [changes]
     # No build-and-test gate (cross-workflow needs is unavailable): the job builds
     # the rocm binary itself and is continue-on-error; ci.yml's required
@@ -326,7 +330,8 @@ jobs:
           path: tests/e2e-cucumber/results/
 
   # Second AMD GPU architecture: the Strix Halo (gfx1151) Ubuntu runner, targeted
-  # by the `strix-halo` label (app-dev-gpu carries `amd-gpu`, not `strix-halo`).
+  # by the `strix-halo` label. These hosts carry `amd-gpu` as well — it marks any
+  # AMD GPU runner, so it never distinguishes one architecture from another.
   # Non-blocking while this hardware is proven out.
   e2e-gpu-strix-ubuntu:
     name: E2E tests (Strix Halo, Ubuntu)

--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -8,11 +8,12 @@ name: E2E self-hosted
 # with their OWN concurrency group — means an offline runner can only ever stall
 # THIS workflow's supersession, never the required checks in ci.yml.
 #
-# These lanes are non-blocking (continue-on-error). NOTE: their check names
-# (`E2E tests (GPU)` etc.) are still in main's required-status-check list, so
-# while a runner is offline they report as missing and can still block a merge;
-# fully closing that requires removing them from the required list (a separate
-# branch-protection change, out of scope for this workflow).
+# These lanes are non-blocking (continue-on-error), and as of 2026-09 their
+# check names do not gate a merge either: PRs #334, #335 and #343 all landed
+# while `E2E tests (Strix Halo, Ubuntu)` reported `cancelled` on the merge_group
+# ref, which a required check under ALLGREEN would have blocked. Renaming a lane
+# is therefore safe. (Branch protection is not readable without admin, so this is
+# inferred from those merges rather than read from the required list.)
 
 on:
   push:
@@ -133,7 +134,7 @@ jobs:
         run: echo "forced=true" >> "$GITHUB_OUTPUT"
 
   e2e-gpu:
-    name: E2E tests (GPU)
+    name: E2E tests (MI300X)
     timeout-minutes: 90
     # `mi300x`, not `amd-gpu`: every AMD GPU runner carries `amd-gpu`, including
     # the Strix Halo hosts, so `[self-hosted, linux, amd-gpu]` let this lane land

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -337,7 +337,7 @@ jobs:
   # BUILD skip above — a regression run is worth doing even with no new commits).
   # Non-blocking, mirrors ci.yml's e2e-gpu job but sets E2E_INCLUDE_NIGHTLY.
   e2e-gpu-nightly:
-    name: E2E tests (GPU, incl. nightly-only)
+    name: E2E tests (MI300X, incl. nightly-only)
     timeout-minutes: 90
     # `mi300x`, not `amd-gpu` — see the same pin on e2e-selfhosted.yml's e2e-gpu.
     runs-on: [self-hosted, linux, mi300x]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -339,7 +339,8 @@ jobs:
   e2e-gpu-nightly:
     name: E2E tests (GPU, incl. nightly-only)
     timeout-minutes: 90
-    runs-on: [self-hosted, linux, amd-gpu]
+    # `mi300x`, not `amd-gpu` — see the same pin on e2e-selfhosted.yml's e2e-gpu.
+    runs-on: [self-hosted, linux, mi300x]
     continue-on-error: true
     env:
       # Include @nightly scenarios (the large-model serve). See src/expectation.rs.

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -32,7 +32,7 @@ separate tier flag or tag filter to maintain.
 | Job | Workflow | Platform | Runner labels |
 |---|---|---|---|
 | `e2e` | `ci.yml` | Mock (no GPU) | GitHub-hosted `ubuntu-latest` |
-| `e2e-gpu` | `e2e-selfhosted.yml` | MI300X (AMD Instinct, bare-metal Linux) | self-hosted `[self-hosted, linux, amd-gpu]` |
+| `e2e-gpu` | `e2e-selfhosted.yml` | MI300X (AMD Instinct, bare-metal Linux) | self-hosted `[self-hosted, linux, mi300x]` |
 | `e2e-gpu-strix-ubuntu` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, strix-halo, native]` |
 | `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on native Windows 11 | self-hosted `[self-hosted, windows, strix-halo, native]` |
 | `e2e-wsl` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu under WSL2 | self-hosted `[self-hosted, linux, strix-halo, wsl]` |
@@ -42,6 +42,14 @@ The Strix Halo lanes pin the extra `native` label because two Linux runners
 share the `strix-halo` label (a native host and a WSL host) and the jobs'
 hardcoded `/home/ubuntu/actions-runner` paths exist only on the native one. The
 WSL lane pins `wsl` for the same reason, from the other side.
+
+Every label in a `runs-on` must narrow the pool to one kind of hardware. In
+particular the MI300X lane pins `mi300x` rather than `amd-gpu`: `amd-gpu` is
+carried by every AMD GPU runner, Strix Halo included, so it selects a
+mixed-silicon pool. `every_self_hosted_lane_pins_a_hardware_label` in
+`xtask/src/workflow_contract.rs` enforces this, because the failure is quiet —
+the lane simply passes on the wrong GPU and reports under the label it was
+named for.
 
 `e2e` is the blocking, GitHub-hosted mock job: `@requires-gpu` scenarios
 resolve to skip here, and known bugs resolve to xfail from

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -37,7 +37,15 @@ mod tests {
     }
 
     /// The self-hosted runner labels that must not appear in a `runs-on`.
-    const SELF_HOSTED_LABELS: [&str; 3] = ["self-hosted", "amd-gpu", "strix-halo"];
+    const SELF_HOSTED_LABELS: [&str; 5] =
+        ["self-hosted", "amd-gpu", "strix-halo", "mi300x", "r9700"];
+
+    /// Labels that do NOT narrow a `runs-on` to one kind of hardware.
+    ///
+    /// `self-hosted`, `linux` and `windows` are self-evidently generic.
+    /// `amd-gpu` reads specific but is not: every AMD GPU runner registers it,
+    /// so a lane selecting on it alone draws from a mixed-silicon pool.
+    const GENERIC_LABELS: [&str; 4] = ["self-hosted", "linux", "windows", "amd-gpu"];
 
     /// Strip a trailing `# …` comment from a YAML line (best-effort: our
     /// workflows never put a literal `#` inside a runs-on/group value).
@@ -816,6 +824,33 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
                     "{workflow} job `{job}` runs on self-hosted GPU hardware but has no \
                      GPU preflight step: on a wedged or occupied GPU it hangs to the job \
                      timeout instead of failing fast with a reason"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_self_hosted_lane_pins_a_hardware_label() {
+        // `e2e-gpu` and `e2e-gpu-nightly` shipped as `[self-hosted, linux,
+        // amd-gpu]`. The Strix Halo Linux hosts carry `amd-gpu` too, so the
+        // MI300X-named lanes were scheduled onto gfx1151 whenever a Strix
+        // runner won the race: red on the WSL host, and a PASS on the native
+        // Ubuntu one — published as `e2e-gpu-report`, which the consolidated
+        // grid labels MI300X. A green run on hardware the lane does not name is
+        // worse than a red one, because nothing prompts anyone to look.
+        //
+        // Derived like its siblings: a new lane is covered the day it lands,
+        // and only a lane whose labels are ALL generic fails, so pinning a new
+        // hardware label needs no change here.
+        for (workflow, text) in self_hosted_workflows() {
+            for (job, runs_on) in self_hosted_e2e_jobs(&text) {
+                let labels = flattened_list_items(&runs_on);
+                assert!(
+                    labels.iter().any(|l| !GENERIC_LABELS.contains(&l.as_str())),
+                    "{workflow} job `{job}` selects its runner with generic labels only \
+                     (`{runs_on}`), so it can land on any AMD GPU host. Pin a label that \
+                     identifies the hardware the lane is named for (e.g. `mi300x`, \
+                     `r9700`, `strix-halo`)"
                 );
             }
         }


### PR DESCRIPTION
## Summary

`e2e-gpu` (`E2E tests (GPU)`) and `e2e-gpu-nightly` selected their runner with
`[self-hosted, linux, amd-gpu]`. Every AMD GPU runner registers `amd-gpu` — the
Strix Halo hosts included — so GitHub scheduled the MI300X-named lanes onto
gfx1151 whenever a Strix runner won the race.

Two symptoms, and the quiet one is the problem:

- On the WSL host the lane fails GPU preflight. A red `E2E tests (GPU)` on an
  unrelated PR is easy to spend time debugging as if it were the PR's fault.
- On a native Strix Ubuntu host the lane **passes on gfx1151** and uploads its
  result as `e2e-gpu-report` — the artifact name `parse_descriptor` maps to
  `("MI300X", "Linux")`. The consolidated grid then reports a green MI300X
  column for a run that never touched an Instinct card.

Both lanes are `continue-on-error`, so neither symptom blocks a merge and the
misfiled results go unnoticed.

The rad3 lane already documents this exact rule — *"`r9700` names the hardware,
not a generic `amd-gpu`: GitHub matches a job to any runner whose labels are a
superset"* — but it reasoned only about that card picking up MI300X-targeted
work, never the reverse. This applies the same rule to the lanes that needed it.

**Changes**

- Pin both MI300X lanes to `mi300x`, which the Instinct pool already registers
  alongside `amd-gpu`.
- Add `every_self_hosted_lane_pins_a_hardware_label`, derived from the workflows
  like its siblings: only a lane whose labels are *all* generic fails, so
  pinning a new hardware label needs no change to the test.
- Correct a comment on the Strix Ubuntu lane that asserted the MI300X host
  "carries `amd-gpu`, not `strix-halo`" — the phrasing implied the two labels
  partition the runners, which is the belief that made this bug possible.
- Rename the lanes to `E2E tests (MI300X)` / `E2E tests (MI300X, incl.
  nightly-only)`. Every sibling names its silicon; the generic "GPU" is part of
  why a Strix run filed under the MI300X column never looked wrong to anyone
  scanning the check list.
- Update the hardware-testing doc's label column and record the rule.

### On renaming a check

Renaming a lane changes its check name, which is only safe if the names do not
gate a merge. They do not: **#334, #335 and #343 all landed** while
`E2E tests (Strix Halo, Ubuntu)` reported `cancelled` on the *merge_group* ref —
a required check under ALLGREEN would have blocked all three. The header comment
in `e2e-selfhosted.yml` asserted the opposite ("still in main's
required-status-check list"); it is replaced with the evidence above.

Branch protection is not readable without admin, so that is an inference from
three consistent merges rather than a read of the required list. **If a
maintainer knows these names are still required, drop the second commit
(`4a143a6`) and the first stands on its own.**

Risk: low for the label pin; low-but-confirm-with-a-maintainer for the rename.

## Evidence

Runner assignment for `E2E tests (GPU)` across the last 40 `e2e-selfhosted`
runs (30 with a completed job):

| Runner | Result | Runs |
|---|---|---|
| `mi300x-0` / `mi300x-1` | success | 25 |
| `mi300x-1` | failure | 1 |
| `strix-halo-wsl` | failure | 2 |
| `strix-halo-ubuntu` / `strix-halo-ubuntu-2` | **success** | 2 |

4 of 30 (~13%) ran on the wrong silicon. A second Strix Ubuntu host has since
joined the pool, so the rate is rising rather than falling.

Run 34209593001 is a worked example of the silent case: the GPU lane ran on
`strix-halo-ubuntu`, passed, and the consolidated job logged
`Consolidated 5 platform report(s)` — the multi-artifact path, where `discover()`
labels from the artifact name and never consults the `platform.json` slug that
would have said `strix-halo-linux`.

## Test plan

- `cargo test -p xtask` — 132 pass.
- New guard verified both ways: with the `runs-on` changes reverted it fails with
  ``e2e-selfhosted.yml job `e2e-gpu` selects its runner with generic labels only``;
  with them applied the suite is green.
- `cargo fmt --all -- --check` and `cargo clippy -p xtask --all-targets` clean.

## Note (not addressed here)

A few `expectations.toml` comments cite behaviour "verified on MI300X" from
specific runs. Any such observation taken from a misrouted run may actually
describe gfx1151. Out of scope for this PR, but worth a look when those rows are
next revisited.

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — CI scheduling fix; no product-bug xfail rows involved.
