### PR TITLE
ci(e2e): gate the consolidated E2E report on the lane it reports on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1020,6 +1020,10 @@ jobs:
       && needs.changes.result == 'success'
       && (github.event_name != 'workflow_dispatch'
           || inputs.platform == 'all' || inputs.platform == 'mock')
+    # Whether this lane actually executed; the consolidated report reuses it so
+    # it never tries to download artifacts a no-op run never produced.
+    outputs:
+      ran: ${{ steps.gate.outputs.run }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1082,12 +1086,17 @@ jobs:
     needs:
       - changes
       - e2e
-    # Consolidate whatever ran. On dispatch `heavy` is unset, so also run when the
-    # trigger was manual; `always()` still lets it collect partial/failed tiers.
+    # Mirrors the `e2e` job's condition exactly so the two are produced and
+    # skipped together. This is a REQUIRED check, so it must always be produced:
+    # branch protection treats a skipped required check as SATISFIED, so any
+    # extra clause narrowing this condition would silently stop the check from
+    # gating anything. `always()` is kept so a failing platform still gets a
+    # rendered report. Which work actually happens is decided per step below.
     if: >-
       always()
-      && (needs.changes.outputs.heavy == 'true'
-        || github.event_name == 'workflow_dispatch')
+      && needs.changes.result == 'success'
+      && (github.event_name != 'workflow_dispatch'
+          || inputs.platform == 'all' || inputs.platform == 'mock')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1103,12 +1112,14 @@ jobs:
       # layout is the norm here; `discover()` handles both (labeling the root
       # file from platform.json's slug).
       - name: Download all E2E reports
+        if: needs.e2e.outputs.ran == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-report'
           path: e2e-artifacts
 
       - name: Build consolidated report + step summary
+        if: needs.e2e.outputs.ran == 'true'
         run: |
           mkdir -p consolidated
           cargo xtask e2e-report \
@@ -1116,8 +1127,26 @@ jobs:
             --html-out consolidated/index.html >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload consolidated report
-        if: always()
+        if: always() && needs.e2e.outputs.ran == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-consolidated-report
           path: consolidated/
+
+      # Rendering the report says nothing about whether the scenarios passed —
+      # it succeeds just as happily on a run full of failures. This job is the
+      # required check that reports on the E2E lane, so it has to carry that
+      # lane's verdict. Runs last because the summary is written by the step
+      # above. `E2E tests` is itself a required check, so this blocks nothing
+      # that was not already blocked.
+      - name: Require the E2E lane to have passed
+        if: always()
+        env:
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ "$E2E_RESULT" = "success" ]; then
+            echo "E2E tests concluded: success"
+            exit 0
+          fi
+          echo "::error::E2E tests concluded '$E2E_RESULT'; failing the consolidated report."
+          exit 1

--- a/xtask/src/workflow_contract.rs
+++ b/xtask/src/workflow_contract.rs
@@ -392,6 +392,29 @@ mod tests {
             .unwrap_or_else(|| panic!("job defines top-level scalar `{key}`"))
     }
 
+    /// The job-level `if:` condition, flattened across folded (`>-`)
+    /// continuation lines so a clause split over several lines cannot hide.
+    ///
+    /// Scoped to the indent-4 key, so a step-level `if:` (indent 8) can never
+    /// be mistaken for the job's own gate.
+    fn job_if(block: &str) -> String {
+        let start = block
+            .lines()
+            .position(|line| indent_of(line) == 4 && line.trim_start().starts_with("if:"))
+            .expect("job declares a job-level `if:`");
+        let scoped = block.lines().skip(start).collect::<Vec<_>>().join("\n");
+        let value = flattened_values(&scoped, "if")
+            .into_iter()
+            .next()
+            .expect("job-level `if:` has an extractable value");
+        // Drop the block-scalar indicator (`>-`, `|`, …) the folded form opens
+        // with, so the condition reads the same however it was spelled.
+        value
+            .trim_start_matches(['>', '|', '-', '+'])
+            .trim()
+            .to_owned()
+    }
+
     fn markdown_table_rows(text: &str, header: &str) -> Vec<Vec<String>> {
         let mut lines = text.lines().skip_while(|line| *line != header);
         assert_eq!(
@@ -707,6 +730,40 @@ trigger-a-workflow#triggering-a-workflow-from-a-workflow"
                 );
             }
         }
