### PR TITLE
spike: WSL2 on the DevLab Dispatch pool (throwaway)

### DIFF
--- a/.github/workflows/e2e-selfhosted.yml
+++ b/.github/workflows/e2e-selfhosted.yml
@@ -8,12 +8,13 @@ name: E2E self-hosted
 # with their OWN concurrency group — means an offline runner can only ever stall
 # THIS workflow's supersession, never the required checks in ci.yml.
 #
-# These lanes are non-blocking (continue-on-error), and as of 2026-09 their
-# check names do not gate a merge either: PRs #334, #335 and #343 all landed
-# while `E2E tests (Strix Halo, Ubuntu)` reported `cancelled` on the merge_group
-# ref, which a required check under ALLGREEN would have blocked. Renaming a lane
-# is therefore safe. (Branch protection is not readable without admin, so this is
-# inferred from those merges rather than read from the required list.)
+# These lanes are non-blocking because none of their check names are in
+# branch protection's required-status-check list (confirmed 2026-09-11) — not
+# because of `continue-on-error`, which is `false` below so a real hardware
+# regression shows red instead of always green. PRs #334, #335 and #343 all
+# landed while `E2E tests (Strix Halo, Ubuntu)` reported `cancelled` on the
+# merge_group ref, which a required check under ALLGREEN would have blocked;
+# renaming a lane is therefore safe.
 
 on:
   push:
@@ -143,8 +144,9 @@ jobs:
     runs-on: [self-hosted, linux, mi300x]
     needs: [changes]
     # No build-and-test gate (cross-workflow needs is unavailable): the job builds
-    # the rocm binary itself and is continue-on-error; ci.yml's required
-    # build-and-test / mock e2e remain the authoritative pre-merge build gate.
+    # the rocm binary itself, and this check isn't in the required list (see the
+    # file header), so a broken build here still can't block a merge; ci.yml's
+    # required build-and-test / mock e2e remain the authoritative build gate.
     if: >-
       always()
       && needs.changes.result == 'success'
@@ -154,7 +156,7 @@ jobs:
         || (github.event_name == 'workflow_dispatch'
           && (inputs.platform == 'all' || inputs.platform == 'app-dev-gpu'))
       )
-    continue-on-error: true
+    continue-on-error: false
     env:
       # Bound serve readiness below the 35-min job cap so a serve that never comes
       # ready fails the scenario with a real error instead of hanging until the
@@ -330,18 +332,27 @@ jobs:
           name: e2e-gpu-report
           path: tests/e2e-cucumber/results/
 
-  # Second AMD GPU architecture: the Strix Halo (gfx1151) Ubuntu runner, targeted
-  # by the `strix-halo` label. These hosts carry `amd-gpu` as well — it marks any
-  # AMD GPU runner, so it never distinguishes one architecture from another.
-  # Non-blocking while this hardware is proven out.
+  # Second AMD GPU architecture: the Strix Halo (gfx1151) Ubuntu lane. DevLab
+  # Dispatch ephemeral pool, opt-in only via the `devlab-dispatch` label (see
+  # e2e-gpu for why an unscoped label can silently mis-route a job to the wrong
+  # architecture; these hosts also carry `strix-halo`, but nothing reaches them
+  # without `devlab-dispatch`). A fresh runner is registered per job and
+  # destroyed after, so there is no cross-run disk to protect: no HOME/
+  # CARGO_HOME override (pool hosts have room under the default paths, unlike
+  # the full-partition static host this replaced), though CARGO_TARGET_DIR
+  # still points at RUNNER_WORKSPACE to dodge checkout's `git clean -ffdx`
+  # mid-job. Non-blocking while this hardware is proven out.
   e2e-gpu-strix-ubuntu:
     name: E2E tests (Strix Halo, Ubuntu)
-    # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
+    # 45min: see e2e-gpu — one collapsed job runs all serves + per-scenario
     # install sdk; the cap must exceed the run so the job writes platform.json.
-    timeout-minutes: 35
-    # `native` disambiguates the two Linux Strix runners: the WSL host also
-    # carries `strix-halo`, but the paths below exist only on the native one.
-    runs-on: [self-hosted, linux, strix-halo, native]
+    # Raised from 35 after moving to the pool: RUNNER_WORKSPACE (CARGO_TARGET_DIR,
+    # e2e-shared, the prewarm tree) is cold every job here, unlike the static host
+    # this replaced, and a run took 26m54s against the old 35min cap (run
+    # 34489547654) versus 18-19m on a warm static host — keep the same headroom
+    # ratio the 35 was chosen for.
+    timeout-minutes: 45
+    runs-on: [self-hosted, linux, devlab-dispatch, strix-halo]
     needs: [changes]
     # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-ubuntu.
     if: >-
@@ -353,27 +364,13 @@ jobs:
         || (github.event_name == 'workflow_dispatch'
           && (inputs.platform == 'all' || inputs.platform == 'strix-ubuntu'))
       )
