### PR TITLE
ci(e2e): pool MI300X/Strix-Ubuntu/rad3 into one PR-triggered Linux GPU lane

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -72,7 +72,10 @@ jobs:
     outputs:
       heavy: ${{ steps.filter.outputs.heavy || steps.all.outputs.forced }}
       # Narrow GPU-serve gate; forced true off-PR so the merge queue always runs
-      # the full matrix and its required checks are never starved.
+      # the OS-coverage lanes and their required checks are never starved.
+      # Consumed by the three lanes that auto-run on push/PR/merge_group:
+      # e2e-gpu-linux (the pooled MI300X/Strix-Ubuntu/rad3 lane), plus
+      # e2e-gpu-strix-windows and e2e-wsl.
       serve: ${{ steps.filter.outputs.serve || steps.all.outputs.forced }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -100,7 +103,8 @@ jobs:
               - 'install*'
               - 'docs/keys/**'
               - '.github/workflows/**'
-            # The real-GPU serve matrix (e2e-gpu*). Narrower than `heavy`: only
+            # The real-GPU serve lanes (e2e-gpu-linux, e2e-gpu-strix-windows,
+            # e2e-wsl). Narrower than `heavy`: only
             # paths that can change serve BEHAVIOUR or the GPU E2E harness — NOT a
             # blanket `**/*.rs`. Compile coverage for every crate already runs on
             # ci.yml's always-on build/test lanes, so a dash-only or unrelated-
@@ -133,14 +137,39 @@ jobs:
         if: github.event_name != 'pull_request'
         run: echo "forced=true" >> "$GITHUB_OUTPUT"
 
-  e2e-gpu:
-    name: E2E tests (MI300X)
+  # Linux GPU pool: MI300X (bare-metal Instinct), Strix Halo Ubuntu (native,
+  # gfx1151), and rad3's Radeon R9700S (gfx1201) all run Ubuntu, so instead of
+  # picking one to represent "Linux" on PRs, `linux-gpu-pool` is a NEW label
+  # shared by all three (added by EAI-8558) and GitHub dispatches this job to
+  # whichever is free. This also fixes the "offline box blocks a required
+  # check" risk noted below: only the Strix box could serve this required
+  # check before, so it going offline made the check go missing; now MI300X
+  # or rad3 can serve it instead.
+  #
+  # A dedicated pool label — not `amd-gpu` — because `amd-gpu` marks EVERY AMD
+  # GPU runner, Strix WSL included (see the `mi300x` pin below and #360): using
+  # it as the pool selector would have pulled the WSL box into this "Linux"
+  # pool too, exactly the mixed-silicon-selection bug #360 fixed for MI300X.
+  # MI300X's own `mi300x` label (installed for #360) is reused here only for
+  # the scoped `workflow_dispatch` override, to force that one box.
+  #
+  # nightly.yml keeps testing all three individually and exhaustively — this
+  # pool only changes what a PR sees, not what gets tested overall.
+  e2e-gpu-linux:
+    name: E2E tests (Linux GPU pool)
+    # 90min: the largest of the collapsed suites (matches MI300X/rad3's old
+    # cap); whichever box serves this run still fits comfortably inside it.
     timeout-minutes: 90
-    # `mi300x`, not `amd-gpu`: every AMD GPU runner carries `amd-gpu`, including
-    # the Strix Halo hosts, so `[self-hosted, linux, amd-gpu]` let this lane land
-    # on gfx1151 — red on the WSL host, and (worse) a silent pass published as
-    # `e2e-gpu-report`, which the consolidated grid renders as MI300X.
-    runs-on: [self-hosted, linux, mi300x]
+    # Defaults to the shared `linux-gpu-pool` label. A scoped `workflow_dispatch`
+    # can still force one specific box via its own distinguishing label
+    # (`app-dev-gpu`/`strix-ubuntu`/`rad3` below); `all` falls through to the pool.
+    runs-on: >-
+      ${{ fromJSON(
+        (github.event_name == 'workflow_dispatch' && inputs.platform == 'app-dev-gpu' && '["self-hosted","linux","mi300x"]')
+        || (github.event_name == 'workflow_dispatch' && inputs.platform == 'strix-ubuntu' && '["self-hosted","linux","strix-halo","native"]')
+        || (github.event_name == 'workflow_dispatch' && inputs.platform == 'rad3' && '["self-hosted","linux","r9700"]')
+        || '["self-hosted","linux","linux-gpu-pool"]'
+      ) }}
     needs: [changes]
     # No build-and-test gate (cross-workflow needs is unavailable): the job builds
     # the rocm binary itself and is continue-on-error; ci.yml's required
@@ -152,16 +181,24 @@ jobs:
         (github.event_name != 'workflow_dispatch'
           && needs.changes.outputs.serve == 'true')
         || (github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'all' || inputs.platform == 'app-dev-gpu'))
+          && (inputs.platform == 'all' || inputs.platform == 'app-dev-gpu'
+              || inputs.platform == 'strix-ubuntu' || inputs.platform == 'rad3'))
       )
     continue-on-error: true
     env:
-      # Bound serve readiness below the 35-min job cap so a serve that never comes
+      # Bound serve readiness below the job cap so a serve that never comes
       # ready fails the scenario with a real error instead of hanging until the
-      # job is cancelled. 300s is ample for a real MI300X vLLM cold-start;
-      # per-scenario overrides in expectations.toml / a `@serve-timeout` tag adjust
-      # it (shorter for known bugs, longer for large models).
+      # job is cancelled. 300s is ample for a real cold-start on any of the
+      # pooled boxes; per-scenario overrides in expectations.toml / a
+      # `@serve-timeout` tag adjust it (shorter for known bugs, longer for
+      # large models).
       E2E_SERVE_TIMEOUT_SECS: "300"
+      # The Strix box (when the pool lands there) shares one physical machine
+      # with the strix-windows/wsl lanes, so a TUI frame that renders well on
+      # an idle runner can miss it while a sibling lane loads a model. Raise
+      # the wait budget uniformly rather than conditioning it on which box was
+      # picked; harmless on the dedicated MI300X/rad3 boxes.
+      E2E_TUI_TIMEOUT_SECS: "90"
       # Opt-in @nightly scenarios on a manual dispatch (default off). The nightly
       # workflow sets this unconditionally; here it lets a scoped dispatch confirm
       # a single nightly scenario (e.g. the 27B serve) without the full nightly run.
@@ -174,6 +211,39 @@ jobs:
       E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # This job can land on any of three boxes with different disk layouts:
+      # the Strix Halo box's root partition is otherwise full (only its nvme
+      # mount at /home/ubuntu/actions-runner has room), while MI300X/rad3 have
+      # a normal $HOME but a size-limited RUNNER_WORKSPACE PVC. Probe for the
+      # nvme mount rather than hardcoding which box gets which path, so the
+      # job behaves correctly regardless of which one the pool picks. This
+      # covers the two disk layouts that actually exist today — a genuinely
+      # new third layout needs a new branch here when it shows up.
+      - name: Resolve scratch-disk paths and GPU floor for this box
+        run: |
+          if [ -d /home/ubuntu/actions-runner ]; then
+            scratch="/home/ubuntu/actions-runner"
+            mkdir -p "$scratch/e2e-home" "$scratch/tmp" "$scratch/pip-cache" "$scratch/uv-cache"
+            {
+              echo "HOME=$scratch/e2e-home"
+              echo "CARGO_HOME=$scratch/.cargo"
+              echo "RUSTUP_HOME=$scratch/.rustup"
+              echo "TMPDIR=$scratch/tmp"
+              echo "PIP_CACHE_DIR=$scratch/pip-cache"
+              echo "E2E_SHARED_UV_CACHE_DIR=$scratch/uv-cache"
+              # gfx1151 shares system memory, so its free-VRAM floor is smaller
+              # than the Instinct/Radeon cards' — see the preflight step below.
+              echo "GPU_PREFLIGHT_MIN_FREE_GIB=8"
+            } >> "$GITHUB_ENV"
+          else
+            {
+              # Keep the uv cache off RUNNER_WORKSPACE, which can sit on a
+              # size-limited PVC on these boxes; /var/tmp is roomy there.
+              echo "E2E_SHARED_UV_CACHE_DIR=/var/tmp/rocm-e2e-uv-cache"
+              echo "GPU_PREFLIGHT_MIN_FREE_GIB=16"
+            } >> "$GITHUB_ENV"
+          fi
 
       # Reclaim the GPU before running: a serve leaked by a killed/timed-out prior
       # run (its Drop teardown never executed) can keep an engine process spinning
