### PR TITLE
chore(lint): enable ARG, BLE, SLF and PL ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         args: [--fix=lf] # repo standardises on LF endings (see .gitattributes)
         exclude: '^THIRD_PARTY_NOTICES\.txt$'
 
-  # Python: lint + format the helper scripts and engine workers.
+  # Python: lint + format the helper scripts and the Sphinx docs config.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.4
     hooks:

--- a/docs/rocm-docs/conf.py
+++ b/docs/rocm-docs/conf.py
@@ -80,6 +80,6 @@ exclude_patterns = []
 # -- Sphinx setup ----------------------------------------------------------
 
 
-def setup(app):
+def setup(_app):
     """Sphinx setup"""
     return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,18 +30,18 @@ ignore = [
     # the `too_many_lines` allow that Cargo.toml grants clippy for the same reason.
     "PLR0911", # too-many-return-statements: early returns beat a nested result variable
     "PLR0912", # too-many-branches: entry-point and validation flows are deliberately linear
-    "PLR0913", # too-many-arguments: keyword-only config/subprocess/HTTP helpers take many named fields
-    "PLR0915", # too-many-statements: splitting these entry points adds no clarity
+    "PLR0913", # too-many-arguments: mostly keyword-only subprocess, HTTP, workflow-builder and config helpers
+    "PLR0915", # too-many-statements: splitting these entry points and self-tests adds no clarity
     "PLR2004", # magic-value-comparison: HTTP statuses, byte sizes, mode bits, lengths, time budgets and self-test literals are clearer inline
 ]
 
 [lint.per-file-ignores]
-# Blind excepts in the GPU and TUI test harnesses are intentional last-resort
-# handlers: each reports the error, hands it to the owning thread, keeps it for
-# the eventual timeout message, or — in a teardown path — deliberately ignores
-# it, so a probe or cleanup failure degrades gracefully instead of crashing the
-# harness. Scoped per file so a blind except added to the build, release or docs
-# config still fails lint.
+# Blind excepts in the GPU, SDK-install and TUI test harnesses are intentional
+# last-resort handlers: each reports the error, hands it to the owning thread,
+# keeps it for the eventual timeout message, or — in a teardown path —
+# deliberately ignores it, so a probe or cleanup failure ends in a clear
+# diagnostic instead of an unhandled traceback. Scoped per file so a blind
+# except added to the build, release or docs config still fails lint.
 "scripts/comfyui_therock_gpu_test.py" = ["BLE001"] # blind-except
 "scripts/therock_sdk_install_test.py" = ["BLE001"] # blind-except
 "scripts/vllm_therock_gpu_test.py" = ["BLE001"]    # blind-except

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,23 +25,27 @@ ignore = [
     "E501", # line length is enforced by the formatter; long comments/URLs are fine
     #
     # Pylint refactor metrics. These are standalone operational scripts: their
-    # `main()` flows are deliberately linear and their helpers thread
-    # argparse-derived config through. Mirrors the `too_many_lines` allow that
-    # Cargo.toml grants clippy for the same reason.
+    # entry points, self-tests and archive/probe validation helpers are
+    # deliberately long and linear rather than split behind indirection. Mirrors
+    # the `too_many_lines` allow that Cargo.toml grants clippy for the same reason.
     "PLR0911", # too-many-return-statements: early returns beat a nested result variable
-    "PLR0912", # too-many-branches: script `main()` flows are deliberately linear
-    "PLR0913", # too-many-arguments: CLI helpers thread argparse-derived config through
+    "PLR0912", # too-many-branches: entry-point and validation flows are deliberately linear
+    "PLR0913", # too-many-arguments: keyword-only config/subprocess/HTTP helpers take many named fields
     "PLR0915", # too-many-statements: splitting these entry points adds no clarity
-    "PLR2004", # magic-value-comparison: HTTP statuses, size/mode bits and retry counts read better inline
-    #
-    # Blind excepts are intentional last-resort handlers in these scripts: each
-    # either reports the error, requeues it to the owning thread, or — in a
-    # teardown path — deliberately ignores it, so a probe or cleanup failure
-    # degrades gracefully instead of crashing the test harness.
-    "BLE001", # blind-except
+    "PLR2004", # magic-value-comparison: HTTP statuses, byte sizes, mode bits, lengths, time budgets and self-test literals are clearer inline
 ]
 
 [lint.per-file-ignores]