-    continue-on-error: true
-    # On this runner `/`, `/home/ubuntu`, and `/tmp` are ALL on a full root
-    # partition; only /home/ubuntu/actions-runner (a 1.7T nvme) has space. So
-    # EVERYTHING the job writes must land on the nvme. Point HOME there (catches
-    # ~/.cache/pip, ~/.config, and any other $HOME writer — pip's cache under the
-    # real /home/ubuntu is what previously failed `install sdk` with ENOSPC),
-    # plus the toolchain, temp, and pip cache. The rustup bootstrap still uses
-    # --no-modify-path so it doesn't touch $HOME/.profile. These paths are
-    # specific to that host, which is why `runs-on` pins `native` above.
+    continue-on-error: false
     env:
-      HOME: /home/ubuntu/actions-runner/e2e-home
-      CARGO_HOME: /home/ubuntu/actions-runner/.cargo
-      RUSTUP_HOME: /home/ubuntu/actions-runner/.rustup
-      TMPDIR: /home/ubuntu/actions-runner/tmp
-      PIP_CACHE_DIR: /home/ubuntu/actions-runner/pip-cache
       E2E_SERVE_TIMEOUT_SECS: "300"
-      # The three Strix lanes share one physical machine, and this workflow now
-      # runs a third of them, so a TUI frame that renders well inside the 30s
-      # default on an idle runner can miss it while a sibling lane loads a model.
-      # Raise the wait budget rather than let that read as a product failure; a
-      # genuine hang still fails, just later.
+      # A pool host can be busy with other CI work between GPU preflight and
+      # the TUI checks, so a frame that renders well inside the 30s default on
+      # an idle runner can miss it. Raise the wait budget rather than let that
+      # read as a product failure; a genuine hang still fails, just later.
       E2E_TUI_TIMEOUT_SECS: "90"
       # Match the MI300X dispatch path: opt into the platform-adaptive large-model
       # scenario only when the manual include_nightly input is enabled.
@@ -383,17 +380,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Prepare writable dirs on the nvme + reclaim GPU from stray E2E procs
+      - name: Reclaim GPU from stray E2E processes
         run: |
-          mkdir -p /home/ubuntu/actions-runner/e2e-home /home/ubuntu/actions-runner/tmp /home/ubuntu/actions-runner/pip-cache
-          # Reclaim the GPU from any serve leaked by a killed/timed-out prior run
-          # (see e2e-gpu). Scoped to e2e leftovers only.
           pkill -f '/tmp/rocm-e2e.*llama-server' 2>/dev/null || true
           pkill -f '/tmp/rocm-e2e.*vllm serve' 2>/dev/null || true
           pkill -f 'e2e-shared.*llama-server' 2>/dev/null || true
           pkill -f '__engine-serve-http.*rocm-e2e' 2>/dev/null || true
           rm -rf /tmp/rocm-e2e-* 2>/dev/null || true
-          echo "prepared + reclaimed"
+          echo "reclaimed"
 
       # GPU preflight: bounded wait so a missing/wedged/held GPU fails fast (~90s)
       # instead of hanging to the job cap. Transient contention (VRAM still
@@ -427,17 +421,17 @@ jobs:
           echo "::error::GPU preflight failed after ${CEILING_SECS}s: ${reason}"
           exit 1
 
-      # Bootstrap rustup ourselves with --no-modify-path so it never writes to
-      # $HOME/.profile (setup-rust-toolchain doesn't expose that flag).
-      # rust-toolchain.toml pins the exact toolchain, installed on first cargo
-      # use. Idempotent.
+      # Pool hosts don't preinstall cargo/rustup; bootstrap ourselves with
+      # --no-modify-path so it never writes to $HOME/.profile (setup-rust-
+      # toolchain doesn't expose that flag). rust-toolchain.toml pins the exact
+      # toolchain, installed on first cargo use. Idempotent.
       - name: Ensure Rust toolchain
         run: |
-          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$CARGO_HOME/bin/cargo" ]; then
+          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
             curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
               | sh -s -- -y --no-modify-path --default-toolchain none
           fi
-          echo "$CARGO_HOME/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Run E2E tests on Strix Halo
         run: |
@@ -495,7 +489,7 @@ jobs:
     # 35min: see e2e-gpu — one collapsed job runs all serves + per-scenario
     # install sdk; the cap must exceed the run so the job writes platform.json.
     timeout-minutes: 35
-    runs-on: [self-hosted, windows, strix-halo, native]
+    runs-on: [self-hosted, windows, devlab-dispatch, strix-halo]
     needs: [changes]
     # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-windows.
     if: >-
@@ -507,13 +501,12 @@ jobs:
         || (github.event_name == 'workflow_dispatch'
           && (inputs.platform == 'all' || inputs.platform == 'strix-windows'))
       )
-    continue-on-error: true
+    continue-on-error: false
     env:
-      # The three Strix lanes share one physical machine, and this workflow now
-      # runs a third of them, so a TUI frame that renders well inside the 30s
-      # default on an idle runner can miss it while a sibling lane loads a model.
-      # Raise the wait budget rather than let that read as a product failure; a
-      # genuine hang still fails, just later.
+      # A pool host can be busy with other CI work between GPU preflight and
+      # the TUI checks, so a frame that renders well inside the 30s default on
+      # an idle runner can miss it. Raise the wait budget rather than let that
+      # read as a product failure; a genuine hang still fails, just later.
       E2E_TUI_TIMEOUT_SECS: "90"
       # Same cold-start budget as every other lane and as this lane's own nightly
       # twin: a first serve on shared hardware loads the model before it answers,
@@ -608,6 +601,18 @@ jobs:
           $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm-multi-arch-v2"
           $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
 
+          # E2E_SHARED_CACHE_DIR: every Linux lane sets this; the harness's own
+          # isolate_env() (tests/e2e-cucumber/tests/e2e.rs) derives HF_HOME,
+          # PIP_CACHE_DIR, and ROCM_CLI_CACHE_DIR (the therock/tool archive cache)
+          # from it per scenario, rather than each scenario's isolated TempDir —
+          # this lane never set it, so on the ephemeral pool (no warm cache
+          # carried over from prior jobs) every one of those downloads was cold
+          # every scenario. Model downloads in particular can outrun serve
+          # readiness (observed: serve-08 never became ready within 240s).
+          # Scenarios reusing the same download within THIS run now get a warm
+          # hit after the first.
+          $env:E2E_SHARED_CACHE_DIR = "$env:RUNNER_WORKSPACE\e2e-shared"
+
           # Build the rocm and rocmd binaries once; reuse them for pre-warm + suite.
           # This job does not set CARGO_TARGET_DIR, so the binaries land in
           # the default target\release (fall back to it when the env var is unset).
@@ -656,6 +661,12 @@ jobs:
     # scenario, so match the dedicated nightly lane's cap and leave room for
     # build, runtime pre-warm, the rest of the suite, and platform.json.
     timeout-minutes: 90
+    # Tried devlab-dispatch here too (2026-09-10): a scoped dispatch sat queued
+    # for 3.5min+ with zero pickup, vs. ~85s for both the Ubuntu and Windows
+    # lanes on the same pool — no pool runner carries `wsl`. This lane isn't
+    # really "Strix Halo hardware," it's a WSL2 guest inside a specific
+    # pre-configured Windows box, which the pool doesn't appear to provide.
+    # Stays on the static runner until/unless that changes.
     runs-on: [self-hosted, linux, strix-halo, wsl]
     needs: [changes]
     # See `e2e-gpu`: no build-and-test gate (cross-workflow); strix-wsl. Gated on
@@ -671,14 +682,13 @@ jobs:
         || (github.event_name == 'workflow_dispatch'
           && (inputs.platform == 'all' || inputs.platform == 'strix-wsl'))
       )
-    continue-on-error: true
+    continue-on-error: false
     env:
       E2E_SERVE_TIMEOUT_SECS: "300"
-      # The three Strix lanes share one physical machine, and this workflow now
-      # runs a third of them, so a TUI frame that renders well inside the 30s
-      # default on an idle runner can miss it while a sibling lane loads a model.
-      # Raise the wait budget rather than let that read as a product failure; a
-      # genuine hang still fails, just later.
+      # WSL2's virtualization overhead can make a TUI frame that renders well
+      # inside the 30s default on native hardware miss it here. Raise the wait
+      # budget rather than let that read as a product failure; a genuine hang
+      # still fails, just later.
       E2E_TUI_TIMEOUT_SECS: "90"
       # Match the other hardware lanes: opt into the platform-adaptive
       # large-model scenario only when the manual include_nightly input is on.
@@ -850,7 +860,7 @@ jobs:
         || (github.event_name == 'workflow_dispatch'
           && (inputs.platform == 'all' || inputs.platform == 'rad3'))
       )
-    continue-on-error: true
+    continue-on-error: false
     env:
       E2E_SERVE_TIMEOUT_SECS: "300"
       E2E_INCLUDE_NIGHTLY: "${{ inputs.include_nightly && '1' || '' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -808,6 +808,15 @@ jobs:
           $prewarm = "$env:RUNNER_WORKSPACE\e2e-prewarm-multi-arch-v2"
           $env:E2E_SHARED_RUNTIMES_DIR = "$prewarm\data\runtimes"
 