@@ -201,12 +271,10 @@ jobs:
       # (e.g. the reclaim step's kills still draining VRAM) self-heals within
       # seconds, so we retry up to a ceiling and succeed the moment the GPU is both
       # responsive AND has enough free VRAM. Only a genuinely absent/wedged/held
-      # GPU reaches the ceiling and fails — with a per-reason message.
+      # GPU reaches the ceiling and fails — with a per-reason message. The floor
+      # itself (GPU_PREFLIGHT_MIN_FREE_GIB) is set per-box by the step above.
       - name: GPU preflight (bounded wait for an available GPU)
         run: |
-          # A serve here needs most of the card; require a generous free-VRAM
-          # floor so a leftover serve (which the reclaim step should have killed)
-          # is caught, while normal baseline (~300 MB used) passes immediately.
           MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
           CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
           min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
@@ -235,33 +303,33 @@ jobs:
           echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
           exit 1
 
-      # cache: false — on this self-hosted runner we persist the build cache
-      # ourselves via CARGO_TARGET_DIR (below). The action's built-in
-      # Swatinem/rust-cache otherwise tries to SAVE the large target dir to
-      # GitHub's cache service in a post-step (slow/hangs) and its cleanup wipes
-      # the local target.
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: false
+      # Bootstrap rustup ourselves with --no-modify-path so it never writes to
+      # $HOME/.profile — needed on the Strix box's overridden HOME above, and
+      # harmless on a normal HOME too, so this one path works on every box in
+      # the pool without needing the reusable setup-rust-toolchain action.
+      # rust-toolchain.toml pins the exact toolchain, installed on first cargo
+      # use. Idempotent.
+      - name: Ensure Rust toolchain
+        run: |
+          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "${CARGO_HOME:-$HOME/.cargo}/bin/cargo" ]; then
+            curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+              | sh -s -- -y --no-modify-path --default-toolchain none
+          fi
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
 
       # `actions/checkout` runs `git clean -ffdx`, which deletes the gitignored
       # `target/` inside the repo every job → a full ~15min rebuild each run.
       # Point CARGO_TARGET_DIR at a sibling of the checkout ($RUNNER_WORKSPACE is
       # the checkout's parent — untouched by git clean and persistent between jobs
       # on a self-hosted runner), so cargo rebuilds incrementally.
-      - name: Run E2E tests on GPU hardware
+      - name: Run E2E tests on Linux GPU hardware
         run: |
           export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
           # Share heavy immutable artifacts (TheRock runtimes ~3.3GB, HF weights,
           # vLLM venv) across scenarios so they download once per runner, not per
           # scenario. Persistent path; service state stays isolated per scenario.
           export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
-          # Share uv's wheel download/build cache so `rocm install sdk` is a warm
-          # ~34s per scenario instead of a cold ~160s (measured on MI300X). Kept
-          # OFF the RUNNER_WORKSPACE Longhorn PVC (near-full) and on the roomy `/`
-          # overlay; ~23GB, one cold fill per pod-life. Not git-cleaned (outside
-          # the checkout) and outside the reclaim step's /tmp/rocm-e2e-* glob.
-          export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
+          # E2E_SHARED_UV_CACHE_DIR is already set per-box by the resolve step.
           # Share ONE installed managed runtime across the serve/chat scenarios so
           # `rocm install sdk` runs once per runner, not once per scenario (the
           # per-scenario install count — each a multi-GiB TheRock SDK whose probe
@@ -327,164 +395,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-gpu-report
-          path: tests/e2e-cucumber/results/
-
-  # Second AMD GPU architecture: the Strix Halo (gfx1151) Ubuntu runner, targeted
-  # by the `strix-halo` label. These hosts carry `amd-gpu` as well — it marks any
-  # AMD GPU runner, so it never distinguishes one architecture from another.
-  # Non-blocking while this hardware is proven out.
-  e2e-gpu-strix-ubuntu:
-    name: E2E tests (Strix Halo, Ubuntu)
-    # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
-    # install sdk; the cap must exceed the run so the job writes platform.json.
-    timeout-minutes: 35
-    # `native` disambiguates the two Linux Strix runners: the WSL host also
-    # carries `strix-halo`, but the paths below exist only on the native one.
-    runs-on: [self-hosted, linux, strix-halo, native]
-    needs: [changes]
-    # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-ubuntu.
-    if: >-
-      always()
-      && needs.changes.result == 'success'
-      && (
-        (github.event_name != 'workflow_dispatch'
-          && needs.changes.outputs.serve == 'true')
-        || (github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'all' || inputs.platform == 'strix-ubuntu'))
-      )
-    continue-on-error: true
-    # On this runner `/`, `/home/ubuntu`, and `/tmp` are ALL on a full root
-    # partition; only /home/ubuntu/actions-runner (a 1.7T nvme) has space. So
-    # EVERYTHING the job writes must land on the nvme. Point HOME there (catches
-    # ~/.cache/pip, ~/.config, and any other $HOME writer — pip's cache under the
-    # real /home/ubuntu is what previously failed `install sdk` with ENOSPC),
-    # plus the toolchain, temp, and pip cache. The rustup bootstrap still uses
-    # --no-modify-path so it doesn't touch $HOME/.profile. These paths are
-    # specific to that host, which is why `runs-on` pins `native` above.
-    env:
-      HOME: /home/ubuntu/actions-runner/e2e-home
-      CARGO_HOME: /home/ubuntu/actions-runner/.cargo
-      RUSTUP_HOME: /home/ubuntu/actions-runner/.rustup
-      TMPDIR: /home/ubuntu/actions-runner/tmp
-      PIP_CACHE_DIR: /home/ubuntu/actions-runner/pip-cache
-      E2E_SERVE_TIMEOUT_SECS: "300"
-      # The three Strix lanes share one physical machine, and this workflow now
-      # runs a third of them, so a TUI frame that renders well inside the 30s
-      # default on an idle runner can miss it while a sibling lane loads a model.
-      # Raise the wait budget rather than let that read as a product failure; a
-      # genuine hang still fails, just later.
-      E2E_TUI_TIMEOUT_SECS: "90"
-      # Match the MI300X dispatch path: opt into the platform-adaptive large-model
-      # scenario only when the manual include_nightly input is enabled.
-      E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
-      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu.
-      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Prepare writable dirs on the nvme + reclaim GPU from stray E2E procs
-        run: |
-          mkdir -p /home/ubuntu/actions-runner/e2e-home /home/ubuntu/actions-runner/tmp /home/ubuntu/actions-runner/pip-cache
-          # Reclaim the GPU from any serve leaked by a killed/timed-out prior run
-          # (see e2e-gpu). Scoped to e2e leftovers only.
-          pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
-          pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
-          pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
-          pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
-          rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
-          echo "prepared + reclaimed"
-
-      # GPU preflight: bounded wait so a missing/wedged/held GPU fails fast (~90s)
-      # instead of hanging to the job cap. Transient contention (VRAM still
-      # draining from the reclaim above) self-heals within the ceiling. See the
-      # e2e-gpu job for the rationale. gfx1151 shares system memory, so the free
-      # floor is smaller than the Instinct card but still catches a leftover serve.
-      - name: GPU preflight (bounded wait for an available GPU)
-        run: |
-          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-8}"
-          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
-          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
-          deadline=$(( SECONDS + CEILING_SECS ))
-          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
-            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
-            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
-            if [ -z "$total" ] || [ -z "$used" ]; then
-              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
-              sleep 5; continue
-            fi
-            free=$(( total - used ))
-            if [ "$free" -ge "$min_free" ]; then
-              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
-              exit 0
-            fi
-            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
-            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
-            sleep 5
-          done
-          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
-          exit 1
-
-      # Bootstrap rustup ourselves with --no-modify-path so it never writes to
-      # $HOME/.profile (setup-rust-toolchain doesn't expose that flag).
-      # rust-toolchain.toml pins the exact toolchain, installed on first cargo
-      # use. Idempotent.
-      - name: Ensure Rust toolchain
-        run: |
-          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$CARGO_HOME/bin/cargo" ]; then
-            curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
-              | sh -s -- -y --no-modify-path --default-toolchain none
-          fi
-          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
-
-      - name: Run E2E tests on Strix Halo
-        run: |
-          export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
-          export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
-          # Share ONE installed managed runtime across serve/chat scenarios, and
-          # PRE-WARM it in place before the suite (mirrors e2e-gpu). This is not an
-          # optimization — it is REQUIRED for correctness. `install sdk` bakes
-          # ABSOLUTE paths (install_root, python_executable, rocm_sdk.*) into the
-          # runtime manifest. If the first scenario installs into its own isolated
-          # /tmp/rocm-e2e-XXXX data dir and only the registry is shared onward, those
-          # baked paths point at that scenario's temp dir — which is deleted when the
-          # scenario ends. Every later serve then sees `status=unusable (install root
-          # is missing)` and fails (diagnosed on the box 2026-07-15). Installing in
-          # place, directly into the persistent shared dir, keeps the baked paths
-          # valid for all scenarios and for the end-of-run version probe.
-          prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
-          export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
-
-          # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
-          export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
-          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
-
-          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
-          # the channel index has moved on — the tree is a cache, not a one-shot.
-          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
-          # existence-only guard froze this lane on its first runtime (EAI-8057).
-          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
-
-          # Optional scenario-name filter for a scoped manual dispatch.
-          NAME_FILTER="${{ github.event.inputs.name_filter }}"
-          if [ -n "$NAME_FILTER" ]; then
-            echo "name filter active: $NAME_FILTER"
-            cargo xtask e2e -- --name "$NAME_FILTER"
-          else
-            cargo xtask e2e
-          fi
-
-      - name: Upload E2E report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: e2e-gpu-strix-ubuntu-report
+          name: e2e-gpu-linux-report
           path: tests/e2e-cucumber/results/
 
   # First real Windows GPU coverage: the Strix Halo Windows 11 runner. The