+    }
+
+    /// `E2E consolidated report` is a required merge check that reports on the
+    /// `E2E tests` lane, so it has to be produced on every run and it has to
+    /// carry that lane's verdict. Both halves have failed silently before: a
+    /// job-level `heavy` clause skips the job on a light PR, and branch
+    /// protection counts a skipped required check as satisfied; and rendering
+    /// the HTML succeeds just as happily when every scenario failed.
+    #[test]
+    fn consolidated_e2e_report_cannot_be_skipped_and_carries_the_lane_verdict() {
+        let ci = read_workflow("ci.yml");
+        let block = job_block(&ci, "e2e-report");
+        let condition = job_if(block);
+
+        assert!(
+            !condition.contains("needs.changes.outputs.heavy"),
+            "e2e-report's job-level `if:` is `{condition}`, which gates on the `heavy` \
+             path filter: on a PR that matches no heavy path the job is SKIPPED, and \
+             GitHub branch protection treats a skipped required check as satisfied, so \
+             the check silently stops gating anything. Mirror the `e2e` job's condition \
+             instead and decide what work happens at the step level."
+        );
+        assert!(
+            block.contains("needs.e2e.result"),
+            "e2e-report never reads `needs.e2e.result`, so its exit status only reflects \
+             whether the HTML rendered — a run in which every E2E scenario failed would \
+             still report this required check as green."
+        );
+        assert!(
+            condition.contains("always()"),
+            "e2e-report's job-level `if:` is `{condition}`, which lacks `always()`: \
+             without it a failed `E2E tests` lane skips the report entirely, and the \
+             failures nobody can see are exactly the ones worth rendering."
+        );
     }
 
     #[test]


### PR DESCRIPTION
- [x] If this PR fixes a bug, searched `tests/e2e-cucumber/expectations.toml` for the fixed ticket ID and removed/narrowed any now-stale xfail rows. — n/a: this changes CI wiring, not product behaviour, and `expectations.toml` has no rows relating to the consolidated report.

## Summary

A pull request could merge with failing E2E scenarios while the required `E2E consolidated report` check showed green. Two independent gaps let that happen, and fixing either one alone leaves the hole open.

**The report job never looked at how the E2E lane concluded.** Its only work was downloading the per-platform artifacts and rendering them into a single HTML page — and rendering succeeds just as happily on a run in which every scenario failed. The check's exit status therefore meant "the report rendered", not "the tests passed". Nothing in the job referenced `needs.e2e.result` at all.

**The job's own condition required the `heavy` path filter to have matched.** On a pull request touching no heavy path the job was skipped — and branch protection counts a *skipped* required check as satisfied, so the gate quietly stopped applying. This was pull-request-specific; pushes and merge-queue runs force `heavy` on.

## What changed

- The `e2e-report` job ends with a step that fails unless the E2E job concluded `success`. It runs last, so the report and the step summary are still produced for a failing run — exactly the runs worth reading — and under `always()` so an earlier step failing cannot skip the verdict.
- The `e2e-report` job condition now mirrors the `e2e` job's condition exactly, so the two are produced and skipped as a pair, and the decision about what work to actually do moves down to the steps. The `e2e` job publishes its existing step-level gate decision as an output, and the download and render steps read it, so the report never tries to download artifacts a no-op run never produced.
- A workflow-contract test locks both halves in place: the job condition must not reference the path filter, must keep `always()`, and the job body must read the lane's result.

## Why this shape

This is the pattern the `e2e` job already uses for exactly this hazard — always run the job, gate the real work at the step level — with the reasoning spelled out in its own comment. Applying the same pattern here keeps the two jobs consistent and avoids inventing a second mechanism.

The obvious alternative, making `cargo xtask e2e-report` itself exit non-zero on failing scenarios, was deliberately **not** taken: the same binary backs the self-hosted and nightly consolidated reports, which are `continue-on-error` by design so that a hardware failure never gates a PR merge. Hard-failing the renderer would flip those advisory lanes red. If that behaviour is ever wanted, an opt-in flag used only by this workflow is the safe shape.

`always()` is retained in the job condition throughout — a failing platform still needs to appear in the report.

## Risk

Low-to-moderate in blast radius terms, and deliberately bounded:

- On a light pull request the `e2e` job still runs and still succeeds (its steps no-op via its own gate), so `needs.e2e.result` is `success` and light PRs are not blocked.
- `E2E tests` is itself a required check, so anything that now fails the report already failed that check. This adds no new merge-blocking surface; it closes a path where the report disagreed with the lane.
- The two job conditions are byte-identical, so the report cannot be skipped while the lane runs.

## Test plan

- `cargo test -p xtask` — 137 pass, including the new contract test.
- `cargo test --workspace --all-targets`, `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, and the `prek` hook set all pass.
- The new test was proven non-vacuous: reverting only the workflow change makes it fail with the explanatory message, and restoring makes it pass.
- The workflow was parsed to confirm the two job conditions are byte-identical, the new output exists, the work steps are gated on it, and the verdict step is last and runs under `always()`.
- The verdict step's shell was exercised directly for `success` / `failure` / `cancelled` / `skipped` / empty, giving exit codes 0 / 1 / 1 / 1 / 1.

## Not in scope

A green E2E lane still does not by itself prove scenarios *executed* — a lane that runs zero scenarios exits successfully. That is a separate gap in the lane rather than in the aggregator, tracked separately, and is intentionally not addressed here.