+          # See e2e-gpu-strix-windows in e2e-selfhosted.yml: the harness's own
+          # isolate_env() derives HF_HOME/PIP_CACHE_DIR/ROCM_CLI_CACHE_DIR from
+          # this per scenario. Without it every serve scenario here re-downloads
+          # its model checkpoint cold, which raced serve-08's readiness timeout
+          # (EAI-8031 / #260) on every nightly run — this host was never actually
+          # warm for it, since Windows doesn't set HOME by default and the
+          # engine's cache lookup didn't fall back to USERPROFILE.
+          $env:E2E_SHARED_CACHE_DIR = "$env:RUNNER_WORKSPACE\e2e-shared"
+
           # See the e2e-gpu lane in e2e-selfhosted.yml for why the
           # e2e-test-hooks feature must match what `cargo xtask e2e` would build.
           cargo build --release -p rocm -p rocmd --features rocm/e2e-test-hooks

--- a/.github/workflows/wsl-pool-spike.yml
+++ b/.github/workflows/wsl-pool-spike.yml
@@ -1,0 +1,81 @@
+name: WSL pool spike (throwaway)
+
+# Answers three unknowns before building a real e2e-wsl lane on the DevLab
+# Dispatch pool (see #377's e2e-wsl, which stays on its static runner because
+# the pool has no wsl-labeled runner):
+#
+#   1. WSL2 needs the "Virtual Machine Platform" + "Windows Subsystem for
+#      Linux" Windows features enabled, which normally needs a reboot to take
+#      effect. GitHub-hosted Windows runners only skip this because it is
+#      baked into their VM image at build time; whether the pool's image has
+#      it baked in too is unknown, and an ephemeral runner cannot survive a
+#      mid-job reboot.
+#   2. A self-hosted runner installed as a background service runs in Session
+#      0, where WSL / Microsoft Store app processes can fail to launch (see
+#      https://github.com/ubuntu/wsl-actions-example, which had to work
+#      around exactly this). Whether the pool's runner avoids Session 0 is
+#      also unknown.
+#   3. GPU passthrough (librocdxg.so, dxcore, /dev/dxg) depends on the AMD
+#      driver already installed on the host — independent of WSL itself, and
+#      not something this spike can fix if missing.
+#
+# workflow_dispatch only: never runs automatically, and this whole file is
+# throwaway once the above are answered (either build the real lane on its
+# findings, or delete this).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wsl-pool-spike:
+    name: WSL pool spike
+    runs-on: [self-hosted, windows, devlab-dispatch, strix-halo]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: WSL status before install
+        shell: powershell
+        run: |
+          Write-Host "--- wsl --status ---"
+          wsl --status 2>&1 | Out-String | Write-Host
+          Write-Host "--- wsl --list --verbose ---"
+          wsl --list --verbose 2>&1 | Out-String | Write-Host
+
+      # ubuntu/WSL's own action (main@3b7a6b2, 2026-09-11): installs the WSL
+      # Store app via winget, then installs+registers the named distro. Its
+      # own first step is continue-on-error, so a failed WSL install falls
+      # through to the distro-install step, which fails loudly with a real
+      # error — exactly the signal this spike wants.
+      - name: Install WSL + Ubuntu-24.04
+        id: wsl_install
+        continue-on-error: true
+        uses: ubuntu/WSL/.github/actions/wsl-install@3b7a6b2a43af18aa541eeee1669ac27656630097
+        with:
+          distro: Ubuntu-24.04
+
+      - name: WSL status after install
+        if: always()
+        shell: powershell
+        run: |
+          Write-Host "--- wsl --status ---"
+          wsl --status 2>&1 | Out-String | Write-Host
+          Write-Host "--- wsl --list --verbose ---"
+          wsl --list --verbose 2>&1 | Out-String | Write-Host
+
+      - name: GPU passthrough plumbing inside the distro
+        if: always()
+        shell: powershell
+        run: |
+          Write-Host "--- inside Ubuntu-24.04 ---"
+          wsl -d Ubuntu-24.04 -- bash -c "cat /proc/version; ls -la /dev/dxg 2>&1; ldconfig -p 2>&1 | grep -i rocdxg || echo 'librocdxg.so: not found'" 2>&1 | Out-String | Write-Host
+
+      - name: Summary
+        if: always()
+        shell: powershell
+        run: |
+          "## WSL pool spike" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          "wsl-install step outcome: ${{ steps.wsl_install.outcome }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          "See the job log for full wsl --status / GPU passthrough output." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append

--- a/.github/workflows/wsl-pool-spike.yml
+++ b/.github/workflows/wsl-pool-spike.yml
@@ -1,35 +1,24 @@
 name: WSL pool spike (throwaway)
 
-# Answers three unknowns before building a real e2e-wsl lane on the DevLab
+# Answered three unknowns before building a real e2e-wsl lane on the DevLab
 # Dispatch pool (see #377's e2e-wsl, which stays on its static runner because
-# the pool has no wsl-labeled runner):
+# the pool has no wsl-labeled runner). Findings from run 34598787128:
 #