@@ -492,12 +403,12 @@ jobs:
   # no GPU. Non-blocking so it never gates the PR.
   e2e-gpu-strix-windows:
     name: E2E tests (Strix Halo, Windows)
-    # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
+    # 35min: see e2e-gpu-linux — one collapsed job runs all serves + per-scenario
     # install sdk; the cap must exceed the run so the job writes platform.json.
     timeout-minutes: 35
     runs-on: [self-hosted, windows, strix-halo, native]
     needs: [changes]
-    # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-windows.
+    # See `e2e-gpu-linux`: no build-and-test gate (cross-workflow); strix-windows.
     if: >-
       always()
       && needs.changes.result == 'success'
@@ -522,7 +433,7 @@ jobs:
       # Match the Linux Strix dispatch path: opt into the platform-adaptive
       # large-model scenario only when the manual input is enabled.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
-      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu.
+      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu-linux.
       E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -534,7 +445,7 @@ jobs:
       # (Windows PowerShell 5.1, always present) rather than `pwsh` (PowerShell 7),
       # which this self-hosted runner does not have installed.
       # Reclaim the GPU from any E2E serve leaked by a killed/timed-out prior run
-      # (see e2e-gpu). PowerShell (5.1) equivalent; best-effort.
+      # (see e2e-gpu-linux). PowerShell (5.1) equivalent; best-effort.
       - name: Reclaim GPU from stray E2E processes
         shell: powershell
         run: |
@@ -596,7 +507,7 @@ jobs:
         shell: powershell
         run: |
           # Share ONE installed managed runtime across serve/chat scenarios, and
-          # PRE-WARM it in place before the suite (mirrors e2e-gpu / strix-ubuntu).
+          # PRE-WARM it in place before the suite (mirrors e2e-gpu-linux).
           # REQUIRED for correctness, not just speed: `install sdk` bakes ABSOLUTE
           # paths (install_root, python_executable, rocm_sdk.*, .rocm-cli-runtime.json)
           # into the runtime manifest. If the first scenario installs into its own
@@ -611,7 +522,7 @@ jobs:
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
           # This job does not set CARGO_TARGET_DIR, so the binaries land in
           # the default target\release (fall back to it when the env var is unset).
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
+          # See the e2e-gpu-linux lane for why the e2e-test-hooks feature must match
           # what `cargo xtask e2e` would build.
           cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -658,7 +569,7 @@ jobs:
     timeout-minutes: 90
     runs-on: [self-hosted, linux, strix-halo, wsl]
     needs: [changes]
-    # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-wsl. Gated on
+    # See `e2e-gpu-linux`: no build-and-test gate (cross-workflow); strix-wsl. Gated on
     # `serve` like the sibling lanes rather than the broader `heavy`: the
     # consolidated report gates on `serve` too, so a heavy-but-not-serve change
     # would otherwise run this lane and then discard its artifact unreported.
@@ -683,7 +594,7 @@ jobs:
       # Match the other hardware lanes: opt into the platform-adaptive
       # large-model scenario only when the manual include_nightly input is on.
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
-      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu.
+      # Heavy @merge-queue serves run only in the merge queue; see e2e-gpu-linux.
       E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -726,7 +637,7 @@ jobs:
       - name: Reclaim GPU from stray E2E processes
         run: |
           # Reclaim from any serve leaked by a killed/timed-out prior run
-          # (see e2e-gpu). Scoped to e2e leftovers only.
+          # (see e2e-gpu-linux). Scoped to e2e leftovers only.
           pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
           pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
           pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
@@ -790,7 +701,7 @@ jobs:
           export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
           export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
           # Share ONE installed managed runtime across serve/chat scenarios and
-          # PRE-WARM it in place (mirrors e2e-gpu-strix-ubuntu). Required for
+          # PRE-WARM it in place (mirrors e2e-gpu-linux). Required for
           # correctness, not speed: `install sdk` bakes ABSOLUTE paths into the
           # runtime manifest, so installing into a per-scenario temp dir leaves
           # every later serve pointing at a deleted install root.
@@ -798,7 +709,7 @@ jobs:
           export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
 
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
+          # See the e2e-gpu-linux lane for why the e2e-test-hooks feature must match
           # what `cargo xtask e2e` would build.
           cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
           export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
@@ -806,7 +717,7 @@ jobs:
 
           # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
           # the channel index has moved on — the tree is a cache, not a one-shot.
-          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
+          # See the e2e-gpu-linux lane and `xtask e2e-prewarm` for why the old
           # existence-only guard froze this lane on its first runtime (EAI-8057).
           HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
             cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
@@ -827,137 +738,6 @@ jobs:
           name: e2e-gpu-strix-wsl-report
           path: tests/e2e-cucumber/results/
 