-# The PTY harness imports winpty on Windows and fcntl/pty/struct/termios on
-# POSIX inside the platform branch; neither set can be imported on the other OS.
-"scripts/tui_e2e_smoke.py" = ["PLC0415"] # import-outside-top-level
+# Blind excepts in the GPU and TUI test harnesses are intentional last-resort
+# handlers: each reports the error, hands it to the owning thread, keeps it for
+# the eventual timeout message, or — in a teardown path — deliberately ignores
+# it, so a probe or cleanup failure degrades gracefully instead of crashing the
+# harness. Scoped per file so a blind except added to the build, release or docs
+# config still fails lint.
+"scripts/comfyui_therock_gpu_test.py" = ["BLE001"] # blind-except
+"scripts/therock_sdk_install_test.py" = ["BLE001"] # blind-except
+"scripts/vllm_therock_gpu_test.py" = ["BLE001"]    # blind-except
+# The PTY harness needs the same allowance, and additionally imports winpty on
+# Windows and fcntl/pty/struct/termios on POSIX inside the platform branch;
+# neither set can be imported on the other OS.
+"scripts/tui_e2e_smoke.py" = ["BLE001", "PLC0415"] # blind-except + import-outside-top-level

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
-# Ruff configuration for the Python helper scripts (scripts/) and engine workers.
+# Ruff configuration for the repository's Python files: the helper scripts in
+# scripts/ and the Sphinx config in docs/rocm-docs/. (engines/ is Rust-only.)
 # Formatting uses Ruff's defaults (88-column, double quotes), which the
 # `ruff-format` pre-commit hook enforces.
 
@@ -15,7 +16,32 @@ select = [
     "SIM", # flake8-simplify
     "C4",  # flake8-comprehensions
     "RUF", # Ruff-specific rules
+    "ARG", # flake8-unused-arguments
+    "BLE", # flake8-blind-except
+    "SLF", # flake8-self (private-member access)
+    "PL",  # Pylint (PLC/PLE/PLR/PLW)
 ]
 ignore = [
     "E501", # line length is enforced by the formatter; long comments/URLs are fine
+    #
+    # Pylint refactor metrics. These are standalone operational scripts: their
+    # `main()` flows are deliberately linear and their helpers thread
+    # argparse-derived config through. Mirrors the `too_many_lines` allow that
+    # Cargo.toml grants clippy for the same reason.
+    "PLR0911", # too-many-return-statements: early returns beat a nested result variable
+    "PLR0912", # too-many-branches: script `main()` flows are deliberately linear
+    "PLR0913", # too-many-arguments: CLI helpers thread argparse-derived config through
+    "PLR0915", # too-many-statements: splitting these entry points adds no clarity
+    "PLR2004", # magic-value-comparison: HTTP statuses, size/mode bits and retry counts read better inline
+    #
+    # Blind excepts are intentional last-resort handlers in these scripts: each
+    # either reports the error, requeues it to the owning thread, or — in a
+    # teardown path — deliberately ignores it, so a probe or cleanup failure
+    # degrades gracefully instead of crashing the test harness.
+    "BLE001", # blind-except
 ]
+
+[lint.per-file-ignores]
+# The PTY harness imports winpty on Windows and fcntl/pty/struct/termios on
+# POSIX inside the platform branch; neither set can be imported on the other OS.
+"scripts/tui_e2e_smoke.py" = ["PLC0415"] # import-outside-top-level

--- a/scripts/local_assistant_therock_gpu_test.py
+++ b/scripts/local_assistant_therock_gpu_test.py
@@ -68,7 +68,7 @@ def main() -> int:
             print_step(f"Copied ROCm runtime registry from {source_state}.")
 
         localize_huggingface_cache(env, repo_root)
