### PR TITLE
fix(dash-tui): Section D nav aliases + job-completion prominence

### DIFF
--- a/crates/rocm-dash-tui/src/ui/automations_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/automations_manager.rs
@@ -134,8 +134,10 @@ pub fn on_key(
     // 3) List navigation + actions.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') => *am = None,
-        KeyCode::Up | KeyCode::Char('k') => a.selected = a.selected.saturating_sub(1),
-        KeyCode::Down | KeyCode::Char('j') if !automations.is_empty() => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
+            a.selected = a.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Right if !automations.is_empty() => {
             a.selected = (a.selected + 1).min(automations.len() - 1);
         }
         KeyCode::Char('l') => return spawn_refresh(a, jobs),
@@ -450,6 +452,21 @@ mod tests {
         assert_eq!(am.as_ref().unwrap().selected, ws.len() - 1);
         for _ in 0..10 {
             on_key(&mut am, &ws, &mut jobs, key(KeyCode::Up));
+        }
+        assert_eq!(am.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut am = Some(AutomationsManagerState::default());
+        let mut jobs = State::default();
+        let ws = automations();
+        for _ in 0..10 {
+            on_key(&mut am, &ws, &mut jobs, key(KeyCode::Right));
+        }
+        assert_eq!(am.as_ref().unwrap().selected, ws.len() - 1);
+        for _ in 0..10 {
+            on_key(&mut am, &ws, &mut jobs, key(KeyCode::Left));
         }
         assert_eq!(am.as_ref().unwrap().selected, 0);
     }

--- a/crates/rocm-dash-tui/src/ui/automations_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/automations_manager.rs
@@ -317,7 +317,7 @@ pub fn draw_automations_manager(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "↑↓ select · Enter/Space toggle (needs approval) · l refresh · Esc close",
+            "↑↓←→ select · Enter/Space toggle (needs approval) · l refresh · Esc close",
             Style::default().fg(theme.muted),
         ))),
         rows[2],

--- a/crates/rocm-dash-tui/src/ui/engine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/engine_manager.rs
@@ -147,8 +147,10 @@ pub fn on_key(
     // 3) List navigation + action requests.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') => *engines = None,
-        KeyCode::Up | KeyCode::Char('k') => em.selected = em.selected.saturating_sub(1),
-        KeyCode::Down | KeyCode::Char('j') => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
+            em.selected = em.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Right => {
             em.selected = (em.selected + 1).min(ENGINE_CATALOG.len() - 1);
         }
         KeyCode::Char('u') => request_op(em, EngineAction::Use),
@@ -335,6 +337,20 @@ mod tests {
         assert_eq!(em.as_ref().unwrap().selected, ENGINE_CATALOG.len() - 1);
         for _ in 0..ENGINE_CATALOG.len() + 3 {
             on_key(&mut em, &mut jobs, key(KeyCode::Up));
+        }
+        assert_eq!(em.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut em = Some(EngineManagerState::default());
+        let mut jobs = State::default();
+        for _ in 0..ENGINE_CATALOG.len() + 3 {
+            on_key(&mut em, &mut jobs, key(KeyCode::Right));
+        }
+        assert_eq!(em.as_ref().unwrap().selected, ENGINE_CATALOG.len() - 1);
+        for _ in 0..ENGINE_CATALOG.len() + 3 {
+            on_key(&mut em, &mut jobs, key(KeyCode::Left));
         }
         assert_eq!(em.as_ref().unwrap().selected, 0);
     }

--- a/crates/rocm-dash-tui/src/ui/engine_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/engine_manager.rs
@@ -287,7 +287,7 @@ pub fn draw_engine_manager(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "↑↓ select · u use · i install · r reinstall · Esc close",
+            "↑↓←→ select · u use · i install · r reinstall · Esc close",
             Style::default().fg(theme.muted),
         ))),
         body[2],

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -110,30 +110,40 @@ pub fn draw_job_console(
         ])
         .split(inner);
 