-  # Third AMD GPU target: the rad3 cluster's Radeon AI PRO R9700S (gfx1201, 32GB),
-  # targeted by the `r9700` label. This runner is a KEDA-scaled pod (0<->1 off the
-  # job queue), so the card is only reserved while a job exists (dev-tooling EAI-8065).
-  # Non-blocking while this hardware is proven out.
-  e2e-gpu-rad3:
-    name: E2E tests (rad3 R9700)
-    # 90min: matches e2e-gpu — same collapsed suite, and the card is smaller, so
-    # do not tighten this below the Instinct lane's cap.
-    timeout-minutes: 90
-    # `r9700` names the hardware, not a generic `amd-gpu`: GitHub matches a job to
-    # any runner whose labels are a superset, so a shared label would let this card
-    # pick up MI300X-targeted work.
-    runs-on: [self-hosted, linux, r9700]
-    needs: [changes]
-    if: >-
-      always()
-      && needs.changes.result == 'success'
-      && (
-        (github.event_name != 'workflow_dispatch'
-          && needs.changes.outputs.serve == 'true')
-        || (github.event_name == 'workflow_dispatch'
-          && (inputs.platform == 'all' || inputs.platform == 'rad3'))
-      )
-    continue-on-error: true
-    env:
-      E2E_SERVE_TIMEOUT_SECS: "300"
-      E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"
-      # Full serve matrix at the merge-queue gate, like every other lane (see e2e-gpu).
-      E2E_MERGE_QUEUE: "${{ github.event_name == 'merge_group' && '1' || '' }}"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      # The pod is usually fresh (scale-to-zero recreates it per job), but the
-      # work PVC is not, and two jobs can share one pod's life. Same reclaim as
-      # e2e-gpu, scoped to e2e leftovers only.
-      - name: Reclaim GPU from stray E2E processes
-        run: |
-          pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
-          pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
-          pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
-          pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
-          pkill -f 'e2e-target/release/rocm daemon' 2>/dev/null || true
-          rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
-          echo "reclaimed"
-
-      # Bounded wait, as in e2e-gpu. The pod requests `amd.com/gpu: 1`, so
-      # rocm-smi sees exactly the one card Kueue admitted it for. The floor is
-      # half of the R9700S's 32GB: high enough to catch a leftover serve still
-      # holding the card, low enough that a clean pod passes on the first poll.
-      - name: GPU preflight (bounded wait for an available GPU)
-        run: |
-          MIN_FREE_GIB="${GPU_PREFLIGHT_MIN_FREE_GIB:-16}"
-          CEILING_SECS="${GPU_PREFLIGHT_CEILING_SECS:-90}"
-          min_free=$(( MIN_FREE_GIB * 1024 * 1024 * 1024 ))
-          deadline=$(( SECONDS + CEILING_SECS ))
-          reason="rocm-smi never returned within its timeout (driver wedged or GPU absent)"
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            out=$(timeout 15 rocm-smi --showmeminfo vram 2>/dev/null) || { sleep 5; continue; }
-            total=$(printf '%s\n' "$out" | grep -i 'VRAM Total Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
-            used=$(printf '%s\n' "$out" | grep -i 'VRAM Total Used Memory' | sed 's/.*: *//' | grep -oE '[0-9]+' | tail -1)
-            if [ -z "$total" ] || [ -z "$used" ]; then
-              reason="rocm-smi returned no VRAM figures (no AMD GPU detected)"
-              sleep 5; continue
-            fi
-            free=$(( total - used ))
-            if [ "$free" -ge "$min_free" ]; then
-              echo "GPU ready: $(( free / 1024 / 1024 / 1024 )) GiB free (>= ${MIN_FREE_GIB} GiB)."
-              exit 0
-            fi
-            reason="VRAM never dropped below the floor: only $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB) — a serve is likely still holding the GPU"
-            echo "waiting: $(( free / 1024 / 1024 / 1024 )) GiB free (< ${MIN_FREE_GIB} GiB)…"
-            sleep 5
-          done
-          echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
-          exit 1
-
-      # cache: false for the same reason as e2e-gpu — the build cache is kept in
-      # CARGO_TARGET_DIR on the PVC, not in GitHub's cache service.
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: false
-
-      - name: Run E2E tests on rad3
-        run: |
-          # $RUNNER_WORKSPACE is on the runner-work PVC, which survives the pod
-          # being scaled away, so the cargo target dir and the shared caches are
-          # still warm on the next job even though the container is not.
-          export CARGO_TARGET_DIR="$RUNNER_WORKSPACE/e2e-target"
-          export E2E_SHARED_CACHE_DIR="$RUNNER_WORKSPACE/e2e-shared"
-          # A SEPARATE PVC is mounted at exactly this path by the runner's cluster
-          # overlay. Keeping the ~23GB uv cache off the work PVC is deliberate; if
-          # you change this path, change the overlay that mounts it too.
-          export E2E_SHARED_UV_CACHE_DIR="/var/tmp/rocm-e2e-uv-cache"
-          # Pre-warm one shared runtime in place before the suite. Not an
-          # optimization — `install sdk` bakes absolute paths into the runtime
-          # manifest, so installing anywhere temporary breaks every later serve.
-          # See e2e-gpu for the full rationale.
-          prewarm="$RUNNER_WORKSPACE/e2e-prewarm"
-          export E2E_SHARED_RUNTIMES_DIR="$prewarm/data/runtimes"
-
-          # See the e2e-gpu lane for why the e2e-test-hooks feature must match
-          # what `cargo xtask e2e` would build.
-          cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks
-          export ROCM_CLI_BINARY="$CARGO_TARGET_DIR/release/rocm"
-          export ROCM_CLI_ROCMD_BINARY="$CARGO_TARGET_DIR/release/rocmd"
-
-          # Pre-warm once, serially, in place (no mv/symlink), and refresh it when
-          # the channel index has moved on — the tree is a cache, not a one-shot.
-          # See the e2e-gpu lane and `xtask e2e-prewarm` for why the old
-          # existence-only guard froze this lane on its first runtime (EAI-8057).
-          HF_HOME="$E2E_SHARED_CACHE_DIR/huggingface" \
-          UV_CACHE_DIR="$E2E_SHARED_UV_CACHE_DIR" \
-            cargo xtask e2e-prewarm --channel release --prewarm-dir "$prewarm"
-
-          # Optional scenario-name filter for a scoped manual dispatch — a cheap
-          # way to exercise this lane against a single scenario without the full suite.
-          NAME_FILTER="${{ github.event.inputs.name_filter }}"
-          if [ -n "$NAME_FILTER" ]; then
-            echo "name filter active: $NAME_FILTER"
-            cargo xtask e2e -- --name "$NAME_FILTER"
-          else
-            cargo xtask e2e
-          fi
-
-      - name: Upload E2E report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: e2e-gpu-rad3-report
-          path: tests/e2e-cucumber/results/
-
   # Consolidate this workflow's self-hosted platform reports into one GPU-side
   # cross-platform grid (Summary + merged HTML). Distinct name from ci.yml's
   # required `E2E consolidated report` so it does NOT collide with that required
@@ -970,11 +750,9 @@ jobs:
     timeout-minutes: 15
     needs:
       - changes
-      - e2e-gpu
-      - e2e-gpu-strix-ubuntu
+      - e2e-gpu-linux
       - e2e-gpu-strix-windows
       - e2e-wsl
-      - e2e-gpu-rad3
     # Gate on `serve`: every lane this report consolidates (the GPU jobs) is now
     # serve-gated, so a serve-only change runs them and their report must still be
     # produced. On dispatch `serve` is unset, so also run when the trigger was

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -32,21 +32,41 @@ separate tier flag or tag filter to maintain.
 | Job | Workflow | Platform | Runner labels |
 |---|---|---|---|
 | `e2e` | `ci.yml` | Mock (no GPU) | GitHub-hosted `ubuntu-latest` |
-| `e2e-gpu` | `e2e-selfhosted.yml` | MI300X (AMD Instinct, bare-metal Linux) | self-hosted `[self-hosted, linux, mi300x]` |
-| `e2e-gpu-strix-ubuntu` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, strix-halo, native]` |
+| `e2e-gpu-linux` | `e2e-selfhosted.yml` | Linux GPU pool: MI300X (AMD Instinct), Strix Halo (gfx1151) on Ubuntu, or Radeon AI PRO R9700 (gfx1201) — whichever box is free | self-hosted `[self-hosted, linux, linux-gpu-pool]` |
 | `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on native Windows 11 | self-hosted `[self-hosted, windows, strix-halo, native]` |
 | `e2e-wsl` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu under WSL2 | self-hosted `[self-hosted, linux, strix-halo, wsl]` |