-        return run_live_acceptance(args, rocm, env, temp_state_root)
+        return run_live_acceptance(args, rocm, env)
     finally:
         if temp_state_root is not None and not args.keep_state:
             print_step(f"Removing temporary ROCm CLI state under {temp_state_root}.")
@@ -79,7 +79,6 @@ def run_live_acceptance(
     args: argparse.Namespace,
     rocm: Path,
     env: dict[str, str],
-    temp_state_root: Path | None,
 ) -> int:
     data_dir = rocm_cli_data_dir(env)
     service_id = args.service_id


### PR DESCRIPTION
## Summary

Turns on four more Ruff rule families for the repository's Python files:

| Family | Catches |
| --- | --- |
| `ARG` (flake8-unused-arguments) | Arguments accepted and never used |
| `BLE` (flake8-blind-except) | `except Exception:` / bare `except:` swallowing failures |
| `SLF` (flake8-self) | Access to another object's private `_attributes` |
| `PL` (Pylint) | The Pylint set — comparison mistakes, useless returns, refactor metrics |

Enabling them across the 11 tracked Python files cost two small code fixes and a
short list of suppressions:

- `SLF` and `ARG` are enforced with **no** suppressions at all. `SLF` was already
  clean; `ARG` needed the two fixes below.
- `PLE*` and `PLW*` are clean, so the whole Pylint error and warning surface is now
  enforced going forward.

## Code fixes

- `docs/rocm-docs/conf.py` — the unused Sphinx `setup(app)` argument is now `_app`.
  Sphinx invokes extension `setup` positionally, so the parameter name is not part
  of the contract.
- `scripts/local_assistant_therock_gpu_test.py` — dropped a dead `temp_state_root`
  parameter from `run_live_acceptance` and its argument at the single call site.
  The value was never read; `main()` still owns the directory and cleans it up in
  its own `finally`.

## Suppressions, and why

Each entry is commented in `ruff.toml` with a one-line reason, following the style
the existing `E501` entry and the clippy allow-list in `Cargo.toml` already use.

- **`PLR0911` / `PLR0912` / `PLR0913` / `PLR0915` / `PLR2004`** — ignored globally.
  These are standalone operational scripts: entry points and self-tests are
  deliberately linear, helpers thread CLI-derived config through, and the literals
  flagged by `PLR2004` are HTTP statuses, size and mode bits, lengths and time
  budgets that read better inline than behind names. This mirrors the
  `too_many_lines` allow `Cargo.toml` already grants clippy for the same reason.
  8 of the 11 Python files trigger at least one of these, so per-file scoping would
  list nearly every file and protect nothing.
- **`BLE001`** — scoped via `[lint.per-file-ignores]` to the four test harnesses
  that need it, not ignored globally. Each of the six blind excepts there reports,
  requeues, or deliberately ignores the error in a teardown path. Keeping the rule
  live everywhere else means a new blind except in the build, release or docs code
  still fails lint.
- **`PLC0415`** — scoped to `scripts/tui_e2e_smoke.py` alone. The PTY harness
  imports `winpty` on Windows and `fcntl`/`pty`/`struct`/`termios` on POSIX inside a
  platform branch; neither set is importable on the other OS.

## Drive-by

`ruff.toml` and `.pre-commit-config.yaml` both described the Python lint scope as
covering "engine workers". `engines/` is Rust-only and contains no Python — the
actual extra coverage beyond `scripts/` is the Sphinx docs config. Both comments
corrected.

## Risk

Low. The only behavioural change is the removal of a parameter that was never read;
everything else is lint configuration and a parameter rename.

## Test plan

- `prek run ruff-check --all-files` — passes
- `prek run ruff-format --all-files` — passes
- `prek run --all-files --no-group local-tools` — all 9 hooks pass (this is what the
  `prek (lint / hygiene)` CI job runs)
- `python scripts/local_assistant_therock_gpu_test.py --self-test` — passes, exercising
  the script whose signature changed

Each suppression was checked against the actual violation sites the rule reports, so
the stated reasons describe the code they cover.

## Note for the reviewer

Three commits: the change, plus two rounds of corrections to the justification
comments. They are one logical unit — please squash on merge.