-    // Header: status badge, plus an animated braille spinner and parsed
-    // percentage while the job runs so progress reads as live motion.
+    // Header: while running, a compact chip + animated braille spinner + parsed
+    // percentage (already visually distinct via motion). Once the job reaches a
+    // terminal state, render a full-width colored banner instead — a small chip
+    // is easy to miss against a whole popup of scrolled output.
     let (label, color) = status_label(job, theme);
-    let mut header = vec![
-        Span::styled(
+    let is_terminal = !matches!(job.status, JobStatus::Running);
+    let mut header = Vec::new();
+    if is_terminal {
+        let glyph = match job.status {
+            JobStatus::Failed { .. } => "✗ ",
+            JobStatus::Cancelled => "○ ",
+            JobStatus::Done { .. } | JobStatus::Running => "✓ ",
+        };
+        header.push(Span::styled(
+            format!(" {glyph}{label} "),
+            Style::default().fg(theme.bg).add_modifier(Modifier::BOLD),
+        ));
+    } else {
+        header.push(Span::styled(
             " status ",
             Style::default()
                 .fg(theme.bg)
                 .bg(color)
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(" "),
-    ];
-    if matches!(job.status, JobStatus::Running) {
+        ));
+        header.push(Span::raw(" "));
         header.push(Span::styled(
             format!("{} ", crate::ui::spinner::spinner_frame(tick_count)),
             Style::default().fg(theme.accent),
         ));
-    }
-    header.push(Span::styled(
-        label,
-        Style::default().fg(color).add_modifier(Modifier::BOLD),
-    ));
-    if matches!(job.status, JobStatus::Running) {
+        header.push(Span::styled(
+            label,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
         // The most recent line carrying a percentage wins (later output is more
         // current than earlier); silently omit the figure when none is present.
         if let Some(pct) = job
@@ -150,7 +160,13 @@ pub fn draw_job_console(
             ));
         }
     }
-    f.render_widget(Paragraph::new(Line::from(header)), rows[0]);
+    let header_para = Paragraph::new(Line::from(header));
+    let header_para = if is_terminal {
+        header_para.style(Style::default().bg(color))
+    } else {
+        header_para
+    };
+    f.render_widget(header_para, rows[0]);
 
     // Body: streamed output lines, with a scrollbar when the ring overflows the
     // viewport so the user can see there's more above/below.
@@ -303,5 +319,79 @@ mod tests {
             code: 0,
         });
         assert_eq!(status_label(s.job("j").unwrap(), &t).0, "done");
+    }
+
+    #[test]
+    fn terminal_status_fills_full_width_banner() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let t = theme();
+        let mut s = State::default();
+        s.apply(StateEvent::StartJob {
+            id: "j".into(),
+            cmd: "echo".into(),
+            args: vec!["hi".into()],
+        });
+        s.apply(StateEvent::JobDone {
+            id: "j".into(),
+            code: 0,
+        });
+        let job = s.job("j").unwrap();
+
+        let backend = TestBackend::new(100, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_job_console(f, f.area(), job, (0, 0), 0, &t);
+        })
+        .unwrap();
+        let buf = term.backend().buffer().clone();
+        let filled = buf
+            .content()
+            .iter()
+            .filter(|c| c.style().bg == Some(t.ok))
+            .count();
+        assert!(
+            filled > 50,
+            "expected a done job to paint a full-width header banner, only {filled} cells colored"
+        );
+        let out: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(out.contains('✓'), "done banner missing glyph: {out:?}");
+    }
+
+    #[test]
+    fn running_status_keeps_compact_chip() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let t = theme();
+        let mut s = State::default();
+        s.apply(StateEvent::StartJob {
+            id: "j".into(),
+            cmd: "echo".into(),
+            args: vec!["hi".into()],
+        });
+        let job = s.job("j").unwrap();
+
+        let backend = TestBackend::new(100, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_job_console(f, f.area(), job, (0, 0), 0, &t);
+        })
+        .unwrap();
+        let buf = term.backend().buffer().clone();
+        let filled = buf
+            .content()
+            .iter()
+            .filter(|c| c.style().bg == Some(t.accent))
+            .count();
+        assert!(
+            filled < 20,
+            "a running job should keep the compact status chip, not a full-width banner: {filled} cells colored"
+        );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -121,7 +121,10 @@ pub fn draw_job_console(
         let glyph = match job.status {
             JobStatus::Failed { .. } => "✗ ",
             JobStatus::Cancelled => "○ ",
-            JobStatus::Done { .. } | JobStatus::Running => "✓ ",
+            JobStatus::Done { code: 0 } => "✓ ",
+            JobStatus::Done { .. } => "! ",
+            // Unreachable: `is_terminal` (above) excludes `Running`.
+            JobStatus::Running => unreachable!("terminal banner only renders for finished jobs"),
         };
         header.push(Span::styled(
             format!(" {glyph}{label} "),
@@ -392,6 +395,46 @@ mod tests {
         assert!(
             filled < 20,
             "a running job should keep the compact status chip, not a full-width banner: {filled} cells colored"
+        );
+    }
+
+    #[test]
+    fn nonzero_exit_gets_a_distinct_glyph_from_success() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let t = theme();
+        let mut s = State::default();
+        s.apply(StateEvent::StartJob {
+            id: "j".into(),
+            cmd: "echo".into(),
+            args: vec!["hi".into()],
+        });
+        s.apply(StateEvent::JobDone {
+            id: "j".into(),
+            code: 1,
+        });
+        let job = s.job("j").unwrap();
+
+        let backend = TestBackend::new(100, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_job_console(f, f.area(), job, (0, 0), 0, &t);
+        })
+        .unwrap();
+        let buf = term.backend().buffer().clone();
+        let out: String = buf
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(
+            !out.contains('✓'),
+            "a nonzero exit banner should not reuse the success glyph: {out:?}"
+        );
+        assert!(
+            out.contains('!'),
+            "a nonzero exit banner should carry a distinct glyph: {out:?}"
         );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/job_console.rs
+++ b/crates/rocm-dash-tui/src/ui/job_console.rs
@@ -20,7 +20,7 @@ use rocm_dash_core::state::{JobState, JobStatus, SideEffect, State, StateEvent};
 
 use crate::app::{ScrollTarget, ScrollbarHandle};
 use crate::ui::modal::{centered_rect, draw_popup_frame};
-use crate::ui::theme::Theme;
+use crate::ui::theme::{Theme, readable_text_on};
 
 /// What a console keypress means to the owning screen.
 ///
@@ -128,13 +128,15 @@ pub fn draw_job_console(
         };
         header.push(Span::styled(
             format!(" {glyph}{label} "),
-            Style::default().fg(theme.bg).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(readable_text_on(color))
+                .add_modifier(Modifier::BOLD),
         ));
     } else {
         header.push(Span::styled(
             " status ",
             Style::default()
-                .fg(theme.bg)
+                .fg(readable_text_on(color))
                 .bg(color)
                 .add_modifier(Modifier::BOLD),
         ));

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -248,7 +248,7 @@ fn draw_menu(f: &mut Frame, area: Rect, state: &AppState, sel: usize, theme: &Th
     ]));
     lines.push(Line::raw(""));
     lines.push(Line::from(Span::styled(
-        "↑↓ move   Enter select   d dashboard   q quit",
+        "↑↓←→ move   Enter select   d dashboard   q quit",
         Style::default().fg(theme.muted),
     )));
     f.render_widget(Paragraph::new(lines), area);

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -84,6 +84,20 @@ pub fn choice_for(sel: usize) -> LauncherChoice {
         .map_or(LauncherChoice::OpenDashboard, |(_, _, _, c)| *c)
 }
 