-| `e2e-gpu-rad3` | `e2e-selfhosted.yml` | Radeon AI PRO R9700 (gfx1201) on Linux | self-hosted `[self-hosted, linux, r9700]` |
 
-The Strix Halo lanes pin the extra `native` label because two Linux runners
-share the `strix-halo` label (a native host and a WSL host) and the jobs'
-hardcoded `/home/ubuntu/actions-runner` paths exist only on the native one. The
-WSL lane pins `wsl` for the same reason, from the other side.
+**The Linux pool (`EAI-8558`).** MI300X, Strix Halo Ubuntu (native), and rad3's
+Radeon R9700 all run Ubuntu, so instead of one dedicated job per box,
+`linux-gpu-pool` is a NEW label shared by all three (added to each box) and
+`e2e-gpu-linux`'s `runs-on` targets that shared label — GitHub dispatches the
+job to whichever box is idle. This also closes a gap noted below: previously
+only the Strix box could serve this required check, so it going offline made
+the check go missing; now MI300X or rad3 can serve it instead. Each box also
+keeps its own distinguishing label (`mi300x`, `strix-halo`+`native`, `r9700`)
+so `nightly.yml` can still test all three individually and exhaustively, and
+so a scoped `workflow_dispatch` can still force one specific box (see Triggers
+below). The Strix Windows and WSL boxes do NOT carry `linux-gpu-pool`, so they
+stay out of the Linux pool.
 
-Every label in a `runs-on` must narrow the pool to one kind of hardware. In
-particular the MI300X lane pins `mi300x` rather than `amd-gpu`: `amd-gpu` is
-carried by every AMD GPU runner, Strix Halo included, so it selects a
-mixed-silicon pool. `every_self_hosted_lane_pins_a_hardware_label` in
+It is a NEW label rather than the existing `amd-gpu`, precisely because of the
+bug described next: `amd-gpu` marks every AMD GPU runner, Strix WSL included,
+so using it as the pool selector would pull the WSL box into this "Linux" pool
+too — exactly the mixed-silicon-selection failure mode `mi300x` was introduced
+to fix for MI300X specifically.
+
+The Strix Halo Ubuntu and WSL runners additionally share the `strix-halo`
+label (a native host and a WSL host); `native`/`wsl` disambiguate them because
+the native host's hardcoded `/home/ubuntu/actions-runner` paths exist only
+there.
+
+Every label in a `runs-on` must narrow the pool to one kind of hardware.
+`amd-gpu` reads specific but is not — it is carried by every AMD GPU runner,
+Strix Halo included, so selecting on it alone (as the MI300X lane once did)
+draws from a mixed-silicon pool: the lane could land on gfx1151, pass, and
+publish its result under the MI300X column. `mi300x` (this lane), `r9700`, and
+`linux-gpu-pool` all narrow to one kind of hardware or the intended pool;
+`every_self_hosted_lane_pins_a_hardware_label` in
 `xtask/src/workflow_contract.rs` enforces this, because the failure is quiet —
 the lane simply passes on the wrong GPU and reports under the label it was
 named for.
@@ -55,8 +75,8 @@ named for.
 resolve to skip here, and known bugs resolve to xfail from
 `expectations.toml`. It is a required check and must stay green.
 
-The self-hosted jobs (`e2e-gpu`, `e2e-gpu-strix-ubuntu`,
-`e2e-gpu-strix-windows`, `e2e-wsl`, and `e2e-gpu-rad3`) run on AMD GPU systems, so they exercise
+The self-hosted jobs (`e2e-gpu-linux`, `e2e-gpu-strix-windows`, and
+`e2e-wsl`) run on AMD GPU systems, so they exercise
 host/GPU detection, engine `detect`/`capabilities`, and live serving scenarios
 that the mock job cannot. GPU availability is advisory in the WSL lane, as
 described below.
@@ -99,39 +119,57 @@ covers the mock platform;
 reports — including partial or failed runs — by scenario id into one HTML report
 and GitHub step summary.
 
-The lane artifacts are named canonically (`e2e-report`, `e2e-gpu-report`,
-`e2e-gpu-rad3-report`, `e2e-gpu-strix-ubuntu-report`, `e2e-gpu-strix-windows-report`,
-`e2e-gpu-strix-wsl-report`) in every workflow, because the report derives each
-platform's name and OS from the artifact name. An unrecognised name renders as a
-guessed platform on Linux, which would report a Windows lane as Linux; `xtask`'s
-`every_uploaded_e2e_artifact_has_a_name_the_report_can_label` guards against it.
+The lane artifacts are named canonically (`e2e-gpu-linux-report`,
+`e2e-gpu-rad3-report`, `e2e-gpu-report`, `e2e-gpu-strix-ubuntu-report`,
+`e2e-gpu-strix-windows-report`, `e2e-gpu-strix-wsl-report`, `e2e-report`) in every workflow,
+because the report derives each platform's name and OS from
+the artifact name. An unrecognised name renders as a guessed platform on
+Linux, which would report a Windows lane as Linux; `xtask`'s
+`every_uploaded_e2e_artifact_has_a_name_the_report_can_label` guards against
+it. `e2e-gpu-linux-report` is the ONE exception: since it can be produced by
+any of the three pooled boxes, `xtask e2e-report`'s `discover()` relabels it
+at runtime from its own `platform.json` rather than trusting the name — see
+`nightly.yml` vs the pool below.
 
 ## Triggers
 
-The GPU jobs (in `e2e-selfhosted.yml`) run automatically on `push`,
-`pull_request`, and `merge_group` when the workflow's own `changes` job's
-`serve` path filter is `true`. `serve` is narrower than `heavy`: it matches only
-paths that can change serve *behaviour* or the GPU E2E harness (the engines, the
-serve code path in `apps/rocm`/`apps/rocmd`, `rocm-core`, the e2e-cucumber crate,
-plus broad-dependency safety nets), **not** a blanket `**/*.rs`. So a Rust change
-that cannot affect serving — e.g. a dashboard-only or unrelated-crate PR — skips
-the heavy GPU matrix, while compile coverage for every crate still runs on
-`ci.yml`'s always-on build/test lanes. Off `pull_request` (push/merge_group) the
-filter is forced `true`, so the full matrix always runs there. Unlike the
-pre-split layout the GPU jobs do **not** gate on the hosted `build-and-test` job
-— cross-workflow `needs` is not possible, so each GPU job builds the `rocm`
-binary itself as its first real step (a broken build fails that job fast and
-non-fatally). `ci.yml`'s required `build-and-test` and mock `e2e` remain the
-authoritative pre-merge build gate.
+All three self-hosted jobs — `e2e-gpu-linux`, `e2e-gpu-strix-windows`, and
+`e2e-wsl` — run automatically on `push`, `pull_request`, and `merge_group`,
+gated on the workflow's own `changes` job's `serve` path filter being `true`.
+`serve` is narrower than `heavy`: it matches only paths that can change serve
+*behaviour* or the GPU E2E harness (the engines, the serve code path in
+`apps/rocm`/`apps/rocmd`, `rocm-core`, the e2e-cucumber crate, plus
+broad-dependency safety nets), **not** a blanket `**/*.rs`. So a Rust change
+that cannot affect serving — e.g. a dashboard-only or unrelated-crate PR —
+skips these lanes, while compile coverage for every crate still runs on
+`ci.yml`'s always-on build/test lanes. Off `pull_request` (push/merge_group)
+the filter is forced `true`, so all three lanes always run there.
 