-#   1. WSL2 needs the "Virtual Machine Platform" + "Windows Subsystem for
-#      Linux" Windows features enabled, which normally needs a reboot to take
-#      effect. GitHub-hosted Windows runners only skip this because it is
-#      baked into their VM image at build time; whether the pool's image has
-#      it baked in too is unknown, and an ephemeral runner cannot survive a
-#      mid-job reboot.
-#   2. A self-hosted runner installed as a background service runs in Session
-#      0, where WSL / Microsoft Store app processes can fail to launch (see
+#   1. Reboot to enable WSL2 features? NO -- `wsl.exe --install` completed and
+#      the distro launched and ran commands within the same job.
+#   2. Session 0 isolation blocking WSL (see
 #      https://github.com/ubuntu/wsl-actions-example, which had to work
-#      around exactly this). Whether the pool's runner avoids Session 0 is
-#      also unknown.
-#   3. GPU passthrough (librocdxg.so, dxcore, /dev/dxg) depends on the AMD
-#      driver already installed on the host — independent of WSL itself, and
-#      not something this spike can fix if missing.
+#      around exactly this)? NO -- the distro genuinely started and executed
+#      `bash -c "..."`, returning real output.
+#   3. GPU passthrough available? Host-level: YES -- /dev/dxg is present. The
+#      ROCm-side userspace bridge (librocdxg.so) was not found, but that is
+#      expected on a fresh guest that never had ROCm's WSL driver package
+#      installed -- a solvable in-job install step, not a host limitation.
 #
-# workflow_dispatch only, EXCEPT: a brand-new workflow file can't be
-# dispatched by name until it exists on the default branch, so the
-# pull_request trigger below (scoped to this file only) is a TEMPORARY way to
-# get one real run on this PR. Remove it once that run has happened; this
-# whole file is throwaway once the three questions above are answered (either
-# build the real lane on its findings, or delete this).
+# Conclusion: a real ephemeral WSL lane looks buildable. This file is
+# throwaway pending a decision on whether/when to build it for real.
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/wsl-pool-spike.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/wsl-pool-spike.yml
+++ b/.github/workflows/wsl-pool-spike.yml
@@ -42,6 +42,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # `2>&1 | Out-String | Write-Host` still lets wsl.exe's own non-zero exit
+      # code (e.g. "not installed yet", entirely expected pre-install) fail
+      # the step under PowerShell's strict native-command handling, which
+      # would skip every step after it. `exit 0` makes these purely
+      # informational: only the printed text matters here, nothing gates on it.
       - name: WSL status before install
         shell: powershell
         run: |
@@ -49,14 +54,18 @@ jobs:
           wsl --status 2>&1 | Out-String | Write-Host
           Write-Host "--- wsl --list --verbose ---"
           wsl --list --verbose 2>&1 | Out-String | Write-Host
+          exit 0
 
       # ubuntu/WSL's own action (main@3b7a6b2, 2026-09-11): installs the WSL
       # Store app via winget, then installs+registers the named distro. Its
       # own first step is continue-on-error, so a failed WSL install falls
       # through to the distro-install step, which fails loudly with a real
-      # error — exactly the signal this spike wants.
+      # error — exactly the signal this spike wants. `if: always()` because
+      # this must run even though the diagnostic step above now always
+      # "succeeds" — belt and suspenders against the same skip-on-failure trap.
       - name: Install WSL + Ubuntu-24.04
         id: wsl_install
+        if: always()
         continue-on-error: true
         uses: ubuntu/WSL/.github/actions/wsl-install@3b7a6b2a43af18aa541eeee1669ac27656630097
         with:
@@ -70,6 +79,7 @@ jobs:
           wsl --status 2>&1 | Out-String | Write-Host
           Write-Host "--- wsl --list --verbose ---"
           wsl --list --verbose 2>&1 | Out-String | Write-Host
+          exit 0
 
       - name: GPU passthrough plumbing inside the distro
         if: always()
@@ -77,6 +87,7 @@ jobs:
         run: |
           Write-Host "--- inside Ubuntu-24.04 ---"
           wsl -d Ubuntu-24.04 -- bash -c "cat /proc/version; ls -la /dev/dxg 2>&1; ldconfig -p 2>&1 | grep -i rocdxg || echo 'librocdxg.so: not found'" 2>&1 | Out-String | Write-Host
+          exit 0
 
       - name: Summary
         if: always()

--- a/.github/workflows/wsl-pool-spike.yml
+++ b/.github/workflows/wsl-pool-spike.yml
@@ -19,11 +19,17 @@ name: WSL pool spike (throwaway)
 #      driver already installed on the host — independent of WSL itself, and
 #      not something this spike can fix if missing.
 #
-# workflow_dispatch only: never runs automatically, and this whole file is
-# throwaway once the above are answered (either build the real lane on its
-# findings, or delete this).
+# workflow_dispatch only, EXCEPT: a brand-new workflow file can't be
+# dispatched by name until it exists on the default branch, so the
+# pull_request trigger below (scoped to this file only) is a TEMPORARY way to
+# get one real run on this PR. Remove it once that run has happened; this
+# whole file is throwaway once the three questions above are answered (either
+# build the real lane on its findings, or delete this).
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/wsl-pool-spike.yml'
 
 permissions:
   contents: read

