### PR TITLE
fix(dash-tui): stop the Engines preview claiming "Lemonade — not installed"

### DIFF
--- a/crates/rocm-dash-tui/src/ui/tabs/pane.rs
+++ b/crates/rocm-dash-tui/src/ui/tabs/pane.rs
@@ -361,23 +361,19 @@ fn live_lines(action: KeyAction, state: &AppState, theme: &Theme) -> Vec<Line<'s
         }
         KeyAction::OpenEngineManager => {
             let mut lines = vec![head("Engines".into())];
-            let lemon = info().and_then(|i| i.lemond_version.clone());
-            lines.push(Line::from(vec![
-                mark(lemon.is_some()),
-                Span::styled(
-                    lemon.map_or_else(
-                        || "Lemonade — not installed".into(),
-                        |v| format!("Lemonade {v}"),
-                    ),
-                    Style::default().fg(theme.fg),
-                ),
-            ]));
-            // The daemon doesn't surface vLLM detection yet — open the manager to
+            // The daemon doesn't surface engine detection yet — `GpuSystemInfo`
+            // has no producer for `lemond_version`, so every value read here
+            // would be `None` no matter what is installed. Open the manager to
             // check rather than claiming a status we don't have.
-            lines.push(Line::from(vec![
-                Span::styled("· ", Style::default().fg(theme.muted)),
-                Span::styled("vLLM — open to check", Style::default().fg(theme.muted)),
-            ]));
+            for engine in ["Lemonade", "vLLM"] {
+                lines.push(Line::from(vec![
+                    Span::styled("· ", Style::default().fg(theme.muted)),
+                    Span::styled(
+                        format!("{engine} — open to check"),
+                        Style::default().fg(theme.muted),
+                    ),
+                ]));
+            }
             lines
         }
         KeyAction::OpenServeWizard => {


### PR DESCRIPTION
## Problem

Fixes #366

The dashboard's *Serving → Engines* preview always rendered `· Lemonade — not installed`, on machines where Lemonade is installed and `rocm engines list` correctly reports `note: Lemonade is ready on your AMD GPU.`

`crates/rocm-dash-tui/src/ui/tabs/pane.rs` read `GpuSystemInfo::lemond_version`, but nothing in the codebase ever writes that field:

```
$ grep -rn "lemond_version" --include=*.rs . | grep -v tests/
crates/rocm-dash-core/src/metrics.rs:59:  pub lemond_version: Option<String>,   # declaration
crates/rocm-dash-daemon/src/demo.rs:557:  lemond_version: None,                # demo fixture
crates/rocm-dash-tui/src/ui/tabs/pane.rs:364: ...clone()                       # only reader
```

`rocm-dash-collectors::AmdSmiCollector::system_info()` → `parse_system_info()` builds `GpuSystemInfo::default()` and fills only `rocm_version`, `driver_version`, model, counts, partition modes and VRAM. So `lemon.is_some()` was statically false, `mark(...)` always drew the "off" glyph, and the `format!("Lemonade {v}")` arm was unreachable — the panel asserted a negative it had no data for, and pushed users into a no-op `rocm engines install lemonade`.

## Change

Drops the false claim and renders Lemonade the way the adjacent vLLM line already does — "open to check", muted — since that branch was already honest about having no detection. Both engine lines now come from one loop.

```rust
// The daemon doesn't surface engine detection yet — `GpuSystemInfo`
// has no producer for `lemond_version`, so every value read here
// would be `None` no matter what is installed. Open the manager to
// check rather than claiming a status we don't have.
for engine in ["Lemonade", "vLLM"] { ... }
```

Before / after in the preview panel:

```
· Lemonade — not installed        · Lemonade — open to check
· vLLM — open to check            · vLLM — open to check
```

vLLM's rendering is byte-identical. `mark()` and `info()` stay in use by the ROCm/driver lines in the same function, so no other call sites changed.

Deliberately minimal: this stops the wrong statement without inventing a detection path. The real fix is to *populate* `lemond_version` in the collector (reusing the resolution `rocm engines list` already performs in `engines/lemonade/src/lib.rs`) so the panel can show `Lemonade 11.5.1` — happy to do that as a follow-up if maintainers prefer it over the honest placeholder, but it means the dash collector learns about engine manifests, which felt like the wrong direction for a drive-by.

Left in place: the sibling fields `llama_server_build`, `ccr_version`, `llamacpp_backend` (`metrics.rs:60-62`) have the same declared-never-written shape. They're currently unread, so no other UI lies today; removing or wiring them up is a separate call.

## Verification

- `rustfmt --edition 2024 --check crates/rocm-dash-tui/src/ui/tabs/pane.rs` → clean
- `cargo check -p rocm-dash-tui --all-targets` → finished, no warnings
- no test asserted on the removed string (`grep -rn "not installed\|open to check\|lemond_version" crates/rocm-dash-tui` matched only the lines changed here); `pane.rs` has no `mod tests`, so nothing to update
- the *before* rendering was reproduced against the live TUI on the reporter's machine; the *after* line reuses the vLLM line's own widgets and style

No test added: `pane.rs` has no test module, so asserting on `live_lines()` means building an `AppState` + `Snapshot` fixture from scratch in a file that deliberately has none — heavier than the 4-line change it would guard. Happy to add one if a maintainer wants it, ideally alongside whoever wires `lemond_version` up for real.

Note: this commit was authored through the GitHub `createCommitOnBranch` API (the same path `.github/workflows/dependabot-manifests-commit.yml` uses), so it is web-flow signed (`verification.verified = true`) and carries a `Signed-off-by` trailer — `cargo xtask verify-commits --require-verified` should pass. The author has no local signing key and the API token cannot register one.
