### PR TITLE
docs(agents): name the commands AGENTS.md's rules require

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,12 @@ features as well as fixes. If the change alters what a user of the CLI can obser
 command output, exit codes, files or paths the CLI creates, or which runtime/engine it
 selects — then that behavior must be covered by a Gherkin scenario in
 `tests/e2e-cucumber/features/`, adding or updating the scenario and its step
-definitions when no existing scenario already covers it:
+definitions when no existing scenario already covers it.
+
+Run those scenarios with `cargo xtask e2e`. `cargo xtask e2e -- -n <scenario>` filters by
+name for a quick loop, but `-n` replaces the harness's own filter and so bypasses OS
+applicability, xfail expectations, and lifecycle selection (see `docs/testing.md`) — the
+unfiltered run is the gate.
 
 - a unit test asserting the internal helper does NOT discharge this; it proves the
   function, not the behavior
@@ -139,6 +144,7 @@ Understand existing patterns first:
 - workspace topology from `Cargo.toml`
 - sibling implementations in `apps/`, `crates/`, and `engines/`
 - existing tests and conventions in `docs/testing.md`
+- setup, commit conventions, and the review bar in `CONTRIBUTING.md`
 
 Fix at the correct layer (root cause), not by shrinking symptom visibility.
 If approach choice is ambiguous, present alternatives and recommend one.
@@ -181,10 +187,24 @@ Required consistency points:
 Minimum quality gate before upstream-ready status:
 
 ```bash
+prek run --all-files                                   # hygiene, ruff, shellcheck, cargo fmt, license headers, generated manifests
 cargo test --workspace --all-targets
 cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --locked -p e2e-cucumber --test e2e -- -D warnings
+cargo xtask e2e                                        # the Gherkin scenarios §3 mandates
 python scripts/smoke_local.py
 ```
+
+Why the list is longer than it looks:
+
+- `cargo test` cannot run the scenarios §3 requires. `tests/e2e-cucumber` sets `test = false` on its `e2e` target, so `cargo test --workspace --all-targets` and `cargo nextest` skip every scenario silently and still report success. Only `cargo xtask e2e` runs them.
+- That same `test = false` also excludes the e2e harness from `cargo clippy --workspace --all-targets`, which is why the separate `cargo clippy --locked -p e2e-cucumber --test e2e` line is listed. CI runs both clippy invocations.
+- `prek run --all-files` runs the pre-commit hooks from `.pre-commit-config.yaml`; the pre-push hooks (clippy, `cargo test`) are the separate lines above, not a subset of it. Install prek per `CONTRIBUTING.md`.
+
+Two of the hooks `prek run --all-files` runs are not equivalent to the CI jobs that gate the same thing:
+
+- license headers: the hook runs `hawkeye check --config licenserc.toml` and fails outright when `hawkeye` is missing, so install it (`cargo install hawkeye`) rather than skipping the hook. The `license-headers` CI job instead downloads a version-pinned, sha256-verified prebuilt (`HAWKEYE_VERSION` in `.github/workflows/ci.yml`), so an unpinned local install can be a different version than the gate.
+- third-party notices: the hook runs `cargo xtask tpn --if-available`, which no-ops when `cargo-about` is absent or not the pinned version — a green local run proves nothing here. Run `cargo xtask tpn --check`, the form the `third-party-notices` CI job uses, after changing the dependency graph, and install the pinned generator per `CONTRIBUTING.md`.
 
 When relevant to touched behavior, also run targeted checks from `docs/testing.md`, such as:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ The manifest hooks only run when you change the dependency graph, and they *rewr
 cargo install cargo-about@0.9.1 --locked --features cli   # optional, for THIRD_PARTY_NOTICES.txt
 ```
 
+Agents working in this repository additionally follow `AGENTS.md`.
+
 ### Workspace layout
 
 | Path | Description |


### PR DESCRIPTION
`AGENTS.md` states rules but, in several places, never names the command that
satisfies them. Someone following it exactly runs none of the behaviour tests it
mandates and fails CI checks with no way to learn from the file what to run.

## What was wrong

- **The prescribed gate could not run the tests the same file mandates.**
  `AGENTS.md` requires user-observable behaviour changes to be covered by a
  Gherkin scenario under `tests/e2e-cucumber/features/`. Its quality gate
  prescribed `cargo test --workspace --all-targets` — but the e2e target sets
  `test = false`, so `cargo test` and `cargo nextest` skip every scenario
  silently and still report success. 17 feature files were reachable only via
  `cargo xtask e2e`, which the file never mentioned.
- **The same `test = false` excludes the harness from the prescribed clippy
  run**, so the e2e step and harness code went unlinted by the gate as written.
  CI covers it with a second, package-scoped invocation; the file did not.
- **Two checks CI enforces hard were named in no contributor-facing document:**
  the licence-header check and the third-party-notices staleness check. Their
  pre-commit hooks also fail differently when the underlying tool is absent
  locally — the notices hook passes `--if-available` and no-ops, so a green
  local run did not mean what CI means, while the licence-header hook is a
  plain `language: system` hook and aborts the run outright.

## What changed

- The quality gate now lists `prek run --all-files`, the package-scoped clippy
  invocation for the e2e harness, and `cargo xtask e2e`, alongside the three
  commands it already had (kept verbatim).
- The scenario rule now names `cargo xtask e2e` at the point where the decision
  to write a scenario is made, including the filter form.
- The licence-header and third-party-notices checks are named with their direct
  CI-equivalent commands and install hints, and the file states how each hook
  behaves when its tool is missing — the notices hook no-ops, the licence-header
  hook aborts — so the difference between a locally green run and a CI-green run
  is explicit.
- `AGENTS.md` and `CONTRIBUTING.md` now cross-reference each other; previously
  neither mentioned the other.

Commands were sourced from the tool configuration and the CI workflow rather
than copied between documents, since for several tools the content did not
exist in either document.

## Test plan

Documentation-only change; no behaviour is added, so no regression test applies.
Every command added to the file was verified by executing it in a clean
checkout:

| Command | Result |
| --- | --- |
| `cargo xtask e2e` | ran 78 scenarios, 74 passed, 2 unexpected failures — pre-existing timing-sensitive `bench` throughput scenarios on a loaded host, unrelated to this change. The harness reconciles expected xfails separately from passes, so the two counts do not sum to the total. |
| `prek run --all-files` | exit 0, 14 hooks passed |
| `hawkeye check --config licenserc.toml` | exit 0, 230 files |
| `cargo xtask tpn --check` | exit 0 |

`prek run --all-files` also passes on the edited files.

## Checklist

- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — Not applicable: documentation-only, no code behaviour changes, so no xfail row can become stale. Confirmed `expectations.toml` is untouched by this PR.

## Notes for reviewers

- The second clippy line (`-p e2e-cucumber --test e2e`) addresses the same
  `test = false` root cause as the e2e gap and comes from the CI workflow. It is
  adjacent to the originally reported problem rather than part of it — happy to
  drop it if you would rather keep this change narrower.
- The pre-existing `cargo clippy --workspace --all-targets` line lacks `--locked`
  while CI uses it; the newly added clippy line matches CI byte-for-byte. Left
  the pre-existing line alone to keep this change scoped, but happy to align it.