+/// Move the selection cursor one step, wrapping around `row_count`.
+///
+/// `forward` selects the next row (Down/j/Right); otherwise the previous row
+/// (Up/k/Left). Pulled out of `run_launcher`'s event loop so the wrapping
+/// arithmetic is unit-testable without a real terminal.
+#[must_use]
+pub const fn move_selection(sel: usize, row_count: usize, forward: bool) -> usize {
+    if forward {
+        (sel + 1) % row_count
+    } else {
+        (sel + row_count - 1) % row_count
+    }
+}
+
 /// True when a model is actively serving (drives the running vs idle variant).
 fn is_running(state: &AppState) -> bool {
     state.instances.values().any(|i| i.status.is_serving())
@@ -302,10 +316,10 @@ pub fn run_launcher(
             KeyCode::Char('d') => break Some(LauncherChoice::OpenDashboard),
             KeyCode::Enter => break Some(choice_for(sel)),
             KeyCode::Down | KeyCode::Char('j') | KeyCode::Right => {
-                sel = (sel + 1) % row_count();
+                sel = move_selection(sel, row_count(), true);
             }
             KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
-                sel = (sel + row_count() - 1) % row_count();
+                sel = move_selection(sel, row_count(), false);
             }
             _ => {}
         }
@@ -464,6 +478,28 @@ mod tests {
         assert_eq!(ROWS[0].3, LauncherChoice::SetUp);
         assert_eq!(ROWS[1].1, "Serve a model");
         assert_eq!(ROWS[1].3, LauncherChoice::Serve);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        // Right must move the selection identically to Down, and Left
+        // identically to Up — `move_selection`'s `forward` flag is the only
+        // thing standing in for the aliased key, so compare it against the
+        // exact wrapping formulas the run_launcher match arms used to inline.
+        let rc = row_count();
+        let mut sel = 0usize;
+        for _ in 0..10 {
+            let via_right = move_selection(sel, rc, true);
+            let via_down = (sel + 1) % rc;
+            assert_eq!(via_right, via_down, "Right must match Down");
+            sel = via_right;
+        }
+        for _ in 0..10 {
+            let via_left = move_selection(sel, rc, false);
+            let via_up = (sel + rc - 1) % rc;
+            assert_eq!(via_left, via_up, "Left must match Up");
+            sel = via_left;
+        }
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/launcher.rs
+++ b/crates/rocm-dash-tui/src/ui/launcher.rs
@@ -301,8 +301,10 @@ pub fn run_launcher(
             KeyCode::Char('q') | KeyCode::Esc => break None,
             KeyCode::Char('d') => break Some(LauncherChoice::OpenDashboard),
             KeyCode::Enter => break Some(choice_for(sel)),
-            KeyCode::Down | KeyCode::Char('j') => sel = (sel + 1) % row_count(),
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Right => {
+                sel = (sel + 1) % row_count();
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
                 sel = (sel + row_count() - 1) % row_count();
             }
             _ => {}

--- a/crates/rocm-dash-tui/src/ui/model_picker.rs
+++ b/crates/rocm-dash-tui/src/ui/model_picker.rs
@@ -78,11 +78,11 @@ impl ModelPicker {
         let len = self.filtered(recipes).len();
         match key {
             KeyCode::Esc => PickerOutcome::Cancelled,
-            KeyCode::Up => {
+            KeyCode::Up | KeyCode::Left => {
                 self.selected = self.selected.saturating_sub(1);
                 PickerOutcome::None
             }
-            KeyCode::Down => {
+            KeyCode::Down | KeyCode::Right => {
                 if len > 0 {
                     self.selected = (self.selected + 1).min(len - 1);
                 }
@@ -284,6 +284,19 @@ mod tests {
             p.on_key(KeyCode::Down, &recipes());
         }
         assert_eq!(p.selected, 2);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut p = ModelPicker::default();
+        for _ in 0..10 {
+            p.on_key(KeyCode::Right, &recipes());
+        }
+        assert_eq!(p.selected, 2);
+        for _ in 0..10 {
+            p.on_key(KeyCode::Left, &recipes());
+        }
+        assert_eq!(p.selected, 0);
     }
 
     #[test]

--- a/crates/rocm-dash-tui/src/ui/model_picker.rs
+++ b/crates/rocm-dash-tui/src/ui/model_picker.rs
@@ -185,7 +185,7 @@ pub fn draw_model_picker(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "type filter · ↑↓ select · Enter choose · Esc cancel",
+            "type filter · ↑↓←→ select · Enter choose · Esc cancel",
             Style::default().fg(theme.muted),
         ))),
         rows[2],

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -471,7 +471,7 @@ pub fn draw_runtime_manager(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "↑↓ select · Enter/a activate · r rollback · x uninstall · o adopt · i import · l refresh · Esc close",
+            "↑↓←→ select · Enter/a activate · r rollback · x uninstall · o adopt · i import · l refresh · Esc close",
             Style::default().fg(theme.muted),
         ))),
         rows[3],

--- a/crates/rocm-dash-tui/src/ui/runtime_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/runtime_manager.rs
@@ -242,8 +242,10 @@ pub fn on_key(
     // 5) List navigation + actions.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') => *rm = None,
-        KeyCode::Up | KeyCode::Char('k') => r.selected = r.selected.saturating_sub(1),
-        KeyCode::Down | KeyCode::Char('j') if !runtimes.is_empty() => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
+            r.selected = r.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Right if !runtimes.is_empty() => {
             r.selected = (r.selected + 1).min(runtimes.len() - 1);
         }
         KeyCode::Char('l') => return spawn_refresh(r, jobs),
@@ -735,6 +737,21 @@ mod tests {
         assert_eq!(rm.as_ref().unwrap().selected, rts.len() - 1);
         for _ in 0..10 {
             on_key(&mut rm, &rts, &mut jobs, key(KeyCode::Up));
+        }
+        assert_eq!(rm.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut rm = Some(RuntimeManagerState::default());
+        let mut jobs = State::default();
+        let rts = runtimes();
+        for _ in 0..10 {
+            on_key(&mut rm, &rts, &mut jobs, key(KeyCode::Right));
+        }
+        assert_eq!(rm.as_ref().unwrap().selected, rts.len() - 1);
+        for _ in 0..10 {
+            on_key(&mut rm, &rts, &mut jobs, key(KeyCode::Left));
         }
         assert_eq!(rm.as_ref().unwrap().selected, 0);
     }

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -316,7 +316,7 @@ pub fn draw_services_manager<S: ::std::hash::BuildHasher>(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "↑↓ select · s stop · r restart · Esc close",
+            "↑↓←→ select · s stop · r restart · Esc close",
             Style::default().fg(theme.muted),
         ))),
         body[1],

--- a/crates/rocm-dash-tui/src/ui/services_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/services_manager.rs
@@ -160,10 +160,10 @@ pub fn on_key<S: ::std::hash::BuildHasher>(
     // 3) List navigation + lifecycle requests.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') => *services = None,
-        KeyCode::Up | KeyCode::Char('k') => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
             sm.selected = sm.selected.saturating_sub(1);
         }
-        KeyCode::Down | KeyCode::Char('j') if !rows.is_empty() => {
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Right if !rows.is_empty() => {
             sm.selected = (sm.selected + 1).min(rows.len() - 1);
         }
         KeyCode::Char('s') => request_lifecycle(sm, &rows, LifecycleAction::Stop),
@@ -444,6 +444,19 @@ mod tests {
         assert_eq!(services.as_ref().unwrap().selected, 1);
         on_key(&mut services, &mut jobs, &insts, key(KeyCode::Down)); // clamp at last
         assert_eq!(services.as_ref().unwrap().selected, 1);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut services = Some(ServicesManagerState::default());
+        let mut jobs = State::default();
+        let insts = instances();
+        on_key(&mut services, &mut jobs, &insts, key(KeyCode::Right));
+        assert_eq!(services.as_ref().unwrap().selected, 1);
+        on_key(&mut services, &mut jobs, &insts, key(KeyCode::Right)); // clamp at last
+        assert_eq!(services.as_ref().unwrap().selected, 1);
+        on_key(&mut services, &mut jobs, &insts, key(KeyCode::Left));
+        assert_eq!(services.as_ref().unwrap().selected, 0);
     }
 
     fn render(

--- a/crates/rocm-dash-tui/src/ui/tabs/home.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/home.rs
@@ -195,8 +195,10 @@ fn draw_activity(f: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     for job in state.jobs.jobs.values().take(feed.height as usize) {
         let (glyph, color) = match job.status {
             rocm_dash_core::state::JobStatus::Failed { .. } => ("✗ ", theme.err),
-            rocm_dash_core::state::JobStatus::Done { .. } => ("✓ ", theme.ok),
-            _ => ("⋯ ", theme.muted),
+            rocm_dash_core::state::JobStatus::Cancelled => ("○ ", theme.muted),
+            rocm_dash_core::state::JobStatus::Done { code: 0 } => ("✓ ", theme.ok),
+            rocm_dash_core::state::JobStatus::Done { .. } => ("! ", theme.warn),
+            rocm_dash_core::state::JobStatus::Running => ("⋯ ", theme.muted),
         };
         lines.push(Line::from(vec![
             Span::styled(glyph, Style::default().fg(color)),
@@ -583,5 +585,48 @@ mod tests {
         for h in [1u16, 2, 3, 5, 8, 11] {
             let _ = render(&s, 80, h);
         }
+    }
+
+    #[test]
+    fn activity_feed_glyphs_match_job_console_vocabulary() {
+        use rocm_dash_core::state::StateEvent;
+
+        let mut s = AppState::new("t".into(), "default-dark".into());
+        s.active_tab = ActiveTab::Home;
+        s.jobs.apply(StateEvent::StartJob {
+            id: "a".into(),
+            cmd: "ok".into(),
+            args: vec![],
+        });
+        s.jobs.apply(StateEvent::JobDone {
+            id: "a".into(),
+            code: 0,
+        });
+        s.jobs.apply(StateEvent::StartJob {
+            id: "b".into(),
+            cmd: "bad".into(),
+            args: vec![],
+        });
+        s.jobs.apply(StateEvent::JobDone {
+            id: "b".into(),
+            code: 1,
+        });
+        s.jobs.apply(StateEvent::StartJob {
+            id: "c".into(),
+            cmd: "cancelled".into(),
+            args: vec![],
+        });
+        s.jobs.apply(StateEvent::CancelJob("c".into()));
+        s.jobs.apply(StateEvent::StartJob {
+            id: "d".into(),
+            cmd: "running".into(),
+            args: vec![],
+        });
+
+        let out = render(&s, 160, 30);
+        assert!(out.contains('✓'), "zero-exit glyph missing: {out:?}");
+        assert!(out.contains('!'), "nonzero-exit glyph missing: {out:?}");
+        assert!(out.contains('○'), "cancelled glyph missing: {out:?}");
+        assert!(out.contains('⋯'), "running glyph missing: {out:?}");
     }
 }

--- a/crates/rocm-dash-tui/src/ui/theme.rs
+++ b/crates/rocm-dash-tui/src/ui/theme.rs
@@ -281,22 +281,29 @@ fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
 /// near-white) reads fine against an arbitrary status color — which breaks
 /// down for some bundled light themes.
 ///
+/// Returns true RGB black/white (`Color::Rgb(0, 0, 0)` / `Color::Rgb(255, 255,
+/// 255)`), not the `Color::Black`/`Color::White` ANSI palette entries — those
+/// are indices into the user's terminal palette and can be remapped to
+/// anything (e.g. Catppuccin Latte's ANSI black is `#5c5f77`, far lighter than
+/// true black), which would silently invalidate the WCAG contrast this
+/// function just computed.
+///
 /// Every color in every bundled theme is built through the `rgb()` helper
 /// above, so `Color::Rgb` is the only arm that actually runs in practice; the
 /// function is still exhaustive over `Color` for correctness, falling back to
-/// black (a safe, conservative default) for every other variant.
+/// true black (a safe, conservative default) for every other variant.
 pub fn readable_text_on(bg: Color) -> Color {
     let Color::Rgb(r, g, b) = bg else {
-        return Color::Black;
+        return Color::Rgb(0, 0, 0);
     };
     let l = relative_luminance(r, g, b);
     // Contrast ratio of white/black text against a background of luminance `l`.
     let white_contrast = (1.0 + 0.05) / (l + 0.05);
     let black_contrast = (l + 0.05) / (0.0 + 0.05);
     if white_contrast > black_contrast {
-        Color::White
+        Color::Rgb(255, 255, 255)
     } else {
-        Color::Black
+        Color::Rgb(0, 0, 0)
     }
 }
 
@@ -647,12 +654,18 @@ mod tests {
 
     #[test]
     fn readable_text_on_white_bg_is_black() {
-        assert_eq!(readable_text_on(Color::Rgb(255, 255, 255)), Color::Black);
+        assert_eq!(
+            readable_text_on(Color::Rgb(255, 255, 255)),
+            Color::Rgb(0, 0, 0)
+        );
     }
 
     #[test]
     fn readable_text_on_black_bg_is_white() {
-        assert_eq!(readable_text_on(Color::Rgb(0, 0, 0)), Color::White);
+        assert_eq!(
+            readable_text_on(Color::Rgb(0, 0, 0)),
+            Color::Rgb(255, 255, 255)
+        );
     }
 
     #[test]
@@ -667,7 +680,7 @@ mod tests {
         assert_eq!(t.bg, Color::Rgb(0xef, 0xf1, 0xf5), "bg is a light color");
         let old_trick_color = t.bg;
         let fixed_color = readable_text_on(t.ok);
-        assert_eq!(fixed_color, Color::Black);
+        assert_eq!(fixed_color, Color::Rgb(0, 0, 0));
         assert_ne!(
             fixed_color, old_trick_color,
             "the fix should pick a different (and better-contrasting) color than the old bg-based trick"

--- a/crates/rocm-dash-tui/src/ui/theme.rs
+++ b/crates/rocm-dash-tui/src/ui/theme.rs
@@ -257,6 +257,49 @@ const fn rgb(r: u8, g: u8, b: u8) -> Color {
     Color::Rgb(r, g, b)
 }
 
+/// WCAG relative luminance of an sRGB color, in `[0.0, 1.0]`.
+///
+/// <https://www.w3.org/TR/WCAG21/#dfn-relative-luminance>
+fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
+    fn channel(c: u8) -> f64 {
+        let c = f64::from(c) / 255.0;
+        if c <= 0.03928 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    }
+    0.0722f64.mul_add(
+        channel(b),
+        0.2126f64.mul_add(channel(r), 0.7152 * channel(g)),
+    )
+}
+
+/// Pick whichever of black/white text has the higher WCAG contrast ratio against `bg`.
+///
+/// This avoids assuming the theme's own `bg` color (usually near-black or
+/// near-white) reads fine against an arbitrary status color — which breaks
+/// down for some bundled light themes.
+///
+/// Every color in every bundled theme is built through the `rgb()` helper
+/// above, so `Color::Rgb` is the only arm that actually runs in practice; the
+/// function is still exhaustive over `Color` for correctness, falling back to
+/// black (a safe, conservative default) for every other variant.
+pub fn readable_text_on(bg: Color) -> Color {
+    let Color::Rgb(r, g, b) = bg else {
+        return Color::Black;
+    };
+    let l = relative_luminance(r, g, b);
+    // Contrast ratio of white/black text against a background of luminance `l`.
+    let white_contrast = (1.0 + 0.05) / (l + 0.05);
+    let black_contrast = (l + 0.05) / (0.0 + 0.05);
+    if white_contrast > black_contrast {
+        Color::White
+    } else {
+        Color::Black
+    }
+}
+
 /// 16-color ANSI palettes. Hex values from each project's canonical source;
 /// the catalogue itself is inspired by <https://ansicolor.com/>.
 mod palettes {
@@ -600,5 +643,34 @@ mod tests {
         assert_eq!(t.muted, p.br_black);
         assert_eq!(t.accent, p.br_cyan);
         assert_eq!(t.err, p.red);
+    }
+
+    #[test]
+    fn readable_text_on_white_bg_is_black() {
+        assert_eq!(readable_text_on(Color::Rgb(255, 255, 255)), Color::Black);
+    }
+
+    #[test]
+    fn readable_text_on_black_bg_is_white() {
+        assert_eq!(readable_text_on(Color::Rgb(0, 0, 0)), Color::White);
+    }
+
+    #[test]
+    fn readable_text_on_beats_the_old_theme_bg_trick_for_catppuccin_latte() {
+        // Regression guard for the job-console contrast bug: the old code used
+        // `Style::default().fg(theme.bg)` as the text color on top of a status
+        // fill, assuming the theme's own bg (near-black/near-white) always
+        // contrasts well against any status color. That's false for
+        // catppuccin-latte, whose bg is light and whose `ok` green is only
+        // mid-brightness.
+        let t = Theme::catppuccin_latte();
+        assert_eq!(t.bg, Color::Rgb(0xef, 0xf1, 0xf5), "bg is a light color");
+        let old_trick_color = t.bg;
+        let fixed_color = readable_text_on(t.ok);
+        assert_eq!(fixed_color, Color::Black);
+        assert_ne!(
+            fixed_color, old_trick_color,
+            "the fix should pick a different (and better-contrasting) color than the old bg-based trick"
+        );
     }
 }

--- a/crates/rocm-dash-tui/src/ui/update_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/update_manager.rs
@@ -278,7 +278,7 @@ pub fn draw_update_manager(
 
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "↑↓ select · Enter run · Esc close",
+            "↑↓←→ select · Enter run · Esc close",
             Style::default().fg(theme.muted),
         ))),
         rows[2],

--- a/crates/rocm-dash-tui/src/ui/update_manager.rs
+++ b/crates/rocm-dash-tui/src/ui/update_manager.rs
@@ -147,8 +147,10 @@ pub fn on_key(
     // 3) Menu navigation + action.
     match key.code {
         KeyCode::Esc | KeyCode::Char('q') => *update = None,
-        KeyCode::Up | KeyCode::Char('k') => u.selected = u.selected.saturating_sub(1),
-        KeyCode::Down | KeyCode::Char('j') => {
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Left => {
+            u.selected = u.selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Right => {
             u.selected = (u.selected + 1).min(ACTIONS.len() - 1);
         }
         KeyCode::Enter => return activate_selected(u, jobs),
@@ -390,6 +392,20 @@ mod tests {
         assert_eq!(u.as_ref().unwrap().selected, ACTIONS.len() - 1);
         for _ in 0..10 {
             on_key(&mut u, &mut jobs, key(KeyCode::Up));
+        }
+        assert_eq!(u.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn left_right_alias_up_down() {
+        let mut u = Some(UpdateManagerState::default());
+        let mut jobs = State::default();
+        for _ in 0..10 {
+            on_key(&mut u, &mut jobs, key(KeyCode::Right));
+        }
+        assert_eq!(u.as_ref().unwrap().selected, ACTIONS.len() - 1);
+        for _ in 0..10 {
+            on_key(&mut u, &mut jobs, key(KeyCode::Left));
         }
         assert_eq!(u.as_ref().unwrap().selected, 0);
     }


### PR DESCRIPTION
## Summary
- Add Left/Right as Up/Down aliases across the 7 hand-rolled list-selection screens (`runtime_manager`, `engine_manager`, `services_manager`, `automations_manager`, `update_manager`, `launcher`, `model_picker`), matching the existing vim `j`/`k` alias pattern.
- Render terminal job status (`done`/`exited (n)`/`failed`/`cancelled`) in `job_console.rs` as a full-width colored banner with a status glyph, instead of a small inline chip, so completion is impossible to miss against the scrolling output. Running jobs keep their existing compact chip + spinner.
- Fix a dead/incorrect glyph match (`Done | Running => "✓"`) so a nonzero exit code gets its own glyph distinct from success.
- Fix marginal text/background contrast on light themes (e.g. catppuccin-latte) by picking banner/chip text color from the actual background's WCAG luminance instead of assuming `theme.bg` always contrasts.
- Extract `launcher.rs`'s inline wraparound selection arithmetic into a pure, unit-testable `move_selection()` fn, closing the one nav screen that had no test for the new aliasing.
- Update the 6 nav screens' footer hints (`"↑↓ select"` → `"↑↓←→ select"`) to document the new aliases.

Addresses the two remaining Section D items from the ROCm CLI UX Evaluation & Action Plan.

## Test plan
- [x] `cargo test -p rocm-dash-tui --lib` — 672 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Manual smoke: `rocm dash`, open each of the 7 screens and confirm Left/Right moves selection like Up/Down; start/complete/fail/cancel a job and confirm the full-width banner + correct glyph