--- a/docs/ci-hardware-testing.md
+++ b/docs/ci-hardware-testing.md
@@ -33,16 +33,19 @@ separate tier flag or tag filter to maintain.
 |---|---|---|---|
 | `e2e` | `ci.yml` | Mock (no GPU) | GitHub-hosted `ubuntu-latest` |
 | `e2e-gpu` | `e2e-selfhosted.yml` | MI300X (AMD Instinct, bare-metal Linux) | self-hosted `[self-hosted, linux, mi300x]` |
-| `e2e-gpu-strix-ubuntu` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, strix-halo, native]` |
-| `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on native Windows 11 | self-hosted `[self-hosted, windows, strix-halo, native]` |
+| `e2e-gpu-strix-ubuntu` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu | self-hosted `[self-hosted, linux, devlab-dispatch, strix-halo]` |
+| `e2e-gpu-strix-windows` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Windows 11 | self-hosted `[self-hosted, windows, devlab-dispatch, strix-halo]` |
 | `e2e-wsl` | `e2e-selfhosted.yml` | Strix Halo (gfx1151) on Ubuntu under WSL2 | self-hosted `[self-hosted, linux, strix-halo, wsl]` |
 | `e2e-gpu-rad3` | `e2e-selfhosted.yml` | Radeon AI PRO R9700 (gfx1201) on Linux | self-hosted `[self-hosted, linux, r9700]` |
 | `e2e-gpu-mi350p` | `e2e-selfhosted.yml` | MI350P (AMD Instinct, gfx950) on Linux | self-hosted `[self-hosted, linux, mi350p]` |
 