-They can also be triggered manually via `e2e-selfhosted.yml`'s
+`e2e-gpu-linux`'s `runs-on` defaults to the shared `linux-gpu-pool` label (see
+Platforms above), so on a normal push/PR/merge_group run GitHub picks whichever
+of MI300X/Strix-Ubuntu/rad3 is idle. A scoped `workflow_dispatch` can still
+force one specific box instead, via a `runs-on` expression that overrides the
+pool label when `platform` names that box specifically (`app-dev-gpu` to
+`mi300x`, `strix-ubuntu` to its native label, `rad3` to `r9700`; `all` falls
+through to the pool).
+
+Unlike the pre-split layout the GPU jobs do **not** gate on the hosted
+`build-and-test` job — cross-workflow `needs` is not possible, so each GPU job
+builds the `rocm` binary itself as its first real step (a broken build fails
+that job fast and non-fatally). `ci.yml`'s required `build-and-test` and mock
+`e2e` remain the authoritative pre-merge build gate.
+
+Every lane can also be triggered manually via `e2e-selfhosted.yml`'s
 `workflow_dispatch`, independent of the `serve` gate, with these inputs:
 
 - `platform` (choice: `all`, `app-dev-gpu`, `strix-ubuntu`, `strix-windows`,
-  `strix-wsl`, `rad3`) — which self-hosted job(s) to run. `app-dev-gpu` maps to
-  `e2e-gpu`, `strix-ubuntu` to `e2e-gpu-strix-ubuntu`, `strix-windows` to
-  `e2e-gpu-strix-windows`, `strix-wsl` to `e2e-wsl`, and `rad3` to
-  `e2e-gpu-rad3`. (The mock lane has its own `platform` input on `ci.yml`; it is
+  `strix-wsl`, `rad3`) — which self-hosted job(s) to run, and (for the pooled
+  Linux job) which box to force. `all` runs every job, with `e2e-gpu-linux`
+  using the pool label. `app-dev-gpu`, `strix-ubuntu`, and `rad3` each run
+  `e2e-gpu-linux` forced onto that specific box (via `mi300x`, `strix-halo`
+  native, and `r9700` respectively) instead of the pool. `strix-windows` and
+  `strix-wsl` run their own dedicated jobs (`e2e-gpu-strix-windows`, `e2e-wsl`)
+  unchanged. (The mock lane has its own `platform` input on `ci.yml`; it is
   not part of this workflow.)
 - `name_filter` (string) — a scenario-name regex forwarded to the cucumber
   harness (`cargo xtask e2e -- --name <regex>`) so a dispatch can run a
@@ -141,10 +179,10 @@ They can also be triggered manually via `e2e-selfhosted.yml`'s
   `@nightly`-tagged scenarios (e.g. large-model serves, cold installs) that
   are otherwise skipped on a normal push/PR run to keep it fast.
 
-Dispatch the GPU lanes with, e.g.:
+Dispatch a specific box in the Linux pool with, e.g.:
 
 ```bash
-gh workflow run e2e-selfhosted.yml --ref <ref> -f platform=app-dev-gpu
+gh workflow run e2e-selfhosted.yml --ref <ref> -f platform=rad3
 ```
 
 ## The shared pre-warmed runtime
@@ -195,30 +233,46 @@ the pre-warm block is duplicated across multiple jobs in two shells;
 
 ## Blocking vs. non-blocking
 
