### PR TITLE
feat(diagnose): recognise the vLLM engine-startup import failure (EAI-8076)

### DIFF
--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1758,10 +1758,12 @@ mod tests {
 
     #[test]
     fn the_engine_import_failure_outranks_the_render_group_false_lead() {
-        // The reported case. On the affected host the GPU is functional and
-        // /dev/kfd is world-writable, but the user happens to be outside the
-        // render group -- so the catalog's best answer to this symptom was fix-4
-        // at 45, and following it meant a usermod, a re-login, and no progress.
+        // The reported case, reduced to what makes the false lead fire: the user
+        // is outside the render and video groups, so the catalog's best answer
+        // to this symptom was fix-4 at 45 (35 render + 10 video), and following
+        // it meant a usermod, a re-login, and no progress. The fixture leaves
+        // `kfd` unset rather than modelling the reported host's permissions,
+        // because fix-4's score here comes from the group membership alone.
         // The fixture reproduces that false lead, so the assertion is about the
         // ranking and not only about the new entry's score.
         let mut e = linux_base();
@@ -1806,6 +1808,9 @@ mod tests {
             .expect("the finding must carry a plan");
         let commands: Vec<&str> = fix.commands.iter().map(String::as_str).collect();
         crate::fix::assert_engine_shell_boundary_is_labelled(&fix.fix_id, &commands);
+        // The boundary check alone leaves the wording free to drift, so pin the
+        // two copies to each other line for line as well.
+        crate::fix::assert_plan_matches_the_catalog_copy(&fix.fix_id, &commands);
     }
 
     #[test]

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -1307,8 +1307,18 @@ fn check_15_msvc_redist(e: &Examination, symptom: &str) -> Diagnosis {
 /// host it reports `framework: unknown` with a `torch import failed` note, so
 /// the deciding fact is absent from the examination entirely. Nothing structural
 /// can fire until that probe targets the active runtime's interpreter, which is
-/// why the parameter is unused: the user has to supply the error text, either
-/// through `--symptom` or from a serve failure note.
+/// why the parameter is unused: the user has to supply the error text through
+/// `rocm diagnose --symptom "<pasted error>"`.
+///
+/// That is the only route to this entry from the symptom, and it is a narrow
+/// one: nothing on the serve or `rocm services` path points at `rocm diagnose`
+/// at all — a service that died at startup renders a `logs:` and a `restart:`
+/// hint and no more — so reaching this requires already knowing to paste the
+/// error into `diagnose`. The recipe is also reachable by name (`rocm fix` lists
+/// it, `rocm fix fix-17-torch-dlpack` prints it), but that needs the id rather
+/// than the symptom. Closing that gap means adding a diagnose hint to the
+/// service-failure output, which changes a shared surface for every failed
+/// service regardless of cause and belongs in its own change.
 fn check_17_torch_dlpack_cuda_variant(_e: &Examination, symptom: &str) -> Diagnosis {
     let (score, evidence) = keyword_score(symptom, KEYWORDS_TORCH_DLPACK_CUDA_VARIANT);
     if score <= 0 {
@@ -1319,19 +1329,33 @@ fn check_17_torch_dlpack_cuda_variant(_e: &Examination, symptom: &str) -> Diagno
     }
     let fix = Fix {
         summary: "Only if the engine's runtime holds a ROCm build of torch in the 2.4-2.9 range with torch-c-dlpack-ext installed: reinstall the engine so its pinned torch is restored, which moves torch off the versions the extension ships prebuilts for.".to_owned(),
+        // Three labelled groups, because the steps run in three different places
+        // and the report renders them as one undifferentiated `$`-prefixed list.
+        // Unlabelled, a user pasting the block wholesale is relying on terminal
+        // stdin buffering to land the probes in the subshell -- and on the
+        // reinstall NOT landing there, since it replaces the very environment
+        // that shell is standing in.
         commands: vec![
-            "# Confirm the trigger before changing anything, and check the torch the".to_owned(),
-            "# ENGINE uses rather than the one on your PATH -- they are different".to_owned(),
-            "# interpreters, and only the engine's decides this failure.".to_owned(),
+            "# --- step 1 of 3, in YOUR shell ---".to_owned(),
+            "# Opens an INTERACTIVE subshell with the engine's environment active,".to_owned(),
+            "# and does not return until you leave it. Run this line on its own.".to_owned(),
             "rocm engines shell vllm".to_owned(),
-            "# ...and run the next two INSIDE the shell it opens:".to_owned(),
+            "# --- step 2 of 3, INSIDE the subshell step 1 opened ---".to_owned(),
+            "# Confirm the trigger before changing anything. It has to be the".to_owned(),
+            "# ENGINE's interpreter, not the one on your PATH -- they are different".to_owned(),
+            "# interpreters, and only the engine's decides this failure.".to_owned(),
             "python -c \"import torch; print(torch.__version__, torch.version.hip)\"".to_owned(),
-            "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\"".to_owned(),
+            "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\""
+                .to_owned(),
             "# This entry applies ONLY when torch.version.hip is set, torch.__version__".to_owned(),
             "# is in the 2.4-2.9 range, and torch-c-dlpack-ext is installed. Outside".to_owned(),
             "# that range the extension raises a handled ImportError and this is not".to_owned(),
-            "# the failure you are looking at.".to_owned(),
-            "# If all three hold, put the engine's pinned torch back:".to_owned(),
+            "# the failure you are looking at. Then leave the subshell:".to_owned(),
+            "exit".to_owned(),
+            "# --- step 3 of 3, back in YOUR OWN shell ---".to_owned(),
+            "# If all three held, put the engine's pinned torch back. Do NOT run".to_owned(),
+            "# this from inside the subshell: it replaces the environment that".to_owned(),
+            "# shell is standing in.".to_owned(),
             "rocm engines install vllm --reinstall".to_owned(),
         ],
         fix_id: "fix-17-torch-dlpack".to_owned(),
@@ -1762,6 +1786,26 @@ mod tests {
             render_group > 0,
             "the render-group suggestion must no longer be the top answer here"
         );
+    }
+
+    #[test]
+    fn the_engine_import_plan_says_which_shell_each_step_runs_in() {
+        // The plan `diagnose` attaches to the finding is a second copy of the
+        // catalog recipe's command block, and it is the copy the reported user
+        // actually saw. Hold it to the same boundary the recipe is held to, so
+        // the two cannot drift into disagreeing about which shell runs what.
+        let report = diagnose(
+            &linux_base(),
+            "OSError: libtorch_cuda.so: cannot open shared object file",
+        );
+        let fix = report
+            .matched
+            .iter()
+            .find(|d| d.id == "fix-17-torch-dlpack")
+            .and_then(|d| d.fix.as_ref())
+            .expect("the finding must carry a plan");
+        let commands: Vec<&str> = fix.commands.iter().map(String::as_str).collect();
+        crate::fix::assert_engine_shell_boundary_is_labelled(&fix.fix_id, &commands);
     }
 
     #[test]

--- a/crates/rocm-core/src/diagnose.rs
+++ b/crates/rocm-core/src/diagnose.rs
@@ -288,6 +288,34 @@ const KEYWORDS_PAGE_FAULT: KeywordTable = &[
     ("out_of_registers", 30, "compiler OUT_OF_REGISTERS"),
 ];
 
+/// The vLLM engine-startup import failure: `torch-c-dlpack-ext` picks its CUDA
+/// prebuilt on a ROCm build of torch, and `ctypes.CDLL` aborts the import.
+///
+/// `libtorch_cuda.so` alone is worth exactly [`MIN_SCORE_FOR_MATCH`], on
+/// purpose. It is the one token in that traceback that cannot mean anything
+/// else — a ROCm build of torch ships `libtorch_hip.so` and never that file —
+/// and a user who pastes only the `OSError` line still has to clear the bar, or
+/// the entry loses to the sub-threshold noise it exists to outrank. Everything
+/// less specific stays below it: `torch_c_dlpack_ext` on its own says the
+/// extension is in the picture, not that it chose the wrong variant.
+const KEYWORDS_TORCH_DLPACK_CUDA_VARIANT: KeywordTable = &[
+    (
+        r"libtorch_cuda\.so",
+        50,
+        "error names libtorch_cuda.so, which a ROCm build of torch does not ship",
+    ),
+    (
+        "torch_c_dlpack_ext",
+        45,
+        "error names the torch_c_dlpack_ext extension",
+    ),
+    (
+        "_optional_torch_c_dlpack",
+        35,
+        "error names tvm_ffi's _optional_torch_c_dlpack shim",
+    ),
+];
+
 /// Score the strongest (top-2) keyword matches in `table` against `symptom`.
 fn keyword_score(symptom: &str, table: KeywordTable) -> (i32, Vec<String>) {
     if symptom.is_empty() {
@@ -1271,6 +1299,61 @@ fn check_15_msvc_redist(e: &Examination, symptom: &str) -> Diagnosis {
     )
 }
 
+/// The vLLM engine-startup import failure (EAI-8012).
+///
+/// Keyword-only, and not by preference. The fact that decides this failure is
+/// the torch version inside the *managed runtime*, and `Examination`'s framework
+/// probe imports torch from the ambient interpreter instead — on an affected
+/// host it reports `framework: unknown` with a `torch import failed` note, so
+/// the deciding fact is absent from the examination entirely. Nothing structural
+/// can fire until that probe targets the active runtime's interpreter, which is
+/// why the parameter is unused: the user has to supply the error text, either
+/// through `--symptom` or from a serve failure note.
+fn check_17_torch_dlpack_cuda_variant(_e: &Examination, symptom: &str) -> Diagnosis {
+    let (score, evidence) = keyword_score(symptom, KEYWORDS_TORCH_DLPACK_CUDA_VARIANT);
+    if score <= 0 {
+        return zero(
+            "fix-17-torch-dlpack",
+            "torch-c-dlpack-ext loads its CUDA variant on ROCm",
+        );
+    }
+    let fix = Fix {
+        summary: "Only if the engine's runtime holds a ROCm build of torch in the 2.4-2.9 range with torch-c-dlpack-ext installed: reinstall the engine so its pinned torch is restored, which moves torch off the versions the extension ships prebuilts for.".to_owned(),
+        commands: vec![
+            "# Confirm the trigger before changing anything, and check the torch the".to_owned(),
+            "# ENGINE uses rather than the one on your PATH -- they are different".to_owned(),
+            "# interpreters, and only the engine's decides this failure.".to_owned(),
+            "rocm engines shell vllm".to_owned(),
+            "# ...and run the next two INSIDE the shell it opens:".to_owned(),
+            "python -c \"import torch; print(torch.__version__, torch.version.hip)\"".to_owned(),
+            "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\"".to_owned(),
+            "# This entry applies ONLY when torch.version.hip is set, torch.__version__".to_owned(),
+            "# is in the 2.4-2.9 range, and torch-c-dlpack-ext is installed. Outside".to_owned(),
+            "# that range the extension raises a handled ImportError and this is not".to_owned(),
+            "# the failure you are looking at.".to_owned(),
+            "# If all three hold, put the engine's pinned torch back:".to_owned(),
+            "rocm engines install vllm --reinstall".to_owned(),
+        ],
+        fix_id: "fix-17-torch-dlpack".to_owned(),
+        auto_applicable: false,
+        verify: "rocm serve <model> --engine vllm   # then `rocm services list --all` and `rocm services logs <service-id>` to confirm the import no longer aborts".to_owned(),
+        notes: vec![
+            "Running vLLM on ROCm is not by itself a reason to apply this. The trigger is narrow: a ROCm build of torch in the 2.4-2.9 range (the versions torch-c-dlpack-ext ships prebuilts for), torch without a native __dlpack_c_exchange_api__, and torch-c-dlpack-ext present -- it arrives as a transitive dependency of tilelang, which vLLM pins.".to_owned(),
+            "The usual way a runtime lands in that range is `rocm install sdk` being re-run after the engine was installed, which overwrites the engine's pinned torch. Reinstalling the engine puts the pin back.".to_owned(),
+            "The defect is upstream and there is nothing to correct locally: torch-c-dlpack-ext picks its variant from torch.cuda.is_available(), which is True on ROCm because PyTorch reuses the torch.cuda namespace for HIP, and it ships no ROCm variant to pick. tvm_ffi imports it as optional but guards only ImportError/AttributeError, while ctypes.CDLL raises OSError -- so an explicitly optional import kills the process.".to_owned(),
+            "A service that failed at startup is hidden from a plain `rocm services list`; pass --all to recover its id.".to_owned(),
+        ],
+        ..Fix::default()
+    };
+    finalize(
+        "fix-17-torch-dlpack",
+        "vLLM engine start aborts on torch-c-dlpack-ext loading its CUDA variant",
+        score,
+        evidence,
+        fix,
+    )
+}
+
 /// A checker plus the OS families it applies to.
 type Checker = (fn(&Examination, &str) -> Diagnosis, &'static [&'static str]);
 
@@ -1290,6 +1373,11 @@ const CHECKERS: &[Checker] = &[
     (check_13_hip_sdk_missing, &["windows"]),
     (check_14_adrenalin_too_old, &["windows"]),
     (check_15_msvc_redist, &["windows"]),
+    // Linux-only: `libtorch_cuda.so` is an ELF name, and the vLLM engine is
+    // gated off native Windows. 17 rather than 16 because the vLLM
+    // out-of-memory entry reserves 16 on its own branch; the number is a stable
+    // handle, so the two do not get to share one.
+    (check_17_torch_dlpack_cuda_variant, &["linux"]),
 ];
 
 /// Run every applicable checker, drop zero-score results, sort by score
@@ -1642,6 +1730,59 @@ mod tests {
                 fix.summary
             );
         }
+    }
+
+    #[test]
+    fn the_engine_import_failure_outranks_the_render_group_false_lead() {
+        // The reported case. On the affected host the GPU is functional and
+        // /dev/kfd is world-writable, but the user happens to be outside the
+        // render group -- so the catalog's best answer to this symptom was fix-4
+        // at 45, and following it meant a usermod, a re-login, and no progress.
+        // The fixture reproduces that false lead, so the assertion is about the
+        // ranking and not only about the new entry's score.
+        let mut e = linux_base();
+        e.in_render_group = Some(false);
+        e.in_video_group = Some(false);
+
+        let report = diagnose(
+            &e,
+            "vllm engine fails to start: OSError: libtorch_cuda.so: cannot open shared object file",
+        );
+        let top = &report.matched[0];
+        assert_eq!(top.id, "fix-17-torch-dlpack");
+        assert!(top.score >= MIN_SCORE_FOR_MATCH, "score was {}", top.score);
+        assert!(report.has_match());
+
+        let render_group = report
+            .matched
+            .iter()
+            .position(|d| d.id == "fix-4-render-group")
+            .expect("the fixture must still produce the false lead this outranks");
+        assert!(
+            render_group > 0,
+            "the render-group suggestion must no longer be the top answer here"
+        );
+    }
+
+    #[test]
+    fn the_extension_name_alone_does_not_establish_the_variant_failure() {
+        // The extension appearing in a traceback says it is involved, not that
+        // it loaded the CUDA variant. Holding this under the threshold is what
+        // stops the entry from answering every vLLM import error.
+        let report = diagnose(
+            &linux_base(),
+            "ImportError raised from torch_c_dlpack_ext during startup",
+        );
+        let hit = report
+            .matched
+            .iter()
+            .find(|d| d.id == "fix-17-torch-dlpack")
+            .expect("the keyword should still register as a weak signal");
+        assert!(
+            hit.score < MIN_SCORE_FOR_MATCH,
+            "score was {}, which would promote a weak signal to an established cause",
+            hit.score
+        );
     }
 
     #[test]

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -384,19 +384,20 @@ const RECIPES: &[FixRecipe] = &[
             "# and does not return until you leave it. Run this line on its own.",
             "rocm engines shell vllm",
             "# --- step 2 of 3, INSIDE the subshell step 1 opened ---",
-            "# Confirm the trigger against the ENGINE's interpreter rather than the",
-            "# one on your PATH -- only the engine's torch decides this failure.",
+            "# Confirm the trigger before changing anything. It has to be the",
+            "# ENGINE's interpreter, not the one on your PATH -- they are different",
+            "# interpreters, and only the engine's decides this failure.",
             "python -c \"import torch; print(torch.__version__, torch.version.hip)\"",
             "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\"",
-            "# Applies ONLY when torch.version.hip is set, torch.__version__ is in the",
-            "# 2.4-2.9 range, and torch-c-dlpack-ext is installed. If any of the three",
-            "# does not hold, this is not the failure you are looking at. Then leave",
-            "# the subshell:",
+            "# This entry applies ONLY when torch.version.hip is set, torch.__version__",
+            "# is in the 2.4-2.9 range, and torch-c-dlpack-ext is installed. Outside",
+            "# that range the extension raises a handled ImportError and this is not",
+            "# the failure you are looking at. Then leave the subshell:",
             "exit",
             "# --- step 3 of 3, back in YOUR OWN shell ---",
-            "# If all three held, put the engine's pinned torch back. Do NOT run this",
-            "# from inside the subshell: it replaces the environment that shell is",
-            "# standing in.",
+            "# If all three held, put the engine's pinned torch back. Do NOT run",
+            "# this from inside the subshell: it replaces the environment that",
+            "# shell is standing in.",
             "rocm engines install vllm --reinstall",
         ],
         needs_sudo: false,
@@ -406,6 +407,7 @@ const RECIPES: &[FixRecipe] = &[
         notes: &[
             "Running vLLM on ROCm is not by itself a reason to apply this. torch-c-dlpack-ext arrives as a transitive dependency of tilelang, which vLLM pins, and it only misbehaves on the torch versions it ships prebuilts for.",
             "The usual way a runtime lands in the failing range is `rocm install sdk` being re-run after the engine was installed, which overwrites the engine's pinned torch. Reinstalling the engine puts the pin back.",
+            "A service that failed at startup is hidden from a plain `rocm services list`; pass --all to recover its id.",
         ],
         applies_on: LINUX_ONLY,
         runner: None,
@@ -419,6 +421,16 @@ const RECIPES: &[FixRecipe] = &[
 /// `Fix` [`crate::diagnose`] attaches to its finding — because a divergence
 /// between them is exactly the kind of thing a reader would meet and not the
 /// author.
+///
+/// Scope, so the guarantee is not read wider than it is: this holds the
+/// *command block* only, and only its shell boundary. It says nothing about
+/// `summary`, `notes` or `verify`. Byte-equality of the two blocks is a
+/// separate check — [`assert_plan_matches_the_catalog_copy`] — and the prose
+/// around them is deliberately not identical, because [`FixRecipe`] has a
+/// `rationale` field that `Fix` has no counterpart for: the upstream-defect
+/// explanation that `diagnose` carries as a note is printed by `rocm fix` out
+/// of `rationale` instead, and duplicating it into `notes` would print it
+/// twice.
 ///
 /// Both renderers print every line of the block with the same `$ ` prefix, so
 /// ordering alone tells a reader nothing: it does not say that
@@ -466,6 +478,26 @@ pub(crate) fn assert_engine_shell_boundary_is_labelled(fix_id: &str, commands: &
         labelled(leave, act, "YOUR OWN shell"),
         "{fix_id}: the block has to say the reinstall runs back in the user's own \
          shell:\n{commands:#?}"
+    );
+}
+
+/// Assert that the command block a [`crate::diagnose::Fix`] carries is
+/// byte-identical to the catalog recipe's, line for line.
+///
+/// The two are hand-maintained copies of one plan in two modules, and the
+/// block is the part a user pastes into a shell, so a silent divergence is a
+/// user pasting steps that no longer match the ones `rocm fix` prints. Holding
+/// the shell boundary in both (see
+/// [`assert_engine_shell_boundary_is_labelled`]) leaves the wording free to
+/// drift; this closes that.
+#[cfg(test)]
+pub(crate) fn assert_plan_matches_the_catalog_copy(fix_id: &str, commands: &[&str]) {
+    let recipe = find_recipe(fix_id)
+        .unwrap_or_else(|| panic!("{fix_id}: no catalog recipe to compare the plan against"));
+    assert_eq!(
+        recipe.commands, commands,
+        "{fix_id}: the plan `diagnose` attaches has drifted from the catalog recipe \
+         `rocm fix` prints; they are one plan and a user may meet either copy"
     );
 }
 

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -372,16 +372,31 @@ const RECIPES: &[FixRecipe] = &[
         title: "Restore the engine's pinned torch (torch-c-dlpack-ext loads the CUDA variant)",
         rationale: "vLLM's engine start aborts at import time when torch-c-dlpack-ext loads its CUDA prebuilt on a ROCm torch: it picks the variant from torch.cuda.is_available(), which is True on ROCm because PyTorch reuses the torch.cuda namespace for HIP, and it ships no ROCm variant. tvm_ffi imports it as OPTIONAL but guards only ImportError/AttributeError, while ctypes.CDLL raises OSError -- so the optional import kills the process. Both defects are upstream; nothing here is misconfigured. What you can change locally is the torch version: outside the 2.4-2.9 range there is no prebuilt to load, the extension raises the handled ImportError, and tvm_ffi falls back to its JIT path with a warning.",
         auto_applicable: false,
+        // Three labelled groups, because the steps run in three different places
+        // and `print_recipe` renders them as one undifferentiated `$`-prefixed
+        // list. Unlabelled, a user pasting the block wholesale is relying on
+        // terminal stdin buffering to land the probes in the subshell -- and on
+        // the reinstall NOT landing there, since it replaces the very
+        // environment that shell is standing in.
         commands: &[
-            "# Confirm the trigger first, against the ENGINE's interpreter rather than",
-            "# the one on your PATH -- only the engine's torch decides this failure.",
+            "# --- step 1 of 3, in YOUR shell ---",
+            "# Opens an INTERACTIVE subshell with the engine's environment active,",
+            "# and does not return until you leave it. Run this line on its own.",
             "rocm engines shell vllm",
-            "# ...and run the next two INSIDE the shell it opens:",
+            "# --- step 2 of 3, INSIDE the subshell step 1 opened ---",
+            "# Confirm the trigger against the ENGINE's interpreter rather than the",
+            "# one on your PATH -- only the engine's torch decides this failure.",
             "python -c \"import torch; print(torch.__version__, torch.version.hip)\"",
             "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\"",
             "# Applies ONLY when torch.version.hip is set, torch.__version__ is in the",
             "# 2.4-2.9 range, and torch-c-dlpack-ext is installed. If any of the three",
-            "# does not hold, this is not the failure you are looking at.",
+            "# does not hold, this is not the failure you are looking at. Then leave",
+            "# the subshell:",
+            "exit",
+            "# --- step 3 of 3, back in YOUR OWN shell ---",
+            "# If all three held, put the engine's pinned torch back. Do NOT run this",
+            "# from inside the subshell: it replaces the environment that shell is",
+            "# standing in.",
             "rocm engines install vllm --reinstall",
         ],
         needs_sudo: false,
@@ -396,6 +411,63 @@ const RECIPES: &[FixRecipe] = &[
         runner: None,
     },
 ];
+
+/// Assert that a recipe whose steps span more than one shell says which shell
+/// each group runs in.
+///
+/// Shared by the two copies of the plan — the catalog recipe here and the
+/// `Fix` [`crate::diagnose`] attaches to its finding — because a divergence
+/// between them is exactly the kind of thing a reader would meet and not the
+/// author.
+///
+/// Both renderers print every line of the block with the same `$ ` prefix, so
+/// ordering alone tells a reader nothing: it does not say that
+/// `rocm engines shell vllm` opened an interactive subshell the probes belong
+/// inside, nor that the reinstall must run outside it because it replaces the
+/// very environment that subshell is standing in. Rendered flat, a user pasting
+/// the block wholesale was left depending on terminal stdin buffering to land
+/// each line in the right shell. Hold the block to marking the boundary in both
+/// directions — ordered (open it, leave it, only then act) and labelled.
+#[cfg(test)]
+pub(crate) fn assert_engine_shell_boundary_is_labelled(fix_id: &str, commands: &[&str]) {
+    let position = |needle: &str| {
+        commands
+            .iter()
+            .position(|c| c.trim() == needle)
+            .unwrap_or_else(|| {
+                panic!("{fix_id}: the plan no longer runs `{needle}`:\n{commands:#?}")
+            })
+    };
+    let open = position("rocm engines shell vllm");
+    let leave = position("exit");
+    let act = position("rocm engines install vllm --reinstall");
+    assert!(
+        open < leave && leave < act,
+        "{fix_id}: the subshell has to be opened, then left, and only then may the \
+         reinstall run -- it replaces the environment that subshell stands in:\n{commands:#?}"
+    );
+    let is_comment = |c: &&str| c.trim_start().starts_with('#');
+    assert!(
+        commands[open + 1..leave].iter().any(|c| !is_comment(c)),
+        "{fix_id}: nothing actually runs inside the subshell, so opening one is \
+         unexplained:\n{commands:#?}"
+    );
+    let labelled = |from: usize, to: usize, want: &str| {
+        commands[from..to]
+            .iter()
+            .any(|c| is_comment(c) && c.contains(want))
+    };
+    assert!(
+        labelled(open, leave, "INSIDE"),
+        "{fix_id}: the block has to say the probes run INSIDE the subshell rather \
+         than merely list them after it:\n{commands:#?}"
+    );
+    assert!(
+        labelled(leave, act, "YOUR OWN shell"),
+        "{fix_id}: the block has to say the reinstall runs back in the user's own \
+         shell:\n{commands:#?}"
+    );
+}
 
 fn find_recipe(fix_id: &str) -> Option<&'static FixRecipe> {
     RECIPES.iter().find(|r| r.fix_id == fix_id)
@@ -1108,6 +1180,13 @@ mod tests {
         ids.dedup();
         assert_eq!(ids.len(), count, "duplicate fix-id in RECIPES");
         assert_eq!(count, 16, "expected 16 catalog entries");
+    }
+
+    #[test]
+    fn the_dlpack_recipe_says_which_shell_each_step_runs_in() {
+        let recipe =
+            find_recipe("fix-17-torch-dlpack").expect("fix-17-torch-dlpack must be in the catalog");
+        assert_engine_shell_boundary_is_labelled(recipe.fix_id, recipe.commands);
     }
 
     #[test]

--- a/crates/rocm-core/src/fix.rs
+++ b/crates/rocm-core/src/fix.rs
@@ -364,6 +364,37 @@ const RECIPES: &[FixRecipe] = &[
         applies_on: WINDOWS_ONLY,
         runner: None,
     },
+    // The number is a stable handle, not a position: `fix-16` is reserved by the
+    // vLLM out-of-memory entry on its own branch, so this one takes 17 rather
+    // than colliding and forcing whichever lands second to rename a published id.
+    FixRecipe {
+        fix_id: "fix-17-torch-dlpack",
+        title: "Restore the engine's pinned torch (torch-c-dlpack-ext loads the CUDA variant)",
+        rationale: "vLLM's engine start aborts at import time when torch-c-dlpack-ext loads its CUDA prebuilt on a ROCm torch: it picks the variant from torch.cuda.is_available(), which is True on ROCm because PyTorch reuses the torch.cuda namespace for HIP, and it ships no ROCm variant. tvm_ffi imports it as OPTIONAL but guards only ImportError/AttributeError, while ctypes.CDLL raises OSError -- so the optional import kills the process. Both defects are upstream; nothing here is misconfigured. What you can change locally is the torch version: outside the 2.4-2.9 range there is no prebuilt to load, the extension raises the handled ImportError, and tvm_ffi falls back to its JIT path with a warning.",
+        auto_applicable: false,
+        commands: &[
+            "# Confirm the trigger first, against the ENGINE's interpreter rather than",
+            "# the one on your PATH -- only the engine's torch decides this failure.",
+            "rocm engines shell vllm",
+            "# ...and run the next two INSIDE the shell it opens:",
+            "python -c \"import torch; print(torch.__version__, torch.version.hip)\"",
+            "python -c \"import importlib.metadata as m; print(m.version('torch-c-dlpack-ext'))\"",
+            "# Applies ONLY when torch.version.hip is set, torch.__version__ is in the",
+            "# 2.4-2.9 range, and torch-c-dlpack-ext is installed. If any of the three",
+            "# does not hold, this is not the failure you are looking at.",
+            "rocm engines install vllm --reinstall",
+        ],
+        needs_sudo: false,
+        needs_reboot: false,
+        needs_relogin: false,
+        verify: "rocm serve <model> --engine vllm   # then `rocm services list --all` and `rocm services logs <service-id>` to confirm the import no longer aborts",
+        notes: &[
+            "Running vLLM on ROCm is not by itself a reason to apply this. torch-c-dlpack-ext arrives as a transitive dependency of tilelang, which vLLM pins, and it only misbehaves on the torch versions it ships prebuilts for.",
+            "The usual way a runtime lands in the failing range is `rocm install sdk` being re-run after the engine was installed, which overwrites the engine's pinned torch. Reinstalling the engine puts the pin back.",
+        ],
+        applies_on: LINUX_ONLY,
+        runner: None,
+    },
 ];
 
 fn find_recipe(fix_id: &str) -> Option<&'static FixRecipe> {
@@ -459,7 +490,7 @@ pub fn apply(fix_id: &str, opts: &FixOptions) -> i32 {
         if looks_like_a_diagnosis_position(fix_id) {
             // `rocm diagnose` ranks findings `#1`, `#2`, and users reach for that
             // number here. It is a position in one report, not a name -- and it
-            // does not line up with the catalog's `fix-1 … fix-15` either, so a
+            // does not line up with the catalog's `fix-N` names either, so a
             // bare "unknown id" left them with nothing to correct.
             eprintln!(
                 "`{fix_id}` looks like a position in a `rocm diagnose` report, not a fix-id."
@@ -1076,7 +1107,7 @@ mod tests {
         let count = ids.len();
         ids.dedup();
         assert_eq!(ids.len(), count, "duplicate fix-id in RECIPES");
-        assert_eq!(count, 15, "expected 15 catalog entries");
+        assert_eq!(count, 16, "expected 16 catalog entries");
     }
 
     #[test]

--- a/tests/e2e-cucumber/features/diagnose.feature
+++ b/tests/e2e-cucumber/features/diagnose.feature
@@ -162,3 +162,23 @@ Feature: Diagnosing failures and listing fixes
     Given a user who hit the vLLM engine-startup import failure
     When the user asks the CLI to diagnose that symptom in machine-readable form
     Then the CLI reports the engine-startup import failure as an established cause
+
+  # Every other recipe in the catalog is a flat sequence for one shell. This one
+  # is not: `rocm engines shell vllm` opens an INTERACTIVE subshell, the two
+  # probes are meant to run inside it, and the reinstall replaces the very
+  # environment that subshell is standing in, so it must not run there. The CLI
+  # renders every command line with the same `$` prefix, so ordering alone said
+  # none of that, and a user pasting the block wholesale was left depending on
+  # terminal stdin buffering to land each line in the right shell. What the user
+  # can observe is the printed plan, so that is what is asserted.
+  #
+  # Deliberately not OS-gated even though the fix is linux-only: the plan is
+  # printed before the fix's own platform gate is reached, so the text under test
+  # is identical on both lanes and the Windows lane exercises it too. The step
+  # therefore asserts the printed block and not the exit code, which does differ
+  # (0 where the fix applies, 3 where it does not).
+  @id:diagnose-fix-says-which-shell-each-step-runs-in
+  Scenario: diagnose-14 - A fix whose steps span two shells says which shell each step runs in
+    Given a user who has chosen the fix for the engine-startup import failure
+    When the user previews that fix without applying it
+    Then the printed plan says which shell each step runs in

--- a/tests/e2e-cucumber/features/diagnose.feature
+++ b/tests/e2e-cucumber/features/diagnose.feature
@@ -140,3 +140,25 @@ Feature: Diagnosing failures and listing fixes
     When the user asks the CLI which fixes it offers
     Then every fix the catalog documents is listed
     And only the fixes the CLI can carry out itself are marked as such
+
+  # This failure mode is reachable ONLY from the error text. The fact that
+  # decides it is the torch version inside the managed runtime, which the host
+  # examination does not read — so unlike every other entry there is no
+  # structural signal to fall back on, and a symptom that does not score is a
+  # symptom that gets the render-group false lead instead. That makes "the text
+  # scores" the whole behaviour, which is why it is asserted directly here.
+  #
+  # The assertion is that the entry CLEARS the report's own threshold, not that
+  # it ranks first: a runner with a real fault of its own (a blacklisted amdgpu)
+  # legitimately scores higher for any symptom, so a ranking assertion would be
+  # a test of the runner's health. Clearing the threshold comes from the keyword
+  # alone and holds on every host.
+  #
+  # @requires-os:linux because the checker is registered linux-only, and
+  # @requires-bare-metal because WSL2 does not run the catalog at all — the two
+  # are not interchangeable, WSL2 reports an os_family of linux.
+  @id:diagnose-recognises-the-engine-import-failure @requires-bare-metal @requires-os:linux
+  Scenario: diagnose-13 - A vLLM engine-startup import failure is recognised from its error text
+    Given a user who hit the vLLM engine-startup import failure
+    When the user asks the CLI to diagnose that symptom in machine-readable form
+    Then the CLI reports the engine-startup import failure as an established cause

--- a/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
@@ -16,6 +16,16 @@ use crate::E2eWorld;
 /// so scenarios assert the shape of a match, not the id.
 const KNOWN_SYMPTOM: &str = "HSA_STATUS_ERROR_INVALID_ISA";
 
+/// The error text a vLLM engine-startup import failure leaves behind, as a user
+/// would paste it. `libtorch_cuda.so` is the token that carries it: a ROCm build
+/// of torch ships `libtorch_hip.so` and never that file, so it scores on its own
+/// without needing the rest of the traceback.
+const ENGINE_IMPORT_SYMPTOM: &str =
+    "vllm engine fails to start: OSError: libtorch_cuda.so: cannot open shared object file";
+
+/// The catalog entry [`ENGINE_IMPORT_SYMPTOM`] must reach.
+const ENGINE_IMPORT_FIX_ID: &str = "fix-17-torch-dlpack";
+
 /// A print-only recipe (no runner, applies on linux+windows) whose `--dry-run`
 /// is deterministic across environments — used for the preview scenario. Other
 /// recipes gate on host state (e.g. `$USER`) and return non-zero even for a
@@ -57,6 +67,10 @@ const CATALOG_FIX_IDS: &[&str] = &[
     "fix-13-hip-sdk-missing",
     "fix-14-adrenalin-too-old",
     "fix-15-msvc-redist",
+    // Not a typo, and not a hole to fill: `fix-16` is reserved by the vLLM
+    // out-of-memory entry on its own branch. The number is a stable handle, so
+    // the two are kept distinct rather than renamed after the fact.
+    "fix-17-torch-dlpack",
 ];
 
 /// The fixes the CLI carries out itself. Every other entry only prints a plan.
@@ -115,6 +129,11 @@ async fn user_hit_known_failure(world: &mut E2eWorld) {
 #[given("a user who hit a failure the CLI does not recognise")]
 async fn user_hit_unknown_failure(world: &mut E2eWorld) {
     world.model_name = Some("xyzzy totally unrelated gibberish".to_string());
+}
+
+#[given("a user who hit the vLLM engine-startup import failure")]
+async fn user_hit_engine_import_failure(world: &mut E2eWorld) {
+    world.model_name = Some(ENGINE_IMPORT_SYMPTOM.to_string());
 }
 
 #[given("a user who has chosen a known fix")]
@@ -320,6 +339,41 @@ async fn assert_json_identifies_match(world: &mut E2eWorld) {
             .and_then(serde_json::Value::as_str)
             .is_some(),
         "the matched cause must name the fix that applies it:\n{output}"
+    );
+}
+
+#[then("the CLI reports the engine-startup import failure as an established cause")]
+async fn assert_engine_import_failure_established(world: &mut E2eWorld) {
+    assert_eq!(
+        world.cli_rc,
+        Some(0),
+        "diagnose should exit 0 (it is a query)"
+    );
+    let (report, output) = parsed_diagnosis(world);
+    // Read the bar out of the document rather than restating 50: the report
+    // publishes it so callers need not hardcode it, and a test that hardcodes it
+    // is not exercising that.
+    let threshold = report
+        .get("min_score_for_match")
+        .and_then(serde_json::Value::as_i64)
+        .expect("diagnose JSON must publish its match threshold");
+    let score = report
+        .get("matched")
+        .and_then(|m| m.as_array())
+        .expect("diagnose JSON has no 'matched' array")
+        .iter()
+        .find(|d| d.get("id").and_then(serde_json::Value::as_str) == Some(ENGINE_IMPORT_FIX_ID))
+        .and_then(|d| d.get("score"))
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_else(|| {
+            panic!("the catalog did not recognise the engine-startup import failure:\n{output}")
+        });
+    // Below the bar the entry is presented among the sub-threshold noise it was
+    // added to outrank, which is the state the report was in before it existed.
+    assert!(
+        score >= threshold,
+        "{ENGINE_IMPORT_FIX_ID} scored {score}, under the report's own threshold \
+         of {threshold}, so it is not an established cause:\n{output}"
     );
 }
 

--- a/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
+++ b/tests/e2e-cucumber/tests/e2e/diagnose_steps.rs
@@ -136,6 +136,11 @@ async fn user_hit_engine_import_failure(world: &mut E2eWorld) {
     world.model_name = Some(ENGINE_IMPORT_SYMPTOM.to_string());
 }
 
+#[given("a user who has chosen the fix for the engine-startup import failure")]
+async fn user_chose_engine_import_fix(world: &mut E2eWorld) {
+    world.model_name = Some(ENGINE_IMPORT_FIX_ID.to_string());
+}
+
 #[given("a user who has chosen a known fix")]
 async fn user_chose_known_fix(world: &mut E2eWorld) {
     world.model_name = Some(PREVIEW_FIX_ID.to_string());
@@ -374,6 +379,54 @@ async fn assert_engine_import_failure_established(world: &mut E2eWorld) {
         score >= threshold,
         "{ENGINE_IMPORT_FIX_ID} scored {score}, under the report's own threshold \
          of {threshold}, so it is not an established cause:\n{output}"
+    );
+}
+
+#[then("the printed plan says which shell each step runs in")]
+async fn assert_plan_says_which_shell_each_step_runs_in(world: &mut E2eWorld) {
+    let output = world.cli_output.as_ref().expect("no fix preview output");
+    // The rendered block is a `Commands:` header followed by one `  $ <line>`
+    // per entry; `map_while` stops at the first line that is not one of those,
+    // which is the `Flags:` row underneath.
+    let commands: Vec<&str> = output
+        .lines()
+        .skip_while(|line| !line.starts_with("Commands:"))
+        .skip(1)
+        .map_while(|line| line.strip_prefix("  $ "))
+        .collect();
+    assert!(
+        !commands.is_empty(),
+        "the preview printed no command block at all:\n{output}"
+    );
+    let position = |needle: &str| {
+        commands
+            .iter()
+            .position(|c| c.trim() == needle)
+            .unwrap_or_else(|| panic!("the printed plan no longer runs `{needle}`:\n{output}"))
+    };
+    let open = position("rocm engines shell vllm");
+    let leave = position("exit");
+    let act = position("rocm engines install vllm --reinstall");
+    // Ordered: the subshell is opened, then left, and only then is the engine
+    // reinstalled -- that step replaces the environment the subshell stands in.
+    assert!(
+        open < leave && leave < act,
+        "the plan must open the subshell, leave it, and only then reinstall:\n{output}"
+    );
+    let is_comment = |c: &&str| c.trim_start().starts_with('#');
+    // And labelled, not merely ordered: with every line carrying the same `$`
+    // prefix, a reader has nothing else to tell the two contexts apart.
+    assert!(
+        commands[open..leave]
+            .iter()
+            .any(|c| is_comment(c) && c.contains("INSIDE")),
+        "the plan must say the probes run INSIDE the subshell:\n{output}"
+    );
+    assert!(
+        commands[leave..act]
+            .iter()
+            .any(|c| is_comment(c) && c.contains("YOUR OWN shell")),
+        "the plan must say the reinstall runs back in the user's own shell:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

`rocm serve --engine vllm` can abort at engine startup with `OSError: libtorch_cuda.so: cannot open shared object file` (EAI-8012), and the closed catalog had no entry for it. Its highest-scoring answer to that symptom was `fix-4-render-group` at 45/100 — a false lead on a host whose `/dev/kfd` `rocm examine` itself reports as world-writable. A user following it runs `usermod`, logs out and back in, and is no closer.

This adds **`fix-17-torch-dlpack`**: a keyword table for the import signature (`libtorch_cuda.so`, `torch_c_dlpack_ext`, `_optional_torch_c_dlpack`) plus a PRINT-ONLY recipe carrying the remediation.

**Before / after**, same command, same host:

```
# before
#1 (fix-4-render-group)  [WEAK   score=45/100] User not in render/video group ...

# after
#1 (fix-17-torch-dlpack) [LIKELY score=50/100] vLLM engine start aborts on torch-c-dlpack-ext loading its CUDA variant
#2 (fix-4-render-group)  [WEAK   score=45/100] User not in render/video group ...
```

### Why keyword-only

The fact that decides this failure is the torch version inside the **managed runtime**. `Examination`'s framework probe imports torch from the ambient interpreter instead — on an affected host it reports `framework: unknown` with a `torch import failed` note — so the deciding fact is absent from the examination and no structural check can fire. Noted in the checker's doc comment so the next reader does not try to add a structural signal that cannot exist yet.

### Discoverability, stated accurately

An earlier revision of this description claimed the entry was reachable "from a serve failure note". **There is no such note** — a service that died at startup renders `logs:` and `restart:` hints and never mentions `diagnose`. Corrected here and in the checker's doc comment, which now records the gap rather than papering over it.

What is true today: the only route from the symptom is the user pasting the error into `rocm diagnose --symptom "<pasted error>"`. The recipe is additionally reachable by name — `rocm fix` lists it, `rocm fix fix-17-torch-dlpack` prints it — but that needs the id, not the symptom.

Closing the gap means adding a `diagnose` hint to the service-failure output. That changes a shared surface for **every** failed service regardless of engine or cause, needs its own scenario, and is a decision about `rocm services` rather than about this catalog entry — so it is deliberately **not** in this PR. Happy to open it as a follow-up if that is the preferred order.

`libtorch_cuda.so` alone is weighted at exactly `MIN_SCORE_FOR_MATCH` (50), deliberately: a ROCm build of torch ships `libtorch_hip.so` and never that file, so the token cannot mean anything else, and a user who pastes only the `OSError` line still has to clear the bar. `torch_c_dlpack_ext` alone stays at 45 — under the bar — because the extension appearing in a traceback says it is involved, not that it chose the wrong variant.

### Wording stays conditional

The trigger conditions are narrow — a ROCm build of torch in the 2.4–2.9 range with `torch-c-dlpack-ext` present — so the entry states the condition before it advises anything, and the first note says outright that running vLLM on ROCm is not by itself a reason to apply it. The commands are confirm-then-act and use only commands this CLI has (`rocm engines shell vllm`, `rocm engines install vllm --reinstall`).

### The command block says which shell each step runs in

This is the only recipe in the catalog whose steps span more than one shell, and both renderers print every line with the same `$ ` prefix — so ordering alone said nothing about it. `rocm engines shell vllm` opens an **interactive subshell**, the two probes belong inside it, and the reinstall replaces the very environment that subshell is standing in, so it must not run there. A user pasting the block wholesale was left depending on terminal stdin buffering to land each line in the right place.

Now split into three labelled groups — your shell / inside the subshell / back in your own shell — with leaving the subshell an explicit `exit` rather than something to infer. Three rather than two because the reinstall was already implicitly outside the subshell and nothing said so. `rocm engines shell` has no non-interactive `-- <cmd>` form (it `bail!`s without a TTY), so collapsing this to one context would have meant inventing a command the CLI does not have.

Both copies of the plan carry it — the catalog recipe and the `Fix` the diagnosis attaches to its finding. Two shared assertions hold them: one checks the shell boundary is labelled in each, and one pins the two command blocks to each other byte for byte, so the block a user sees cannot drift from the block `rocm fix` prints. An earlier revision of this description claimed the single boundary assertion already guaranteed that; it did not — it checked three command strings and two label substrings, and the step-2 wording had in fact drifted between the copies. Both are now identical and the equality check keeps them so.

The surrounding prose is deliberately *not* identical, because `FixRecipe` has a `rationale` field that `Fix` has no counterpart for: the upstream-defect explanation `diagnose` carries as a note is printed by `rocm fix` out of `rationale`, so copying it into `notes` would print it twice. `verify` is byte-identical in both.

This does **not** fix the upstream defects (`torch-c-dlpack-ext` 0.1.5 still selects the CUDA variant on ROCm; `tvm_ffi`'s optional-import guard still misses the `OSError`). It recognises the failure and names the remedy that moves the runtime off the versions with prebuilts.

### Fix-id numbering

`fix-16` is reserved by the vLLM out-of-memory entry on #251, so this takes **17**. The id is a stable handle external tooling reproduces, so the two are kept distinct rather than one being renamed after it ships. The gap is commented in all three places a reader would meet it.

The **AUTO set is unchanged** — the new entry is PRINT-ONLY, so `exactly_the_four_known_fixes_are_auto` passes untouched. That assertion being untouched is the evidence that nothing was promoted to auto-applicable.

## Test plan

- [x] **Red first** — the ranking/threshold tests fail on unmodified `main`, the first with `left: "fix-4-render-group"`, which is precisely the reported false lead. The two shell-boundary tests were falsified the same way: dropping the `exit` line fails both with `the plan no longer runs 'exit'`, and dropping the step-3 label fails both with `the block has to say the reinstall runs back in the user's own shell`.
- [x] `crates/rocm-core/src/diagnose.rs` — a ranking test (the entry must outrank the render-group false lead on a fixture that produces it), a threshold test (the extension name alone must stay below `MIN_SCORE_FOR_MATCH`), and a shell-boundary test on the plan the diagnosis attaches to its finding.
- [x] `crates/rocm-core/src/fix.rs` — catalog count 15 → 16, plus a shell-boundary test on the catalog recipe. Both boundary tests share one assertion; a second shared assertion, `assert_plan_matches_the_catalog_copy`, pins the two command blocks to each other line for line. Falsified by rewording one copy's step-3 label: that reworded line still satisfied the boundary check, so the equality check catches drift the boundary check provably cannot.
- [x] **Scenario `@id:diagnose-recognises-the-engine-import-failure`** (`diagnose-13`) covers the user-observable behaviour per AGENTS.md §3. It asserts the entry clears the report's *own* published threshold rather than that it ranks first — a runner with a real fault of its own legitimately outranks it for any symptom, so a ranking assertion there would test the runner's health instead. `@id:diagnose-fix-catalog-is-complete` covers the listing via `CATALOG_FIX_IDS`.
- [x] **Scenario `@id:diagnose-fix-says-which-shell-each-step-runs-in`** (`diagnose-14`) covers the printed command block, which is the surface the reviewer was reading. Not OS-gated: the plan is printed before the fix's own platform gate is reached, so the Windows lane exercises the same text; the step therefore asserts the block and not the exit code, which does differ (0 where the fix applies, 3 where it does not).
- [x] `cargo test --workspace --all-targets` — green (30 test binaries, 0 failures).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `python3 scripts/smoke_local.py` — ok.
- [x] Full `diagnose.feature` run on Linux: 14 scenarios, 51 steps, all passing.
- [x] Behavioural check with the ticket's verbatim symptom string, output above; and `rocm fix fix-17-torch-dlpack` read back to confirm the three groups render as intended.

Lanes not run locally: Windows (the checker is linux-only, so the entry is inert there) and WSL2 (no lane exists; the catalog is not run on that platform at all).