-The Strix Halo lanes pin the extra `native` label because two Linux runners
-share the `strix-halo` label (a native host and a WSL host) and the jobs'
-hardcoded `/home/ubuntu/actions-runner` paths exist only on the native one. The
-WSL lane pins `wsl` for the same reason, from the other side.
+The Ubuntu and Windows Strix Halo lanes run on the AMD Ryzen DevLab Dispatch
+pool: a fresh runner is registered per job and destroyed after, opt-in only via
+the `devlab-dispatch` label, so the pool never picks up a job by accident even
+though its hosts also carry `strix-halo`. `e2e-wsl` stays on a static, always-on
+host (a WSL2 guest on a specific pre-configured Windows box, not generic Strix
+Halo hardware — the pool doesn't provide an equivalent) and pins the extra
+`wsl` label to disambiguate it from any other Linux Strix Halo runner.
 
 Every label in a `runs-on` must narrow the pool to one kind of hardware. In
 particular the MI300X lane pins `mi300x` rather than `amd-gpu`: `amd-gpu` is
@@ -217,29 +220,34 @@ the pre-warm block is duplicated across multiple jobs in two shells;
 
 The self-hosted jobs — `e2e-gpu`, `e2e-gpu-strix-ubuntu`,
 `e2e-gpu-strix-windows`, `e2e-wsl`, `e2e-gpu-rad3`, and `e2e-gpu-mi350p` — all run with
-`continue-on-error: true`, so a hardware failure that RUNS never gates a PR
-merge. Their results still surface
-in the self-hosted consolidated report for visibility.
+check names that are absent from branch protection's required-status-check
+list (see below), so a hardware failure never gates a PR merge no matter how
+it reports. Five of them run with `continue-on-error: false`, so a real
+regression shows red instead of always green; `e2e-gpu-mi350p` still runs with
+`continue-on-error: true`, unchanged and out of scope here. Their results also
+surface in the self-hosted consolidated report for visibility.
 
-### Timeouts on the shared Strix box
+### Timeouts on the Strix lanes
 
-Three of those lanes — the two native Strix ones and `e2e-wsl` — run on the same
-physical machine and can be in flight together, so a wait that is comfortable on
-an idle runner can expire while a sibling lane loads a model. Two budgets are
-raised there rather than letting contention read as a product failure:
-`E2E_SERVE_TIMEOUT_SECS` for serve readiness, and `E2E_TUI_TIMEOUT_SECS` for the
-PTY-driven dashboard waits. Both only lengthen how long a wait may take; a
-genuine hang still fails, just later.
+Every Strix Halo lane raises two budgets rather than letting a slow host read
+as a product failure: `E2E_SERVE_TIMEOUT_SECS` for serve readiness, and
+`E2E_TUI_TIMEOUT_SECS` for the PTY-driven dashboard waits. On the pool-hosted
+Ubuntu/Windows lanes this covers a busy or cold-starting pool host; `e2e-wsl`
+additionally shares its physical machine with nothing else in this workflow
+now that the other two lanes moved to the pool, but WSL2's own virtualization
+overhead can still make a wait that's comfortable on native hardware run long.
+Both budgets only lengthen how long a wait may take; a genuine hang still
+fails, just later.
 
-**Required-check caveat.** These three job names (plus, historically, a
-consolidated-report name) are still in `main`'s required-status-check list.
-`continue-on-error` neutralizes a job that ran and failed, but a required check
-that *never reports* — because its self-hosted runner is offline — is treated as
-missing and still blocks the merge. The workflow split removes the catastrophic
-concurrency stall (an offline runner can no longer freeze `ci.yml`'s hosted
-required checks), but fully unblocking merges while a runner is offline
-additionally requires removing these self-hosted checks from the required list —
-a branch-protection change tracked separately from the workflow split.
+**Required-check history.** These job names — and `E2E consolidated report
+(self-hosted)` — used to be in `main`'s required-status-check list, where a
+required check that *never reports* (because its self-hosted runner is
+offline) is treated as missing and still blocks the merge, `continue-on-error`
+notwithstanding. That branch-protection change has since landed: none of the
+self-hosted lane names, nor the self-hosted consolidated report, are in the
+required list anymore (`ci.yml`'s own mock `E2E tests` / `E2E consolidated
+report` are the required checks with those overlapping names). An offline or
+unclaimed self-hosted runner can no longer block a merge.
 
 ## Fork safety
 

--- a/tests/e2e-cucumber/expectations.toml
+++ b/tests/e2e-cucumber/expectations.toml
@@ -178,33 +178,3 @@ flaky = true
 when = { is_wsl = true, therock_family = "gfx*" }
 bug = "EAI-7998"
 reason = "`examine --json` reports has_amd_gpu:false on a WSL2 host whose own summary names a gfx target."
-
-# --- EAI-8031 (public mirror: ROCm/rocm-cli#260): on a Strix Halo WINDOWS host,
-# serving a canonical Hugging Face checkpoint through the `owner/repo:variant`
-# direct-serve path (`unsloth/Qwen3-0.6B-GGUF:Q4_0`) exits 0 but `/v1/models`
-# never lists the model, so the endpoint never becomes ready. Fails on every run
-# since the scenario was introduced by 37a3b63c (#242, 2026-08-12); it is the
-# lane's only host-independent unexpected failure.
-#
-# os=windows: this is specific to Windows AND to this serve path — the Strix Halo
-# Ubuntu lane passes the scenario, and on Windows the short-recipe-name path
-# (`serve-lemonade-inference`, same checkpoint) passes too. So it is not lemonade
-# managed serve at large, and must not widen to a bare `when = {}`.
-# therock_family/has_amd_gpu mirror the sibling rows and document intent: the
-# scenario is @requires-gpu, so on a no-GPU Windows lane it is SKIPPED, never
-# xfail'd.
-#
-# serve_timeout_secs: the lane leaves `E2E_SERVE_TIMEOUT_SECS` unset, so this
-# waits out the full 600s default on a serve that never arrives — ~10 minutes of
-# every run spent on a known bug. A HEALTHY lemonade serve of this same
-# (cache-warm) checkpoint on this host reaches ready in ~120s: measured on run
-# 32185662513, where the three passing GPU-serve scenarios took 117s, 117s and
-# 120s. 240s therefore keeps ~2x headroom — deliberately NOT the 90s used by the
-# EAI-7423 rows above, which is below a healthy serve here and would mask the
-# fix by keeping the scenario red once the bug is closed. Remove this row when
-# EAI-8031 lands; the resulting XPASS is the signal that it did. ---
-[["serve-hf-checkpoint-inference"]]
-when = { os = "windows", therock_family = "gfx*", has_amd_gpu = true }
-bug = "EAI-8031"
-reason = "Managed lemonade serve of a Hugging Face `owner/repo:variant` checkpoint exits 0 but the endpoint never becomes ready on Windows."
-serve_timeout_secs = 240

--- a/tests/e2e-cucumber/src/expectation.rs
+++ b/tests/e2e-cucumber/src/expectation.rs
@@ -1107,48 +1107,6 @@ flaky = true
         assert!(!m.is_xfail("examine-both-forms-agree-on-gpu", &cap("wsl"), "lemonade"));
     }
 
-    /// EAI-8031 is the Windows `owner/repo:variant` direct-serve path only. The
-    /// row must not widen: the Strix Halo Ubuntu lane serves the same checkpoint
-    /// correctly, and on Windows the short-recipe-name path still passes, so
-    /// letting either inherit the xfail would turn a real regression into a
-    /// silently expected failure.
-    #[test]
-    fn hf_checkpoint_serve_xfail_is_scoped_to_windows_gpu_hosts() {
-        let m = Expectations::parse(include_str!("../expectations.toml")).unwrap();
-        assert!(m.is_xfail(
-            "serve-hf-checkpoint-inference",
-            &cap("strix-windows"),
-            "lemonade"
-        ));
-        assert!(!m.is_xfail(
-            "serve-hf-checkpoint-inference",
-            &cap("strix-ubuntu"),
-            "lemonade"
-        ));
-        assert!(!m.is_xfail(
-            "serve-lemonade-inference",
-            &cap("strix-windows"),
-            "lemonade"
-        ));
-    }
-
-    /// The shortened wait must stay clear of a HEALTHY serve on this host (~120s
-    /// measured), or a fixed EAI-8031 would keep failing and never surface as the
-    /// XPASS that tells us to delete the row.
-    #[test]
-    fn hf_checkpoint_serve_xfail_shortens_the_wait_with_headroom() {
-        let m = Expectations::parse(include_str!("../expectations.toml")).unwrap();
-        let secs = m
-            .serve_timeout_for(
-                "serve-hf-checkpoint-inference",
-                &cap("strix-windows"),
-                "lemonade",
-            )
-            .expect("the EAI-8031 row shortens the serve wait");
-        assert!(secs < 600, "must be shorter than the global default");
-        assert!(secs >= 240, "must stay well above a ~120s healthy serve");
-    }
-
     #[test]
     fn glob_matches_family() {
         assert!(glob_match("gfx94*", "gfx942"));


### PR DESCRIPTION
## Summary
Stacked on #377. Answers whether the DevLab Dispatch pool can support a real `e2e-wsl`-equivalent lane, per https://ubuntu.com/wsl/docs/stable/reference/actions/#reference-actions-wsl-install, before building one for real.

Three open questions, checked by a single throwaway `workflow_dispatch`-only job (`wsl-pool-spike.yml`) that never runs automatically:

1. **Reboot to enable WSL2 features.** GitHub-hosted Windows runners skip this because it's baked into their VM image at build time; unknown whether the pool's image has it baked in, and an ephemeral runner can't survive a mid-job reboot.
2. **Session 0 isolation.** A self-hosted runner installed as a background service runs in Session 0, where WSL/Store-app processes can fail to launch ([`ubuntu/wsl-actions-example`](https://github.com/ubuntu/wsl-actions-example) had to work around exactly this with an interactive auto-logon session). Unknown whether the pool's runner avoids this.
3. **GPU passthrough** (`librocdxg.so`, dxcore, `/dev/dxg`) depends on the AMD driver already on the host, independent of WSL itself.

## Results

Ran twice (a temporary `pull_request` trigger, scoped to this file only, was needed to get the first dispatch — `workflow_dispatch` can't target a workflow file that doesn't exist on the default branch yet). First attempt tripped a workflow-authoring bug of my own (a diagnostic step's expected non-zero exit skipped every step after it, including the actual install); fixed in [`c77c9b0f`](https://github.com/ROCm/rocm-cli/pull/387/commits/c77c9b0f), then reran clean: [run 34598787128](https://github.com/ROCm/rocm-cli/actions/runs/34598787128).

| Question | Result |
|---|---|
| 1. Reboot needed? | **No.** `wsl.exe --install` completed and the distro launched and ran commands, all within the same job — no reboot. |
| 2. Session 0 blocking WSL? | **No.** The distro genuinely started and executed `bash -c "..."`, returning real output. |
| 3. GPU passthrough available? | **Host-level: yes.** `/dev/dxg` is present (`crw-rw-rw- 1 root root 10, 258 ... /dev/dxg`) — the DirectX GPU paravirtualization device the hypervisor/AMD driver needs to expose is there. `librocdxg.so` (ROCm's WSL userspace bridge) was *not* found, but that's expected on a completely fresh, just-installed Ubuntu-24.04 guest that's never had ROCm's WSL driver component installed — a software install step inside the guest, not a host limitation. |

Raw evidence from the clean run's log:
```
Distribution successfully installed. It can be launched via 'wsl.exe -d Ubuntu-24.04'
Created a new distro with user: root
--- wsl --list --verbose ---
    NAME                   STATE           VERSION
  * Ubuntu-24.04            Running         2
--- inside Ubuntu-24.04 ---
Linux version 6.18.33.2-microsoft-standard-WSL2 (root@f1bbfb02316b) ...
crw-rw-rw- 1 root root 10, 258 Sep 11  2026 /dev/dxg
librocdxg.so: not found
```

**Conclusion: a real ephemeral WSL lane looks buildable.** All three risks turned out to be non-issues, or a solvable in-job install step (installing ROCm's WSL driver package inside the fresh guest before running the suite). Next step, if pursued: install that package as part of the lane, then verify `rocm examine` reports `driver_status: wsl_rocdxg_ready` the same way the static `e2e-wsl` lane does.

## This PR is throwaway
Findings are in. Leaving this PR open as the record rather than building the real lane in it — decision on whether/when to build the real lane is pending.

## Test plan
- [x] Dispatch `wsl-pool-spike.yml` against this branch and inspect the job log / step summary for each of the three questions above.