-The self-hosted jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`,
-`e2e-gpu-strix-windows`, `e2e-wsl`, and `e2e-gpu-rad3` — all run with `continue-on-error: true`, so a
+The self-hosted jobs — `e2e-gpu-linux`, `e2e-gpu-strix-windows`, and
+`e2e-wsl` — all run with `continue-on-error: true`, so a
 hardware failure that RUNS never gates a PR merge. Their results still surface
 in the self-hosted consolidated report for visibility.
 
 ### Timeouts on the shared Strix box
 
-Three of those lanes — the two native Strix ones and `e2e-wsl` — run on the same
-physical machine and can be in flight together, so a wait that is comfortable on
-an idle runner can expire while a sibling lane loads a model. Two budgets are
-raised there rather than letting contention read as a product failure:
-`E2E_SERVE_TIMEOUT_SECS` for serve readiness, and `E2E_TUI_TIMEOUT_SECS` for the
-PTY-driven dashboard waits. Both only lengthen how long a wait may take; a
+`e2e-gpu-strix-windows` and `e2e-wsl` always run on the physical Strix Halo
+box; `e2e-gpu-linux` runs there too whenever the pool (or a scoped dispatch)
+lands it on the Strix Ubuntu runner. Up to three lanes can then be in flight on
+that one machine together, so a wait that is comfortable on an idle runner can
+expire while a sibling lane loads a model. Two budgets are raised unconditionally
+in every self-hosted lane rather than letting contention read as a product
+failure: `E2E_SERVE_TIMEOUT_SECS` for serve readiness, and
+`E2E_TUI_TIMEOUT_SECS` for the PTY-driven dashboard waits — harmless on the
+dedicated MI300X/rad3 boxes too. Both only lengthen how long a wait may take; a
 genuine hang still fails, just later.
 
-**Required-check caveat.** These three job names (plus, historically, a
-consolidated-report name) are still in `main`'s required-status-check list.
-`continue-on-error` neutralizes a job that ran and failed, but a required check
-that *never reports* — because its self-hosted runner is offline — is treated as
-missing and still blocks the merge. The workflow split removes the catastrophic
-concurrency stall (an offline runner can no longer freeze `ci.yml`'s hosted
-required checks), but fully unblocking merges while a runner is offline
-additionally requires removing these self-hosted checks from the required list —
-a branch-protection change tracked separately from the workflow split.
+**Required-check caveat.** These three job **display names** (plus, historically, a
+consolidated-report name) were historically documented as being in `main`'s
+required-status-check list: `E2E tests (Linux GPU pool)` (`e2e-gpu-linux`,
+formerly `E2E tests (Strix Halo, Ubuntu)` before the `EAI-8558` pooling
+change), `E2E tests (Strix Halo, Windows)` (`e2e-gpu-strix-windows`), and
+`E2E tests (Strix Halo, WSL2)` (`e2e-wsl`). `continue-on-error` neutralizes a
+job that ran and failed, but a required check that *never reports* — because
+its self-hosted runner is offline — would be treated as missing and block the
+merge, IF these checks are actually required. As of 2026-09, recent evidence
+says otherwise: PRs #334, #335, and #343 all landed while
+`E2E tests (Strix Halo, Ubuntu)` reported `cancelled` on the `merge_group`
+ref, which a required check under ALLGREEN would have blocked. Branch
+protection is not readable without admin access, so this is inferred from
+those merges rather than confirmed from the required list — renaming or
+restructuring these lanes (as this pooling change does) is therefore likely
+safe either way. Pooling still narrows the theoretical risk for the Linux
+check specifically: previously only the Strix box could serve it, so it going
+offline would make the check go missing if it is in fact required; now MI300X
+or rad3 can serve it instead. If these checks *are* still required, fully
+removing the risk for the remaining two (Windows/WSL) additionally requires
+removing them from the required list — a branch-protection change tracked
+separately from the workflow split.
 
 ## Fork safety
 

--- a/xtask/src/e2e_report.rs
+++ b/xtask/src/e2e_report.rs
@@ -58,13 +58,23 @@ pub fn run(artifacts_dir: &Path, html_out: &Path) -> Result<()> {
     Ok(())
 }
 
+/// The pooled Linux GPU lane's artifact name (`e2e-gpu-linux` in
+/// `e2e-selfhosted.yml`): MI300X, Strix Halo Ubuntu, and rad3 all share one
+/// `runs-on` label, so this fixed name carries no real hardware identity by
+/// itself — unlike every other lane's name, which names one specific box.
+/// `discover()` special-cases it below to recover the real identity from
+/// `platform.json` instead of trusting the name.
+const POOLED_LINUX_ARTIFACT_NAME: &str = "e2e-gpu-linux-report";
+
 /// Return `(label, report_json_path)` for each platform report under `dir`,
 /// sorted by label for stable output.
 ///
 /// Two layouts are handled, because `actions/download-artifact@v8` does NOT
 /// always create a per-artifact subdirectory:
 ///   * multi-artifact download → `dir/<artifact-name>/report.json` (one subdir
-///     per artifact); the subdir name is the label.
+///     per artifact); the subdir name is the label — EXCEPT for the pooled
+///     Linux lane's artifact, which is relabeled from `platform.json` (see
+///     `POOLED_LINUX_ARTIFACT_NAME`).
 ///   * single-artifact download → `dir/report.json` at the ROOT. When exactly
 ///     one artifact matches the download `pattern`, v8 extracts it straight into
 ///     the `path` (its source picks `resolvedPath` when `artifacts.length === 1`,
@@ -85,7 +95,7 @@ fn discover(dir: &Path) -> Result<Vec<(String, PathBuf)>> {
     // Single-artifact layout: a report.json sits directly in `dir`.
     let root_report = dir.join("report.json");
     if root_report.is_file() {
-        inputs.push((label_for_root_report(dir), root_report));
+        inputs.push((label_from_platform_slug(dir), root_report));
     }
 
     for entry in entries {
@@ -96,10 +106,18 @@ fn discover(dir: &Path) -> Result<Vec<(String, PathBuf)>> {
         let subdir = entry.path();
         let report = subdir.join("report.json");
         if report.is_file() {
-            // Pass the raw artifact/dir name through; the e2e-report crate parses
-            // it into Platform / OS / Tier and owns all display formatting.
+            // Pass the raw artifact/dir name through — the e2e-report crate
+            // parses it into Platform / OS / Tier and owns all display
+            // formatting — EXCEPT the pooled Linux lane's fixed name, which
+            // could have been served by any of three real boxes and must be
+            // relabeled from its own `platform.json` instead.
             let raw = entry.file_name().to_string_lossy().into_owned();
-            inputs.push((raw, report));
+            let label = if raw == POOLED_LINUX_ARTIFACT_NAME {
+                label_from_platform_slug(&subdir)
+            } else {
+                raw
+            };
+            inputs.push((label, report));
         }
     }
 
@@ -107,10 +125,10 @@ fn discover(dir: &Path) -> Result<Vec<(String, PathBuf)>> {
     Ok(inputs)
 }
 
-/// Label for a root-level (single-artifact) `report.json`. Recovers the platform
-/// from the sibling `platform.json`'s `platform_slug` and maps it to the same
-/// artifact-name shape `e2e_report::parse_descriptor` expects, so a flattened
-/// download renders identically to a per-subdir one.
+/// Recover a platform's canonical artifact-name-shaped label from the
+/// `platform_slug` in `dir/platform.json`, so both the single-artifact
+/// (flattened) layout and the pooled Linux lane's subdir render identically to
+/// a normally-named per-subdir artifact.
 ///
 /// The sidecar can be ABSENT even for a GPU run: the harness writes `report.json`
 /// first and, on a parsing/hook error, exits BEFORE writing `platform.json` (see
@@ -119,7 +137,7 @@ fn discover(dir: &Path) -> Result<Vec<(String, PathBuf)>> {
 /// the grid. Only an explicit `mock` slug maps to the mock artifact; anything
 /// missing or unknown gets a neutral `e2e-unknown-report`, which
 /// `parse_descriptor` renders as "Unknown" rather than claiming a real platform.
-fn label_for_root_report(dir: &Path) -> String {
+fn label_from_platform_slug(dir: &Path) -> String {
     let slug = std::fs::read_to_string(dir.join("platform.json"))
         .ok()
         .and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok())
@@ -179,11 +197,17 @@ mod tests {
     /// Linux, which is how a Windows lane comes to be reported as Linux.
     ///
     /// `e2e-unknown-report` is deliberately absent despite being recognised.
-    /// It is a runtime-only sentinel: [`label_for_root_report`] emits it for a
+    /// It is a runtime-only sentinel: [`label_from_platform_slug`] emits it for a
     /// report whose `platform.json` was missing or carried an unknown slug, and
     /// `parse_descriptor` maps it to Unknown/Unknown precisely so it escapes the
     /// Linux default. No workflow can name it, so a workflow that did would be
     /// claiming an identity it has no business asserting.
+    ///
+    /// `e2e-gpu-linux-report` is the pooled Linux lane's fixed artifact name
+    /// (`e2e-selfhosted.yml` only — `nightly.yml` still uploads the three real
+    /// per-box names below unpooled). It resolves to one of those three real
+    /// identities at runtime via `platform.json`, never rendering under its own
+    /// literal name — see `discover()`'s `POOLED_LINUX_ARTIFACT_NAME` handling.
     const CANONICAL_REPORT_ARTIFACTS: &[&str] = &[
         "e2e-report",
         "e2e-gpu-report",
@@ -191,6 +215,7 @@ mod tests {
         "e2e-gpu-strix-ubuntu-report",
         "e2e-gpu-strix-windows-report",
         "e2e-gpu-strix-wsl-report",
+        "e2e-gpu-linux-report",
     ];
 
     /// Every workflow in `.github/workflows`, so a new one cannot upload under a
@@ -249,6 +274,19 @@ mod tests {
         // The nightly workflow exists to run *more* scenarios on the *same*
         // platforms. If the two ever diverge, the nightly grid is comparing
         // different hardware than the PR grid without saying so.
+        //
+        // `e2e-gpu-linux` (PR-side) is a pool: at runtime it can resolve, via
+        // its own `platform.json`, to any of the three real identities below
+        // (see `POOLED_LINUX_ARTIFACT_NAME`). So it can't be compared by literal
+        // name — nightly must still individually publish all three, or full
+        // hardware coverage would quietly shrink to "whichever box happened to
+        // serve the last PR". Every OTHER (non-pooled) PR artifact must still
+        // match nightly 1:1, same as before pooling existed.
+        const POOLED_LINUX_IDENTITIES: &[&str] = &[
+            "e2e-gpu-report",
+            "e2e-gpu-rad3-report",
+            "e2e-gpu-strix-ubuntu-report",
+        ];
         let lanes = |file: &str| {
             let mut names = uploaded_e2e_artifacts(
                 &Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -261,7 +299,24 @@ mod tests {
             names.sort();
             names
         };
-        assert_eq!(lanes("nightly.yml"), lanes("e2e-selfhosted.yml"));
+        let nightly = lanes("nightly.yml");
+        for name in POOLED_LINUX_IDENTITIES {
+            assert!(
+                nightly.iter().any(|n| n == name),
+                "nightly.yml must still individually publish `{name}` — the pooled \
+                 e2e-gpu-linux lane can resolve to it at runtime, so nightly is the \
+                 only place that hardware is tested exhaustively"
+            );
+        }
+        for name in lanes("e2e-selfhosted.yml") {
+            if name == POOLED_LINUX_ARTIFACT_NAME {
+                continue;
+            }
+            assert!(
+                nightly.iter().any(|n| *n == name),
+                "nightly.yml is missing the non-pooled per-PR lane `{name}`"
+            );
+        }
     }
 
     #[test]
@@ -318,6 +373,71 @@ mod tests {
             let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
             assert_eq!(names, vec![expected], "slug {slug}");
         }
+    }
+
+    // A subdir named after the pooled Linux lane's fixed artifact name is
+    // relabeled from its own platform.json, just like the root-level
+    // (flattened) case — since the pool can be served by any of three real
+    // boxes, the fixed name itself carries no identity to trust.
+    #[test]
+    fn discover_finds_pooled_linux_subdir_labeled_from_slug() {
+        for (slug, expected) in [
+            ("mi300x", "e2e-gpu-report"),
+            ("gfx1201", "e2e-gpu-rad3-report"),
+            ("strix-halo-linux", "e2e-gpu-strix-ubuntu-report"),
+        ] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let root = tmp.path();
+            let pooled = root.join(POOLED_LINUX_ARTIFACT_NAME);
+            std::fs::create_dir_all(&pooled).unwrap();
+            std::fs::write(pooled.join("report.json"), "[]").unwrap();
+            std::fs::write(
+                pooled.join("platform.json"),
+                format!(r#"{{"platform_slug":"{slug}"}}"#),
+            )
+            .unwrap();
+
+            let got = discover(root).expect("discover");
+            let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
+            assert_eq!(names, vec![expected], "slug {slug}");
+        }
+    }
+
+    // A pooled-lane subdir with no platform.json (or an unrecognized slug)
+    // still resolves to the neutral unknown label, not its own literal name —
+    // the whole point of relabeling it is that the fixed name is never a real
+    // identity, so falling back to it would silently reintroduce the bug.
+    #[test]
+    fn discover_pooled_linux_subdir_without_sidecar_is_neutral() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let pooled = root.join(POOLED_LINUX_ARTIFACT_NAME);
+        std::fs::create_dir_all(&pooled).unwrap();
+        std::fs::write(pooled.join("report.json"), "[]").unwrap();
+
+        let got = discover(root).expect("discover");
+        let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["e2e-unknown-report"]);
+    }
+
+    // Every OTHER (non-pooled) subdir name is passed through raw, even if its
+    // platform.json carries a mismatched or unexpected slug — proving the
+    // pooled-name special case in `discover()` doesn't regress the
+    // well-working per-box lanes, which already carry a correct, meaningful
+    // name and need no runtime relabeling.
+    #[test]
+    fn discover_non_pooled_subdir_ignores_platform_json_slug() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let d = root.join("e2e-gpu-strix-windows-report");
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(d.join("report.json"), "[]").unwrap();
+        // Deliberately mismatched slug — a non-pooled lane's name must win.
+        std::fs::write(d.join("platform.json"), r#"{"platform_slug":"mi300x"}"#).unwrap();
+
+        let got = discover(root).expect("discover");
+        let names: Vec<&str> = got.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["e2e-gpu-strix-windows-report"]);
     }
 
     // A root report.json with no platform.json still resolves (rather than being

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -119,6 +119,34 @@ mod tests {
         items.into_iter().filter(|item| !item.is_empty()).collect()
     }
 
+    /// Recover the canonical (default/fallback) label list from a dynamic
+    /// `runs-on: ${{ fromJSON(...) }}` expression, so a job whose runner
+    /// depends on `github.event_name`/`inputs.*` (e.g. the pooled Linux GPU
+    /// lane, which a scoped `workflow_dispatch` can override to one specific
+    /// box) is still recognized as self-hosted and documented under the label
+    /// set it actually uses on push/pull_request/merge_group — every
+    /// conditional branch before it is guarded by an `inputs.platform` check
+    /// that is false for those triggers, so the LAST single-quoted JSON array
+    /// literal in the expression is always the unconditional fallback.
+    ///
+    /// A job with a plain literal `runs-on` (no `fromJSON(`) is returned
+    /// unchanged.
+    fn canonical_runs_on(value: &str) -> String {
+        if !value.contains("fromJSON(") {
+            return value.to_owned();
+        }
+        let literal = value
+            .rsplit('\'')
+            .find(|s| s.trim_start().starts_with('['))
+            .unwrap_or_else(|| {
+                panic!("no quoted JSON array literal found in dynamic runs-on: {value}")
+            });
+        let labels: Vec<String> = serde_json::from_str(literal).unwrap_or_else(|e| {
+            panic!("dynamic runs-on literal `{literal}` is not a JSON array of strings: {e}")
+        });
+        format!("[{}]", labels.join(", "))
+    }
+
     /// Extract the top-level `concurrency.group` value, joining folded (`>-`)
     /// continuation lines. Returns the whole group expression as one string.
     fn concurrency_group(text: &str) -> String {
@@ -325,7 +353,7 @@ mod tests {
                 );
                 // A job without a runs-on (e.g. one that only `uses:` a
                 // reusable workflow) schedules nothing self-hosted.
-                let runs_on = values.pop()?.trim().to_owned();
+                let runs_on = canonical_runs_on(values.pop()?.trim());
                 let labels = flattened_list_items(&runs_on);
                 SELF_HOSTED_LABELS
                     .iter()
@@ -718,11 +746,7 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
             values.iter().any(|v| v.contains("self-hosted")),
             "e2e-selfhosted.yml must schedule at least one `self-hosted` runner (EAI-7548)"
         );
-        for job in [
-            "e2e-gpu:",
-            "e2e-gpu-strix-ubuntu:",
-            "e2e-gpu-strix-windows:",
-        ] {
+        for job in ["e2e-gpu-linux:", "e2e-gpu-strix-windows:"] {
             assert!(
                 sh.contains(job),
                 "e2e-selfhosted.yml must define the self-hosted job `{job}` (EAI-7548)"


### PR DESCRIPTION
## Summary

PR-triggered E2E tests used to run the full 5-box hardware/OS matrix, which was slow and added review friction. This merges three of those jobs — MI300X, Strix Halo Ubuntu, and rad3's Radeon R9700 — into a single pooled `e2e-gpu-linux` job that runs on whichever of the three boxes is free, so a PR gets one fast Linux GPU check instead of three. Nightly testing is unaffected — it still exercises every box individually and exhaustively every night.

Rebased on top of #360, which pinned the MI300X lanes to a dedicated `mi300x` label after discovering `amd-gpu` is carried by every AMD GPU runner (Strix WSL included) — so this PR's pool uses a new dedicated `linux-gpu-pool` label rather than `amd-gpu`, to avoid pulling the WSL box into the Linux pool too.

## Improvements / fixes

- **Pooled Linux GPU lane** — `e2e-gpu`, `e2e-gpu-strix-ubuntu`, and `e2e-gpu-rad3` are now one job, `e2e-gpu-linux`, scheduled via a new shared `linux-gpu-pool` runner label.
- **More resilient required check** — previously only the Strix box could serve this required check, so it going offline blocked merges; now MI300X or rad3 can serve it instead.
- **Scoped dispatch still supported** — `workflow_dispatch` can still force one specific box (`app-dev-gpu`/`strix-ubuntu`/`rad3`) to validate against a particular machine.
- **Fixed a report mislabeling bug** — the consolidated E2E report trusted artifact names to identify hardware, which breaks once one name can come from three different boxes; it now reads the real hardware identity from `platform.json` at runtime.
- **Test coverage preserved** — taught `workflow_contract.rs`'s parser to understand the new dynamic `runs-on` expression, so the pooled job stays covered by the existing regression tests instead of silently falling out of them.

## Manual follow-ups required (outside this repo)

- [ ] Add a new `linux-gpu-pool` label to the MI300X, Strix Halo Ubuntu (native), and rad3 runners (all three — none of them have it yet). Do **not** add it to the Strix Windows or WSL runners.
- [ ] Update `main`'s required-status-check list (if these checks are in fact required — see the "Required-check caveat" note in `docs/ci-hardware-testing.md`, which #360 cast some doubt on): replace `E2E tests (Strix Halo, Ubuntu)` with `E2E tests (Linux GPU pool)`.

## Test plan

- [x] `cargo test -p xtask` — all 135 tests pass, including 2 new tests for the pooled-artifact relabeling and a rewritten nightly/PR artifact-parity test
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `cargo check -p xtask` compiles cleanly
- [ ] End-to-end pool dispatching across all 3 boxes can only be confirmed after the `linux-gpu-pool` label is added to the runners (first PR after this merges)

Refs: EAI-8558